### PR TITLE
Add simple TUI example

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -1,0 +1,1 @@
+- The TUI crate uses crossterm for manual drawing. Added simple_tui binary as a minimal example.

--- a/src/tui/Cargo.toml
+++ b/src/tui/Cargo.toml
@@ -19,3 +19,7 @@ serde_repr = "0.1"
 notify = "6.1.1"
 futures = "0.3.30"
 futures-timer = "3.0.3"
+
+[[bin]]
+name = "simple_tui"
+path = "src/simple_tui.rs"

--- a/src/tui/src/simple_tui.rs
+++ b/src/tui/src/simple_tui.rs
@@ -1,0 +1,27 @@
+use crossterm::{
+    event::{self, Event as CEvent, KeyCode},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use std::io::{self, Write};
+
+/// A very small TUI example that just prints a message and waits for `q` to quit.
+fn main() -> crossterm::Result<()> {
+    enable_raw_mode()?;
+    execute!(io::stdout(), EnterAlternateScreen)?;
+
+    println!("Press 'q' to exit the new TUI");
+
+    loop {
+        if let CEvent::Key(key_event) = event::read()? {
+            if key_event.code == KeyCode::Char('q') {
+                break;
+            }
+        }
+    }
+
+    disable_raw_mode()?;
+    execute!(io::stdout(), LeaveAlternateScreen)?;
+    io::stdout().flush()?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- provide minimal TUI example using crossterm
- document new binary in Cargo
- start codebase insights file

## Testing
- `cargo build` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_b_683dd412a0f88332bd2582fdeb3423e4

(EDIT: google gemini deep research doc export (but probably not used in this case succesfully: https://docs.google.com/document/d/1giuRCvHABq6pdDUHkVuJABOEnMsjdBgliXKaLNuKUoc/edit?usp=sharing )) 

TODO: maybe add the dependenices in setup, so it can continue (or do it more step by step )