### PR TITLE
fix: try to report errors for `ct arb` in a better way

### DIFF
--- a/src/ct/codetracer.nim
+++ b/src/ct/codetracer.nim
@@ -17,6 +17,6 @@ try:
     customValidateConfig(conf)
     runInitial(conf)
 except Exception as ex:
-  errorPrint "Unhandled exception"
-  errorPrint getStackTrace(ex)
-  errorPrint "Unhandled " & ex.msg
+  echo "Error: Unhandled exception"
+  echo getStackTrace(ex)
+  echo "Unhandled " & ex.msg

--- a/src/ct/launch/launch.nim
+++ b/src/ct/launch/launch.nim
@@ -147,7 +147,9 @@ proc runInitial*(conf: CodetracerConf) =
       of ArbCommand.deploy:
         deployStylus()
       of ArbCommand.listRecentTx:
-        let res = Json.encode(getTrackableTransactions())
+        # discard getTrackableTransactions()
+        let transactions = getTrackableTransactions()
+        let res = Json.encode(transactions)
         echo res
     # of StartupCommand.host:
     #   host(

--- a/src/ct/stylus/arb_node_utils.nim
+++ b/src/ct/stylus/arb_node_utils.nim
@@ -135,5 +135,4 @@ proc getTrackableTransactions*(maxAge: int = 3600): seq[StylusTransaction] {.rai
       toAddress: tx["to"].getStr(),
       time: fromUnix(tx["timestamp"].getInt()).format("MM-dd hh:mm"),
     ))
-
   return result

--- a/src/frontend/trace_metadata.nim
+++ b/src/frontend/trace_metadata.nim
@@ -54,8 +54,13 @@ proc findRecentTransactions*(app: ElectronApp, limit: int): Future[seq[StylusTra
 
   if res.isOk:
     let raw = res.value
-    let traces = cast[seq[StylusTransaction]](JSON.parse(raw))
-    return traces
+    try:
+      let traces = cast[seq[StylusTransaction]](JSON.parse(raw))
+      return traces
+    except:
+      # assuming that json parse failed => assuming this is raw error output and output it
+      echo ""
+      echo "error: loading recent transactions problem: ", raw, " (or possibly invalid json)"
   else:
     echo "error: trying to run the codetracer arb listRecentTx command: ", res.error
     app.quit(1)


### PR DESCRIPTION
try to show in a better way the problem if no devnode / no connection for `ct arb explorer`, at least showing the underlying exception

for `ct arb deploy` @zah agreed on no rustup/cargo builtin and shelling out for now, if we have a good error; for now no cargo/rust seems to result in
```
Error: Unhandled exception
codetracer.nim:18        codetracer
launch.nim:148           runInitial
deploy.nim:105           deployStylus
deploy.nim:53            doDebugBuild
osproc.nim:1021          startProcess
osproc.nim:1131          startProcessAuxFork
oserr.nim:95             raiseOSError

Unhandled No such file or directory
Additional info: Could not find command: 'cargo'. OS error: No such file or directory
``` 

which does seem clear to me, maybe we can try to add additional context: in a future PR if needed 