### PR TITLE
Add basic DAP client and session test

### DIFF
--- a/src/db-backend/src/lib.rs
+++ b/src/db-backend/src/lib.rs
@@ -22,6 +22,7 @@ pub mod task;
 pub mod trace_processor;
 pub mod tracepoint_interpreter;
 pub mod value;
+pub mod dap;
 
 // use event_db::{DbEventKind, EventDb};
 // use task::{ProgramEvent, UpdateTableArgs};

--- a/src/db-backend/tests/dap_protocol.rs
+++ b/src/db-backend/tests/dap_protocol.rs
@@ -1,0 +1,60 @@
+use db_backend::dap::{from_json, to_json, DapMessage, ProtocolMessage, Response};
+use serde_json::json;
+
+#[test]
+fn test_parse_initialize_request() {
+    let json_text = r#"{"seq":1,"type":"request","command":"initialize","arguments":{"adapterID":"small-lang"}}"#;
+    let message = from_json(json_text).expect("valid message");
+    match message {
+        DapMessage::Request(req) => {
+            assert_eq!(req.base.seq, 1);
+            assert_eq!(req.command, "initialize");
+            assert_eq!(req.arguments["adapterID"], "small-lang");
+        }
+        _ => panic!("expected request"),
+    }
+}
+
+#[test]
+fn test_serialize_initialize_response() {
+    let resp = Response {
+        base: ProtocolMessage { seq: 2, type_: "response".to_string() },
+        request_seq: 1,
+        success: true,
+        command: "initialize".to_string(),
+        message: None,
+        body: json!({}),
+    };
+    let original = DapMessage::Response(resp);
+    let json_text = to_json(&original).expect("serialize");
+    let deserialized = from_json(&json_text).expect("deserialize");
+    assert_eq!(original, deserialized);
+}
+
+#[test]
+fn test_session_sequence_parse() {
+    let messages = vec![
+        r#"{"seq":1,"type":"request","command":"initialize","arguments":{}}"#,
+        r#"{"seq":2,"type":"response","request_seq":1,"success":true,"command":"initialize"}"#,
+        r#"{"seq":3,"type":"event","event":"initialized"}"#,
+        r#"{"seq":4,"type":"request","command":"launch","arguments":{"program":"main"}}"#,
+        r#"{"seq":5,"type":"response","request_seq":4,"success":true,"command":"launch"}"#,
+    ];
+    let parsed: Vec<_> = messages.iter().map(|m| from_json(m).unwrap()).collect();
+    assert_eq!(parsed.len(), messages.len());
+    match &parsed[0] {
+        DapMessage::Request(req) => assert_eq!(req.command, "initialize"),
+        _ => panic!("unexpected type"),
+    }
+    match &parsed[2] {
+        DapMessage::Event(ev) => assert_eq!(ev.event, "initialized"),
+        _ => panic!("unexpected type"),
+    }
+    match &parsed[4] {
+        DapMessage::Response(resp) => {
+            assert!(resp.success);
+            assert_eq!(resp.command, "launch");
+        }
+        _ => panic!("unexpected type"),
+    }
+}

--- a/src/db-backend/tests/dap_session.rs
+++ b/src/db-backend/tests/dap_session.rs
@@ -1,0 +1,87 @@
+use db_backend::dap::{self, DapClient, DapMessage, Event, ProtocolMessage, Response};
+use serde_json::json;
+use std::io::BufReader;
+use std::os::unix::net::UnixStream;
+use std::thread;
+
+fn run_server(stream: UnixStream) {
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    let mut writer = stream;
+    let mut seq = 1i64;
+    loop {
+        let msg = match dap::from_reader(&mut reader) {
+            Ok(m) => m,
+            Err(_) => break,
+        };
+        match msg {
+            DapMessage::Request(req) if req.command == "initialize" => {
+                let resp = DapMessage::Response(Response {
+                    base: ProtocolMessage { seq, type_: "response".to_string() },
+                    request_seq: req.base.seq,
+                    success: true,
+                    command: "initialize".to_string(),
+                    message: None,
+                    body: json!({}),
+                });
+                seq += 1;
+                dap::write_message(&mut writer, &resp).unwrap();
+            }
+            DapMessage::Request(req) if req.command == "launch" => {
+                let event = DapMessage::Event(Event {
+                    base: ProtocolMessage { seq, type_: "event".to_string() },
+                    event: "initialized".to_string(),
+                    body: json!({}),
+                });
+                seq += 1;
+                dap::write_message(&mut writer, &event).unwrap();
+                let resp = DapMessage::Response(Response {
+                    base: ProtocolMessage { seq, type_: "response".to_string() },
+                    request_seq: req.base.seq,
+                    success: true,
+                    command: "launch".to_string(),
+                    message: None,
+                    body: json!({}),
+                });
+                seq += 1;
+                dap::write_message(&mut writer, &resp).unwrap();
+            }
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn test_simple_session() {
+    let (client_stream, server_stream) = UnixStream::pair().unwrap();
+    let handle = thread::spawn(move || run_server(server_stream));
+
+    let mut reader = BufReader::new(client_stream.try_clone().unwrap());
+    let mut writer = client_stream;
+
+    let mut client = DapClient::default();
+    let init = client.request("initialize", json!({"adapterID":"small-lang"}));
+    dap::write_message(&mut writer, &init).unwrap();
+
+    let launch = client.request("launch", json!({"program":"main"}));
+    dap::write_message(&mut writer, &launch).unwrap();
+
+    let msg1 = dap::from_reader(&mut reader).unwrap();
+    match msg1 {
+        DapMessage::Response(resp) => assert_eq!(resp.command, "initialize"),
+        _ => panic!("expected response"),
+    }
+    let msg2 = dap::from_reader(&mut reader).unwrap();
+    match msg2 {
+        DapMessage::Event(ev) => assert_eq!(ev.event, "initialized"),
+        _ => panic!("expected event"),
+    }
+    let msg3 = dap::from_reader(&mut reader).unwrap();
+    match msg3 {
+        DapMessage::Response(resp) => assert_eq!(resp.command, "launch"),
+        _ => panic!("expected response"),
+    }
+
+    drop(writer);
+    drop(reader);
+    handle.join().unwrap();
+}


### PR DESCRIPTION
## Summary
- extend the DAP module with a helper client and message I/O helpers
- implement parsing/writing of DAP messages with headers
- create an integration test running a simple DAP session

## Testing
- `cargo build`
- `cargo test`
- `cargo clippy`

------
https://chatgpt.com/codex/tasks/task_b_683d8b22b83c8331a3a82cf480bca35f