### PR TITLE
Add tests for small-lang

### DIFF
--- a/src/small-lang/Cargo.lock
+++ b/src/small-lang/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -54,8 +60,9 @@ dependencies = [
 
 [[package]]
 name = "runtime_tracing"
-version = "0.7.0"
-source = "git+https://github.com/metacraft-labs/runtime_tracing.git?tag=0.7.0#7ea8754a201963d882d15edf69548806c2a67aac"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eafd7c2c0304ff7196100ad4b6d33ff61e27d7bdcc10efe75784364b86292451"
 dependencies = [
  "num-derive",
  "num-traits",
@@ -72,18 +79,18 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -92,11 +99,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -126,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/small-lang/Cargo.toml
+++ b/src/small-lang/Cargo.toml
@@ -12,4 +12,4 @@ num-derive = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_repr = "0.1"
-runtime_tracing = { git = "https://github.com/metacraft-labs/runtime_tracing.git", tag = "0.7.0" }
+runtime_tracing = "0.10.0"

--- a/src/small-lang/src/main.rs
+++ b/src/small-lang/src/main.rs
@@ -239,6 +239,7 @@ impl Interpreter {
                     .collect();
                 ValueRecord::Sequence {
                     elements: trace_items,
+                    is_slice: false,
                     type_id,
                 }
             }
@@ -356,6 +357,7 @@ impl Interpreter {
                             place: runtime_tracing::Place((*item_value_id) as i64),
                         })
                         .collect(),
+                    is_slice: false,
                     type_id,
                 };
                 self.tracer.register_compound_value(

--- a/src/small-lang/tests/basic.rs
+++ b/src/small-lang/tests/basic.rs
@@ -1,0 +1,30 @@
+use std::process::Command;
+use std::env;
+use std::fs;
+
+fn run_small(program: &str) -> String {
+    let dir = env::temp_dir();
+    let file_name = format!("test_{}.small", std::time::SystemTime::now().elapsed().unwrap().as_nanos());
+    let file_path = dir.join(file_name);
+    fs::write(&file_path, program).unwrap();
+    let bin = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target/debug/small-lang");
+    let output = Command::new(bin)
+        .arg(&file_path)
+        .output()
+        .expect("failed to run small-lang");
+    assert!(output.status.success());
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+#[test]
+fn prints_add_result() {
+    let result = run_small("(print (add 2 3))");
+    assert_eq!(result, "5");
+}
+
+#[test]
+fn prints_loop_numbers() {
+    let result = run_small("(loop i 0 3 (print i))");
+    assert_eq!(result, "0\n1\n2");
+}


### PR DESCRIPTION
## Summary
- update small-lang to use runtime_tracing 0.10.0
- adjust sequence value recording for new API
- add integration tests that run the `small-lang` binary

## Testing
- `cargo test --quiet --offline` in `src/db-backend`
- `cargo test --quiet --offline` in `src/small-lang`
- `cargo clippy --quiet --offline` *(fails: `cargo-clippy` not installed)*