### PR TITLE
feat: DAP client uses per-process socket path

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -1,4 +1,4 @@
 # Codebase insights
 
 - The `tui` crate contains a sample trace under `src/tui/trace/` used for basic testing.
-- The Debug Adapter Protocol client communicates over stdio with messages framed by a `Content-Length` header, implemented in `src/tui/src/dap_client.rs`.
+- The Debug Adapter Protocol client communicates over a Unix domain socket using the same framing protocol, implemented in `src/tui/src/dap_client.rs`.


### PR DESCRIPTION
## Summary
- make DAP socket path unique per process by appending the pid
- update codebase insight about DAP communication

## Testing
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_b_68404621d9488332964c237138e151be