### PR TITLE
feat: upgrade runtime_tracing to 0.9 for db-backend: adapt/add support for some new values

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,16 +168,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1740042702,
-        "narHash": "sha256-qA43GWoM4u647PL53L15tzhhR3S5xku5ypz0VvOwRpE=",
-        "owner": "blocksense-network",
+        "lastModified": 1747325343,
+        "narHash": "sha256-V9GDwHzx6z67swDo662SSJBTpAOxI2WqlwWgSx6YcZY=",
+        "owner": "metacraft-labs",
         "repo": "noir",
-        "rev": "8584e105549d6daa29d7b2be83bd5883016cfbd7",
+        "rev": "e47c24d418436e6c0cf148b16477efc31bbaad5c",
         "type": "github"
       },
       "original": {
-        "owner": "blocksense-network",
-        "ref": "blocksense",
+        "owner": "metacraft-labs",
+        "ref": "codetracer-temp",
         "repo": "noir",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
     };
 
     noir = {
-      url = "github:blocksense-network/noir?ref=blocksense";
+      url = "github:metacraft-labs/noir?ref=codetracer-temp";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
       flake = true;
     };

--- a/src/common/common_types.nim
+++ b/src/common/common_types.nim
@@ -416,6 +416,7 @@ type
     member*: seq[Value]
     refValue*: Value
     address*: langstring
+    isMutable*: bool
     strong*: int
     weak*: int
     r*: langstring

