### PR TITLE
fix: use the real current directory, if lang is not Noir, for db record

### DIFF
--- a/src/ct/db_backend_record.nim
+++ b/src/ct/db_backend_record.nim
@@ -125,10 +125,18 @@ proc recordDb(
   # (noirExe from src/common/paths.nim)
   #   we should try to not always depend on env var paths though
   echo "codetracer: starting language tracer with:"
+  let workdir = if lang == LangNoir:
+        # for noir, we must start in the noir project directory
+        # for the trace command to work
+        programDir
+      else:
+        # for other languages, we must start in the real inherited
+        # work dir
+        getCurrentDir()
   let process = startProcess(
     vmExe,
     args = startArgs.concat(args),
-    workingDir = programDir,
+    workingDir = workdir,
     options = {poEchoCmd, poParentStreams})
   let exitCode = waitForExit(process)
   if exitCode != 0:


### PR DESCRIPTION
found while dogfooding ruby recording

EDIT: @Madman10K found a problem:

actual fix depends on lang being noir: initial fix was to always use the normal workdir,
but Stan Vasilev pressed and revealed this be a problem for Noir
