### PR TITLE
Implement Ruby each loop detection

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -1,0 +1,4 @@
+# Codebase insights
+- Ruby loops were originally detected only for 'while' and 'until'.
+- 'each' loops can be recognized by handling 'call' nodes with a block whose method name is 'each'.
+- Added a regression test ensuring `ExprLoader` detects Ruby `each` loops correctly.


### PR DESCRIPTION
## Summary
- detect Ruby `each` loops by looking at `call` nodes that have a block with method name `each`
- document Ruby loop insight
- add a regression test ensuring `ExprLoader` detects Ruby `each` loops

## Testing
- `cargo build`
- `cargo test`
- `cargo clippy` *(fails: `cargo-clippy` not installed)*
