### PR TITLE
fix(examples): fix `ruby_maze_solver` now print maze on multiple lines

### DIFF
--- a/examples/ruby_maze_solver/lib/maze_solver/maze.rb
+++ b/examples/ruby_maze_solver/lib/maze_solver/maze.rb
@@ -61,16 +61,16 @@ module MazeSolver
       @grid.each_with_index do |row, x|
         row.each_with_index do |cell, y|
           if [x, y] == [@start.x, @start.y]
-            p "S "
+            print "S "
           elsif [x, y] == [@end.x, @end.y]
-            p "E "
+            print "E "
           elsif path_points.include?([x, y])
-            p "* "
+            print "* "
           else
-            p cell == 1 ? "# " : ". "
+            print cell == 1 ? "# " : ". "
           end
         end
-        puts  
+        puts
       end
     end
 


### PR DESCRIPTION
A small change to fix the ruby_maze_solver example.
Now it prints the output on multiple lines.