### PR TITLE
Add BigInt comparison handling

### DIFF
--- a/.agents/tasks/2025/06/06-1357-bigint-compare.txt
+++ b/.agents/tasks/2025/06/06-1357-bigint-compare.txt
@@ -1,0 +1,3 @@
+In `src/tracepoint_interpreter/operator_functions.rs` there aren't cases that handle ValueRecord::BigInt. Implement them for the comparison functions.
+
+In order for the code to be more readable, implement a function that accepts ValueRecord::BigInt as parameter and returns num_bigint::BigInt.


### PR DESCRIPTION
## Summary
- support `ValueRecord::BigInt` in comparison operators
- add `bigint_from_valuerecord` helper to decode big integers
- record task details

## Testing
- `cargo build`
- `cargo test`
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_b_6842f2fcd3b4833190583331178867e4