### PR TITLE
Implement DAP initialize step in simple-tui

### DIFF
--- a/.agents/tasks/2025/06/05-1717-fix-send-initialize.txt
+++ b/.agents/tasks/2025/06/05-1717-fix-send-initialize.txt
@@ -1,0 +1,1 @@
+read .agents/tasks/2025/06/05-1644-fix-send-initialize and do it

--- a/src/tui/src/simple_main.rs
+++ b/src/tui/src/simple_main.rs
@@ -74,6 +74,8 @@ impl App {
         };
 
         if let Some(client) = dap.as_mut() {
+            // Initialize the DAP session before requesting the launch
+            client.initialize()?;
             // Inform the DAP server about the trace we want to analyze
             client.launch(trace_dir, program)?;
         }


### PR DESCRIPTION
## Summary
- add `DapClient::initialize` to issue an initial handshake request
- call `initialize` from `simple_main` before launching the program
- record task instructions

## Testing
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_b_6841d0379854833297e2a71e5eb7278c