--- a/src/db-backend/Cargo.lock
+++ b/src/db-backend/Cargo.lock
@@ -543,9 +543,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "runtime_tracing"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6cf2858c5b474be12fd597b5dca533c1b917cfcf2f233ad4c75981567ba00a"
+checksum = "eafd7c2c0304ff7196100ad4b6d33ff61e27d7bdcc10efe75784364b86292451"
 dependencies = [
  "num-derive",
  "num-traits",

--- a/src/db-backend/Cargo.lock
+++ b/src/db-backend/Cargo.lock
@@ -543,8 +543,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "runtime_tracing"
-version = "0.6.0"
-source = "git+https://github.com/metacraft-labs/runtime_tracing.git?tag=0.6.0#aa37e95d856aec97c926372d9eae79037a65e434"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af6cf2858c5b474be12fd597b5dca533c1b917cfcf2f233ad4c75981567ba00a"
 dependencies = [
  "num-derive",
  "num-traits",

--- a/src/db-backend/Cargo.toml
+++ b/src/db-backend/Cargo.toml
@@ -30,7 +30,7 @@ tokio = {version = "1.37.0", features=["full", "rt", "net", "signal"]}
 futures = "0.3.30"
 futures-timer = "3.0.3"
 clap = { version = "4.5.4", features = ["derive"] }
-runtime_tracing = "0.9.0" # { git = "https://github.com/metacraft-labs/runtime_tracing.git", tag = "0.6.0" }
+runtime_tracing = "0.10.0" # { git = "https://github.com/metacraft-labs/runtime_tracing.git", tag = "0.6.0" }
 tree-sitter-tracepoint = { path = "./tree-sitter-trace/" }
 
 [lib]

--- a/src/db-backend/Cargo.toml
+++ b/src/db-backend/Cargo.toml
@@ -30,7 +30,7 @@ tokio = {version = "1.37.0", features=["full", "rt", "net", "signal"]}
 futures = "0.3.30"
 futures-timer = "3.0.3"
 clap = { version = "4.5.4", features = ["derive"] }
-runtime_tracing = { git = "https://github.com/metacraft-labs/runtime_tracing.git", tag = "0.6.0" }
+runtime_tracing = "0.9.0" # { git = "https://github.com/metacraft-labs/runtime_tracing.git", tag = "0.6.0" }
 tree-sitter-tracepoint = { path = "./tree-sitter-trace/" }
 
 [lib]

--- a/src/db-backend/src/flow_preloader.rs
+++ b/src/db-backend/src/flow_preloader.rs
@@ -312,8 +312,8 @@ impl<'a> CallFlowPreloader<'a> {
             );
         }
 
-        for (variable_id, value_id) in &db.variable_cells[step_id] {
-            let value_record = db.load_value_for_id(*value_id, step_id);
+        for (variable_id, place) in &db.variable_cells[step_id] {
+            let value_record = db.load_value_for_place(*place, step_id);
             let full_value_record = FullValueRecord {
                 variable_id: *variable_id,
                 value: value_record,

--- a/src/db-backend/src/handler.rs
+++ b/src/db-backend/src/handler.rs
@@ -258,10 +258,10 @@ impl Handler {
         // TODO: fix random order here as well: ensure order(or in final locals?)
         let value_tracking_locals: Vec<Variable> = self.db.variable_cells[self.step_id]
             .iter()
-            .map(|(variable_id, value_id)| {
+            .map(|(variable_id, place)| {
                 let name = self.db.variable_name(*variable_id);
-                info!("log local {variable_id:?} {name} value id: {value_id:?}");
-                let value = self.db.load_value_for_id(*value_id, self.step_id);
+                info!("log local {variable_id:?} {name} place: {place:?}");
+                let value = self.db.load_value_for_place(*place, self.step_id);
                 Variable {
                     expression: self.db.variable_name(*variable_id).to_string(),
                     value: self.db.to_ct_value(&value),

--- a/src/db-backend/src/task.rs
+++ b/src/db-backend/src/task.rs
@@ -14,7 +14,7 @@ use crate::lang::*;
 use crate::value::{Type, Value};
 
 // IMPORTANT: must keep in sync with `EventLogKind` definition in common_types.nim!
-pub const EVENT_KINDS_COUNT: usize = 11;
+pub const EVENT_KINDS_COUNT: usize = 13;
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/db-backend/src/tracepoint_interpreter/executor.rs
+++ b/src/db-backend/src/tracepoint_interpreter/executor.rs
@@ -188,7 +188,17 @@ pub fn execute_bytecode(
                     #[allow(clippy::unwrap_used)]
                     let array = stack.pop().unwrap();
 
-                    if let ValueRecord::Sequence { elements, type_id: _ } = array {
+                    if let ValueRecord::Sequence { elements, type_id: _ , is_slice} = array {
+                        if is_slice {
+                            let mut err_value = Value::new(TypeKind::Error, eval_error_type.clone());
+                            err_value.msg = "Slices not supported currently".to_string();
+                            locals.push(StringAndValueTuple {
+                                field0: source[opcode.position.start_byte..opcode.position.end_byte].to_string(),
+                                field1: err_value,
+                            });
+                            return locals;
+                        }
+
                         if let ValueRecord::Int { i, type_id: _ } = index {
                             if i < 0 || i >= elements.len() as i64 {
                                 let mut err_value = Value::new(TypeKind::Error, eval_error_type.clone());

--- a/src/db-backend/src/value.rs
+++ b/src/db-backend/src/value.rs
@@ -15,6 +15,9 @@ pub struct Value {
     pub elements: Vec<Value>,
     pub msg: String,
     pub r: String,
+    pub address: i64,
+    pub ref_value: Option<Box<Value>>,
+    pub is_mutable: bool,
     pub typ: Type,
 }
 
@@ -27,6 +30,8 @@ pub struct Type {
     pub c_type: String,
     // pub elements: Vec<Type>,
     pub labels: Vec<String>,
+    pub element_type: Option<Box<Type>>,
+    pub member_types: Vec<Type>,
 }
 
 impl Value {


### PR DESCRIPTION
TODO: currently there is a bug with the `runtime_tracing` `Reference` to pointer mapping: or at least it shows an error in the state panel. Tested with temporarily overriding the noir exe to a manually built on from `nargo_trace` of the blocksense noir compiler (also some other unrelated(?) issues there)

* adapt: use place instead of value_id
* adapt to is_slice: maybe we should've used SLICE type as originally, but think about this more out of this PR: for now support what the lib supports
* add support for `runtime_tracing` tuples and hopefully for references(adding isMutable for them)
* for now leave `runtime_tracing` Variants for the future: want to think more of the repr