### PR TITLE
Fix selectable footer status text

### DIFF
--- a/.agents/tasks/2025/06/05-1719-footer-no-select.txt
+++ b/.agents/tasks/2025/06/05-1719-footer-no-select.txt
@@ -1,0 +1,9 @@
+In the footer of CodeTracers UI it is possible to select the text of the following elements:
+
+<span id="stable-status" class="ready-status">stable: ready</span>
+
+<span class="status-inline">UTF-8</span>
+
+<span class="location-path status-inline" data-toggle="tooltip" data-placement="bottom" title="/home/franz/code/repos/codetracer/examples/noir_simple_sha/src/main.nr:4#0">/home/franz/code/repos/codetracer/examples/noir_simple_sha/src/main.nr:4#0</span>
+
+Make changes so that the text can not be selected

--- a/src/frontend/styles/components/status_bar.styl
+++ b/src/frontend/styles/components/status_bar.styl
@@ -138,6 +138,13 @@
       overflow: hidden
       text-overflow: ellipsis
       text-align: end
+      user-select: none
+
+    .status-inline
+      user-select: none
+
+    .ready-status
+      user-select: none
 
     .whitespace-set
       width: 10px


### PR DESCRIPTION
Bug: The elements in the footer can be selected as shown in the screenshot below:
![image](https://github.com/user-attachments/assets/189ef524-cb0a-4822-9485-9cc990853bf3)


## Summary
- prevent selection of status bar items in the UI

## Testing
- `cargo test` in `src/db-backend`
- `cargo clippy` in `src/db-backend`
- `cargo build` in `src/db-backend`

------
https://chatgpt.com/codex/tasks/task_b_6841d0a52ccc832abf0aad675cd175c3