### PR TITLE
Only show the install menu outside of local builds/packages

### DIFF
--- a/appimage-scripts/build_appimage.sh
+++ b/appimage-scripts/build_appimage.sh
@@ -157,6 +157,9 @@ rm -rf "${APP_DIR}/config"
 rm -rf "${APP_DIR}/public"
 cp -Lr "${ROOT_PATH}/src/config" "${APP_DIR}/config"
 
+# Enable the installation prompt
+sed -i "s/skipInstall.*/skipInstall: false/g" "${APP_DIR}/config/default_config.yaml"
+
 cp -Lr "${ROOT_PATH}/src/public" "${APP_DIR}/public"
 chmod -R +wr "${APP_DIR}/public"
 

--- a/non-nix-build/build.sh
+++ b/non-nix-build/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 NON_NIX_BUILD_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-cd $NON_NIX_BUILD_DIR
+cd "$NON_NIX_BUILD_DIR"
 
 source env.sh
 

--- a/non-nix-build/build_css.sh
+++ b/non-nix-build/build_css.sh
@@ -13,10 +13,10 @@ pushd "$ROOT_DIR"
 
 mkdir -p "$DIST_DIR/frontend/styles/"
 stylus="$ROOT_DIR/node_modules/.bin/stylus"
-node $stylus -o "$DIST_DIR/frontend/styles/" src/frontend/styles/default_white_theme.styl
-node $stylus -o "$DIST_DIR/frontend/styles/" src/frontend/styles/default_dark_theme.styl
-node $stylus -o "$DIST_DIR/frontend/styles/" src/frontend/styles/loader.styl
-node $stylus -o "$DIST_DIR/frontend/styles/" src/frontend/styles/subwindow.styl
+node "$stylus" -o "$DIST_DIR/frontend/styles/" src/frontend/styles/default_white_theme.styl
+node "$stylus" -o "$DIST_DIR/frontend/styles/" src/frontend/styles/default_dark_theme.styl
+node "$stylus" -o "$DIST_DIR/frontend/styles/" src/frontend/styles/loader.styl
+node "$stylus" -o "$DIST_DIR/frontend/styles/" src/frontend/styles/subwindow.styl
 
 popd
 

--- a/non-nix-build/build_in_simple_env.sh
+++ b/non-nix-build/build_in_simple_env.sh
@@ -12,8 +12,8 @@ export CODETRACER_BUILD_OS="$2"
 rm -rf "$DIST_DIR"
 rm -rf "$ROOT_DIR/non-nix-build/CodeTracer.app"
 
-mkdir -p $DIST_DIR/bin
-mkdir -p $DIST_DIR/src
+mkdir -p "$DIST_DIR/bin"
+mkdir -p "$DIST_DIR/src"
 
 # setup node deps
 bash setup_node_deps.sh
@@ -21,7 +21,7 @@ bash setup_node_deps.sh
 # build our css files
 bash build_css.sh
 
-cd $ROOT_DIR
+cd "$ROOT_DIR"
 # build/setup nim-based files
 bash ./non-nix-build/build_with_nim.sh
 
@@ -37,21 +37,23 @@ bash build_db_backend.sh
 #   src/build-debug!
 
 # setup/copy/link other files
-cp $ROOT_DIR/resources/electron $DIST_DIR/bin/
+cp "$ROOT_DIR"/resources/electron "$DIST_DIR"/bin/
 
 # The built-in macOS ruby binary is too old and has to be hacked around
-cp $(brew --prefix ruby)/bin/ruby $DIST_DIR/bin/ruby
+cp "$(brew --prefix ruby)/bin/ruby" "$DIST_DIR/bin/ruby"
 
