### PR TITLE
Implement initial DAP server

### DIFF
--- a/src/db-backend/src/dap_server.rs
+++ b/src/db-backend/src/dap_server.rs
@@ -1,0 +1,62 @@
+use crate::dap::{self, DapMessage, Event, ProtocolMessage, Response};
+use serde_json::json;
+use std::io::BufReader;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::error::Error;
+
+const DAP_SOCKET_PATH: &str = "/tmp/ct_dap_socket";
+
+pub fn socket_path_for(pid: usize) -> PathBuf {
+    PathBuf::from(format!("{DAP_SOCKET_PATH}_{}", pid))
+}
+
+pub fn run(socket_path: &Path) -> Result<(), Box<dyn Error>> {
+    let _ = std::fs::remove_file(socket_path);
+    let listener = UnixListener::bind(socket_path)?;
+    let (stream, _) = listener.accept()?;
+    handle_client(stream)
+}
+
+fn handle_client(stream: UnixStream) -> Result<(), Box<dyn Error>> {
+    let mut reader = BufReader::new(stream.try_clone()?);
+    let mut writer = stream;
+    let mut seq = 1i64;
+    while let Ok(msg) = dap::from_reader(&mut reader) {
+        match msg {
+            DapMessage::Request(req) if req.command == "initialize" => {
+                let resp = DapMessage::Response(Response {
+                    base: ProtocolMessage { seq, type_: "response".to_string() },
+                    request_seq: req.base.seq,
+                    success: true,
+                    command: "initialize".to_string(),
+                    message: None,
+                    body: json!({}),
+                });
+                seq += 1;
+                dap::write_message(&mut writer, &resp)?;
+            }
+            DapMessage::Request(req) if req.command == "launch" => {
+                let event = DapMessage::Event(Event {
+                    base: ProtocolMessage { seq, type_: "event".to_string() },
+                    event: "initialized".to_string(),
+                    body: json!({}),
+                });
+                seq += 1;
+                dap::write_message(&mut writer, &event)?;
+                let resp = DapMessage::Response(Response {
+                    base: ProtocolMessage { seq, type_: "response".to_string() },
+                    request_seq: req.base.seq,
+                    success: true,
+                    command: "launch".to_string(),
+                    message: None,
+                    body: json!({}),
+                });
+                seq += 1;
+                dap::write_message(&mut writer, &resp)?;
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}

--- a/src/db-backend/src/lib.rs
+++ b/src/db-backend/src/lib.rs
@@ -23,6 +23,7 @@ pub mod trace_processor;
 pub mod tracepoint_interpreter;
 pub mod value;
 pub mod dap;
+pub mod dap_server;
 
 // use event_db::{DbEventKind, EventDb};
 // use task::{ProgramEvent, UpdateTableArgs};

--- a/src/db-backend/tests/dap_backend_server.rs
+++ b/src/db-backend/tests/dap_backend_server.rs
@@ -1,0 +1,66 @@
+use db_backend::dap::{self, DapClient, DapMessage};
+use db_backend::dap_server;
+use serde_json::json;
+use std::fs;
+use std::io::BufReader;
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::Duration;
+
+fn wait_for_socket(path: &Path) {
+    for _ in 0..50 {
+        if path.exists() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    panic!("socket not created");
+}
+
+#[test]
+fn test_backend_dap_server() {
+    let bin = env!("CARGO_BIN_EXE_db-backend");
+    let pid = std::process::id() as usize;
+    let tmp_dir = std::env::temp_dir().join(format!("dap_test_{pid}"));
+    let _ = fs::remove_dir_all(&tmp_dir);
+    fs::create_dir_all(&tmp_dir).unwrap();
+
+    let trace_src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("loop-trace/trace.json");
+    let trace_file = tmp_dir.join("trace.json");
+    fs::copy(&trace_src, &trace_file).unwrap();
+    let metadata_file = tmp_dir.join("trace_metadata.json");
+    fs::write(&metadata_file, "{\"workdir\":\"/tmp\",\"program\":\"test\",\"args\":[]}").unwrap();
+
+    let mut child = Command::new(bin)
+        .arg(pid.to_string())
+        .arg(&trace_file)
+        .arg(&metadata_file)
+        .spawn()
+        .unwrap();
+
+    let socket_path = dap_server::socket_path_for(pid);
+    wait_for_socket(&socket_path);
+
+    let stream = UnixStream::connect(&socket_path).unwrap();
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    let mut writer = stream;
+
+    let mut client = DapClient::default();
+    let init = client.request("initialize", json!({}));
+    dap::write_message(&mut writer, &init).unwrap();
+    let launch = client.request("launch", json!({"program":"main"}));
+    dap::write_message(&mut writer, &launch).unwrap();
+
+    let msg1 = dap::from_reader(&mut reader).unwrap();
+    match msg1 { DapMessage::Response(r) => assert_eq!(r.command, "initialize"), _ => panic!() }
+    let msg2 = dap::from_reader(&mut reader).unwrap();
+    match msg2 { DapMessage::Event(e) => assert_eq!(e.event, "initialized"), _ => panic!() }
+    let msg3 = dap::from_reader(&mut reader).unwrap();
+    match msg3 { DapMessage::Response(r) => assert_eq!(r.command, "launch"), _ => panic!() }
+
+    drop(writer);
+    drop(reader);
+    let _ = child.wait().unwrap();
+}


### PR DESCRIPTION
## Summary
- add a simple DAP server implementation
- start the DAP server in db-backend instead of the old protocol
- provide integration test that communicates with db-backend over DAP

## Testing
- `cargo build`
- `cargo test`
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_b_683ef83ee06c8332a630b1f447a765f3