### PR TITLE
fix: small fixes, cleanups and improvements for `ct`/trace sharing

### DIFF
--- a/config/default_config.yaml
+++ b/config/default_config.yaml
@@ -10,6 +10,7 @@ events: true
 # history: experimental support
 history: true
 repl: true
+traceSharingEnabled: false
 
 # === feature settings
 
@@ -54,7 +55,11 @@ defaultBuild: ""
 showMinimap: true
 
 # for now local setup
-webApiRoot: http://100.87.206.30:57103/api/codetracer
+baseUrl: http://localhost:55500/api/codetracer
+
+downloadApi: /download
+uploadApi: /upload
+deleteApi: /delete
 
 # # you can use KEY+OTHER
 # # use PageUp, PageDown, CTRL, ALT, SHIFT

--- a/src/ct/launch/launch.nim
+++ b/src/ct/launch/launch.nim
@@ -1,14 +1,12 @@
 import
-  std/[strutils, strformat, osproc],
-  ../../common/[ paths, types, intel_fix, install_utils, trace_index, start_utils ],
-  ../utilities/[ git, env ],
+  ../../common/[ paths, types, intel_fix, install_utils ],
+  ../utilities/[ git ],
   ../online_sharing/trace_manager,
   ../cli/[ logging, list, help ],
   ../trace/[ replay, record, run, metadata ],
   ../codetracerconf,
   ../version,
   ../globals,
-  cleanup,
   electron,
   results,
   backends

--- a/src/ct/online_sharing/security_upload.nim
+++ b/src/ct/online_sharing/security_upload.nim
@@ -1,4 +1,5 @@
 import nimcrypto, zip/zipfiles, std/[ sequtils, strutils, strformat, os, httpclient, mimetypes, uri ]
+from stew / byteutils import toBytes
 import ../../common/[ config ]
 
 proc generateSecurePassword*(): string =
@@ -22,17 +23,6 @@ proc pkcs7Unpad*(data: seq[byte]): seq[byte] =
 
   result = data[0 ..< data.len - padLen]
 
-func toBytes*(s: string): seq[byte] =
-  ## Convert a string to the corresponding byte sequence - since strings in
-  ## nim essentially are byte sequences without any particular encoding, this
-  ## simply copies the bytes without a null terminator
-  when nimvm:
-    var r = newSeq[byte](s.len)
-    for i, c in s:
-      r[i] = cast[byte](c)
-    r
-  else:
-    @(s.toOpenArrayByte(0, s.high))
 
 proc encryptZip(zipFile, password: string) =
   var iv: seq[byte] = password.toBytes()[0..15]
@@ -81,3 +71,5 @@ proc uploadEncyptedZip*(file: string): (string, int) =
     client.close()
   
   (response, exitCode)
+
+export toBytes

--- a/src/ct/trace/record.nim
+++ b/src/ct/trace/record.nim
@@ -154,7 +154,7 @@ proc record(cmd: string, args: seq[string], compileCommand: string,
   except OsError:
     let foundExe = findExe(executable)
     if foundExe == "":
-      error &"Can't find {executable}"
+      errorMessage fmt"Can't find {executable}"
       quit(1)
     else:
       executable = foundExe


### PR DESCRIPTION
* fix: copy default config to `config/` as well TODO in the future: hopefully fix build/usage of config to `src/config`, and cleanup the root `config/
* fix: add a simple password length check to show a custom error, instead of exception
* import toBytes from nim-stew
* add a custom print message for manual `ct download` and `ct upload`(also a warning)
* fix some warnings(removing unused imports; probably we have them from before!)
* make `ct` trace sharing commands honor the `traceSharingEnabled` config flag