### PR TITLE
fix: prevent text selection in footer

### DIFF
--- a/.agents/tasks/2025/06/05-1719-footer-no-select.txt
+++ b/.agents/tasks/2025/06/05-1719-footer-no-select.txt
@@ -1,0 +1,9 @@
+In the footer of CodeTracers UI it is possible to select the text of the following elements:
+
+<span id="stable-status" class="ready-status">stable: ready</span>
+
+<span class="status-inline">UTF-8</span>
+
+<span class="location-path status-inline" data-toggle="tooltip" data-placement="bottom" title="/home/franz/code/repos/codetracer/examples/noir_simple_sha/src/main.nr:4#0">/home/franz/code/repos/codetracer/examples/noir_simple_sha/src/main.nr:4#0</span>
+
+Make changes so that the text can not be selected

--- a/src/frontend/styles/components/status_bar.styl
+++ b/src/frontend/styles/components/status_bar.styl
@@ -138,6 +138,13 @@
       overflow: hidden
       text-overflow: ellipsis
       text-align: end
+      user-select: none
+
+    .status-inline
+      user-select: none
+
+    .ready-status
+      user-select: none
 
     .whitespace-set
       width: 10px


### PR DESCRIPTION
Added user-select:none styles for location path, inline status, and ready-status spans so text in the status bar can't be highlighted.

originally #198 with codex