### PR TITLE
feat: Stabilize extension components

### DIFF
--- a/src/db-backend/src/dap.rs
+++ b/src/db-backend/src/dap.rs
@@ -532,7 +532,7 @@ impl DapClient {
                 seq: self.next_seq(),
                 type_: "event".to_string(),
             },
-            event: "ct/updated-events_content".to_string(),
+            event: "ct/updated-events-content".to_string(),
             body: serde_json::to_value(contents)?,
         }))
     }

--- a/src/db-backend/src/dap.rs
+++ b/src/db-backend/src/dap.rs
@@ -1,4 +1,4 @@
-use crate::task::{self, TableUpdate};
+use crate::task::{self};
 use log::info;
 use serde::{de::DeserializeOwned, de::Error as SerdeError, Deserialize, Serialize};
 use serde_json::Value;

--- a/src/db-backend/src/dap_server.rs
+++ b/src/db-backend/src/dap_server.rs
@@ -152,6 +152,7 @@ fn handle_request<W: Write>(
         "threads" => handler.threads(req.clone())?,
         "stackTrace" => handler.stack_trace(req.clone(), req.load_args::<dap::StackTraceArguments>()?)?,
         "variables" => handler.variables(req.clone(), req.load_args::<dap::VariablesArguments>()?)?,
+        "restart" => handler.run_to_entry(Task {kind: TaskKind::RunToEntry, id: TaskId("run-to-entry-0".to_string())})?,
         "ct/load-locals" => handler.load_locals(req.clone(), req.load_args::<dap::CtLoadLocalsArguments>()?)?,
         "ct/update-table" => handler.update_table(req.clone(), req.load_args::<UpdateTableArgs>()?)?,
         "ct/event-load" => handler.event_load(req.clone())?,

--- a/src/db-backend/src/event_db.rs
+++ b/src/db-backend/src/event_db.rs
@@ -264,7 +264,7 @@ impl EventDb {
             // Table update without search
             if args.table_args.search.value.is_empty() {
                 let mut start = args.table_args.start;
-                if self.single_tables.len() > 0
+                if !self.single_tables.is_empty()
                     && self.single_tables[0].events.len() != self.global_table.len()
                     && args.table_args.start != 0
                 {

--- a/src/db-backend/src/handler.rs
+++ b/src/db-backend/src/handler.rs
@@ -647,11 +647,11 @@ impl Handler {
         self.event_db.register_events(DbEventKind::Record, &events, vec![-1]);
         self.event_db.refresh_global();
 
-        // let raw_event = self.dap_client.updated_events(first_events)?;
-        // self.send_dap(&raw_event)?;
+        let raw_event = self.dap_client.updated_events(first_events)?;
+        self.send_dap(&raw_event)?;
 
-        // let raw_event_content = self.dap_client.updated_events_content(contents)?;
-        // self.send_dap(&raw_event_content)?;
+        let raw_event_content = self.dap_client.updated_events_content(contents)?;
+        self.send_dap(&raw_event_content)?;
 
         Ok(())
     }

--- a/src/db-backend/src/handler.rs
+++ b/src/db-backend/src/handler.rs
@@ -1237,8 +1237,8 @@ impl Handler {
         Ok(())
     }
 
-    pub fn update_table(&mut self, req: dap::Request, args: UpdateTableArgs) -> Result<(), Box<dyn Error>> {
-        let (table_update, trace_values_option) = self.event_db.update_table(args)?;
+    pub fn update_table(&mut self, _req: dap::Request, args: UpdateTableArgs) -> Result<(), Box<dyn Error>> {
+        let (table_update, _trace_values_option) = self.event_db.update_table(args)?;
         // TODO: For now no trace values are available
         // if let Some(trace_values) = trace_values_option {
         //     self.send_event((
@@ -1358,7 +1358,7 @@ impl Handler {
         msg: &str,
         is_operation_status: bool,
     ) -> Result<(), Box<dyn Error>> {
-        let notification = Notification::new(kind, msg, is_operation_status);
+        let _notification = Notification::new(kind, msg, is_operation_status);
         // TODO: Fix using dap protocol
         // self.send_event((
         //     EventKind::NewNotification,

--- a/src/db-backend/src/handler.rs
+++ b/src/db-backend/src/handler.rs
@@ -1612,10 +1612,7 @@ mod tests {
         let db = setup_db();
         let (sender_tx, _receiver_rx) = mpsc::channel();
         let mut handler: Handler = Handler::new(Box::new(db), sender_tx.clone());
-        handler.event_load(Task {
-            kind: TaskKind::EventLoad,
-            id: TaskId("0".to_string()),
-        })?;
+        handler.event_load(dap::Request::default())?;
         handler.run_tracepoints(
             make_tracepoints_args(1, 0),
             Task {
@@ -1633,10 +1630,7 @@ mod tests {
         let db = setup_db();
         let (sender_tx, _receiver_rx) = mpsc::channel();
         let mut handler: Handler = Handler::new(Box::new(db), sender_tx.clone());
-        handler.event_load(Task {
-            kind: TaskKind::EventLoad,
-            id: TaskId("0".to_string()),
-        })?;
+        handler.event_load(dap::Request::default())?;
         // TODO
         // this way we are resetting them after reforms
         // needs to pass multiple tracepoints at once now
@@ -1681,10 +1675,7 @@ mod tests {
         let db: Db = setup_db();
         let (sender_tx, _receiver_rx) = mpsc::channel();
         let mut handler: Handler = Handler::new(Box::new(db), sender_tx.clone());
-        handler.event_load(Task {
-            kind: TaskKind::EventLoad,
-            id: TaskId("0".to_string()),
-        })?;
+        handler.event_load(dap::Request::default())?;
         handler.run_tracepoints(
             make_multiple_tracepoints_with_multiline_logs(3, size),
             Task {
@@ -1715,10 +1706,7 @@ mod tests {
         let db: Db = setup_db_loop(size);
         let (sender_tx, _receiver_rx) = mpsc::channel();
         let mut handler: Handler = Handler::new(Box::new(db), sender_tx.clone());
-        handler.event_load(Task {
-            kind: TaskKind::EventLoad,
-            id: TaskId("0".to_string()),
-        })?;
+        handler.event_load(dap::Request::default())?;
         handler.run_tracepoints(
             make_tracepoints_args(2, 0),
             Task {
@@ -1739,10 +1727,7 @@ mod tests {
         let db: Db = setup_db_with_step_count(count);
         let (sender_tx, _receiver_rx) = mpsc::channel();
         let mut handler: Handler = Handler::new(Box::new(db), sender_tx.clone());
-        handler.event_load(Task {
-            kind: TaskKind::EventLoad,
-            id: TaskId("0".to_string()),
-        })?;
+        handler.event_load(dap::Request::default())?;
         handler.run_tracepoints(
             make_tracepoints_with_count(count),
             Task {
@@ -1780,34 +1765,25 @@ mod tests {
             line: 3,
         };
         handler.source_line_jump(
-            source_location,
-            Task {
-                kind: TaskKind::SourceLineJump,
-                id: TaskId("0".to_string()),
-            },
+            dap::Request::default(),
+            source_location
         )?;
         assert_eq!(handler.step_id, StepId(2));
         handler.source_line_jump(
+            dap::Request::default(),
             SourceLocation {
                 path: path.to_string(),
                 line: 2,
-            },
-            Task {
-                kind: TaskKind::SourceLineJump,
-                id: TaskId("1".to_string()),
-            },
+            }
         )?;
         assert_eq!(handler.step_id, StepId(1));
         handler.source_call_jump(
+            dap::Request::default(),
             SourceCallJumpTarget {
                 path: "/test/workdir".to_string(),
                 line: 1,
                 token: "<top-level>".to_string(),
-            },
-            Task {
-                kind: TaskKind::SourceCallJump,
-                id: TaskId("0".to_string()),
-            },
+            }
         )?;
         assert_eq!(handler.step_id, StepId(0));
         Ok(())
@@ -1872,7 +1848,7 @@ mod tests {
 
     fn test_load_flow(handler: &mut Handler, _path: &PathBuf) {
         handler
-            .load_flow(handler.load_location(handler.step_id), gen_task(TaskKind::LoadFlow))
+            .load_flow(dap::Request::default(), handler.load_location(handler.step_id))
             .unwrap();
     }
 

--- a/src/frontend/types.nim
+++ b/src/frontend/types.nim
@@ -620,6 +620,7 @@ type
     isTooltipValue*:     bool
     isScratchpadValue*:  bool
     isOperationRunning*: bool
+    historyScrollTop*:   int
 
   ScratchpadComponent* = ref object of Component
     i*:             int

--- a/src/frontend/ui/calltrace.nim
+++ b/src/frontend/ui/calltrace.nim
@@ -451,7 +451,7 @@ proc searchResultView(self: CalltraceComponent, call: Call): VNode =
   buildHtml(
     tdiv(
       class = "search-result",
-      onclick = proc =
+      onmousedown = proc =
         self.calltraceJump(location)
         self.redrawForExtension()
     )
@@ -765,7 +765,7 @@ proc localCalltraceView*(self: CalltraceComponent): VNode =
 proc registerSearchRes(self: CalltraceComponent, searchResults: seq[Call]) =
   self.searchResults = searchResults
   self.isSearching = true
-  self.data.redraw()
+  self.redrawForExtension()
 
 
   self.lastSearch = now()

--- a/src/frontend/ui/state.nim
+++ b/src/frontend/ui/state.nim
@@ -88,7 +88,8 @@ method register*(self: StateComponent, api: MediatorWithSubscribers) =
   # api.subscribe(DapStopped, proc(kind: CtEventKind, response: DapStoppedEvent, sub: Subscriber) =
     # discard self.onMove())
   api.subscribe(CtCompleteMove, proc(kind: CtEventKind, response: MoveState, sub: Subscriber) =
-    discard self.onMove())
+    discard self.onCompleteMove(response)
+  )
   api.subscribe(CtLoadLocalsResponse, proc(kind: CtEventKind, response: CtLoadLocalsResponseBody, sub: Subscriber) =
     self.registerLocals(response)
   )
@@ -153,12 +154,12 @@ method render*(self: StateComponent): VNode =
         onclick = proc(ev: Event, tg: VNode) =
           self.chevronClicked = false
           ev.preventDefault(),
-        onmousemove = proc(ev: Event, tg:VNode) =
-          if self.chevronClicked:
-            resizeColumns(ev,tg),
-        onmousedown = proc(ev: Event, tg:VNode) =
-          if self.chevronClicked:
-            initialPosition = cast[MouseEvent](ev).screenX.toJs.to(float), 
+        # onmousemove = proc(ev: Event, tg:VNode) =
+        #   if self.chevronClicked:
+        #     resizeColumns(ev,tg),
+        # onmousedown = proc(ev: Event, tg:VNode) =
+        #   if self.chevronClicked:
+        #     initialPosition = cast[MouseEvent](ev).screenX.toJs.to(float), 
         onmouseup = proc =
           self.chevronClicked = false,
         onmouseleave = proc = self.chevronClicked = false
@@ -260,4 +261,6 @@ proc excerpt(self: StateComponent): VNode =
   
 method onCompleteMove*(self: StateComponent, response: MoveState) {.async.} =
   self.location = response.location
+  for value in self.values:
+    value.location = response.location
   await self.onMove()

--- a/src/frontend/ui/terminal_output.nim
+++ b/src/frontend/ui/terminal_output.nim
@@ -17,7 +17,6 @@ proc ensureLine(self: TerminalOutputComponent) =
 proc appendToTerminalLine(self: TerminalOutputComponent, text: cstring, eventIndex: int) =
   self.ensureLine()
   var lineTerminalEvents = self.cachedLines[self.currentLine]
-  echo "#### GOING THROUGH THE APPEND TO TERMINAL = ", text
 
   lineTerminalEvents.add(TerminalEvent(
     text: text,


### PR DESCRIPTION
Things that are fixed for the dap support and extension support:

- Value history and value history jump
- Value history scroll position and onWheel event listener
- Event log redraw on start when CtUpdatedEvents has been received
- Add terminal jump and initialUpdate on CtUpdatedEvents for the terminal output component
- Add support for vscode "restart" message so it doesn't hang
- Fix calltrace search handling and call jump from the results