-cp $(which ctags) $DIST_DIR/bin/ctags
-cp $ROOT_DIR/libs/codetracer-ruby-recorder/src/*.rb $DIST_DIR/src/
-cp $ROOT_DIR/src/helpers.js $DIST_DIR/src/helpers.js
-cp $ROOT_DIR/src/helpers.js $DIST_DIR/helpers.js
-cp $ROOT_DIR/src/frontend/*.html $DIST_DIR/src/
-cp $ROOT_DIR/src/frontend/*.html $DIST_DIR/
-rm -f $DIST_DIR/config
-rm -f $DIST_DIR/public
-cp -r $ROOT_DIR/src/config $DIST_DIR/config
-cp -r $ROOT_DIR/src/public $DIST_DIR/public
-cp $BIN_DIR/nargo $DIST_DIR/bin/
-cp $BIN_DIR/wazero $DIST_DIR/bin/
+cp "$(which ctags)" "$DIST_DIR"/bin/ctags
+cp "$ROOT_DIR"/libs/codetracer-ruby-recorder/src/*.rb "$DIST_DIR"/src/
+cp "$ROOT_DIR"/src/helpers.js "$DIST_DIR"/src/helpers.js
+cp "$ROOT_DIR"/src/helpers.js "$DIST_DIR"/helpers.js
+cp "$ROOT_DIR"/src/frontend/*.html "$DIST_DIR"/src/
+cp "$ROOT_DIR"/src/frontend/*.html "$DIST_DIR"/
+rm -f "$DIST_DIR"/config
+rm -f "$DIST_DIR"/public
+cp -r "$ROOT_DIR"/src/config "$DIST_DIR"/config
+cp -r "$ROOT_DIR"/src/public "$DIST_DIR"/public
+cp "$BIN_DIR"/nargo "$DIST_DIR"/bin/
+cp "$BIN_DIR"/wazero "$DIST_DIR"/bin/
 
+# Enable the installation prompt. Extra argument to be compatible with FreeBSD coreutils
+sed -i "" "s/skipInstall.*/skipInstall: false/g" "$DIST_DIR/config/default_config.yaml"

--- a/non-nix-build/build_mac_app.sh
+++ b/non-nix-build/build_mac_app.sh
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
+set -e
 
-cd $DIST_DIR
+cd "$DIST_DIR"
 
-mkdir -p $DIST_DIR/../Resources/
-iconutil -c icns $ROOT_DIR/resources/Icon.iconset --output $DIST_DIR/../Resources/CodeTracer.icns
-cp $ROOT_DIR/resources/Info.plist $DIST_DIR/..
+mkdir -p "$DIST_DIR"/../Resources/
+iconutil -c icns "$ROOT_DIR"/resources/Icon.iconset --output "$DIST_DIR"/../Resources/CodeTracer.icns
+cp "$ROOT_DIR"/resources/Info.plist "$DIST_DIR"/..
 
 # In the `public` folder, we have some symlinks to this awkwardly placed directory
-cd $DIST_DIR/..
+cd "$DIST_DIR"/..
 ln -s MacOS/node_modules ./
 
 # Hack because basically every OS-level string is labeled as Electron instead CodeTracer. Can be resolved by using a bundler
-cp $ROOT_DIR/resources/Info.plist "$(realpath MacOS/node_modules)"/electron/dist/Electron.app/Contents/Info.plist
-cp $DIST_DIR/../Resources/CodeTracer.icns "$(realpath MacOS/node_modules)"/electron/dist/Electron.app/Contents/Resources/
+cp "$ROOT_DIR"/resources/Info.plist "$(realpath MacOS/node_modules)"/electron/dist/Electron.app/Contents/Info.plist
+cp "$DIST_DIR"/../Resources/CodeTracer.icns "$(realpath MacOS/node_modules)"/electron/dist/Electron.app/Contents/Resources/
 
 # macOS uses core utils from FreeBSD so the additional "" is needed to execute this sed call.
 #

--- a/non-nix-build/build_with_nim.sh
+++ b/non-nix-build/build_with_nim.sh
@@ -28,7 +28,7 @@ nim -d:release \
     --boundChecks:on --stacktrace:on --linetrace:on \
     -d:chronicles_sinks=json -d:chronicles_line_numbers=true \
     -d:chronicles_timestamps=UnixTime \
