### PR TITLE
ci: Deploy docs via Github Pages

### DIFF
--- a/ci/deploy/docs.sh
+++ b/ci/deploy/docs.sh
@@ -10,10 +10,16 @@ pushd docs/book/
 # for now depending on global project devshell 
 mdbook build # build output is in the `book` directory
 
-# TODO: deploy book to codetracer.com ? ask Zahary?
-
-echo '###############################################################################'
-echo "TODO upload book"
-echo '###############################################################################'
+# If the gh-pages branch already exists, this will overwrite it
+# so that the history is not kept, which can be very expensive.
+git worktree add --orphan -B gh-pages gh-pages
+cp -a book/. gh-pages
+git config user.name "Deploy from CI"
+git config user.email ""
+cd gh-pages
+git add -A
+git commit -m 'deploy new book'
+git push origin +gh-pages
+cd ..
 
 popd


### PR DESCRIPTION
When we merge to main this should deploy our docs to https://metacraft-labs.github.io/codetracer