### PR TITLE
Add dependabot config for github action workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Some of our workflows are sensitive to security vulnerabilities, so it's good to have dependabot set up to remind us to update these workflows as soon as possible. This config is needed because there are no security notifications about action workflows in the security tab as of now, so this is the only way to get notified about such issues.