### PR TITLE
Add --version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ Run `ct --help` to see the full list of supported subcommands, but the most comm
    - `ct replay --id=<trace-id>` - Opens a trace by its trace id.
    - `ct replay --trace-folder=<trace-folder>` - Opens a trace by its trace folder.
 1. `ct` - Launches the startup screen of the CodeTracer GUI.
-1. `ct help / ct --help` - Gives you a help message.
-1. `ct version` - Returns the current version of CodeTracer.
+1. `ct help`/`ct --help` - Gives you a help message.
+1. `ct version`/`ct --version` - Returns the current version of CodeTracer.
 
 ## Keyboard Shortcuts
 
@@ -181,7 +181,7 @@ CodeTracer includes a miniature Lisp-like language called **small** used in some
 | `(print expr ...)` | `(print x)` | Print to stdout |
 | `(write-file path data)` | `(write-file "out.txt" "hi")` | Write a file |
 
-### runtime_tracing events
+### runtime\_tracing events
 
 | Event | Purpose |
 |-------|---------|

--- a/docs/book/src/usage_guide/CLI.md
+++ b/docs/book/src/usage_guide/CLI.md
@@ -18,8 +18,8 @@ Run `ct --help` to see the full list of supported subcommands, but the most comm
    - `ct replay --id=<trace-id>` - Opens a trace by its trace id.
    - `ct replay --trace-folder=<trace-folder>` - Opens a trace by its trace folder.
 1. `ct` - Launches the startup screen of the CodeTracer GUI.
-1. `ct help / ct --help` - Gives you a help message.
-1. `ct version` - Returns the current version of CodeTracer.
+1. `ct help`/`ct --help` - Gives you a help message.
+1. `ct version`/`ct --version` - Returns the current version of CodeTracer.
 
 Unlike other debuggers, where the debugger is attached to your application process, here you have to launch your application
 through the CodeTracer CLI with commands like `ct run` or `ct record`(or through the user interface, which is documented in the next chapter).

--- a/src/ct/codetracer.nim
+++ b/src/ct/codetracer.nim
@@ -3,11 +3,17 @@
 import
   ../common/types,
   launch/[ launch ],
-  codetracerconf, confutils
+  codetracerconf, confutils,
+  version
 
 try:
   if not eventuallyWrapElectron():
-    let conf = CodetracerConf.load()
+    # TODO: When confutils gets updated with nim 2 make sure to improve on the copyright banner, as newer versions
+    # support having prefix and postfix banners. The banner here is only a prefix banner
+    let conf = CodetracerConf.load(
+      version="CodeTracer version: " & string(version.CodeTracerVersionStr) & string(when defined(debug): "(debug)" else: ""),
+      copyrightBanner="CodeTracer - the user-friendly time-travelling debugger"
+    )
     customValidateConfig(conf)
     runInitial(conf)
 except Exception as ex:

--- a/src/ct/codetracerconf.nim
+++ b/src/ct/codetracerconf.nim
@@ -31,7 +31,6 @@ type
 
     list,
     help,
-    version,
 
     electron,
 
@@ -148,10 +147,6 @@ type
       .}: string
     of help:
       helpArgs* {.
-        ignore
-      .} : seq[string]
-    of version:
-      versionArgs* {.
         ignore
       .} : seq[string]
     of console:
@@ -428,7 +423,7 @@ proc customValidateConfig*(conf: CodetracerConf) =
         isSetTraceFolder.int + isSetInteractive.int
       if setArgsCount > 1:
         errorMessage "configuration error: expected no more than one arg to command to be passed"
-        echo "Try `codetracer --help` for more information"
+        echo "Try `ct --help` for more information"
         quit(1)
       if not isSetPattern and not isSetTraceId and not isSetTraceFolder:
         replayInteractive = true

--- a/src/ct/launch/launch.nim
+++ b/src/ct/launch/launch.nim
@@ -6,7 +6,6 @@ import
   ../online_sharing/[ upload, download, delete ],
   ../trace/[ replay, record, run, metadata ],
   ../codetracerconf,
-  ../version,
   ../globals,
   electron,
   results,
@@ -104,8 +103,6 @@ proc runInitial*(conf: CodetracerConf) =
       listCommand(conf.listTarget, conf.listFormat)
     of StartupCommand.help:
       displayHelp()
-    of StartupCommand.version:
-      echo "CodeTracer ", when defined(debug): "debug " else: "", CodeTracerVersionStr
     of StartupCommand.console:
       # similar to replay
       notSupportedCommand($conf.cmd)


### PR DESCRIPTION
This PR adds the following:

1. A `version` command which already existed but was implemented in a custom manner
1. A `--version` flag
1. A nice top banner that tells the users what the ct binary is in the help message