### PR TITLE
Add configurationDone to DAP

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -8,3 +8,5 @@
 - When using the DAP stdio transport, all diagnostic output must go to stderr
   to avoid corrupting the message stream.
 
+
+- The db-backend DAP server now responds to the `configurationDone` request.

--- a/.agents/tasks/2025/06/09-1454-feat-add-support-for-configuration-done-dap
+++ b/.agents/tasks/2025/06/09-1454-feat-add-support-for-configuration-done-dap
@@ -4,3 +4,6 @@ a `TODO` comment that we will run to entry/continue here, after
 setting the `launch` field
 
 add a test that we receive it to the existing session tests
+
+--- FOLLOW UP TASK ---
+add a test for configurationDone to the dap_backend_stdio.rs and dap_backend_server.rs

--- a/src/db-backend/src/dap_server.rs
+++ b/src/db-backend/src/dap_server.rs
@@ -172,6 +172,22 @@ fn handle_client<R: BufRead, W: Write>(reader: &mut R, writer: &mut W) -> Result
                 seq += 1;
                 dap::write_message(writer, &resp)?;
             }
+            DapMessage::Request(req) if req.command == "configurationDone" => {
+                // TODO: run to entry/continue here, after setting the `launch` field
+                let resp = DapMessage::Response(Response {
+                    base: ProtocolMessage {
+                        seq,
+                        type_: "response".to_string(),
+                    },
+                    request_seq: req.base.seq,
+                    success: true,
+                    command: "configurationDone".to_string(),
+                    message: None,
+                    body: json!({}),
+                });
+                seq += 1;
+                dap::write_message(writer, &resp)?;
+            }
             DapMessage::Request(req) if req.command == "stepIn" => {
                 if let Some(h) = handler.as_mut() {
                     let _ = h.step(

--- a/src/db-backend/tests/dap_backend_server.rs
+++ b/src/db-backend/tests/dap_backend_server.rs
@@ -55,9 +55,16 @@ fn test_backend_dap_server() {
         DapMessage::Event(e) => assert_eq!(e.event, "initialized"),
         _ => panic!(),
     }
+    let conf_done = client.request("configurationDone", RequestArguments::Other(json!({})));
+    dap::write_message(&mut writer, &conf_done).unwrap();
     let msg3 = dap::from_reader(&mut reader).unwrap();
     match msg3 {
         DapMessage::Response(r) => assert_eq!(r.command, "launch"),
+        _ => panic!(),
+    }
+    let msg4 = dap::from_reader(&mut reader).unwrap();
+    match msg4 {
+        DapMessage::Response(r) => assert_eq!(r.command, "configurationDone"),
         _ => panic!(),
     }
 

--- a/src/db-backend/tests/dap_backend_stdio.rs
+++ b/src/db-backend/tests/dap_backend_stdio.rs
@@ -43,9 +43,16 @@ fn test_backend_dap_server_stdio() {
         DapMessage::Event(e) => assert_eq!(e.event, "initialized"),
         _ => panic!(),
     }
+    let conf_done = client.request("configurationDone", RequestArguments::Other(json!({})));
+    dap::write_message(&mut writer, &conf_done).unwrap();
     let msg3 = dap::from_reader(&mut reader).unwrap();
     match msg3 {
         DapMessage::Response(r) => assert_eq!(r.command, "launch"),
+        _ => panic!(),
+    }
+    let msg4 = dap::from_reader(&mut reader).unwrap();
+    match msg4 {
+        DapMessage::Response(r) => assert_eq!(r.command, "configurationDone"),
         _ => panic!(),
     }
 


### PR DESCRIPTION
## Summary
- support `configurationDone` request in db-backend's DAP server
- respond to `configurationDone` in tests
- document new DAP capability in codebase insights
- add tests verifying configurationDone handling in stdio and socket DAP backends

## Testing
- `cargo build`
- `cargo test`
- `cargo clippy`


------
https://chatgpt.com/codex/tasks/task_b_6846f63a8da4833283eaf2a6a8c7c078