-    -d:ctTest -d:ssl -d:testing --hint[XDeclaredButNotUsed]:off \
+    -d:ctTest -d:ssl -d:testing "--hint[XDeclaredButNotUsed]:off" \
     -d:libcPath=libc \
     -d:builtWithNix \
     -d:ctEntrypoint \
@@ -54,7 +54,7 @@ nim -d:release \
     --boundChecks:on --stacktrace:on --linetrace:on \
     -d:chronicles_sinks=json -d:chronicles_line_numbers=true \
     -d:chronicles_timestamps=UnixTime \
-    -d:ctTest -d:ssl -d:testing --hint[XDeclaredButNotUsed]:off \
+    -d:ctTest -d:ssl -d:testing "--hint[XDeclaredButNotUsed]:off" \
     -d:libcPath=libc \
     -d:builtWithNix \
     -d:ctEntrypoint \

--- a/non-nix-build/env.sh
+++ b/non-nix-build/env.sh
@@ -3,7 +3,7 @@
 set -e
 
 NON_NIX_BUILD_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
-cd $NON_NIX_BUILD_DIR
+cd "$NON_NIX_BUILD_DIR"
 
 export ROOT_DIR=$NON_NIX_BUILD_DIR/..
 
@@ -29,8 +29,8 @@ fi
 export platform
 export os
 
-: ${BIN_DIR:=$NON_NIX_BUILD_DIR/bin}
-: ${DEPS_DIR:=$NON_NIX_BUILD_DIR/deps}
+: "${BIN_DIR:="$NON_NIX_BUILD_DIR"/bin}"
+: "${DEPS_DIR:="$NON_NIX_BUILD_DIR"/deps}"
 
 echo "BIN_DIR" "${BIN_DIR}"
 echo "DEPS_DIR" "${DEPS_DIR}"
@@ -45,8 +45,8 @@ export DIST_DIR
 export RUSTUP_HOME=$DEPS_DIR/rustup
 export CARGO_HOME=$DEPS_DIR/cargo
 
-if [ ! -f $ROOT_DIR/ct_paths.json ]; then
-  echo "{\"PYTHONPATH\": \"\",\"LD_LIBRARY_PATH\":\"\"}" > $ROOT_DIR/ct_paths.json
+if [ ! -f "$ROOT_DIR"/ct_paths.json ]; then
+  echo "{\"PYTHONPATH\": \"\",\"LD_LIBRARY_PATH\":\"\"}" > "$ROOT_DIR"/ct_paths.json
 fi
 
 export PATH=$DEPS_DIR/nim/bin:$ROOT_DIR/node_modules/.bin:$BIN_DIR:$CARGO_HOME/bin:$ROOT_DIR/src/build-debug/bin:$PATH
@@ -66,7 +66,7 @@ else
   DEFAULT_DIST_DIR=$NON_NIX_BUILD_DIR/dist
 fi
 
-: ${DIST_DIR:=$DEFAULT_DIST_DIR}
+: "${DIST_DIR:=$DEFAULT_DIST_DIR}"
 
 pushd "$ROOT_DIR"
   [ ! -d node_modules ] && ln -s node-packages/node_modules ./

--- a/non-nix-build/install_nargo.sh
+++ b/non-nix-build/install_nargo.sh
@@ -9,7 +9,7 @@ else
   echo nargo is missing! building...
 fi
 
-: ${DEPS_DIR:=$PWD/deps}
+: "${DEPS_DIR:=$PWD/deps}"
 cd "$DEPS_DIR"
 
 out=$(PWD=$(realpath ../../) ../find_git_hash_from_lockfile.py noir)
@@ -19,12 +19,12 @@ folder="noir"
 
 mkdir ${folder} || echo "Folder already exists"
 cd "${folder}"
-if [ $(git rev-parse HEAD) != "${commit}" ]; then
+if [ "$(git rev-parse HEAD)" != "${commit}" ]; then
   cd ../
   rm -rf "${folder}"
   git clone "${repo}"
   cd "${folder}"
   git checkout "$commit"
   cargo build --release
