### PR TITLE
Add DAP breakpoint handling

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -4,3 +4,5 @@
 - Added a regression test ensuring `ExprLoader` detects Ruby `each` loops correctly.
 - The `tui` crate contains a sample trace under `src/tui/trace/` used for basic testing.
 - The Debug Adapter Protocol client communicates over a Unix domain socket using the same framing protocol, implemented in `src/tui/src/dap_client.rs`.
+- Added initial SetBreakpoints handling in db-backend DAP server.
+

--- a/src/db-backend/src/dap.rs
+++ b/src/db-backend/src/dap.rs
@@ -34,10 +34,61 @@ pub struct LaunchRequestArguments {
     pub restart: Option<Value>,
 }
 
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct Source {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(rename = "sourceReference", skip_serializing_if = "Option::is_none")]
+    pub source_reference: Option<i64>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct SourceBreakpoint {
+    pub line: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub column: Option<i64>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct SetBreakpointsArguments {
+    pub source: Source,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub breakpoints: Option<Vec<SourceBreakpoint>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lines: Option<Vec<i64>>,
+    #[serde(rename = "sourceModified", skip_serializing_if = "Option::is_none")]
+    pub source_modified: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct Breakpoint {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<i64>,
+    pub verified: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<Source>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line: Option<i64>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct SetBreakpointsResponseBody {
+    pub breakpoints: Vec<Breakpoint>,
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(untagged)]
 pub enum RequestArguments {
     Launch(LaunchRequestArguments),
+    SetBreakpoints(SetBreakpointsArguments),
     Other(Value),
 }
 
@@ -103,6 +154,10 @@ impl DapClient {
 
     pub fn launch(&mut self, args: LaunchRequestArguments) -> DapMessage {
         self.request("launch", RequestArguments::Launch(args))
+    }
+
+    pub fn set_breakpoints(&mut self, args: SetBreakpointsArguments) -> DapMessage {
+        self.request("setBreakpoints", RequestArguments::SetBreakpoints(args))
     }
 }
 

--- a/src/db-backend/src/dap_server.rs
+++ b/src/db-backend/src/dap_server.rs
@@ -1,6 +1,10 @@
-use crate::dap::{self, DapMessage, Event, ProtocolMessage, RequestArguments, Response};
+use crate::dap::{
+    self, Breakpoint, DapMessage, Event, ProtocolMessage, RequestArguments, Response, SetBreakpointsResponseBody,
+    Source,
+};
 use crate::trace_processor::load_trace_metadata;
 use serde_json::json;
+use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::io::BufReader;
 use std::os::unix::net::{UnixListener, UnixStream};
@@ -23,6 +27,7 @@ fn handle_client(stream: UnixStream) -> Result<(), Box<dyn Error>> {
     let mut reader = BufReader::new(stream.try_clone()?);
     let mut writer = stream;
     let mut seq = 1i64;
+    let mut breakpoints: HashMap<String, HashSet<i64>> = HashMap::new();
     while let Ok(msg) = dap::from_reader(&mut reader) {
         match msg {
             DapMessage::Request(req) if req.command == "initialize" => {
@@ -36,6 +41,63 @@ fn handle_client(stream: UnixStream) -> Result<(), Box<dyn Error>> {
                     command: "initialize".to_string(),
                     message: None,
                     body: json!({}),
+                });
+                seq += 1;
+                dap::write_message(&mut writer, &resp)?;
+            }
+            DapMessage::Request(req) if req.command == "setBreakpoints" => {
+                let mut results = Vec::new();
+                if let RequestArguments::SetBreakpoints(args) = req.arguments {
+                    if let Some(path) = args.source.path.clone() {
+                        let lines: Vec<i64> = if let Some(bps) = args.breakpoints {
+                            bps.into_iter().map(|b| b.line).collect()
+                        } else {
+                            args.lines.unwrap_or_default()
+                        };
+                        let entry = breakpoints.entry(path.clone()).or_default();
+                        for line in lines {
+                            entry.insert(line);
+                            results.push(Breakpoint {
+                                id: None,
+                                verified: true,
+                                message: None,
+                                source: Some(Source {
+                                    name: args.source.name.clone(),
+                                    path: Some(path.clone()),
+                                    source_reference: args.source.source_reference,
+                                }),
+                                line: Some(line),
+                            });
+                        }
+                    } else {
+                        let lines = args
+                            .breakpoints
+                            .unwrap_or_default()
+                            .into_iter()
+                            .map(|b| b.line)
+                            .collect::<Vec<_>>();
+                        for line in lines {
+                            results.push(Breakpoint {
+                                id: None,
+                                verified: false,
+                                message: Some("missing source path".to_string()),
+                                source: None,
+                                line: Some(line),
+                            });
+                        }
+                    }
+                }
+                let body = SetBreakpointsResponseBody { breakpoints: results };
+                let resp = DapMessage::Response(Response {
+                    base: ProtocolMessage {
+                        seq,
+                        type_: "response".to_string(),
+                    },
+                    request_seq: req.base.seq,
+                    success: true,
+                    command: "setBreakpoints".to_string(),
+                    message: None,
+                    body: serde_json::to_value(body)?,
                 });
                 seq += 1;
                 dap::write_message(&mut writer, &resp)?;

--- a/src/db-backend/tests/dap_session.rs
+++ b/src/db-backend/tests/dap_session.rs
@@ -1,5 +1,6 @@
 use db_backend::dap::{
-    self, DapClient, DapMessage, Event, LaunchRequestArguments, ProtocolMessage, RequestArguments, Response,
+    self, Breakpoint, DapClient, DapMessage, Event, LaunchRequestArguments, ProtocolMessage, RequestArguments,
+    Response, SetBreakpointsArguments, SetBreakpointsResponseBody, Source, SourceBreakpoint,
 };
 use serde_json::json;
 use std::io::BufReader;
@@ -61,6 +62,59 @@ fn run_server(stream: UnixStream) {
     }
 }
 
+fn run_breakpoint_server(stream: UnixStream) {
+    let mut reader = BufReader::new(stream.try_clone().unwrap());
+    let mut writer = stream;
+    let mut seq = 1i64;
+    loop {
+        let msg = match dap::from_reader(&mut reader) {
+            Ok(m) => m,
+            Err(_) => break,
+        };
+        match msg {
+            DapMessage::Request(req) if req.command == "setBreakpoints" => {
+                if let RequestArguments::SetBreakpoints(args) = req.arguments {
+                    let lines: Vec<i64> = args
+                        .breakpoints
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|b| b.line)
+                        .collect();
+                    let bps: Vec<Breakpoint> = lines
+                        .into_iter()
+                        .map(|l| Breakpoint {
+                            id: None,
+                            verified: true,
+                            message: None,
+                            source: args.source.clone().path.map(|p| Source {
+                                name: None,
+                                path: Some(p),
+                                source_reference: None,
+                            }),
+                            line: Some(l),
+                        })
+                        .collect();
+                    let body = SetBreakpointsResponseBody { breakpoints: bps };
+                    let resp = DapMessage::Response(Response {
+                        base: ProtocolMessage {
+                            seq,
+                            type_: "response".to_string(),
+                        },
+                        request_seq: req.base.seq,
+                        success: true,
+                        command: "setBreakpoints".to_string(),
+                        message: None,
+                        body: serde_json::to_value(body).unwrap(),
+                    });
+                    seq += 1;
+                    dap::write_message(&mut writer, &resp).unwrap();
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
 #[test]
 fn test_simple_session() {
     let (client_stream, server_stream) = UnixStream::pair().unwrap();
@@ -95,6 +149,47 @@ fn test_simple_session() {
     let msg3 = dap::from_reader(&mut reader).unwrap();
     match msg3 {
         DapMessage::Response(resp) => assert_eq!(resp.command, "launch"),
+        _ => panic!("expected response"),
+    }
+
+    drop(writer);
+    drop(reader);
+    handle.join().unwrap();
+}
+
+#[test]
+fn test_set_breakpoints_roundtrip() {
+    let (client_stream, server_stream) = UnixStream::pair().unwrap();
+    let handle = thread::spawn(move || run_breakpoint_server(server_stream));
+
+    let mut reader = BufReader::new(client_stream.try_clone().unwrap());
+    let mut writer = client_stream;
+
+    let mut client = DapClient::default();
+    let args = SetBreakpointsArguments {
+        source: Source {
+            name: None,
+            path: Some("file.rs".to_string()),
+            source_reference: None,
+        },
+        breakpoints: Some(vec![
+            SourceBreakpoint { line: 10, column: None },
+            SourceBreakpoint { line: 20, column: None },
+        ]),
+        lines: None,
+        source_modified: None,
+    };
+    let req = client.set_breakpoints(args);
+    dap::write_message(&mut writer, &req).unwrap();
+
+    let msg = dap::from_reader(&mut reader).unwrap();
+    match msg {
+        DapMessage::Response(resp) => {
+            assert_eq!(resp.command, "setBreakpoints");
+            let body: SetBreakpointsResponseBody = serde_json::from_value(resp.body).unwrap();
+            assert_eq!(body.breakpoints.len(), 2);
+            assert!(body.breakpoints.iter().all(|b| b.verified));
+        }
         _ => panic!("expected response"),
     }
 


### PR DESCRIPTION
## Summary
- support `setBreakpoints` in the db-backend DAP server
- add types for breakpoints to the DAP module
- test setBreakpoints roundtrip
- document the new feature in `codebase-insights.txt`
- merge breakpoint test into existing session tests

## Testing
- `cargo clippy`
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_6841aba3ef34833195dbc69137644597