### PR TITLE
Support/fixes for wasm tracing (and download/import db trace fixes by Nedi)

### DIFF
--- a/appimage-scripts/build_appimage.sh
+++ b/appimage-scripts/build_appimage.sh
@@ -109,6 +109,12 @@ bash "${ROOT_PATH}"/appimage-scripts/build_db_backend.sh
 cp -Lr "${ROOT_PATH}/src/links/nargo" "${APP_DIR}/bin/"
 chmod +x "${APP_DIR}/bin/nargo"
 
+# Wazero
+nix build "${ROOT_PATH}#packages.${CURRENT_NIX_SYSTEM}.wazero"
+
+WAZERO=$(nix eval --raw "${ROOT_PATH}#packages.${CURRENT_NIX_SYSTEM}.wazero.out")
+cp -L "${WAZERO}"/bin/wazero "${APP_DIR}"/bin
+
 # ctags
 cp -Lr "${ROOT_PATH}/src/links/ctags" "${APP_DIR}/bin/"
 chmod +x "${APP_DIR}/bin/ctags"
@@ -201,6 +207,7 @@ fi
 patchelf --set-interpreter "${INTERPRETER_PATH}" "${APP_DIR}"/bin/ct_unwrapped
 patchelf --set-interpreter "${INTERPRETER_PATH}" "${APP_DIR}"/bin/db-backend
 patchelf --set-interpreter "${INTERPRETER_PATH}" "${APP_DIR}"/bin/nargo
+patchelf --set-interpreter "${INTERPRETER_PATH}" "${APP_DIR}"/bin/wazero
 patchelf --set-interpreter "${INTERPRETER_PATH}" "${APP_DIR}"/bin/ctags
 patchelf --set-interpreter "${INTERPRETER_PATH}" "${APP_DIR}"/ruby/bin/ruby
 

--- a/appimage-scripts/build_with_nim.sh
+++ b/appimage-scripts/build_with_nim.sh
@@ -48,7 +48,7 @@ nim \
     -d:chronicles_sinks=json -d:chronicles_line_numbers=true \
     -d:chronicles_timestamps=UnixTime \
     -d:ssl \
-    -d:ctTest -d:testing --hint[XDeclaredButNotUsed]:off \
+    -d:ctTest -d:testing --hint"[XDeclaredButNotUsed]":off \
     -d:linksPathConst=.. \
     -d:libcPath=libc \
     -d:builtWithNix \

--- a/appimage-scripts/build_with_nim.sh
+++ b/appimage-scripts/build_with_nim.sh
@@ -40,6 +40,27 @@ nim -d:release \
     --out:"${APP_DIR}/bin/ct_unwrapped" c ./src/ct/codetracer.nim
 
 
+nim \
+    -d:release -d:asyncBackend=asyncdispatch \
+    --gc:refc --hints:off --warnings:off \
+    --debugInfo --lineDir:on \
+    --boundChecks:on --stacktrace:on --linetrace:on \
+    -d:chronicles_sinks=json -d:chronicles_line_numbers=true \
+    -d:chronicles_timestamps=UnixTime \
+    -d:ssl \
+    -d:ctTest -d:testing --hint[XDeclaredButNotUsed]:off \
+    -d:linksPathConst=.. \
+    -d:libcPath=libc \
+    -d:builtWithNix \
+    -d:ctEntrypoint \
+    --dynlibOverride:"sqlite3" \
+    --dynlibOverride:"pcre" \
+    --dynlibOverride:"libzip" \
+    --passL:"${APP_DIR}/lib/libsqlite3.so.0" \
+    --passL:"${APP_DIR}/lib/libpcre.so.1" \
+    --passL:"${APP_DIR}/lib/libzip.so.5" \
+    --nimcache:nimcache \
+    --out:"${APP_DIR}/bin/db-backend-record" c ./src/ct/db_backend_record.nim
 
     # --passL:"-lsqlite3" \
     #--passL:"${APPDIR}/lib/libcrypto.so.3" \

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -11,6 +11,7 @@
 - [Tracepoints](./usage_guide/tracepoints.md)
 - [CodeTracer Shell](./usage_guide/codetracer_shell.md)
 
+
 ## Backends
 
 - [DB backend](./backends/db_backend.md)
@@ -19,6 +20,7 @@
   - [Python](./backends/db-backend/py.md)
   - [Lua](./backends/db-backend/lua.md)
   - [small](./backends/db-backend/small.md)
+  - [Stylus and WASM](./usage_guide/stylus_and_wasm.md)
   
 - [RR backend](./backends/rr_backend.md)
   - [C & C++](./backends/rr-backend/c_and_cpp.md)

--- a/docs/book/src/backends/db-backend/stylus_and_wasm.md
+++ b/docs/book/src/backends/db-backend/stylus_and_wasm.md
@@ -1,0 +1,21 @@
+## Stylus / WASM
+
+We are adding MVP support for Stylus contracts written in Rust and using WASM.
+
+The support is implemented in a general way, by patching the [wazero]() WASM interpreter, so
+it can be used for various WASM languages/usecases, but the first iteration is a bit more tested with
+the Stylus contract usecase or small example Rust-based WASM programs.
+
+### instructions for trying and example with Stylus 
+
+TODO
+
+### a simpler example only with Rust
+
+```
+# install rustup
+# TODO: rustup add wasmi target 
+# TODO: add rustc wasm command and an example rs file
+ct record /tmp/rust_example.wasm
+ct replay rust_example.wasm
+```

--- a/docs/book/src/introduction.md
+++ b/docs/book/src/introduction.md
@@ -58,8 +58,12 @@ cargo test --release --bin db-backend # test most cases: non-ignored
 cargo test --release --bin db-backend -- --ignored # test the ignored cases: ignored by default as they're slower
 ```
 
-We are planning on restoring the e2e tests for db-backend: currently they don't work, 
-as they were created originally with native language test programs in our older repo targetting the rr-backend.
+some initial simple end to end playwright tests:
+
+```bash
+just test-e2e
+````
+
 We hope to write a lot more e2e tests, as we haven't covered most features/cases.
 
 ### Enabling `cachix`

--- a/flake.lock
+++ b/flake.lock
@@ -324,11 +324,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746806454,
-        "narHash": "sha256-xnPl4jIJl0IpDYVZQENfBrESTq1bRkW+SMoEuJfoLFg=",
+        "lastModified": 1747308822,
+        "narHash": "sha256-L+n0pYV1iUHeRjo4jq5c+rIE9X6t0utwTyA8qaZ6I7g=",
         "owner": "metacraft-labs",
         "repo": "codetracer-wasm-recorder",
-        "rev": "afeef07f04e629a391da3e6ea4da143e0d9e75fe",
+        "rev": "6964dbf313ec54f2e169cb811f845263e07c29d6",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -59,6 +59,28 @@
         "type": "github"
       }
     },
+    "fenix_3": {
+      "inputs": {
+        "nixpkgs": [
+          "wazero",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src_3"
+      },
+      "locked": {
+        "lastModified": 1744785355,
+        "narHash": "sha256-A2nwWS6g4xX92/Fj7hrRz5e/MjRIiBzV6+qBzMLaL6Q=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "a04587e142d4bc2519787ab5b8b879e72015d912",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -89,6 +111,24 @@
         "owner": "hercules-ci",
         "repo": "flake-parts",
         "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -143,6 +183,21 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       }
     },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1735471104,
@@ -190,7 +245,8 @@
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
-        "noir": "noir"
+        "noir": "noir",
+        "wazero": "wazero"
       }
     },
     "rust-analyzer-src": {
@@ -227,6 +283,23 @@
         "type": "github"
       }
     },