-  cp ./target/release/nargo $BIN_DIR/
+  cp ./target/release/nargo "$BIN_DIR/"
 fi

--- a/non-nix-build/install_nim_osx.sh
+++ b/non-nix-build/install_nim_osx.sh
@@ -11,7 +11,7 @@ else
   echo nim is missing! installing...
 fi
 
-: ${DEPS_DIR:=$PWD/deps}
+: "${DEPS_DIR:=$PWD/deps}"
 cd "$DEPS_DIR"
 
 # based on https://forum.nim-lang.org/t/10373#69081: from Araq:

--- a/non-nix-build/install_rust.sh
+++ b/non-nix-build/install_rust.sh
@@ -16,11 +16,11 @@ else
   echo rust is missing! installing...
 fi
 
-: ${DEPS_DIR:=$PWD/deps}
+: "${DEPS_DIR:=$PWD/deps}"
 
 export RUSTUP_INIT_SKIP_PATH_CHECK=yes
 
 curl --proto '=https' --tlsv1.2 -sf https://sh.rustup.rs | sh -s -- --no-modify-path -y --default-toolchain nightly
 
-source $CARGO_HOME/env # adds rustc to our PATH
+source "$CARGO_HOME"/env # adds rustc to our PATH
 

--- a/non-nix-build/install_tup.sh
+++ b/non-nix-build/install_tup.sh
@@ -8,7 +8,7 @@ WANTED_TUP_VERSION=v0.8-8
 if command -v tup &> /dev/null; then
   TUP_VERSION=$(tup --version)
   if [ "$TUP_VERSION" == "tup $WANTED_TUP_VERSION-g$WANTED_TUP_REVISION" ]; then
-    echo $TUP_VERSION is already installed
+    echo "$TUP_VERSION" is already installed
     exit 0
   else
     echo "$TUP_VERSION present, but we need $WANTED_TUP_VERSION-$WANTED_TUP_REVISION! installing..."
@@ -18,12 +18,12 @@ else
 fi
 
 brew install pkg-config pcre2 macFUSE
-: ${DEPS_DIR:=$PWD/deps}
+: "${DEPS_DIR:=$PWD/deps}"
 cd "$DEPS_DIR"
 rm -rf tup
 git clone https://github.com/gittup/tup
 cd tup
 git checkout $WANTED_TUP_REVISION
 ./bootstrap.sh
-cp ./tup $BIN_DIR/
+cp ./tup "$BIN_DIR"/
 

--- a/non-nix-build/install_wazero.sh
+++ b/non-nix-build/install_wazero.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-: ${DEPS_DIR:=$PWD/deps}
+: "${DEPS_DIR:=$PWD/deps}"
 cd "$DEPS_DIR"
 
 out=$(PWD=$(realpath ../../) ../find_git_hash_from_lockfile.py wazero)
@@ -12,13 +12,13 @@ folder="codetracer-wasm-recorder"
 
 mkdir "${folder}" || echo "Folder already exists"
 cd "${folder}"
-if [ $(git rev-parse HEAD) != "${commit}" ]; then
+if [ "$(git rev-parse HEAD)" != "${commit}" ]; then
   cd ../
   rm -rf "${folder}"
   git clone "${repo}"
   cd "${folder}"
   git checkout "$commit"
   go build cmd/wazero/wazero.go
-  cp ./wazero $BIN_DIR/
+  cp ./wazero "$BIN_DIR/"
 fi
 

--- a/non-nix-build/setup_node_deps.sh
+++ b/non-nix-build/setup_node_deps.sh
@@ -8,17 +8,17 @@ echo "-----------"
 
 # setup node deps
 #   node modules and webpack/frontend_bundle.js
-pushd $ROOT_DIR/node-packages
+pushd "$ROOT_DIR"/node-packages
 echo y | npx yarn
 npx yarn add electron
 
-pushd $ROOT_DIR
+pushd "$ROOT_DIR"
 node_modules/.bin/webpack
 
