### PR TITLE
feat: binary trace format

### DIFF
--- a/src/common/start_utils.nim
+++ b/src/common/start_utils.nim
@@ -36,12 +36,15 @@ proc startCoreProcess*(traceId: int, recordCore: bool, callerPid: int, test: boo
     debugprint "noOutput ", noOutput
     debugprint "options ", options
     if IS_DB_BASED[trace.lang]:
+      var traceFile = traceFolder / "trace.bin"
+      if not fileExists(traceFile):
+        traceFile = traceFolder / "trace.json"
       result = startProcess(
         dbBackendExe,
         workingDir = workdir,
         args = @[
           $callerPid,
-          traceFolder / "trace.json",
+          traceFile,
           traceFolder / "trace_metadata.json"
         ],
         options=options)

--- a/src/ct/trace/storage_and_import.nim
+++ b/src/ct/trace/storage_and_import.nim
@@ -97,7 +97,11 @@ proc importDbTrace*(
 
   let traceFolder = traceMetadataPath.parentDir
   let tracePathsPath = traceFolder / "trace_paths.json"
-  let tracePath = traceFolder / "trace.json"
+  var traceFileName = "trace.bin"
+  var tracePath = traceFolder / traceFileName
+  if not fileExists(tracePath):
+    traceFileName = "trace.json"
+    tracePath = traceFolder / traceFileName
 
   let outputFolder = fmt"{codetracerTraceDir}/trace-{traceID}/"
   if traceIdArg == NO_TRACE_ID:
@@ -109,7 +113,7 @@ proc importDbTrace*(
       echo "WARNING: probably no trace_paths.json: no self-contained support in this case:"
       echo "  ", e.msg
       echo "  skipping trace_paths file"
-    copyFile(tracePath, outputFolder / "trace.json")
+    copyFile(tracePath, outputFolder / traceFileName)
 
   var rawPaths: string
   try:

--- a/src/db-backend/Cargo.lock
+++ b/src/db-backend/Cargo.lock
@@ -115,6 +115,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
+name = "capnp"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64b3560604b407fe0ab6f89b81ac11887b4ae07f8d31486581dee5b353e48f06"
+dependencies = [
+ "embedded-io",
+]
+
+[[package]]
+name = "capnpc"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5af589f7a7f3e6d920120b913345bd9a2fc65dfd76c5053a142852a5ea2e8609"
+dependencies = [
+ "capnp",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +220,12 @@ dependencies = [
  "tree-sitter-tracepoint",
  "tree-sitter-traversal2",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "env_filter"
@@ -570,10 +594,11 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 [[package]]
 name = "runtime_tracing"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84de89a9028e4fb9efeff11437acc97fcab74cadcffc1417f337c584d320a62f"
+source = "git+https://github.com/metacraft-labs/runtime_tracing.git?branch=binary_trace_format#11e985d87751a54798367d2255e124a9bf5d70e8"
 dependencies = [
  "base64",
+ "capnp",
+ "capnpc",
  "num-derive",
  "num-traits",
  "serde",

--- a/src/db-backend/Cargo.lock
+++ b/src/db-backend/Cargo.lock
@@ -593,8 +593,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "runtime_tracing"
-version = "0.11.0"
-source = "git+https://github.com/metacraft-labs/runtime_tracing.git?branch=binary_trace_format#11e985d87751a54798367d2255e124a9bf5d70e8"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28859a4bcc3e4cbf1989aae2d1021f2a342c65aaaac716c4a7dfa90e2a7b3ca3"
 dependencies = [
  "base64",
  "capnp",

--- a/src/db-backend/Cargo.toml
+++ b/src/db-backend/Cargo.toml
@@ -30,7 +30,7 @@ tokio = {version = "1.37.0", features=["full", "rt", "net", "signal"]}
 futures = "0.3.30"
 futures-timer = "3.0.3"
 clap = { version = "4.5.4", features = ["derive"] }
-runtime_tracing = { git = "https://github.com/metacraft-labs/runtime_tracing.git", branch = "binary_trace_format" }
+runtime_tracing = "0.12.0"
 tree-sitter-tracepoint = { path = "./tree-sitter-trace/" }
 num-bigint = "0.4.6"
 

--- a/src/db-backend/Cargo.toml
+++ b/src/db-backend/Cargo.toml
@@ -30,7 +30,7 @@ tokio = {version = "1.37.0", features=["full", "rt", "net", "signal"]}
 futures = "0.3.30"
 futures-timer = "3.0.3"
 clap = { version = "4.5.4", features = ["derive"] }
-runtime_tracing = "0.11.0" # { git = "https://github.com/metacraft-labs/runtime_tracing.git", branch = "feat-bigint" }
+runtime_tracing = { git = "https://github.com/metacraft-labs/runtime_tracing.git", branch = "binary_trace_format" }
 tree-sitter-tracepoint = { path = "./tree-sitter-trace/" }
 num-bigint = "0.4.6"
 

--- a/src/db-backend/src/handler.rs
+++ b/src/db-backend/src/handler.rs
@@ -1743,9 +1743,14 @@ mod tests {
         }
     }
     fn load_db_for_trace(path: &Path) -> Db {
-        let trace_file = path.join("trace.json");
+        let mut trace_file = path.join("trace.bin");
+        let mut trace_file_format = runtime_tracing::TraceEventsFileFormat::Binary;
+        if !trace_file.exists() {
+            trace_file = path.join("trace.json");
+            trace_file_format = runtime_tracing::TraceEventsFileFormat::Json;
+        }
         let trace_metadata_file = path.join("trace_metadata.json");
-        let trace = load_trace_data(&trace_file).expect("expected that it can load the trace file");
+        let trace = load_trace_data(&trace_file, trace_file_format).expect("expected that it can load the trace file");
         let trace_metadata =
             load_trace_metadata(&trace_metadata_file).expect("expected that it can load the trace metadata file");
         let mut db = Db::new(&trace_metadata.workdir);

--- a/src/db-backend/src/main.rs
+++ b/src/db-backend/src/main.rs
@@ -130,7 +130,12 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // loading trace and metadata
     let start = Instant::now();
-    let trace = load_trace_data(&cli.trace_file)?;
+    let trace_file_format = if cli.trace_file.ends_with(".json") {
+        runtime_tracing::TraceEventsFileFormat::Json
+    } else {
+        runtime_tracing::TraceEventsFileFormat::Binary
+    };
+    let trace = load_trace_data(&cli.trace_file, trace_file_format)?;
     let trace_metadata = load_trace_metadata(&cli.trace_metadata_file)?;
     let duration = start.elapsed();
     info!("loading trace: duration: {:?}", duration);

--- a/src/db-backend/src/main.rs
+++ b/src/db-backend/src/main.rs
@@ -130,7 +130,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // loading trace and metadata
     let start = Instant::now();
-    let trace_file_format = if cli.trace_file.ends_with(".json") {
+    let trace_file_format = if cli.trace_file.extension() == Some(std::ffi::OsStr::new("json")) {
         runtime_tracing::TraceEventsFileFormat::Json
     } else {
         runtime_tracing::TraceEventsFileFormat::Binary

--- a/src/db-backend/src/trace_processor.rs
+++ b/src/db-backend/src/trace_processor.rs
@@ -411,13 +411,11 @@ impl<'a> TraceProcessor<'a> {
 }
 
 #[allow(clippy::panic)]
-pub fn load_trace_data(trace_file: &PathBuf) -> Result<Vec<TraceLowLevelEvent>, Box<dyn Error>> {
-    let raw_bytes = fs::read(trace_file).unwrap_or_else(|_| panic!("trace file {trace_file:?} read error"));
-    let raw = str::from_utf8(&raw_bytes)?;
+pub fn load_trace_data(trace_file: &PathBuf, file_format: runtime_tracing::TraceEventsFileFormat) -> Result<Vec<TraceLowLevelEvent>, Box<dyn Error>> {
+    let mut tracer = runtime_tracing::Tracer::new("", &[]);
+    tracer.load_trace_events(trace_file, file_format)?;
 
-    let trace: Vec<TraceLowLevelEvent> = serde_json::from_str(raw)?;
-
-    Ok(trace)
+    Ok(tracer.events)
 }
 
 #[allow(clippy::panic)]


### PR DESCRIPTION
This adds support for the binary trace format, introduced in runtime_tracing version 0.12.0. It is already supported by the Noir trace generator in:

https://github.com/noir-lang/noir/pull/7758

The previous JSON format is still supported for backwards compatibility, and to support the language backends that still haven't implemented the binary format.