### PR TITLE
Implement DAP capabilities in initialize response

### DIFF
--- a/src/db-backend/src/dap.rs
+++ b/src/db-backend/src/dap.rs
@@ -84,6 +84,35 @@ pub struct SetBreakpointsResponseBody {
     pub breakpoints: Vec<Breakpoint>,
 }
 
+#[derive(Serialize, Deserialize, Debug, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct Capabilities {
+    #[serde(
+        rename = "supportsLoadedSourcesRequest",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub supports_loaded_sources_request: Option<bool>,
+    #[serde(rename = "supportsStepBack", skip_serializing_if = "Option::is_none")]
+    pub supports_step_back: Option<bool>,
+    #[serde(
+        rename = "supportsConfigurationDoneRequest",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub supports_configuration_done_request: Option<bool>,
+    #[serde(
+        rename = "supportsDisassembleRequest",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub supports_disassemble_request: Option<bool>,
+    #[serde(rename = "supportsLogPoints", skip_serializing_if = "Option::is_none")]
+    pub supports_log_points: Option<bool>,
+    #[serde(
+        rename = "supportsRestartRequest",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub supports_restart_request: Option<bool>,
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(untagged)]
 pub enum RequestArguments {
@@ -109,6 +138,19 @@ pub struct Response {
     pub message: Option<String>,
     #[serde(default)]
     pub body: Value,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct InitializeResponse {
+    #[serde(flatten)]
+    pub base: ProtocolMessage,
+    pub request_seq: i64,
+    pub success: bool,
+    pub command: String,
+    #[serde(default)]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body: Option<Capabilities>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]

--- a/src/db-backend/src/dap_server.rs
+++ b/src/db-backend/src/dap_server.rs
@@ -1,6 +1,6 @@
 use crate::dap::{
-    self, Breakpoint, DapMessage, Event, ProtocolMessage, RequestArguments, Response, SetBreakpointsResponseBody,
-    Source,
+    self, Breakpoint, Capabilities, DapMessage, Event, ProtocolMessage, RequestArguments,
+    Response, SetBreakpointsResponseBody, Source,
 };
 use crate::db::Db;
 use crate::handler::Handler;
@@ -45,6 +45,14 @@ fn handle_client<R: BufRead, W: Write>(reader: &mut R, writer: &mut W) -> Result
     while let Ok(msg) = dap::from_reader(reader) {
         match msg {
             DapMessage::Request(req) if req.command == "initialize" => {
+                let capabilities = Capabilities {
+                    supports_loaded_sources_request: Some(true),
+                    supports_step_back: Some(true),
+                    supports_configuration_done_request: Some(true),
+                    supports_disassemble_request: Some(true),
+                    supports_log_points: Some(true),
+                    supports_restart_request: Some(true),
+                };
                 let resp = DapMessage::Response(Response {
                     base: ProtocolMessage {
                         seq,
@@ -54,7 +62,7 @@ fn handle_client<R: BufRead, W: Write>(reader: &mut R, writer: &mut W) -> Result
                     success: true,
                     command: "initialize".to_string(),
                     message: None,
-                    body: json!({}),
+                    body: serde_json::to_value(capabilities)?,
                 });
                 seq += 1;
                 dap::write_message(writer, &resp)?;

--- a/src/db-backend/tests/dap_backend_server.rs
+++ b/src/db-backend/tests/dap_backend_server.rs
@@ -47,7 +47,15 @@ fn test_backend_dap_server() {
 
     let msg1 = dap::from_reader(&mut reader).unwrap();
     match msg1 {
-        DapMessage::Response(r) => assert_eq!(r.command, "initialize"),
+        DapMessage::Response(r) => {
+            assert_eq!(r.command, "initialize");
+            assert!(r.body["supportsLoadedSourcesRequest"].as_bool().unwrap());
+            assert!(r.body["supportsStepBack"].as_bool().unwrap());
+            assert!(r.body["supportsConfigurationDoneRequest"].as_bool().unwrap());
+            assert!(r.body["supportsDisassembleRequest"].as_bool().unwrap());
+            assert!(r.body["supportsLogPoints"].as_bool().unwrap());
+            assert!(r.body["supportsRestartRequest"].as_bool().unwrap());
+        }
         _ => panic!(),
     }
     let msg2 = dap::from_reader(&mut reader).unwrap();

--- a/src/db-backend/tests/dap_backend_stdio.rs
+++ b/src/db-backend/tests/dap_backend_stdio.rs
@@ -35,7 +35,15 @@ fn test_backend_dap_server_stdio() {
 
     let msg1 = dap::from_reader(&mut reader).unwrap();
     match msg1 {
-        DapMessage::Response(r) => assert_eq!(r.command, "initialize"),
+        DapMessage::Response(r) => {
+            assert_eq!(r.command, "initialize");
+            assert!(r.body["supportsLoadedSourcesRequest"].as_bool().unwrap());
+            assert!(r.body["supportsStepBack"].as_bool().unwrap());
+            assert!(r.body["supportsConfigurationDoneRequest"].as_bool().unwrap());
+            assert!(r.body["supportsDisassembleRequest"].as_bool().unwrap());
+            assert!(r.body["supportsLogPoints"].as_bool().unwrap());
+            assert!(r.body["supportsRestartRequest"].as_bool().unwrap());
+        }
         _ => panic!(),
     }
     let msg2 = dap::from_reader(&mut reader).unwrap();

--- a/src/db-backend/tests/dap_protocol.rs
+++ b/src/db-backend/tests/dap_protocol.rs
@@ -22,6 +22,14 @@ fn test_parse_initialize_request() {
 
 #[test]
 fn test_serialize_initialize_response() {
+    let body = json!({
+        "supportsLoadedSourcesRequest": true,
+        "supportsStepBack": true,
+        "supportsConfigurationDoneRequest": true,
+        "supportsDisassembleRequest": true,
+        "supportsLogPoints": true,
+        "supportsRestartRequest": true
+    });
     let resp = Response {
         base: ProtocolMessage {
             seq: 2,
@@ -31,7 +39,7 @@ fn test_serialize_initialize_response() {
         success: true,
         command: "initialize".to_string(),
         message: None,
-        body: json!({}),
+        body,
     };
     let original = DapMessage::Response(resp);
     let json_text = to_json(&original).expect("serialize");
@@ -43,7 +51,7 @@ fn test_serialize_initialize_response() {
 fn test_session_sequence_parse() {
     let messages = vec![
         r#"{"seq":1,"type":"request","command":"initialize","arguments":{}}"#,
-        r#"{"seq":2,"type":"response","request_seq":1,"success":true,"command":"initialize"}"#,
+        r#"{"seq":2,"type":"response","request_seq":1,"success":true,"command":"initialize","body":{"supportsLoadedSourcesRequest":true,"supportsStepBack":true,"supportsConfigurationDoneRequest":true,"supportsDisassembleRequest":true,"supportsLogPoints":true,"supportsRestartRequest":true}}"#,
         r#"{"seq":3,"type":"event","event":"initialized"}"#,
         r#"{"seq":4,"type":"request","command":"launch","arguments":{"program":"main"}}"#,
         r#"{"seq":5,"type":"response","request_seq":4,"success":true,"command":"launch"}"#,
@@ -52,6 +60,18 @@ fn test_session_sequence_parse() {
     assert_eq!(parsed.len(), messages.len());
     match &parsed[0] {
         DapMessage::Request(req) => assert_eq!(req.command, "initialize"),
+        _ => panic!("unexpected type"),
+    }
+    match &parsed[1] {
+        DapMessage::Response(resp) => {
+            assert_eq!(resp.command, "initialize");
+            assert!(resp.body["supportsLoadedSourcesRequest"].as_bool().unwrap());
+            assert!(resp.body["supportsStepBack"].as_bool().unwrap());
+            assert!(resp.body["supportsConfigurationDoneRequest"].as_bool().unwrap());
+            assert!(resp.body["supportsDisassembleRequest"].as_bool().unwrap());
+            assert!(resp.body["supportsLogPoints"].as_bool().unwrap());
+            assert!(resp.body["supportsRestartRequest"].as_bool().unwrap());
+        }
         _ => panic!("unexpected type"),
     }
     match &parsed[2] {


### PR DESCRIPTION
## Summary
- add `Capabilities` and typed `InitializeResponse`
- send capabilities from DAP server
- check capabilities in protocol and integration tests

## Testing
- `cargo build` *(fails: command not found)*
- `cargo test` *(fails: command not found)*
- `cargo clippy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846fc9490dc8332afa195efe69280fa