### PR TITLE
Add stdio transport for db-backend DAP

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -5,4 +5,6 @@
 - The `tui` crate contains a sample trace under `src/tui/trace/` used for basic testing.
 - The Debug Adapter Protocol client communicates over a Unix domain socket using the same framing protocol, implemented in `src/tui/src/dap_client.rs`.
 - Added initial SetBreakpoints handling in db-backend DAP server.
+- When using the DAP stdio transport, all diagnostic output must go to stderr
+  to avoid corrupting the message stream.
 

--- a/src/db-backend/src/main.rs
+++ b/src/db-backend/src/main.rs
@@ -43,6 +43,9 @@ struct Args {
     /// Path to the Unix domain socket for DAP communication.
     /// If omitted, a path based on the process id will be used.
     socket_path: Option<std::path::PathBuf>,
+    /// Use stdio transport for DAP communication instead of a Unix socket.
+    #[arg(long)]
+    stdio: bool,
 }
 
 // Already panicking so the unwraps won't change anything
@@ -56,17 +59,23 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let cli = Args::parse();
 
-    let socket_path = if let Some(p) = cli.socket_path {
-        p
+    eprintln!("pid {:?}", std::process::id());
+    let handle = if cli.stdio {
+        thread::spawn(move || {
+            let _ = db_backend::dap_server::run_stdio();
+        })
     } else {
-        let pid = std::process::id() as usize;
-        db_backend::dap_server::socket_path_for(pid)
+        let socket_path = if let Some(p) = cli.socket_path {
+            p
+        } else {
+            let pid = std::process::id() as usize;
+            db_backend::dap_server::socket_path_for(pid)
+        };
+        thread::spawn(move || {
+            let _ = db_backend::dap_server::run(&socket_path);
+        })
     };
 
-    println!("pid {:?}", std::process::id());
-    let handle = thread::spawn(move || {
-        let _ = db_backend::dap_server::run(&socket_path);
-    });
     match handle.join() {
         Ok(_) => Ok(()),
         Err(_) => Err("dap server thread panicked".into()),

--- a/src/db-backend/tests/dap_backend_stdio.rs
+++ b/src/db-backend/tests/dap_backend_stdio.rs
@@ -1,0 +1,55 @@
+use db_backend::dap::{self, DapClient, DapMessage, LaunchRequestArguments, RequestArguments};
+use serde_json::json;
+use std::io::BufReader;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+#[test]
+fn test_backend_dap_server_stdio() {
+    let bin = env!("CARGO_BIN_EXE_db-backend");
+    let pid = std::process::id() as usize;
+    let trace_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("trace");
+
+    let mut child = Command::new(bin)
+        .arg("--stdio")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let mut writer = child.stdin.take().unwrap();
+    let mut reader = BufReader::new(child.stdout.take().unwrap());
+
+    let mut client = DapClient::default();
+    let init = client.request("initialize", RequestArguments::Other(json!({})));
+    dap::write_message(&mut writer, &init).unwrap();
+    let launch_args = LaunchRequestArguments {
+        program: Some("main".to_string()),
+        trace_folder: Some(trace_dir),
+        pid: Some(pid as u64),
+        no_debug: None,
+        restart: None,
+    };
+    let launch = client.launch(launch_args);
+    dap::write_message(&mut writer, &launch).unwrap();
+
+    let msg1 = dap::from_reader(&mut reader).unwrap();
+    match msg1 {
+        DapMessage::Response(r) => assert_eq!(r.command, "initialize"),
+        _ => panic!(),
+    }
+    let msg2 = dap::from_reader(&mut reader).unwrap();
+    match msg2 {
+        DapMessage::Event(e) => assert_eq!(e.event, "initialized"),
+        _ => panic!(),
+    }
+    let msg3 = dap::from_reader(&mut reader).unwrap();
+    match msg3 {
+        DapMessage::Response(r) => assert_eq!(r.command, "launch"),
+        _ => panic!(),
+    }
+
+    drop(writer);
+    drop(reader);
+    let _ = child.wait().unwrap();
+}


### PR DESCRIPTION
## Summary
- support `--stdio` CLI flag for DAP communication
- implement stdio transport in `dap_server`
- send diagnostic output to stderr when using stdio
- document insight about stdio output rules
- add an integration test using the stdio transport

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_6846e4ecbb4c8332a5fcebae48dd01f4