### PR TITLE
feat: handle DAP events in simple_tui

### DIFF
--- a/src/tui/src/actions.rs
+++ b/src/tui/src/actions.rs
@@ -3,12 +3,12 @@ use futures::{future::FutureExt, select, StreamExt};
 // use std::time::Duration;
 use tokio::sync::mpsc;
 
-use crate::event::Event as TuiEvent;
+use crate::event::{CtEvent, Event as TuiEvent};
 use crossterm::event::EventStream;
 
 // copied and adapted from
 // https://github.com/crossterm-rs/crossterm/blob/master/examples/event-stream-tokio.rs
-pub fn track_keyboard_events(tx: mpsc::Sender<TuiEvent>) {
+pub fn track_keyboard_events(tx: mpsc::Sender<CtEvent>) {
     tokio::spawn(async move {
         let mut reader = EventStream::new();
         // eprintln!("track_keyboard_events");
@@ -26,7 +26,9 @@ pub fn track_keyboard_events(tx: mpsc::Sender<TuiEvent>) {
                         Some(Ok(event)) => {
                             if let crossterm::event::Event::Key(k) = event {
                                 eprintln!("Event::{:?}\r", event);
-                                let _res = tx.send(TuiEvent::Keyboard { key_event: k }).await;
+                                let _res = tx
+                                    .send(CtEvent::Builtin(TuiEvent::Keyboard { key_event: k }))
+                                    .await;
                                 // eprintln!("{res:?}");
                             }
                         }

--- a/src/tui/src/core.rs
+++ b/src/tui/src/core.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::str;
 use std::time;
 
-use crate::event::Event;
+use crate::event::{CtEvent, Event};
 use crate::task::{gen_task_id, to_event_kind, to_task_kind_text, EventId, TaskId, TaskKind};
 use serde::Serialize;
 use tokio;
@@ -146,7 +146,7 @@ fn load_response(line: &str) -> Event {
     }
 }
 
-pub fn track_responses(tx: mpsc::Sender<Event>) {
+pub fn track_responses(tx: mpsc::Sender<CtEvent>) {
     tokio::spawn(async move {
         let mut next_line_index = 0usize;
         loop {
@@ -161,7 +161,7 @@ pub fn track_responses(tx: mpsc::Sender<Event>) {
                         // eprintln!("load [{line}]");
                         let event = load_response(&line);
                         // eprintln!("send {event:?}");
-                        tx.send(event).await.unwrap();
+                        tx.send(CtEvent::Builtin(event)).await.unwrap();
                     }
                 }
                 // last_line_length = lines.len();

--- a/src/tui/src/event.rs
+++ b/src/tui/src/event.rs
@@ -1,4 +1,5 @@
 use crate::task::{EventId, EventKind};
+use serde_json::Value;
 
 #[derive(Debug)]
 pub enum Event {
@@ -13,4 +14,10 @@ pub enum Event {
     Error {
         message: String,
     },
+}
+
+#[derive(Debug)]
+pub enum CtEvent {
+    Builtin(Event),
+    Dap(Value),
 }


### PR DESCRIPTION
## Summary
- add unified `CtEvent` to simple_tui
- spawn threads for keyboard and DAP events
- process events through a central channel and update status

## Testing
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_b_6840829c21108332aa2e159d0c3ea155