### PR TITLE
Run receiver in a separate thread

### DIFF
--- a/src/db-backend/src/receiver.rs
+++ b/src/db-backend/src/receiver.rs
@@ -1,14 +1,12 @@
 use log::{error, info};
 use std::error::Error;
-use std::fs;
-use std::io::Write;
 use std::io::{BufRead, BufReader};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 
 use crate::core::{Core, NO_CALLER_PROCESS_PID};
 use crate::handler::Handler;
-use crate::sender::Sender;
+use std::sync::mpsc;
 use crate::task::{to_task_kind, Task, TaskId, TaskKind};
 
 const CT_SOCKET_PATH: &str = "/tmp/ct_socket";
@@ -85,9 +83,8 @@ impl Receiver {
 
     // _tx: mpsc::Sender<Response>?
     #[allow(clippy::expect_used)]
-    pub fn receive_loop(&mut self, handler: &mut Handler) -> Result<(), Box<dyn Error>> {
+    pub fn receive_loop(&mut self, tx: mpsc::Sender<Task>) -> Result<(), Box<dyn Error>> {
         let stream = self.receiving_socket.as_ref().expect("valid socket");
-        let mut sending_socket = stream.try_clone().expect("can clone");
         // based, copied and adapted from
         // http://kmdouglass.github.io/posts/a-simple-unix-socket-listener-in-rust/
         let stream = BufReader::new(stream);
@@ -102,30 +99,8 @@ impl Receiver {
                     let message_res = self.parse_message(&line);
                     match message_res {
                         Ok(task) => {
-                            let res = self.handle_task(handler, task);
-                            if let Err(handle_error) = res {
-                                error!("backend: handle error: {:?}", handle_error);
-                            } else if handler.indirect_send {
-                                let responses = handler.get_responses_for_sending_and_clear();
-                                let mut sender = Sender::new();
-                                let _ = sender.setup(self.core.caller_process_pid, false);
-                                for response in responses {
-                                    let (message, path, payload) = sender.prepare_message(response);
-                                    let write_res = fs::write(path.clone(), payload);
-                                    info!("wrote {:?}", path);
-                                    match write_res {
-                                        Ok(_) => {
-                                            let send_res = sending_socket.write_all(message.as_bytes());
-                                            if let Err(send_error) = send_res {
-                                                error!("sender couldn't send message: {:?}", send_error);
-                                            }
-                                            info!("sent to client {:?}", message);
-                                        }
-                                        Err(e) => {
-                                            error!("sender couldn't save to {}: {}", path.display(), e);
-                                        }
-                                    }
-                                }
+                            if let Err(send_error) = tx.send(task) {
+                                error!("backend: could not forward task: {:?}", send_error);
                             }
                         }
                         Err(e) => {
@@ -140,9 +115,8 @@ impl Receiver {
 
             // TODO: parse to Message
             // call handle_message
-            // TODO: in future, maybe run receiver in separate thread
-            // and send message to handler thread
-            // for now easier like that tho
+            // receiver now runs in its own thread and
+            // sends tasks to the handler thread
         }
         Ok(())
     }
@@ -162,50 +136,51 @@ impl Receiver {
         }
     }
 
-    pub fn handle_task(&self, handler: &mut Handler, task: Task) -> Result<(), Box<dyn Error>> {
-        // we can make a proxy like DispatcherSender -> Sender in sender thread
-        // for now just using handler helper methods which use handler.tx
-        info!("handle_task {:?}", task);
-        match task.kind {
-            // TODO: configure arg if needed
-            TaskKind::Configure => handler.configure(self.core.read_arg(&task.id)?, task),
-            TaskKind::Start => handler.start(task),
-            TaskKind::RunToEntry => handler.run_to_entry(task),
-            TaskKind::LoadLocals => handler.load_locals(task),
-            TaskKind::LoadCallstack => handler.load_callstack(task),
-            TaskKind::CollapseCalls => handler.collapse_calls(self.core.read_arg(&task.id)?, task),
-            TaskKind::ExpandCalls => handler.expand_calls(self.core.read_arg(&task.id)?, task),
-            TaskKind::LoadCallArgs => handler.load_call_args(self.core.read_arg(&task.id)?, task),
-            TaskKind::LoadFlow => handler.load_flow(self.core.read_arg(&task.id)?, task),
-            TaskKind::Step => handler.step(self.core.read_arg(&task.id)?, task),
-            TaskKind::EventLoad => handler.event_load(task),
-            TaskKind::EventJump => handler.event_jump(self.core.read_arg(&task.id)?, task),
-            TaskKind::CalltraceJump => handler.calltrace_jump(self.core.read_arg(&task.id)?, task),
-            TaskKind::SourceLineJump => handler.source_line_jump(self.core.read_arg(&task.id)?, task),
-            TaskKind::SourceCallJump => handler.source_call_jump(self.core.read_arg(&task.id)?, task),
-            TaskKind::AddBreak => handler.add_breakpoint(self.core.read_arg(&task.id)?, task),
-            TaskKind::DeleteBreak => handler.delete_breakpoint(self.core.read_arg(&task.id)?, task),
-            TaskKind::Disable => handler.toggle_breakpoint(self.core.read_arg(&task.id)?, task),
-            TaskKind::Enable => handler.toggle_breakpoint(self.core.read_arg(&task.id)?, task),
-            TaskKind::RunTracepoints => handler.run_tracepoints(self.core.read_arg(&task.id)?, task),
-            TaskKind::TraceJump => handler.trace_jump(self.core.read_arg(&task.id)?, task),
-            TaskKind::HistoryJump => handler.history_jump(self.core.read_arg(&task.id)?, task),
-            TaskKind::LoadHistory => handler.load_history(self.core.read_arg(&task.id)?, task),
-            TaskKind::UpdateTable => handler.update_table(self.core.read_arg(&task.id)?, task),
-            TaskKind::TracepointDelete => handler.tracepoint_delete(self.core.read_arg(&task.id)?, task),
-            TaskKind::TracepointToggle => handler.tracepoint_toggle(self.core.read_arg(&task.id)?, task),
-            TaskKind::CalltraceSearch => handler.calltrace_search(self.core.read_arg(&task.id)?, task),
-            TaskKind::SearchProgram => handler.search_program(self.core.read_arg(&task.id)?, task),
-            TaskKind::LoadStepLines => handler.load_step_lines(self.core.read_arg(&task.id)?, task),
-            TaskKind::LocalStepJump => handler.local_step_jump(self.core.read_arg(&task.id)?, task),
-            TaskKind::RegisterEvents => handler.register_events(self.core.read_arg(&task.id)?, task),
-            TaskKind::RegisterTracepointLogs => handler.register_tracepoint_logs(self.core.read_arg(&task.id)?, task),
-            TaskKind::SetupTraceSession => handler.setup_trace_session(self.core.read_arg(&task.id)?, task),
-            TaskKind::LoadAsmFunction => handler.load_asm_function(self.core.read_arg(&task.id)?, task),
-            TaskKind::LoadTerminal => handler.load_terminal(task),
-            _ => {
-                unimplemented!()
-            }
+}
+
+pub fn handle_task(core: &Core, handler: &mut Handler, task: Task) -> Result<(), Box<dyn Error>> {
+    // we can make a proxy like DispatcherSender -> Sender in sender thread
+    // for now just using handler helper methods which use handler.tx
+    info!("handle_task {:?}", task);
+    match task.kind {
+        // TODO: configure arg if needed
+        TaskKind::Configure => handler.configure(core.read_arg(&task.id)?, task),
+        TaskKind::Start => handler.start(task),
+        TaskKind::RunToEntry => handler.run_to_entry(task),
+        TaskKind::LoadLocals => handler.load_locals(task),
+        TaskKind::LoadCallstack => handler.load_callstack(task),
+        TaskKind::CollapseCalls => handler.collapse_calls(core.read_arg(&task.id)?, task),
+        TaskKind::ExpandCalls => handler.expand_calls(core.read_arg(&task.id)?, task),
+        TaskKind::LoadCallArgs => handler.load_call_args(core.read_arg(&task.id)?, task),
+        TaskKind::LoadFlow => handler.load_flow(core.read_arg(&task.id)?, task),
+        TaskKind::Step => handler.step(core.read_arg(&task.id)?, task),
+        TaskKind::EventLoad => handler.event_load(task),
+        TaskKind::EventJump => handler.event_jump(core.read_arg(&task.id)?, task),
+        TaskKind::CalltraceJump => handler.calltrace_jump(core.read_arg(&task.id)?, task),
+        TaskKind::SourceLineJump => handler.source_line_jump(core.read_arg(&task.id)?, task),
+        TaskKind::SourceCallJump => handler.source_call_jump(core.read_arg(&task.id)?, task),
+        TaskKind::AddBreak => handler.add_breakpoint(core.read_arg(&task.id)?, task),
+        TaskKind::DeleteBreak => handler.delete_breakpoint(core.read_arg(&task.id)?, task),
+        TaskKind::Disable => handler.toggle_breakpoint(core.read_arg(&task.id)?, task),
+        TaskKind::Enable => handler.toggle_breakpoint(core.read_arg(&task.id)?, task),
+        TaskKind::RunTracepoints => handler.run_tracepoints(core.read_arg(&task.id)?, task),
+        TaskKind::TraceJump => handler.trace_jump(core.read_arg(&task.id)?, task),
+        TaskKind::HistoryJump => handler.history_jump(core.read_arg(&task.id)?, task),
+        TaskKind::LoadHistory => handler.load_history(core.read_arg(&task.id)?, task),
+        TaskKind::UpdateTable => handler.update_table(core.read_arg(&task.id)?, task),
+        TaskKind::TracepointDelete => handler.tracepoint_delete(core.read_arg(&task.id)?, task),
+        TaskKind::TracepointToggle => handler.tracepoint_toggle(core.read_arg(&task.id)?, task),
+        TaskKind::CalltraceSearch => handler.calltrace_search(core.read_arg(&task.id)?, task),
+        TaskKind::SearchProgram => handler.search_program(core.read_arg(&task.id)?, task),
+        TaskKind::LoadStepLines => handler.load_step_lines(core.read_arg(&task.id)?, task),
+        TaskKind::LocalStepJump => handler.local_step_jump(core.read_arg(&task.id)?, task),
+        TaskKind::RegisterEvents => handler.register_events(core.read_arg(&task.id)?, task),
+        TaskKind::RegisterTracepointLogs => handler.register_tracepoint_logs(core.read_arg(&task.id)?, task),
+        TaskKind::SetupTraceSession => handler.setup_trace_session(core.read_arg(&task.id)?, task),
+        TaskKind::LoadAsmFunction => handler.load_asm_function(core.read_arg(&task.id)?, task),
+        TaskKind::LoadTerminal => handler.load_terminal(task),
+        _ => {
+            unimplemented!()
         }
     }
 }


### PR DESCRIPTION
## Summary
- start receiver loop in its own thread
- dispatch socket messages to a handler thread via a task channel
- adapt virtualization-layers binary to the new threaded receiver

## Testing
- `cargo build`
- `cargo test`
- `cargo clippy` *(fails: `clippy` component not installed)*