+    "rust-analyzer-src_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1744743084,
+        "narHash": "sha256-0J4rF/TO42gpCetm/PfX20aMBPJ30QiThlmwVgRJjn8=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "bdd04916685657b22cf38b9405c9f87cdaae4242",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
     "systems": {
       "locked": {
         "lastModified": 1681028828,
@@ -239,6 +312,29 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "wazero": {
+      "inputs": {
+        "fenix": "fenix_3",
+        "flake-parts": "flake-parts_3",
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1746791013,
+        "narHash": "sha256-TXumrlHfVgbscYwHbHfFpX1EgG6Hl4ZjukB/nTg85Ek=",
+        "owner": "metacraft-labs",
+        "repo": "codetracer-wasm-recorder",
+        "rev": "2d9178ad42715fc0875f8550f13fb735077b85b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "metacraft-labs",
+        "ref": "feat-mvp-trace",
+        "repo": "codetracer-wasm-recorder",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -168,16 +168,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1740042702,
-        "narHash": "sha256-qA43GWoM4u647PL53L15tzhhR3S5xku5ypz0VvOwRpE=",
-        "owner": "blocksense-network",
+        "lastModified": 1747325343,
+        "narHash": "sha256-V9GDwHzx6z67swDo662SSJBTpAOxI2WqlwWgSx6YcZY=",
+        "owner": "metacraft-labs",
         "repo": "noir",
-        "rev": "8584e105549d6daa29d7b2be83bd5883016cfbd7",
+        "rev": "e47c24d418436e6c0cf148b16477efc31bbaad5c",
         "type": "github"
       },
       "original": {
-        "owner": "blocksense-network",
-        "ref": "blocksense",
+        "owner": "metacraft-labs",
+        "ref": "codetracer-temp",
         "repo": "noir",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -324,11 +324,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746791013,
-        "narHash": "sha256-TXumrlHfVgbscYwHbHfFpX1EgG6Hl4ZjukB/nTg85Ek=",
+        "lastModified": 1746806454,
+        "narHash": "sha256-xnPl4jIJl0IpDYVZQENfBrESTq1bRkW+SMoEuJfoLFg=",
         "owner": "metacraft-labs",
         "repo": "codetracer-wasm-recorder",
-        "rev": "2d9178ad42715fc0875f8550f13fb735077b85b3",
+        "rev": "afeef07f04e629a391da3e6ea4da143e0d9e75fe",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,17 +2,19 @@
   description = "Code Tracer";
 
   nixConfig = {
-    extra-substituters = ["https://metacraft-labs-codetracer.cachix.org"];
-    extra-trusted-public-keys = ["metacraft-labs-codetracer.cachix.org-1:6p7pd81m6sIh59yr88yGPU9TFYJZkIrFZoFBWj/y4aE="];
+    extra-substituters = [ "https://metacraft-labs-codetracer.cachix.org" ];
+    extra-trusted-public-keys = [
+      "metacraft-labs-codetracer.cachix.org-1:6p7pd81m6sIh59yr88yGPU9TFYJZkIrFZoFBWj/y4aE="
+    ];
   };
 
   inputs = {
-    nixpkgs.url = github:NixOS/nixpkgs/nixos-unstable;
-    nixpkgs-unstable.url = github:NixOS/nixpkgs/nixos-unstable;
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     appimage-channel.url = "github:NixOS/nixpkgs/nixos-24.11";
 
-    flake-utils.url = github:numtide/flake-utils;
+    flake-utils.url = "github:numtide/flake-utils";
 
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
@@ -29,6 +31,13 @@
       inputs.nixpkgs.follows = "nixpkgs-unstable";
       flake = true;
     };
+
+    wazero = {
+      url = "github:metacraft-labs/codetracer-wasm-recorder?ref=feat-mvp-trace"; # " ref=blocksense-with-new-event-log-kinds";
+      inputs.nixpkgs.follows = "nixpkgs-unstable";
+      flake = true;
+    };
+
   };
 
   # outputs = {
@@ -54,42 +63,50 @@
   #   devShell."${system}" = import ./shell.nix {inherit pkgs;};
   # };
 
-  outputs = inputs @ {
-    nixpkgs,
-    nixpkgs-unstable,
-    flake-parts,
-    fenix,
-    ...
-  }:
-    flake-parts.lib.mkFlake {inherit inputs;} {
-      systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+  outputs =
+    inputs@{
+      nixpkgs,
+      nixpkgs-unstable,
+      flake-parts,
+      fenix,
+      ...
+    }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
       imports = [
         ./nix/shells
         ./nix/packages
       ];
 
-      perSystem = {system, ...}: {
-        _module.args.pkgs = import nixpkgs {
-          inherit system;
-          config = {
-            # tup is currently considered broken by Nix, but this is not true
-            # TODO: this is already fixed in nixpkgs/unstable, so it may become
-            #       unnecessary after a future `flake update`
-            allowBroken = true;
-            permittedInsecurePackages = [
-              "electron-24.8.6"
-            ];
+      perSystem =
+        { system, ... }:
+        {
+          _module.args.pkgs = import nixpkgs {
+            inherit system;
+            config = {
+              # tup is currently considered broken by Nix, but this is not true
+              # TODO: this is already fixed in nixpkgs/unstable, so it may become
+              #       unnecessary after a future `flake update`
+              allowBroken = true;
+              permittedInsecurePackages = [
+                "electron-24.8.6"
+              ];
+            };
           };
-        };
 
-        _module.args.unstablePkgs = import nixpkgs-unstable {
-          inherit system;
-          config = {
-            permittedInsecurePackages = [
-              "electron-24.8.6"
-            ];
+          _module.args.unstablePkgs = import nixpkgs-unstable {
+            inherit system;
+            config = {
+              permittedInsecurePackages = [
+                "electron-24.8.6"
+              ];
+            };
           };
         };
-      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
     };
 
     noir = {
-      url = "github:blocksense-network/noir?ref=blocksense";
+      url = "github:metacraft-labs/noir?ref=codetracer-temp";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
       flake = true;
     };

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
     };
 
     wazero = {
-      url = "github:metacraft-labs/codetracer-wasm-recorder?ref=feat-mvp-trace"; # " ref=blocksense-with-new-event-log-kinds";
+      url = "github:metacraft-labs/codetracer-wasm-recorder?ref=feat-mvp-trace";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
       flake = true;
     };

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -209,9 +209,6 @@
 
           cargoLock = {
             lockFile = ../../src/db-backend/Cargo.lock;
-            outputHashes = {
-              "runtime_tracing-0.6.1" = "sha256-wx2D7gazcW/COWG06DT8yrN13LjAARFuPsTYBencp5U=";
-            };
           };
 
           checkFlags = [

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -23,6 +23,8 @@
 
         noir = inputs.noir.packages.${system}.default;
 
+        wazero = inputs.wazero.packages.${system}.default;
+
         sqlite = pkgs.sqlite;
 
         pcre = pkgs.pcre;

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -210,7 +210,7 @@
           cargoLock = {
             lockFile = ../../src/db-backend/Cargo.lock;
             outputHashes = {
-              "runtime_tracing-0.6.0" = "sha256-9DoalWBiIctD6tmBjBcVlpJlLHRoFp57uuyfBB1lw0g=";
+              "runtime_tracing-0.6.1" = "sha256-wx2D7gazcW/COWG06DT8yrN13LjAARFuPsTYBencp5U=";
             };
           };
 

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -305,6 +305,7 @@
             uiJavascript
             upstream-nim-codetracer
             noir
+            wazero
             ruby-recorder
             pkgs.universal-ctags
           ] ++ staticDeps.paths;
@@ -527,6 +528,8 @@
           buildInputs = [
             pkgs.rustc
             pkgs.sqlite
+            pkgs.libzip
+            pkgs.openssl
             # pkgs.zip
           ];
 
@@ -573,6 +576,8 @@
               -d:builtWithNix \
               -d:ctEntrypoint \
               --passL:${pkgs.sqlite.out}/lib/libsqlite3.so.0 \
+              --passL:${pkgs.openssl.out}/lib/libssl.so \
+              --passL:${pkgs.openssl.out}/lib/libcrypto.so \
               --nimcache:nimcache \
               --out:db-backend-record c ./src/ct/db_backend_record.nim
           '';

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -11,11 +11,10 @@
       inherit (pkgs) stdenv;
 
       src = ../../.;
-      root = src;
     in
     {
       packages = rec {
-        upstream-nim-codetracer = pkgs.buildPackages.nim1.overrideAttrs (old: {
+        upstream-nim-codetracer = pkgs.buildPackages.nim1.overrideAttrs (_: {
           postInstallPhase = ''
             mv $out/nim $out/upstream-nim
           '';
@@ -25,15 +24,14 @@
 
         wazero = inputs.wazero.packages.${system}.default;
 
-        sqlite = pkgs.sqlite;
+        inherit (pkgs)
+          sqlite
+          pcre
+          libzip
+          openssl
+          ;
 
-        pcre = pkgs.pcre;
-
-        libzip = pkgs.libzip;
-
-        openssl = pkgs.openssl;
-
-        chromedriver-102 = pkgs.chromedriver.overrideAttrs (old: {
+        chromedriver-102 = pkgs.chromedriver.overrideAttrs (_: {
           version = "102.0.5005.27";
           src = builtins.fetchurl {
             url = "https://chromedriver.storage.googleapis.com/102.0.5005.27/chromedriver_linux64.zip";

--- a/nix/shells/main.nix
+++ b/nix/shells/main.nix
@@ -220,6 +220,7 @@ mkShell {
     [ ! -f links/cmp ] && ln -s ${diffutils.outPath}/bin/cmp links/cmp
     [ ! -f links/ruby ] && ln -s ${ruby.outPath}/bin/ruby links/ruby
     [ ! -f links/nargo ] && ln -s ${ourPkgs.noir.outPath}/bin/nargo links/nargo
+    [ ! -f links/wazero ] && ln -s ${ourPkgs.wazero.outPath}/bin/wazero links/wazero
     [ ! -f links/electron ] && ln -s ${electron_33.outPath}/bin/electron links/electron
     [ ! -f links/ctags ] && ln -s ${universal-ctags.outPath}/bin/ctags links/ctags
     # TODO: try to add an option to link to libs/upstream-nim, libs/rr

--- a/nix/shells/main.nix
+++ b/nix/shells/main.nix
@@ -63,7 +63,6 @@ mkShell {
 
       cargo
       rustfmt
-      rustc
       # ourPkgs.codetracer-rust-wrapped
       clippy
 

--- a/non-nix-build/build_in_simple_env.sh
+++ b/non-nix-build/build_in_simple_env.sh
@@ -50,4 +50,5 @@ rm -f $DIST_DIR/public
 cp -r $ROOT_DIR/config $DIST_DIR/config
 cp -r $ROOT_DIR/src/public $DIST_DIR/public
 cp $BIN_DIR/nargo $DIST_DIR/bin/
+cp $BIN_DIR/wazero $DIST_DIR/bin/
 

--- a/non-nix-build/build_with_nim.sh
+++ b/non-nix-build/build_with_nim.sh
@@ -37,6 +37,23 @@ nim -d:release \
     -d:nimDebugDlOpen \
     --out:"$DIST_DIR/bin/ct" c ./src/ct/codetracer.nim
 
+nim -d:release \
+    -d:asyncBackend=asyncdispatch \
+    --dynlibOverride: "libzip" \
+    --passL:"${GIT_ROOT}/non-nix-build/CodeTracer.app/Contents/Frameworks/libzip.dylib" \
+    --gc:refc --hints:on --warnings:off \
+    --debugInfo --lineDir:on \
+    --boundChecks:on --stacktrace:on --linetrace:on \
+    -d:chronicles_sinks=json -d:chronicles_line_numbers=true \
+    -d:chronicles_timestamps=UnixTime \
+    -d:ctTest -d:ssl -d:testing --hint[XDeclaredButNotUsed]:off \
+    -d:libcPath=libc \
+    -d:builtWithNix \
+    -d:ctEntrypoint \
+    --nimcache:nimcache \
+    -d:nimDebugDlOpen \
+    --out:"$DIST_DIR/bin/db-backend-record" c ./src/ct/db_backend_record.nim
+
 # this works    --passL:/nix/store/f6afb4jw9g5f94ixw0jn6cl0ah4liy35-sqlite-3.45.3/lib/libsqlite3.so.0 \
 
     # TODO conditional for nixos?--passL:$LIBSQLITE3_PATH

--- a/non-nix-build/env.sh
+++ b/non-nix-build/env.sh
@@ -52,7 +52,7 @@ fi
 export PATH=$DEPS_DIR/nim/bin:$ROOT_DIR/node_modules/.bin:$BIN_DIR:$CARGO_HOME/bin:$ROOT_DIR/src/build-debug/bin:$PATH
 
 if [ "$os" == "mac" ]; then
-  brew install sqlite3 ruby node universal-ctags
+  brew install sqlite3 ruby node universal-ctags go
 fi
 
 ./install_rust.sh

--- a/non-nix-build/env.sh
+++ b/non-nix-build/env.sh
@@ -57,6 +57,7 @@ fi
 
 ./install_rust.sh
 ./install_nargo.sh
+./install_wazero.sh
 ./install_nim_osx.sh
 
 if [[ "$platform" == "mac" ]]; then

--- a/non-nix-build/install_wazero.sh
+++ b/non-nix-build/install_wazero.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+WANTED_WAZERO_REVISION=e347615557a19e4cbf6ae210a0d745014613e4a0
+
+: ${DEPS_DIR:=$PWD/deps}
+cd "$DEPS_DIR"
+
+rm -rf codetracer-wasm-recorder
+git clone https://github.com/metacraft-labs/codetracer-wasm-recorder.git
+cd codetracer-wasm-recorder
+git checkout $WANTED_WAZERO_REVISION
+go build cmd/wazero/wazero.go
+cp ./wazero $BIN_DIR/
+

--- a/src/Tupfile
+++ b/src/Tupfile
@@ -24,6 +24,7 @@ include_rules
 : links/node |> !tup_preserve |> bin/node
 : links/ruby |> !tup_preserve |> bin/ruby
 : links/nargo |> !tup_preserve |> bin/nargo
+: links/wazero |> !tup_preserve |> bin/wazero
 : links/ctags |> !tup_preserve |> bin/ctags
 : links/electron |> !tup_preserve |> bin/electron
 # : links/unzip |> !tup_preserve |> bin/unzip

--- a/src/common/common_lang.nim
+++ b/src/common/common_lang.nim
@@ -7,10 +7,12 @@
 import strutils, os
 
 type
-  Lang* = enum ## Identifies a programming language
+  Lang* = enum ## Identifies a programming language implementation
     LangC, LangCpp, LangRust, LangNim, LangGo,
     LangPascal, LangPython, LangRuby, LangRubyDb, LangJavascript,
-    LangLua, LangAsm, LangNoir, LangSmall, LangUnknown
+    LangLua, LangAsm, LangNoir,
+    LangRustWasm, LangCppWasm, # wasm
+    LangSmall, LangUnknown
 
 var CURRENT_LANG*: Lang = LangUnknown ## The current lang in the codetraces session
 
@@ -19,12 +21,14 @@ proc isVMLang*(lang: Lang): bool =
   false # lang in {LangRuby, LangPython, LangLua, LangJavascript, LangUnknown}
 
 var IS_DB_BASED*: array[Lang, bool] = [
-  false, false, false, false, false, false, false, false, false, false, false, false, false, false, false
+  false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false
 ]
 
 IS_DB_BASED[LangRubyDb] = true
 IS_DB_BASED[LangNoir] = true
 IS_DB_BASED[LangSmall] = true
+IS_DB_BASED[LangRustWasm] = true
+IS_DB_BASED[LangCppWasm] = true
 
 proc isDbBased*(lang: Lang): bool =
   ## return true if `lang` uses the db backend
@@ -32,12 +36,17 @@ proc isDbBased*(lang: Lang): bool =
 
 proc toCLang*(lang: Lang): string =
   ## convert Lang_ to string
-  let langs: array[Lang, string] = ["c", "cpp", "rust", "nim", "go", "pascal", "python", "ruby", "ruby", "javascript", "lua", "assembly", "noir", "small", "uknown"]
+  let langs: array[Lang, string] = ["c", "cpp", "rust", "nim", "go", "pascal", "python", "ruby", "ruby", "javascript", "lua", "assembly", "noir", "rust", "c++", "small", "uknown"]
   result = langs[lang]
 
 proc toName*(lang: Lang): string =
   ## convert Lang_ to string
-  let langs: array[Lang, string] = ["C", "C++", "Rust", "Nim", "Go", "Pascal", "Python", "Ruby", "Ruby(db)", "Javascript", "Lua", "assembly language", "Noir", "Small", "unknown"]
+  let langs: array[Lang, string] = [
+       "C", "C++", "Rust", "Nim", "Go",
+       "Pascal", "Python", "Ruby", "Ruby(db)", "Javascript", "Lua", "assembly language", "Noir",
+       "Rust(wasm)", "C++(wasm)",
+       "Small", "unknown"
+  ]
   result = langs[lang]
 
 proc toLang*(lang: string): Lang

--- a/src/common/common_types.nim
+++ b/src/common/common_types.nim
@@ -844,8 +844,10 @@ type
   EventLogKind* {.pure.} = enum ## EventLog kinds
     Write,
     WriteFile,
+    WriteOther,
     Read,
     ReadFile,
+    ReadOther,
     # not really used for now
     # we might remove them or implement them
     # in the future
@@ -867,7 +869,9 @@ type
     highLevelLine*: int
     # eventually: might be available in the future
     # lowLevelLocation*: Location
-    filenameMetadata*: langstring ## metadata for read/write file events:
+    ## metadata: file for read/write file events 
+    ## or a more general kind of key for WriteOther/ReadOther
+    metadata*: langstring 
     bytes*: int
     stdout*: bool
     directLocationRRTicks*: int
@@ -951,7 +955,7 @@ type
     lowLevelLocation*: langstring
     kind*: EventLogKind
     content*: langstring
-    filenameMetadata*: langstring
+    metadata*: langstring
     base64Encoded*: bool
     stdout*: bool
 

--- a/src/common/common_types.nim
+++ b/src/common/common_types.nim
@@ -416,6 +416,7 @@ type
     member*: seq[Value]
     refValue*: Value
     address*: langstring
+    isMutable*: bool
     strong*: int
     weak*: int
     r*: langstring

--- a/src/common/common_types.nim
+++ b/src/common/common_types.nim
@@ -1393,6 +1393,8 @@ const
     ["{", "}", "[", "]", "[", "]"],             # LangLua
     ["{", "}", "[", "]", "[", "]"],             # LangAsm
     ["{", "}", "[", "]", "[", "]"],             # LangNoir
+    ["{", "}", "[", "]", "[", "]"],             # LangRustWasm
+    ["{", "}", "[", "]", "[", "]"],             # LangCppWasm
     ["{", "}", "[", "]", "[", "]"],             # LangSmall
     ["", "", "", "", "", ""]                    # LangUnknown
   ]
@@ -1411,6 +1413,8 @@ const
     @["write"], # LangLua
     @["write"], # LangAsm
     @["write"], # LangNoir
+    @["write"], # LangRustWasm
+    @["write"], # LangCppWasm
     @["write"], # LangSmall
     @["write"]  # LangUnknown
   ]
@@ -1429,6 +1433,8 @@ const
     @[], # LangLua
     @[], # LangAsm
     @[], # LangNoir
+    @[], # LangRustWasm
+    @[], # LangCppWasm
     @[], # LangSmall
     @[]  # LangUnknown
   ]
@@ -1451,6 +1457,8 @@ const
     @[], # LangLua
     @[], # LangAsm
     @[], # LangNoir
+    @["main"], # LangRustWasm
+    @["main"], # LangCppWasm
     @[], # LangSmall
     @[]  # LangUnknown
   ]

--- a/src/common/lang.nim
+++ b/src/common/lang.nim
@@ -47,6 +47,8 @@ proc getExtension*(lang: Lang): string =
     "lua",
     "asm",
     "nr",
+    "rs",
+    "cpp",
     "small",
     ""
   ]

--- a/src/common/paths.nim
+++ b/src/common/paths.nim
@@ -82,6 +82,7 @@ let
   rubyTracerPath* = linksPath / "src" / "trace.rb"
   smallExe* = linksPath / "bin" / "small-lang"
   noirExe* = env.get("CODETRACER_NOIR_EXE_PATH", linksPath / "bin" / "nargo" )
+  wazeroExe* = env.get("CODETRACER_WAZERO_VM_PATH", linksPath / "bin" / "wazero")
   dbBackendExe* = linksPath / "bin" / "db-backend"
   dbBackendRecordExe* = linksPath / "bin" / "db-backend-record"
   virtualizationLayersExe* = linksPath / "bin" / "virtualization-layers"

--- a/src/common/paths.nim
+++ b/src/common/paths.nim
@@ -84,7 +84,7 @@ let
   noirExe* = env.get("CODETRACER_NOIR_EXE_PATH", linksPath / "bin" / "nargo" )
   wazeroExe* = env.get("CODETRACER_WAZERO_VM_PATH", linksPath / "bin" / "wazero")
   dbBackendExe* = linksPath / "bin" / "db-backend"
-  dbBackendRecordExe* = linksPath / "bin" / "db-backend-record"
+  dbBackendRecordExe* = codetracerExeDir / "bin" / "db-backend-record"
   virtualizationLayersExe* = linksPath / "bin" / "virtualization-layers"
   ctagsExe* = linksPath / "bin" / "ctags"
 

--- a/src/ct/codetracerconf.nim
+++ b/src/ct/codetracerconf.nim
@@ -209,6 +209,13 @@ type
         desc: "Export zip file for the recording"
       .} : string
 
+      recordStylusTrace* {.
+        name: "stylus-trace"
+        abbr: "t"
+        defaultValue: ""
+        desc: "Path to a stylus emv trace json file"
+      .} : string
+
       recordProgram* {.
         argument
         desc: "Program to record"

--- a/src/ct/ct_wrapper.nim
+++ b/src/ct/ct_wrapper.nim
@@ -39,7 +39,7 @@ proc start(args: seq[string]) =
 
     # don't debug/log with echo: breaks ct trace_metadata json output
     # writeFile("ct_wrapper.log", "CT WRAPPER: putting pid " & $codetracerWrapperPid)
-    
+
     let p = startProcess(
       getAppDir() / "codetracer_depending_on_env_vars_in_tup",
       # workingDir = getAppDir().parentDir.parentDir, # repo folder

--- a/src/ct/db_backend_record.nim
+++ b/src/ct/db_backend_record.nim
@@ -219,7 +219,7 @@ proc record(
       recordSymbols(executable, outputFolder, lang)
       var vmPath = ""
       if lang in {LangRustWasm, LangCppWasm}: # executable.endsWith(".wasm"):
-        vmPath = getEnv("CODETRACER_WAZERO_VM_PATH", "")
+        vmPath = wazeroExe
         echo "wasm vm path ", vmPath
       else:
         vmPath = noirExe

--- a/src/ct/launch/launch.nim
+++ b/src/ct/launch/launch.nim
@@ -125,7 +125,10 @@ proc runInitial*(conf: CodetracerConf) =
     of StartupCommand.build:
       build(conf.buildProgramPath, conf.buildOutputPath)
     of StartupCommand.record:
-      discard record(conf.recordLang, conf.recordOutputFolder, conf.recordExportFile, conf.recordLang, conf.recordProgram, conf.recordArgs)
+      discard record(
+        conf.recordLang, conf.recordOutputFolder,
+        conf.recordExportFile, conf.recordLang, conf.recordStylusTrace,
+        conf.recordProgram, conf.recordArgs)
     of StartupCommand.run:
       run(conf.runTracePathOrId, conf.runArgs)
     of StartupCommand.start_core:

--- a/src/ct/online_sharing/download.nim
+++ b/src/ct/online_sharing/download.nim
@@ -38,7 +38,7 @@ proc downloadTrace*(fileId, traceDownloadKey: string, key: array[32, byte], conf
       pathValue = item.getStr("")
       break
 
-  let lang = detectFileLang(pathValue.split("/")[^1], isWasm)
+  let lang = detectLang(pathValue.split("/")[^1], LangUnknown, isWasm)
   discard importDbTrace(traceMetadataPath, traceId, lang, DB_SELF_CONTAINED_DEFAULT, traceDownloadKey)
   return traceId
 

--- a/src/ct/online_sharing/download.nim
+++ b/src/ct/online_sharing/download.nim
@@ -35,7 +35,7 @@ proc downloadTrace*(fileId, traceDownloadKey: string, key: array[32, byte], conf
       pathValue = item.getStr("")
       break
 
-  let lang = detectLang(pathValue, LangUnknown)
+  let lang = detectFileLang(pathValue.split("/")[^1])
   discard importDbTrace(traceMetadataPath, traceId, lang, DB_SELF_CONTAINED_DEFAULT, traceDownloadKey)
   return traceId
 

--- a/src/ct/online_sharing/download.nim
+++ b/src/ct/online_sharing/download.nim
@@ -28,14 +28,17 @@ proc downloadTrace*(fileId, traceDownloadKey: string, key: array[32, byte], conf
   let tracePath = unzippedLocation / "trace.json"
   let traceJson = parseJson(readFile(tracePath))
   let traceMetadataPath = unzippedLocation / "trace_metadata.json"
-  var pathValue = ""
+  let metadataJson = parseJson(readFile(traceMetadataPath))
   let tracePathsMetadata = parseJson(readFile(unzippedLocation / "trace_paths.json"))
+  let isWasm = metadataJson{"program"}.getStr("").split("/")[^1].split(".")[^1] == "wasm" # Check if language is wasm
+
+  var pathValue = ""
   for item in tracePathsMetadata:
     if item.getStr("") != "":
       pathValue = item.getStr("")
       break
 
-  let lang = detectFileLang(pathValue.split("/")[^1])
+  let lang = detectFileLang(pathValue.split("/")[^1], isWasm)
   discard importDbTrace(traceMetadataPath, traceId, lang, DB_SELF_CONTAINED_DEFAULT, traceDownloadKey)
   return traceId
 

--- a/src/ct/trace/record.nim
+++ b/src/ct/trace/record.nim
@@ -25,6 +25,7 @@ proc record*(lang: string,
              outputFolder: string,
              backend: string,
              exportFile: string,
+             stylusTrace: string,
              program: string,
              args: seq[string]): Trace =
   let detectedLang = detectLang(program, toLang(lang))
@@ -38,6 +39,10 @@ proc record*(lang: string,
   if exportFile != "":
     pargs.add("-e")
     pargs.add(exportFile)
+  if stylusTrace != "":
+    pargs.add("--stylus-trace")
+    pargs.add(stylusTrace)
+
   pargs.add(program)
   if args.len != 0:
     pargs = concat(pargs, args)

--- a/src/ct/trace/record.nim
+++ b/src/ct/trace/record.nim
@@ -41,11 +41,14 @@ proc record*(lang: string,
   pargs.add(program)
   if args.len != 0:
     pargs = concat(pargs, args)
-
+  # wazero <-> 
+  #   
+  
   if detectedLang in @[LangRubyDb, LangNoir, LangSmall]:
     let configPath = getEnv(
       "CODETRACER_CT_PATHS",
       getAppDir().parentDir.parentDir.parentDir / "ct_paths.json")
+    echo dbBackendRecordExe, " ", detectedLang
     return recordInternal(dbBackendRecordExe, pargs, configPath)
   else:
     let ctConfig = loadConfig(folder=getCurrentDir(), inTest=false)

--- a/src/ct/trace/record.nim
+++ b/src/ct/trace/record.nim
@@ -41,10 +41,8 @@ proc record*(lang: string,
   pargs.add(program)
   if args.len != 0:
     pargs = concat(pargs, args)
-  # wazero <-> 
-  #   
-  
-  if detectedLang in @[LangRubyDb, LangNoir, LangSmall]:
+
+  if detectedLang in @[LangRubyDb, LangNoir, LangRustWasm, LangCppWasm, LangSmall]:
     let configPath = getEnv(
       "CODETRACER_CT_PATHS",
       getAppDir().parentDir.parentDir.parentDir / "ct_paths.json")

--- a/src/ct/trace/run.nim
+++ b/src/ct/trace/run.nim
@@ -34,6 +34,7 @@ proc runWithRestart(
                              outputFolder="",
                              backend="",
                              exportFile="",
+                             stylusTrace="",
                              program=recordArgs[0],
                              args=recordArgs[1..^1])
     if not recordedTrace.isNil:

--- a/src/ct/trace/storage_and_import.nim
+++ b/src/ct/trace/storage_and_import.nim
@@ -123,7 +123,7 @@ proc importDbTrace*(
   if rawPaths.len > 0:
     paths = Json.decode(rawPaths, seq[string])
 
-  if selfContained:
+  if selfContained and downloadKey == "":
     # for now assuming it happens on the original machine
     # when the source files are still available and unchanged
     if paths.len > 0:

--- a/src/ct/trace/storage_and_import.nim
+++ b/src/ct/trace/storage_and_import.nim
@@ -10,7 +10,7 @@ proc storeTraceFiles(paths: seq[string], traceFolder: string, lang: Lang) =
 
   var sourcePaths = paths
 
-  if lang == LangNoir:
+  if lang in {LangNoir, LangRustWasm, LangCppWasm}:
     var baseFolder = ""
     for path in paths:
       if path.len > 0 and path.startsWith('/'):

--- a/src/ct/utilities/language_detection.nim
+++ b/src/ct/utilities/language_detection.nim
@@ -30,13 +30,22 @@ const LANGS = {
   "rb": LangRubyDb, # default for ruby for now
   "nr": LangNoir,
   "small": LangSmall,
+  "wasm": LangRustWasm,
 }.toTable()
 
-proc detectFileLang*(program: string): Lang =
+const WASM_LANGS = {
+  "rs": LangRustWasm,
+}.toTable()
+
+proc detectFileLang*(program: string, isWasm: bool = false): Lang =
   if "." in program:
     let extension = rsplit(program[1..^1], ".", 1)[1].toLowerAscii()
-    if LANGS.hasKey(extension):
-      return LANGS[extension]
+    if not isWasm:
+      if LANGS.hasKey(extension):
+        return LANGS[extension]
+    else:
+      if WASM_LANGS.hasKey(extension):
+        return WASM_LANGS[extension]
   return LangUnknown
 
 proc detectLang*(program: string, lang: Lang): Lang =
@@ -47,9 +56,7 @@ proc detectLang*(program: string, lang: Lang): Lang =
     if "." in program:
       let extension = rsplit(absProgram[1..^1], ".", 1)[1].toLowerAscii()
       if LANGS.hasKey(extension):
-        result = LANGS[extension]
-      elif extension == "wasm":
-        result = LangRustWasm # TODO detectLangFromTrace(traceId)
+        result = LANGS[extension] # TODO detectLangFromTrace(traceId)
     elif dirExists(program):
       result = detectFolderLang(program)
     else:

--- a/src/ct/utilities/language_detection.nim
+++ b/src/ct/utilities/language_detection.nim
@@ -32,6 +32,7 @@ proc detectLang*(program: string, lang: Lang): Lang =
     "rb": LangRubyDb, # default for ruby for now
     "nr": LangNoir,
     "small": LangSmall,
+    "wasm": LangNoir,
   }.toTable()
 
   if lang == LangUnknown:

--- a/src/ct/utilities/language_detection.nim
+++ b/src/ct/utilities/language_detection.nim
@@ -41,15 +41,14 @@ const WASM_LANGS = {
 
 proc detectLang*(program: string, lang: Lang, isWasm: bool = false): Lang =
   echo "detectLang ", program
+  var possiblyExpandedPath = ""
+  try:
+    possiblyExpandedPath = expandFileName(program)
+  except CatchableError:
+    possiblyExpandedPath = program
 
   if lang == LangUnknown:
-    if "." in program:
-      var possiblyExpandedPath = ""
-      try:
-        possiblyExpandedPath = expandFileName(program)
-      except CatchableError:
-        possiblyExpandedPath = program
-
+    if "." in possiblyExpandedPath:
       let extension = rsplit(possiblyExpandedPath[1..^1], ".", 1)[1].toLowerAscii()
       if not isWasm:
         if LANGS.hasKey(extension):

--- a/src/ct/utilities/language_detection.nim
+++ b/src/ct/utilities/language_detection.nim
@@ -49,6 +49,7 @@ proc detectLang*(program: string, lang: Lang, isWasm: bool = false): Lang =
 
   if lang == LangUnknown:
     if "." in possiblyExpandedPath:
+      echo "in"
       let extension = rsplit(possiblyExpandedPath[1..^1], ".", 1)[1].toLowerAscii()
       if not isWasm:
         if LANGS.hasKey(extension):

--- a/src/ct/utilities/language_detection.nim
+++ b/src/ct/utilities/language_detection.nim
@@ -20,27 +20,34 @@ proc detectFolderLang(folder: string): Lang =
     LangUnknown
 
 
+const LANGS = {
+  "c": LangC,
+  "cpp": LangCpp,
+  "rs": LangRust,
+  "nim": LangNim,
+  "go": LangGo,
+  "py": LangPython,
+  "rb": LangRubyDb, # default for ruby for now
+  "nr": LangNoir,
+  "small": LangSmall,
+}.toTable()
+
+proc detectFileLang*(program: string): Lang =
+  if "." in program:
+    let extension = rsplit(program[1..^1], ".", 1)[1].toLowerAscii()
+    if LANGS.hasKey(extension):
+      return LANGS[extension]
+  return LangUnknown
+
 proc detectLang*(program: string, lang: Lang): Lang =
   echo "detectLang ", program
-  var langs = {
-    "c": LangC,
-    "cpp": LangCpp,
-    "rs": LangRust,
-    "nim": LangNim,
-    "go": LangGo,
-    "py": LangPython,
-    "rb": LangRubyDb, # default for ruby for now
-    "nr": LangNoir,
-    "small": LangSmall,
-    # "wasm": LangRustWasm,
-  }.toTable()
 
   if lang == LangUnknown:
     let absProgram = expandFileName(program)
     if "." in program:
       let extension = rsplit(absProgram[1..^1], ".", 1)[1].toLowerAscii()
-      if langs.hasKey(extension):
-        result = langs[extension]
+      if LANGS.hasKey(extension):
+        result = LANGS[extension]
       elif extension == "wasm":
         result = LangRustWasm # TODO detectLangFromTrace(traceId)
     elif dirExists(program):

--- a/src/ct/utilities/language_detection.nim
+++ b/src/ct/utilities/language_detection.nim
@@ -37,26 +37,24 @@ const WASM_LANGS = {
   "rs": LangRustWasm,
 }.toTable()
 
-proc detectFileLang*(program: string, isWasm: bool = false): Lang =
-  if "." in program:
-    let extension = rsplit(program[1..^1], ".", 1)[1].toLowerAscii()
-    if not isWasm:
-      if LANGS.hasKey(extension):
-        return LANGS[extension]
-    else:
-      if WASM_LANGS.hasKey(extension):
-        return WASM_LANGS[extension]
-  return LangUnknown
-
-proc detectLang*(program: string, lang: Lang): Lang =
+proc detectLang*(program: string, lang: Lang, isWasm: bool = false): Lang =
   echo "detectLang ", program
 
   if lang == LangUnknown:
-    let absProgram = expandFileName(program)
     if "." in program:
-      let extension = rsplit(absProgram[1..^1], ".", 1)[1].toLowerAscii()
-      if LANGS.hasKey(extension):
-        result = LANGS[extension] # TODO detectLangFromTrace(traceId)
+      var possiblyExpandedPath = ""
+      try:
+        possiblyExpandedPath = expandFileName(program)
+      except CatchableError:
+        possiblyExpandedPath = program
+
+      let extension = rsplit(possiblyExpandedPath[1..^1], ".", 1)[1].toLowerAscii()
+      if not isWasm:
+        if LANGS.hasKey(extension):
+          result = LANGS[extension] # TODO detectLangFromTrace(traceId)
+      else:
+        if WASM_LANGS.hasKey(extension):
+          result = WASM_LANGS[extension]        
     elif dirExists(program):
       result = detectFolderLang(program)
     else:

--- a/src/ct/utilities/language_detection.nim
+++ b/src/ct/utilities/language_detection.nim
@@ -35,6 +35,8 @@ const LANGS = {
 
 const WASM_LANGS = {
   "rs": LangRustWasm,
+  "cpp": LangCppWasm,
+  "c": LangCppWasm,
 }.toTable()
 
 proc detectLang*(program: string, lang: Lang, isWasm: bool = false): Lang =

--- a/src/ct/utilities/language_detection.nim
+++ b/src/ct/utilities/language_detection.nim
@@ -21,7 +21,7 @@ proc detectFolderLang(folder: string): Lang =
 
 
 proc detectLang*(program: string, lang: Lang): Lang =
-  # echo "detectLang ", program
+  echo "detectLang ", program
   var langs = {
     "c": LangC,
     "cpp": LangCpp,
@@ -32,7 +32,7 @@ proc detectLang*(program: string, lang: Lang): Lang =
     "rb": LangRubyDb, # default for ruby for now
     "nr": LangNoir,
     "small": LangSmall,
-    "wasm": LangNoir,
+    # "wasm": LangRustWasm,
   }.toTable()
 
   if lang == LangUnknown:
@@ -41,6 +41,8 @@ proc detectLang*(program: string, lang: Lang): Lang =
       let extension = rsplit(absProgram[1..^1], ".", 1)[1].toLowerAscii()
       if langs.hasKey(extension):
         result = langs[extension]
+      elif extension == "wasm":
+        result = LangRustWasm # TODO detectLangFromTrace(traceId)
     elif dirExists(program):
       result = detectFolderLang(program)
     else:
@@ -55,3 +57,4 @@ proc detectLang*(program: string, lang: Lang): Lang =
         result = LangUnknown
   else:
     result = lang
+  echo "result ", result

--- a/src/db-backend/Cargo.lock
+++ b/src/db-backend/Cargo.lock
@@ -543,9 +543,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "runtime_tracing"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6cf2858c5b474be12fd597b5dca533c1b917cfcf2f233ad4c75981567ba00a"
+checksum = "eafd7c2c0304ff7196100ad4b6d33ff61e27d7bdcc10efe75784364b86292451"
 dependencies = [
  "num-derive",
  "num-traits",

--- a/src/db-backend/Cargo.lock
+++ b/src/db-backend/Cargo.lock
@@ -543,8 +543,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "runtime_tracing"
-version = "0.6.0"
-source = "git+https://github.com/metacraft-labs/runtime_tracing.git?tag=0.6.0#aa37e95d856aec97c926372d9eae79037a65e434"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af6cf2858c5b474be12fd597b5dca533c1b917cfcf2f233ad4c75981567ba00a"
 dependencies = [
  "num-derive",
  "num-traits",

--- a/src/db-backend/Cargo.toml
+++ b/src/db-backend/Cargo.toml
@@ -30,7 +30,7 @@ tokio = {version = "1.37.0", features=["full", "rt", "net", "signal"]}
 futures = "0.3.30"
 futures-timer = "3.0.3"
 clap = { version = "4.5.4", features = ["derive"] }
-runtime_tracing = "0.9.0" # { git = "https://github.com/metacraft-labs/runtime_tracing.git", tag = "0.6.0" }
+runtime_tracing = "0.10.0" # { git = "https://github.com/metacraft-labs/runtime_tracing.git", tag = "0.6.0" }
 tree-sitter-tracepoint = { path = "./tree-sitter-trace/" }
 
 [lib]

--- a/src/db-backend/Cargo.toml
+++ b/src/db-backend/Cargo.toml
@@ -30,7 +30,7 @@ tokio = {version = "1.37.0", features=["full", "rt", "net", "signal"]}
 futures = "0.3.30"
 futures-timer = "3.0.3"
 clap = { version = "4.5.4", features = ["derive"] }
-runtime_tracing = { git = "https://github.com/metacraft-labs/runtime_tracing.git", tag = "0.6.0" }
+runtime_tracing = "0.9.0" # { git = "https://github.com/metacraft-labs/runtime_tracing.git", tag = "0.6.0" }
 tree-sitter-tracepoint = { path = "./tree-sitter-trace/" }
 
 [lib]

--- a/src/db-backend/src/event_db.rs
+++ b/src/db-backend/src/event_db.rs
@@ -165,7 +165,7 @@ impl EventDb {
             direct_location_rr_ticks: trace.rr_ticks as i64,
             tracepoint_result_index: trace.tracepoint_id as i64,
             event_index: trace.iteration,
-            filename_metadata: "".to_string(),
+            metadata: "".to_string(),
             bytes: 0,
             stdout: false,
             base64_encoded: false,
@@ -217,7 +217,7 @@ impl EventDb {
             self.register_in_global_table(events, SingleTableId(0));
         }
         // for event in events {
-        //     info!("filename_metadata {:?}", event.filename_metadata);
+        //     info!("metadata {:?}", event.metadata);
         // }
         // info!("self {self:?}");
     }

--- a/src/db-backend/src/expr_loader.rs
+++ b/src/db-backend/src/expr_loader.rs
@@ -40,18 +40,20 @@ static NODE_NAMES: Lazy<HashMap<Lang, NodeNames>> = Lazy::new(|| {
             values: vec!["identifier".to_string()],
         },
     );
-    m.insert(
-        Lang::Noir,
-        NodeNames {
-            if_conditions: vec!["if_expression".to_string()],
-            else_conditions: vec!["else_clause".to_string()],
-            loops: vec!["for_expression".to_string()],
-            branches_body: vec!["block".to_string()],
-            branches: vec!["block".to_string()],
-            functions: vec!["function_item".to_string()],
-            values: vec!["identifier".to_string()],
-        },
-    );
+
+    let rust_node_names = NodeNames {
+        if_conditions: vec!["if_expression".to_string()],
+        else_conditions: vec!["else_clause".to_string()],
+        loops: vec!["for_expression".to_string()],
+        branches_body: vec!["block".to_string()],
+        branches: vec!["block".to_string()],
+        functions: vec!["function_item".to_string()],
+        values: vec!["identifier".to_string()],
+    };
+
+    m.insert(Lang::Noir, rust_node_names.clone());
+    m.insert(Lang::RustWasm, rust_node_names);
+
     m.insert(
         Lang::Small,
         NodeNames {
@@ -137,7 +139,7 @@ impl ExprLoader {
             } else if extension == "small" {
                 Lang::Small
             } else if extension == "rs" {
-                Lang::Noir // TODO RustWasm?
+                Lang::RustWasm // TODO RustWasm?
             } else {
                 Lang::Unknown
             }
@@ -151,7 +153,7 @@ impl ExprLoader {
         let lang = self.get_current_language(path);
 
         let mut parser = Parser::new();
-        if lang == Lang::Noir {
+        if lang == Lang::Noir || lang == Lang::RustWasm {
             parser.set_language(&tree_sitter_rust::LANGUAGE.into())?;
         } else if lang == Lang::Ruby {
             parser.set_language(&tree_sitter_ruby::LANGUAGE.into())?;
@@ -165,8 +167,6 @@ impl ExprLoader {
         parser
             .parse(raw, None)
             .ok_or(format!("problem with parsing {:?}", path).into())
-        //ok_or(|| Err("problem with parsing".into()));
-        //Ok(tree)
     }
 
     pub fn get_source_line(&self, path: &PathBuf, row: usize) -> String {

--- a/src/db-backend/src/expr_loader.rs
+++ b/src/db-backend/src/expr_loader.rs
@@ -136,6 +136,8 @@ impl ExprLoader {
                 Lang::Ruby
             } else if extension == "small" {
                 Lang::Small
+            } else if extension == "rs" {
+                Lang::Noir // TODO RustWasm?
             } else {
                 Lang::Unknown
             }
@@ -245,6 +247,12 @@ impl ExprLoader {
         let start = self.get_first_line(node);
         let end = self.get_last_line(node);
         let lang = self.get_current_language(path);
+        // info!(
+        //    "process_node {:?} {:?} {:?}",
+        //    lang,
+        //    NODE_NAMES[&lang].values,
+        //    node.kind()
+        //);
         // extract variable names
         if NODE_NAMES[&lang].values.contains(&node.kind().to_string()) {
             let value = self.extract_expr(node, path, row);
@@ -379,6 +387,10 @@ impl ExprLoader {
     }
 
     pub fn get_loop_shape(&self, step: &DbStep, path: &PathBuf) -> Option<LoopShape> {
+        info!(
+            "get_loop_shape {} {:?}",
+            step.line.0, self.processed_files[path].position_loops
+        );
         if let Some(loop_shape_id) = self.processed_files[path].position_loops.get(&Position(step.line.0)) {
             return Some(self.processed_files[path].loop_shapes[loop_shape_id.0 as usize].clone());
         }

--- a/src/db-backend/src/flow_preloader.rs
+++ b/src/db-backend/src/flow_preloader.rs
@@ -312,8 +312,8 @@ impl<'a> CallFlowPreloader<'a> {
             );
         }
 
-        for (variable_id, value_id) in &db.variable_cells[step_id] {
-            let value_record = db.load_value_for_id(*value_id, step_id);
+        for (variable_id, place) in &db.variable_cells[step_id] {
+            let value_record = db.load_value_for_place(*place, step_id);
             let full_value_record = FullValueRecord {
                 variable_id: *variable_id,
                 value: value_record,

--- a/src/db-backend/src/handler.rs
+++ b/src/db-backend/src/handler.rs
@@ -258,10 +258,10 @@ impl Handler {
         // TODO: fix random order here as well: ensure order(or in final locals?)
         let value_tracking_locals: Vec<Variable> = self.db.variable_cells[self.step_id]
             .iter()
-            .map(|(variable_id, value_id)| {
+            .map(|(variable_id, place)| {
                 let name = self.db.variable_name(*variable_id);
-                info!("log local {variable_id:?} {name} value id: {value_id:?}");
-                let value = self.db.load_value_for_id(*value_id, self.step_id);
+                info!("log local {variable_id:?} {name} place: {place:?}");
+                let value = self.db.load_value_for_place(*place, self.step_id);
                 Variable {
                     expression: self.db.variable_name(*variable_id).to_string(),
                     value: self.db.to_ct_value(&value),

--- a/src/db-backend/src/handler.rs
+++ b/src/db-backend/src/handler.rs
@@ -1359,7 +1359,7 @@ impl Handler {
             bytes: event_record.content.len(),
             rr_event_id: index,
             direct_location_rr_ticks: step_id_int,
-            filename_metadata: "".to_string(),
+            metadata: "".to_string(),
             stdout: true,
             event_index: index,
             tracepoint_result_index: NO_INDEX,

--- a/src/db-backend/src/lang.rs
+++ b/src/db-backend/src/lang.rs
@@ -18,6 +18,8 @@ pub enum Lang {
     Lua,
     Asm,
     Noir,
+    RustWasm,
+    CppWasm,
     Small,
     Unknown,
 }

--- a/src/db-backend/src/task.rs
+++ b/src/db-backend/src/task.rs
@@ -605,7 +605,7 @@ pub struct ProgramEvent {
     pub rr_event_id: usize,
     pub high_level_path: String,
     pub high_level_line: i64,
-    pub filename_metadata: String,
+    pub metadata: String,
     pub bytes: usize,
     pub stdout: bool,
     #[serde(rename = "directLocationRRTicks")]
@@ -802,7 +802,7 @@ pub struct TableRow {
     pub low_level_location: String,
     pub kind: EventLogKind,
     pub content: String,
-    pub filename_metadata: String,
+    pub metadata: String,
     pub stdout: bool,
 }
 
@@ -824,7 +824,7 @@ impl TableRow {
             kind: event.kind,
             content: event.content.to_string(),
             base64_encoded: event.base64_encoded,
-            filename_metadata: event.filename_metadata.clone(),
+            metadata: event.metadata.clone(),
             stdout: event.stdout,
         }
     }

--- a/src/db-backend/src/task.rs
+++ b/src/db-backend/src/task.rs
@@ -14,7 +14,7 @@ use crate::lang::*;
 use crate::value::{Type, Value};
 
 // IMPORTANT: must keep in sync with `EventLogKind` definition in common_types.nim!
-pub const EVENT_KINDS_COUNT: usize = 11;
+pub const EVENT_KINDS_COUNT: usize = 13;
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/db-backend/src/trace_processor.rs
+++ b/src/db-backend/src/trace_processor.rs
@@ -213,13 +213,15 @@ impl<'a> TraceProcessor<'a> {
                 // we must have a top-level call which means
                 // we should have no return for it!
                 // we should have always at least it there: at least 1
-                assert!(self.depth > 1);
-                assert!(self.call_stack.len() > 1);
+                // assert!(self.depth > 1);
+                // assert!(self.call_stack.len() > 1);
                 self.depth -= 1;
                 self.db.calls[self.current_call_key].return_value = return_record.return_value.clone();
                 let _ = self.call_stack.pop();
                 let _ = self.db.local_variable_cells.pop();
-                self.current_call_key = self.call_stack[self.call_stack.len() - 1];
+                if self.call_stack.len() >= 1 {
+                    self.current_call_key = self.call_stack[self.call_stack.len() - 1];
+                }
             }
             TraceLowLevelEvent::Event(record_event) => {
                 self.db.events.push(DbRecordEvent {

--- a/src/db-backend/src/tracepoint_interpreter/executor.rs
+++ b/src/db-backend/src/tracepoint_interpreter/executor.rs
@@ -188,7 +188,17 @@ pub fn execute_bytecode(
                     #[allow(clippy::unwrap_used)]
                     let array = stack.pop().unwrap();
 
-                    if let ValueRecord::Sequence { elements, type_id: _ } = array {
+                    if let ValueRecord::Sequence { elements, type_id: _ , is_slice} = array {
+                        if is_slice {
+                            let mut err_value = Value::new(TypeKind::Error, eval_error_type.clone());
+                            err_value.msg = "Slices not supported currently".to_string();
+                            locals.push(StringAndValueTuple {
+                                field0: source[opcode.position.start_byte..opcode.position.end_byte].to_string(),
+                                field1: err_value,
+                            });
+                            return locals;
+                        }
+
                         if let ValueRecord::Int { i, type_id: _ } = index {
                             if i < 0 || i >= elements.len() as i64 {
                                 let mut err_value = Value::new(TypeKind::Error, eval_error_type.clone());

--- a/src/db-backend/src/tracepoint_interpreter/tests.rs
+++ b/src/db-backend/src/tracepoint_interpreter/tests.rs
@@ -152,6 +152,7 @@ fn lang_to_string(lang: Lang) -> Result<String, Box<dyn Error>> {
     match lang {
         Lang::Ruby | Lang::RubyDb => Ok("ruby".to_string()),
         Lang::Noir => Ok("noir".to_string()),
+        Lang::RustWasm => Ok("rust(wasm)".to_string()),
         _ => Err("Unsupported language".into()),
     }
 }
@@ -160,7 +161,10 @@ fn record_ruby_trace(program_dir: &PathBuf, target_dir: &PathBuf) {
     let main_path = program_dir.join("main.rb");
     let trace_path = target_dir.join("trace.json");
     let result = Command::new("ruby")
-        .args(["../../libs/codetracer-ruby-recorder/src/trace.rb", main_path.to_str().unwrap()])
+        .args([
+            "../../libs/codetracer-ruby-recorder/src/trace.rb",
+            main_path.to_str().unwrap(),
+        ])
         .env("CODETRACER_DB_TRACE_PATH", trace_path.to_str().unwrap())
         .output()
         .unwrap();
@@ -182,10 +186,15 @@ fn record_noir_trace(program_dir: &PathBuf, target_dir: &PathBuf) {
     }
 }
 
+fn record_rust_wasm_trace(_program_dir: &PathBuf, _target_dir: &PathBuf) {
+    todo!()
+}
+
 fn record_trace(program_dir: &PathBuf, target_dir: &PathBuf, lang: Lang) -> Result<(), Box<dyn Error>> {
     match lang {
         Lang::Ruby | Lang::RubyDb => record_ruby_trace(program_dir, target_dir),
         Lang::Noir => record_noir_trace(program_dir, target_dir),
+        Lang::RustWasm => record_rust_wasm_trace(program_dir, target_dir),
         _ => return Err("Unsupported language".into()),
     }
 

--- a/src/db-backend/src/value.rs
+++ b/src/db-backend/src/value.rs
@@ -15,6 +15,9 @@ pub struct Value {
     pub elements: Vec<Value>,
     pub msg: String,
     pub r: String,
+    pub address: i64,
+    pub ref_value: Option<Box<Value>>,
+    pub is_mutable: bool,
     pub typ: Type,
 }
 
@@ -27,6 +30,8 @@ pub struct Type {
     pub c_type: String,
     // pub elements: Vec<Type>,
     pub labels: Vec<String>,
+    pub element_type: Option<Box<Type>>,
+    pub member_types: Vec<Type>,
 }
 
 impl Value {

--- a/src/frontend/lang.nim
+++ b/src/frontend/lang.nim
@@ -48,6 +48,7 @@ proc toJsLang*(lang: Lang): cstring =
     cstring"c", cstring"cpp", cstring"rust", cstring"nim", cstring"go",
     cstring"pascal", cstring"python", cstring"ruby", cstring"ruby",
     cstring"javascript", cstring"lua", cstring"assembler", cstring"noir",
+    cstring"rust", cstring"cpp",
     cstring"small",
     cstring"unknown"
   ]
@@ -58,7 +59,7 @@ proc toSet(names: seq[cstring]): JsAssoc[cstring, bool] =
   for name in names:
     result[name] = true
 
-let SUPPORTED_LANGS* = @[LangC, LangCpp, LangRust, LangNim, LangGo, LangRubyDb, LangNoir, LangSmall]
+let SUPPORTED_LANGS* = @[LangC, LangCpp, LangRust, LangNim, LangGo, LangRubyDb, LangNoir, LangRustWasm, LangCppWasm, LangSmall]
 
 let RESERVED_NAMES*: array[Lang, JsAssoc[cstring, bool]] = [
   toSet(@[]),
@@ -67,6 +68,8 @@ let RESERVED_NAMES*: array[Lang, JsAssoc[cstring, bool]] = [
   toSet(@[j"for", j"if", j"while", j"proc"]),
   toSet(@[]),
   toSet(@[]), # LangGo: TODO
+  toSet(@[]),
+  toSet(@[]),
   toSet(@[]),
   toSet(@[]),
   toSet(@[]),

--- a/src/frontend/lang.nim
+++ b/src/frontend/lang.nim
@@ -96,6 +96,8 @@ proc getExtension*(lang: Lang): cstring =
     "lua",
     "asm",
     "nr",
+    "rs",
+    "cpp",
     "small",
     ""
   ]

--- a/src/frontend/services/event_log_service.nim
+++ b/src/frontend/services/event_log_service.nim
@@ -20,7 +20,7 @@ proc loadEvents*(self: EventLogService, update: TableData) =
         kind: row.kind,
         content: row.content,
         rrEventId: row.rrEventId,
-        filenameMetadata: row.filenameMetadata,
+        metadata: row.metadata,
         highLevelPath: row.fullPath,
         directLocationRRTicks: row.directLocationRRTicks,
         eventIndex: i,
@@ -107,7 +107,7 @@ data.services.eventLog.onUpdatedEventsContent = proc(self: EventLogService, resp
   while lineIndex < lines.len and eventsIndex < self.events.len:
     while true:
       if eventsIndex < self.events.len:
-        if self.events[eventsIndex].kind in {Write, WriteFile, Read, ReadFile}:
+        if self.events[eventsIndex].kind in {Write, WriteFile, WriteOther, Read, ReadFile, ReadOther}:
           self.events[eventsIndex].content = lines[lineIndex]
           lineIndex += 1
         eventsIndex += 1

--- a/src/frontend/tests/test_suites/regression_tests/event_log_jump_to_all_events.nim
+++ b/src/frontend/tests/test_suites/regression_tests/event_log_jump_to_all_events.nim
@@ -48,6 +48,8 @@ const AFTER_INITIAL_READS_EVENT_INDEX: array[Lang, int] = [
   0, # Lua
   0, # Asm
   0, # Noir
+  0, # Rust wasm
+  0, # C++ wasm
   0, # Small
   0 # unknown
 ]

--- a/src/frontend/ui/flow.nim
+++ b/src/frontend/ui/flow.nim
@@ -353,6 +353,8 @@ let KEYWORDS: array[Lang, JsAssoc[cstring, bool]] = [
   emptyKeywords,
   emptyKeywords,
   emptyKeywords,
+  emptyKeywords,
+  emptyKeywords,
   emptyKeywords
 ]
 

--- a/src/frontend/ui/trace.nim
+++ b/src/frontend/ui/trace.nim
@@ -227,7 +227,7 @@ proc renderTableResults(
           rrEventId: cast[int](datatableRow.rrEventId),
           directLocationRRTicks: cast[int](datatableRow.directLocationRRTicks),
           content: cstring"",
-          filenameMetadata: cstring"",
+          metadata: cstring"",
           maxRRTicks: data.maxRRTicks,
         )
 


### PR DESCRIPTION
also adapt to runtime_tracing 0.10.0 with a temp branch of our older noir commit that we were supporting(adapting also to runtime_tracing 0.10.0: TODO in the future, not this PR: eventually integrate with newer noir which initiated actual support for those values)

rebased on `feat-upgrade-db-backend-runtime-tracing` from https://github.com/metacraft-labs/codetracer/pull/95 : closing #95 as it's integrated here