### PR TITLE
Add setBreakpoints support

### DIFF
--- a/.agents/tasks/2025/06/05-1620-fix-set-breakpoints.txt
+++ b/.agents/tasks/2025/06/05-1620-fix-set-breakpoints.txt
@@ -1,0 +1,9 @@
+You're working on a custom debugger backend (`db-backend`) that implements the Debug Adapter Protocol (DAP). You need to handle the `setBreakpoints` request by calling the internal `add_breakpoint` function to register breakpoints in the backend.
+
+**Requirements:**
+
+1. Use the provided `add_breakpoints` function to store breakpoints.
+2. Accept a request of the following structure (DAP-compliant):
+3. The test should be with our own db-backend as server
+--- FOLLOW UP TASK ---
+Please address any inline comments on the diff, as well as any additional instructions below.


### PR DESCRIPTION
## Summary
- add helper to persist breakpoints for the DAP server
- register breakpoints from `setBreakpoints` requests
- exercise the server in new test

## Testing
- `cargo build`
- `cargo test`
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_b_6841bfe7f4a883318e83db6248652463