### PR TITLE
Add Stylus token vesting demo

### DIFF
--- a/.agents/tasks/2025/06/17-1557-stylus-vesting-demo
+++ b/.agents/tasks/2025/06/17-1557-stylus-vesting-demo
@@ -1,0 +1,1 @@
+Create a demo Stylus token vesting contract in ui-tests/programs per spec

--- a/ui-tests/programs/rs_stylus_vesting/Cargo.toml
+++ b/ui-tests/programs/rs_stylus_vesting/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "stylus_vesting"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+stylus-sdk = "0.4"
+alloy-primitives = "0.6"
+

--- a/ui-tests/programs/rs_stylus_vesting/src/errors.rs
+++ b/ui-tests/programs/rs_stylus_vesting/src/errors.rs
@@ -1,0 +1,31 @@
+use stylus_sdk::solidity::SolError;
+
+/// Caller is not the contract owner.
+#[derive(Debug, SolError)]
+#[sol(error_name = "NotOwner")]
+pub struct NotOwner;
+
+/// Schedule not found for a given ID.
+#[derive(Debug, SolError)]
+#[sol(error_name = "ScheduleNotFound")]
+pub struct ScheduleNotFound;
+
+/// Attempted to revoke a non-revocable schedule.
+#[derive(Debug, SolError)]
+#[sol(error_name = "NotRevocable")]
+pub struct NotRevocable;
+
+/// Invalid vesting duration or cliff.
+#[derive(Debug, SolError)]
+#[sol(error_name = "InvalidDuration")]
+pub struct InvalidDuration;
+
+/// No tokens are available for release.
+#[derive(Debug, SolError)]
+#[sol(error_name = "NothingToRelease")]
+pub struct NothingToRelease;
+
+/// Start timestamp cannot be in the past.
+#[derive(Debug, SolError)]
+#[sol(error_name = "TimestampError")]
+pub struct TimestampError;

--- a/ui-tests/programs/rs_stylus_vesting/src/events.rs
+++ b/ui-tests/programs/rs_stylus_vesting/src/events.rs
@@ -1,0 +1,24 @@
+use stylus_sdk::alloy_primitives::{Address, U256};
+use stylus_sdk::event;
+
+/// Event emitted when a new schedule is created.
+#[event]
+pub struct ScheduleCreated {
+    pub schedule_id: U256,
+    pub beneficiary: Address,
+    pub amount: U256,
+}
+
+/// Event emitted when tokens are released.
+#[event]
+pub struct TokensReleased {
+    pub schedule_id: U256,
+    pub beneficiary: Address,
+    pub amount: U256,
+}
+
+/// Event emitted when a schedule is revoked.
+#[event]
+pub struct ScheduleRevoked {
+    pub schedule_id: U256,
+}

