### PR TITLE
fix(ssl): Use ssl3 for ct binary

### DIFF
--- a/appimage-scripts/build_appimage.sh
+++ b/appimage-scripts/build_appimage.sh
@@ -76,6 +76,8 @@ cp -L "${LIBZIP}"/lib/libzip.so.5 "${APP_DIR}"/lib
 
 OPENSSL=$(nix eval --raw "${ROOT_PATH}#packages.${CURRENT_NIX_SYSTEM}.openssl.out")
 cp -L "${OPENSSL}"/lib/libssl.so.3 "${APP_DIR}"/lib
+cp -L "${OPENSSL}"/lib/libssl.so "${APP_DIR}"/lib
+cp -L "${OPENSSL}"/lib/libcrypto.so "${APP_DIR}"/lib
 
 # Copy over electron
 # bash "${ROOT_PATH}"/appimage-scripts/install_electron_nix.sh

--- a/appimage-scripts/build_appimage.sh
+++ b/appimage-scripts/build_appimage.sh
@@ -15,7 +15,7 @@ cleanup() {
   rm -rf ./squashfs-root
 }
 
-trap cleanup EXIT
+# trap cleanup EXIT
 
 ROOT_PATH=$(git rev-parse --show-toplevel)
 export ROOT_PATH
@@ -78,6 +78,7 @@ OPENSSL=$(nix eval --raw "${ROOT_PATH}#packages.${CURRENT_NIX_SYSTEM}.openssl.ou
 cp -L "${OPENSSL}"/lib/libssl.so.3 "${APP_DIR}"/lib
 cp -L "${OPENSSL}"/lib/libssl.so "${APP_DIR}"/lib
 cp -L "${OPENSSL}"/lib/libcrypto.so "${APP_DIR}"/lib
+cp -L "${OPENSSL}"/lib/libcrypto.so.3 "${APP_DIR}"/lib
 
 # Copy over electron
 # bash "${ROOT_PATH}"/appimage-scripts/install_electron_nix.sh
@@ -208,6 +209,7 @@ fi
 # Patchelf the executable's interpreter
 patchelf --set-interpreter "${INTERPRETER_PATH}" "${APP_DIR}"/bin/ct_unwrapped
 patchelf --set-interpreter "${INTERPRETER_PATH}" "${APP_DIR}"/bin/db-backend
+patchelf --set-interpreter "${INTERPRETER_PATH}" "${APP_DIR}"/bin/db-backend-record
 patchelf --set-interpreter "${INTERPRETER_PATH}" "${APP_DIR}"/bin/nargo
 patchelf --set-interpreter "${INTERPRETER_PATH}" "${APP_DIR}"/bin/wazero
 patchelf --set-interpreter "${INTERPRETER_PATH}" "${APP_DIR}"/bin/ctags

--- a/appimage-scripts/build_appimage.sh
+++ b/appimage-scripts/build_appimage.sh
@@ -15,7 +15,7 @@ cleanup() {
   rm -rf ./squashfs-root
 }
 
-# trap cleanup EXIT
+trap cleanup EXIT
 
 ROOT_PATH=$(git rev-parse --show-toplevel)
 export ROOT_PATH

--- a/appimage-scripts/build_with_nim.sh
+++ b/appimage-scripts/build_with_nim.sh
@@ -29,6 +29,7 @@ nim -d:release \
     --passL:"${APP_DIR}/lib/libpcre.so.1" \
     --passL:"${APP_DIR}/lib/libzip.so.5" \
     --passL:"${APP_DIR}/lib/libcrypto.so" \
+    --passL:"${APP_DIR}/lib/libcrypto.so.3" \
     --passL:"${APP_DIR}/lib/libssl.so" \
     --boundChecks:on \
     -d:useOpenssl3 \

--- a/appimage-scripts/build_with_nim.sh
+++ b/appimage-scripts/build_with_nim.sh
@@ -23,10 +23,15 @@ nim -d:release \
     --dynlibOverride:"sqlite3" \
     --dynlibOverride:"pcre" \
     --dynlibOverride:"libzip" \
+    --dynlibOverride:"libcrypto" \
+    --dynlibOverride:"libssl" \
     --passL:"${APP_DIR}/lib/libsqlite3.so.0" \
     --passL:"${APP_DIR}/lib/libpcre.so.1" \
     --passL:"${APP_DIR}/lib/libzip.so.5" \
+    --passL:"${APP_DIR}/lib/libcrypto.so" \
+    --passL:"${APP_DIR}/lib/libssl.so" \
     --boundChecks:on \
+    -d:useOpenssl3 \
     -d:ssl \
     -d:chronicles_sinks=json -d:chronicles_line_numbers=true \
     -d:chronicles_timestamps=UnixTime \


### PR DESCRIPTION
TODO: The versions of the ssl package in nixpkgs DO NOT coincide with standard ssl releases.
We should figure out a way to get the correct libraries we need