-rm -rf $ROOT_DIR/node_modules
-rm -rf $DIST_DIR/node_modules
-ln -s $ROOT_DIR/node-packages/node_modules $ROOT_DIR/node_modules
-cp -r $ROOT_DIR/node-packages/node_modules $DIST_DIR/node_modules
+rm -rf "$ROOT_DIR"/node_modules
+rm -rf "$DIST_DIR"/node_modules
+ln -s "$ROOT_DIR"/node-packages/node_modules "$ROOT_DIR"/node_modules
+cp -r "$ROOT_DIR"/node-packages/node_modules "$DIST_DIR"/node_modules
 
 # => now we have node_modules, and $ROOT_DIR/src/public/dist/frontend_bundle.js
 # <=> $DIST_DIR/public/dist/frontend_bundle.js

--- a/src/common/config.nim
+++ b/src/common/config.nim
@@ -64,6 +64,7 @@ type
       ctPaths: "",
       debugInfoToolPath: ""
     ).}:                                                  RRBackendConfig
+    skipInstall:                                          bool
 
   Config* = ref ConfigObject
 

--- a/src/config/default_config.yaml
+++ b/src/config/default_config.yaml
@@ -54,7 +54,7 @@ theme: "default_dark"
 # project open
 default: ""
 
-# what command to use by default for build and update while editing
+# what commands to use by default for build and update while editing
 defaultBuild: ""
 
 # === editor/shortcut settings
@@ -116,6 +116,8 @@ rrBackend:
   path: ""
   ctPaths: ""
   debugInfoToolPath: ""
+
+skipInstall: true
 
 # TODO: Use this somehow
 version: "0.1alpha"

--- a/src/frontend/index.nim
+++ b/src/frontend/index.nim
@@ -29,7 +29,7 @@ var close = false
 proc showOpenDialog(dialog: JsObject, browserWindow: JsObject, options: JsObject): Future[JsObject] {.importjs: "#.showOpenDialog(#,#)".}
 proc loadExistingRecord(traceId: int) {.async.}
 proc prepareForLoadingTrace(traceId: int, pid: int) {.async.}
-proc isCtInstalled: bool
+proc isCtInstalled(config: Config): bool
 
 
 proc onClose(e: js) =