--- a/ui-tests/programs/rs_stylus_vesting/src/lib.rs
+++ b/ui-tests/programs/rs_stylus_vesting/src/lib.rs
@@ -1,0 +1,170 @@
+//! Demo Stylus vesting contract used by CodeTracer UI tests.
+//! It implements token vesting logic showcasing storage access,
+//! conditional branching, loops and function calls.
+
+use stylus_sdk::prelude::*;
+use stylus_sdk::storage::{StorageAddress, StorageMap, StorageU256, StorageVec};
+use stylus_sdk::alloy_primitives::{Address, U256};
+
+mod vesting;
+mod events;
+mod errors;
+
+use vesting::VestingSchedule;
+use events::*;
+use errors::*;
+
+#[solidity_storage]
+#[entrypoint]
+pub struct VestingContract {
+    owner: StorageAddress,
+    token: StorageAddress,
+    schedules: StorageMap<U256, VestingSchedule>,
+    beneficiary_schedules: StorageMap<Address, StorageVec<U256>>,
+    next_schedule_id: StorageU256,
+}
+
+impl VestingContract {
+    /// Initialize the contract with the ERC20 token address.
+    #[external]
+    pub fn init(&mut self, token_address: Address) {
+        self.owner.set(msg::sender());
+        self.token.set(token_address);
+        self.next_schedule_id.set(U256::from(0));
+    }
+
+    /// Owner-only schedule creation.
+    #[external]
+    pub fn create_schedule(
+        &mut self,
+        beneficiary: Address,
+        start_time: u64,
+        duration_seconds: u64,
+        cliff_seconds: u64,
+        amount: U256,
+        revocable: bool,
+    ) -> Result<U256, SolError> {
+        if msg::sender() != *self.owner {
+            return Err(NotOwner.into());
+        }
+        if duration_seconds == 0 || cliff_seconds > duration_seconds {
+            return Err(InvalidDuration.into());
+        }
+        if start_time < block::timestamp() {
+            return Err(TimestampError.into());
+        }
+
+        let schedule_id = *self.next_schedule_id;
+        self.next_schedule_id.set(schedule_id + U256::from(1));
+
+        let schedule = VestingSchedule {
+            beneficiary,
+            start_time,
+            duration_seconds,
+            cliff_seconds,
+            total_amount: amount,
+            released_amount: U256::from(0),
+            is_revocable: revocable,
+        };
+
+        self.schedules.insert(schedule_id, schedule.clone());
+        let mut vec = self
+            .beneficiary_schedules
+            .get(beneficiary)
+            .unwrap_or_default();
+        vec.push(schedule_id);
+        self.beneficiary_schedules.insert(beneficiary, vec);
+        emit(ScheduleCreated {
+            schedule_id,
+            beneficiary,
+            amount,
+        });
+        Ok(schedule_id)
+    }
+
+    /// Calculate releasable amount for a given schedule.
+    #[view]
+    pub fn compute_releasable_amount(&self, schedule_id: U256) -> Result<U256, SolError> {
+        let schedule = self
+            .schedules
+            .get(schedule_id)
+            .ok_or(ScheduleNotFound)?;
+
+        let current = block::timestamp();
+        if current < schedule.start_time + schedule.cliff_seconds {
+            return Ok(U256::from(0));
+        }
+        if current >= schedule.start_time + schedule.duration_seconds {
+            return Ok(schedule.total_amount - schedule.released_amount);
+        }
+        let elapsed = current - schedule.start_time;
+        let vested =
+            (schedule.total_amount * U256::from(elapsed)) / U256::from(schedule.duration_seconds);
+        Ok(vested - schedule.released_amount)
+    }
+
+    /// Release vested tokens from a specific schedule.
+    #[external]
+    pub fn release(&mut self, schedule_id: U256) -> Result<(), SolError> {
+        let amount = self.compute_releasable_amount(schedule_id)?;
+        if amount == U256::from(0) {
+            return Err(NothingToRelease.into());
+        }
+        let mut schedule = self
+            .schedules
+            .get(schedule_id)
+            .ok_or(ScheduleNotFound)?;
+        schedule.released_amount += amount;
+        self.schedules.insert(schedule_id, schedule.clone());
+        // perform token transfer
+        call::transfer(*self.token, schedule.beneficiary, amount)?;
+        emit(TokensReleased {
+            schedule_id,
+            beneficiary: schedule.beneficiary,
+            amount,
+        });
+        Ok(())
+    }
+
+    /// Release tokens from all schedules of a beneficiary.
+    #[external]
+    pub fn release_all_for_beneficiary(&mut self, beneficiary: Address) -> Result<(), SolError> {
+        let mut vec = self
+            .beneficiary_schedules
+            .get(beneficiary)
+            .unwrap_or_default();
+        for schedule_id in vec.iter() {
+            let _ = self.release(*schedule_id);
+        }
+        Ok(())
+    }
+
+    /// Revoke a schedule and return unvested tokens to owner.
+    #[external]
+    pub fn revoke(&mut self, schedule_id: U256) -> Result<(), SolError> {
+        if msg::sender() != *self.owner {
+            return Err(NotOwner.into());
+        }
+        let mut schedule = self
+            .schedules
+            .get(schedule_id)
+            .ok_or(ScheduleNotFound)?;
+        if !schedule.is_revocable {
+            return Err(NotRevocable.into());
+        }
+
+        let releasable = self.compute_releasable_amount(schedule_id)?;
+        let unvested = schedule.total_amount - schedule.released_amount - releasable;
+        if releasable > U256::from(0) {
+            call::transfer(*self.token, schedule.beneficiary, releasable)?;
+        }
+        if unvested > U256::from(0) {
+            call::transfer(*self.token, *self.owner, unvested)?;
+        }
+        schedule.released_amount += releasable;
+        schedule.total_amount = schedule.released_amount;
+        self.schedules.insert(schedule_id, schedule);
+        emit(ScheduleRevoked { schedule_id });
+        Ok(())
+    }
+}

--- a/ui-tests/programs/rs_stylus_vesting/src/vesting.rs
+++ b/ui-tests/programs/rs_stylus_vesting/src/vesting.rs
@@ -1,0 +1,13 @@
+use stylus_sdk::alloy_primitives::{Address, U256};
+
+/// Parameters defining a single vesting schedule.
+#[derive(Clone, Default)]
+pub struct VestingSchedule {
+    pub beneficiary: Address,
+    pub start_time: u64,
+    pub duration_seconds: u64,
+    pub cliff_seconds: u64,
+    pub total_amount: U256,
+    pub released_amount: U256,
+    pub is_revocable: bool,
+}


### PR DESCRIPTION
## Summary
- add Stylus vesting example program for CodeTracer demos
- define contract storage and schedule structures
- implement create, release, batch release and revoke logic
- include event and error definitions for demo

## Testing
- `cargo build` in `src/db-backend`
- `cargo test` in `src/db-backend`
- `cargo clippy` in `src/db-backend`

------
https://chatgpt.com/codex/tasks/task_b_68518ff09894832aadf18eddca82f5a1