### PR TITLE
Fix a hanging record process bug

### DIFF
--- a/non-nix-build/install_nargo.sh
+++ b/non-nix-build/install_nargo.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-WANTED_NARGO_REVISION=ad2f0701d32edb91592fcca37ce98d3c491cde77
+WANTED_NARGO_REVISION=8584e105549d6daa29d7b2be83bd5883016cfbd7
 
 if command -v nargo &> /dev/null; then
   echo nargo is already installed

--- a/src/frontend/lib.nim
+++ b/src/frontend/lib.nim
@@ -434,7 +434,12 @@ when defined(ctIndex) or defined(ctTest):
       # debugPrint "OPTIONS: ", $(options.to(cstring))
 
       setupLdLibraryPath()
-      let process = nodeStartProcess.spawn(path, args, options)
+ 
+      var processOptions = options
+      # important to ignore stderr, as otherwise too much of it can lead to
+      # the spawned process hanging: this is a bugfix for such a situation
+      processOptions.stdio = cstring"ignore"
+      let process = nodeStartProcess.spawn(path, args, processOptions)
 
       process.stdout.setEncoding(cstring"utf8")
 


### PR DESCRIPTION
* upgrade noir for non-nix build
* fix hanging process in the record dialog: ignore stdio for spawn

the older version of noir was producing more warnings, and probably
this might have led to overfilling the stderr buffer like in this case: https://stackoverflow.com/questions/20792427/why-is-my-node-child-process-that-i-created-via-spawn-hanging/20792428#20792428

the proposed `options.stdio` ignore fix prevents this problem