@@ -1340,7 +1340,8 @@ proc init(data: var ServerData, config: Config, layout: js, helpers: Helpers) {.
   # data.layout = layout
   # data.helpers = helpers
 
-  data.startOptions.isInstalled = isCtInstalled()
+  data.startOptions.isInstalled = isCtInstalled(data.config)
+  data.config.skipInstall = data.startOptions.isInstalled
 
   if data.startOptions.shellUi:
     await wait(1_000)
@@ -1450,29 +1451,22 @@ when not defined(ctRepl) and not defined(server):
 
 var process {.importc.}: js
 
-proc isCtInstalled: bool =
-  if process.platform == "darwin".toJs:
-    let ctLaunchersPath = cstring($paths.home / ".local" / "share" / "codetracer" / "shell-launchers" / "ct")
-    fs.existsSync(ctLaunchersPath)
+proc isCtInstalled(config: Config): bool =
+  if not config.skipInstall:
+    if process.platform == "darwin".toJs:
+      let ctLaunchersPath = cstring($paths.home / ".local" / "share" / "codetracer" / "shell-launchers" / "ct")
+      return fs.existsSync(ctLaunchersPath)
+    else:
+      let dataHome = getEnv("XDG_DATA_HOME", getEnv("HOME") / ".local/share")
+      let dataDirs = getEnv("XDG_DATA_DIRS", "/usr/local/share:/usr/share").split(':')
+
+      # if we find the desktop file then it's installed by the package manager automatically
+      for d in @[dataHome] & dataDirs:
+        if fs.existsSync(d / "applications/codetracer.desktop"):
+          return true
+      return false
   else:
-    let ctInstalledPath = cstring($paths.home / ".local" / "bin" / "ct")
-    let desktopFilePath = cstring($paths.home / ".local" / "share" / "applications" / "codetracer.desktop")
-
-    # var isDesktopOk : bool = false;
-    # if fs.existsSync(desktopFilePath):
-    #   echo desktopFilePath
-    #   let execField = extractExecCommandJs($desktopFilePath)
-    #   echo "Exec field: ", execField
-    #   if fs.existsSync(execField):
-    #     isDesktopOk = true;
-
-    fs.existsSync(ctInstalledPath) and fs.existsSync(desktopFilePath)
-
-
-proc hasUserConfigSetup: bool =
-  let userConfigFilePath = userConfigDir / configPath
-  fs.existsSync(userConfigFilePath)
-
+    return true
 
 proc waitForResponseFromInstall: Future[InstallResponse] {.async.} =
   return newPromise() do (resolve: proc(response: InstallResponse)):
@@ -1483,12 +1477,17 @@ proc ready {.async.} =
   # we configure the listeners
   configureIpcMain()
 
-  if not hasUserConfigSetup() and not isCtInstalled():
+  # we load the config file
+  var config = await mainWindow.loadConfig(data.startOptions, home=paths.home.cstring, send=true)
+
+  config.skipInstall = isCtInstalled(config)
+  if not config.skipInstall:
     installDialogWindow = createInstallSubwindow()
     discard await waitForResponseFromInstall()
 
   debugPrint "index: creating window"
   mainWindow = createMainWindow()
+
   when not defined(server):
     mainWindow.setMenuBarVisibility(false)
     mainWindow.setMenu(jsNull)
@@ -1525,9 +1524,6 @@ proc ready {.async.} =
       let serialized = JSON.stringify(response, replacer, 2.toJs)
       debugIndex fmt"frontend ... <=== index: {id}"  # TODO? too big: {serialized}"
       ipc.socket.emit(id, serialized)
-
-  # we load the config file
-  let config = await mainWindow.loadConfig(data.startOptions, home=paths.home.cstring, send=true)
 
   # we load the layout
   # let layout = if data.startOptions.inTest:

--- a/src/frontend/types.nim
+++ b/src/frontend/types.nim
@@ -1466,7 +1466,7 @@ type
 
   Config* = ref object
     # The config object is the schema for config yaml files
-    # keep it in sync with config_c.nim definition
+    # keep it in sync with common/config.nim definition
     theme*:                   cstring
     version*:                 cstring
     flow*:                    FlowConfigObjWrapper
@@ -1485,7 +1485,8 @@ type
     shortcutMap*:             ShortcutMap
     defaultBuild*:            cstring
     showMinimap*:             bool
-    traceSharing*:         TraceSharingConfigObj
+    traceSharing*:            TraceSharingConfigObj
+    skipInstall*:             bool
 
   BreakpointSave* = ref object of js
     # Serialized breakpoint

--- a/src/frontend/ui_js.nim
+++ b/src/frontend/ui_js.nim
@@ -626,7 +626,7 @@ proc onTraceLoaded(
   if data.startOptions.rawTestStrategy.len > 0:
     data.testRunner = cast[JsObject](runUiTest(data.startOptions.rawTestStrategy))
 
-  if not data.startOptions.isInstalled and not response.dontAskAgain:
+  if not data.startOptions.isInstalled and not response.dontAskAgain and not data.config.skipInstall:
     installMessage()
 
 

--- a/src/tests/.config.yaml
+++ b/src/tests/.config.yaml
@@ -117,5 +117,7 @@ rrBackend:
   ctPaths: ""
   debugInfoToolPath: ""
 
+skipInstall: true
+
 # TODO: Use this somehow
 version: "0.1alpha"


### PR DESCRIPTION
This PR fixes #80 by adding a `skipInstall` setting to the config file. This setting is used to enable/disable showing the installation menu when launching codetracer for the first time.

An algorithm for finding the desktop file was also added in order to skip installation for our distribution packages, including the nix package.

With this change the install menu will only show up for the AppImage and macOS application bundle, where it will really only show up for the AppImage if the AppImage is not distributed as a package by a third-party distribution already, because our packages automatically install the resource files in the required directories.

Tested on:

1. Linux
   - With tup
   - With nix
   - With the AppImage
1. macOS
