### PR TITLE
Fix AppImage on non-NixOS systems that have Nix installed

### DIFF
--- a/appimage-scripts/build_appimage.sh
+++ b/appimage-scripts/build_appimage.sh
@@ -225,6 +225,7 @@ fi
 ARCH=$APPIMAGE_ARCH appimagetool "${APP_DIR}" CodeTracer.AppImage
 
 patchelf --set-interpreter "${INTERPRETER_PATH}" "${ROOT_PATH}"/CodeTracer.AppImage
+patchelf --set-rpath "/lib:/lib64:/usr/lib:/usr/lib64:$(patchelf --print-rpath "${ROOT_PATH}"/CodeTracer.AppImage)" "${ROOT_PATH}"/CodeTracer.AppImage
 
 echo "============================"
 echo "AppImage successfully built!"


### PR DESCRIPTION
Fixes #97 

After playing around inspecting the produced AppImage binary I found that we were not setting the rpath correctly, so I added some additional entries where we should be looking.

> [!CAUTION]
> The patch only works for the latest master so retroactively applying it to the current latest release is not possible.