### PR TITLE
Add simple DAP client to TUI

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -1,0 +1,4 @@
+# Codebase insights
+
+- The `tui` crate contains a sample trace under `src/tui/trace/` used for basic testing.
+- The Debug Adapter Protocol client communicates over stdio with messages framed by a `Content-Length` header, implemented in `src/tui/src/dap_client.rs`.

--- a/src/tui/src/dap_client.rs
+++ b/src/tui/src/dap_client.rs
@@ -1,0 +1,113 @@
+use serde_json::json;
+use std::error::Error;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+pub struct DapClient {
+    child: Child,
+    reader: BufReader<ChildStdout>,
+    writer: ChildStdin,
+    seq: i64,
+}
+
+impl DapClient {
+    pub fn start(server_bin: &str) -> Result<Self, Box<dyn Error>> {
+        let mut child = Command::new(server_bin)
+            .arg("--stdio")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()?;
+
+        let writer = child.stdin.take().ok_or("failed to capture stdin")?;
+        let reader = child.stdout.take().ok_or("failed to capture stdout")?;
+
+        Ok(Self {
+            child,
+            reader: BufReader::new(reader),
+            writer,
+            seq: 1,
+        })
+    }
+
+    /// Send a launch request to the DAP server with the current process id and
+    /// the path to the trace directory as custom fields.
+    pub fn launch(&mut self, trace_path: &str) -> Result<(), Box<dyn Error>> {
+        let seq = self.seq;
+        self.seq += 1;
+        let pid = std::process::id();
+        let req = json!({
+            "seq": seq,
+            "type": "request",
+            "command": "launch",
+            "arguments": {
+                "pid": pid,
+                "tracePath": trace_path
+            }
+        });
+        self.send_message(&req)?;
+        let resp = self.read_message()?;
+        if resp.get("type").and_then(|v| v.as_str()) == Some("response")
+            && resp.get("command").and_then(|v| v.as_str()) == Some("launch")
+            && resp.get("success").and_then(|v| v.as_bool()) == Some(true)
+        {
+            return Ok(());
+        }
+        Err("launch failed".into())
+    }
+
+    fn send_message(&mut self, msg: &serde_json::Value) -> Result<(), Box<dyn Error>> {
+        let data = serde_json::to_string(msg)?;
+        let header = format!("Content-Length: {}\r\n\r\n", data.len());
+        self.writer.write_all(header.as_bytes())?;
+        self.writer.write_all(data.as_bytes())?;
+        self.writer.flush()?;
+        Ok(())
+    }
+
+    fn read_message(&mut self) -> Result<serde_json::Value, Box<dyn Error>> {
+        let mut header = Vec::new();
+        let mut buf = [0u8; 1];
+        while !header.ends_with(b"\r\n\r\n") {
+            self.reader.read_exact(&mut buf)?;
+            header.push(buf[0]);
+        }
+        let header_str = String::from_utf8(header)?;
+        let len_line = header_str
+            .lines()
+            .find(|l| l.starts_with("Content-Length:"))
+            .ok_or("missing content length")?;
+        let len: usize = len_line["Content-Length:".len()..].trim().parse()?;
+        let mut data = vec![0u8; len];
+        self.reader.read_exact(&mut data)?;
+        Ok(serde_json::from_slice(&data)?)
+    }
+
+    pub fn request_source(&mut self, path: &str) -> Result<String, Box<dyn Error>> {
+        let seq = self.seq;
+        self.seq += 1;
+        let req = json!({
+            "seq": seq,
+            "type": "request",
+            "command": "source",
+            "arguments": {
+                "source": {"path": path},
+                "sourceReference": 0
+            }
+        });
+        self.send_message(&req)?;
+        let resp = self.read_message()?;
+        if resp.get("type").and_then(|v| v.as_str()) == Some("response")
+            && resp.get("command").and_then(|v| v.as_str()) == Some("source")
+        {
+            if let Some(content) = resp
+                .get("body")
+                .and_then(|b| b.get("content"))
+                .and_then(|c| c.as_str())
+            {
+                return Ok(content.to_string());
+            }
+        }
+        Err("unexpected response".into())
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement a minimal Debug Adapter Protocol client
- allow `simple-tui` to connect to a DAP server to fetch source
- expect trace directory instead of single file
- send launch request to DAP with PID and trace directory

## Testing
- `cargo build` *(fails: `cargo` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f0b82039c83329445bdf1554ec5b0