### PR TITLE
fix: sending events from `ct record` to ci service directly

### DIFF
--- a/nix/shells/main.nix
+++ b/nix/shells/main.nix
@@ -92,7 +92,7 @@ mkShell {
       # zip
       # unzip
       libzip
-      # curl
+      curl
 
       # for pgrep at least
       procps
@@ -234,6 +234,8 @@ mkShell {
     [ ! -f links/wazero ] && ln -s ${ourPkgs.wazero.outPath}/bin/wazero links/wazero
     [ ! -f links/electron ] && ln -s ${electron_33.outPath}/bin/electron links/electron
     [ ! -f links/ctags ] && ln -s ${universal-ctags.outPath}/bin/ctags links/ctags
+    [ ! -f links/curl ] && ln -s ${curl.outPath}/bin/curl links/curl
+
     # TODO: try to add an option to link to libs/upstream-nim, libs/rr
     #   for faster iteration when patching them as Zahary suggested?
     [ ! -f links/upstream-nim ] && ln -s ${ourPkgs.upstream-nim-codetracer.outPath}/bin/nim links/upstream-nim

--- a/src/Tupfile
+++ b/src/Tupfile
@@ -29,7 +29,7 @@ include_rules
 : links/electron |> !tup_preserve |> bin/electron
 # : links/unzip |> !tup_preserve |> bin/unzip
 # : links/zip |> !tup_preserve |> bin/zip
-# : links/curl |> !tup_preserve |> bin/curl
+: links/curl |> !tup_preserve |> bin/curl
 : foreach *.json *.yaml   |> !tup_preserve |>
 : frontend/index.html |> !tup_preserve |> index.html
 : frontend/subwindow.html |> !tup_preserve |> subwindow.html

--- a/src/ct/codetracerconf.nim
+++ b/src/ct/codetracerconf.nim
@@ -220,6 +220,19 @@ type
         desc: "Path to a stylus emv trace json file"
       .} : string
 
+      recordAddress* {.
+        name: "address"
+        abbr: "a"
+        defaultValue: ""
+        desc: "Address when we are recording in ci mode/environment"
+      .}: string
+
+      recordSocket* {.
+        name: "socket"
+        defaultValue: ""
+        desc: "Path to socket for sending the trace events metadata when in ci mode/environment"
+      .}: string
+
       recordProgram* {.
         argument
         desc: "Program to record"

--- a/src/ct/launch/launch.nim
+++ b/src/ct/launch/launch.nim
@@ -127,6 +127,7 @@ proc runInitial*(conf: CodetracerConf) =
       discard record(
         conf.recordLang, conf.recordOutputFolder,
         conf.recordExportFile, conf.recordLang, conf.recordStylusTrace,
+        conf.recordAddress, conf.recordSocket,
         conf.recordProgram, conf.recordArgs)
     of StartupCommand.run:
       run(conf.runTracePathOrId, conf.runArgs)

--- a/src/ct/stylus/record.nim
+++ b/src/ct/stylus/record.nim
@@ -48,7 +48,7 @@ proc recordStylus*(hash: string): Trace {.raises: [IOError, ValueError, OSError,
 
   echo "WASM with debug info: ", wasm, " EVM trace: ", evmTrace
 
-  result = record("", ".", "", "", evmTrace, wasm, @[])
+  result = record("", ".", "", "", evmTrace, "", "", wasm, @[])
   updateField(result.id, "program", hash, false)
   result.program = hash
 

--- a/src/ct/trace/record.nim
+++ b/src/ct/trace/record.nim
@@ -18,8 +18,8 @@ proc recordInternal(exe: string, args: seq[string], configPath: string): Trace =
     options = {poStdErrToStdOut})
 
   let (lines, exCode) = p.readLines
-  echo args
-  echo exCode
+  # echo args
+  # echo exCode
   for line in lines:
     echo line
 
@@ -34,6 +34,8 @@ proc record*(lang: string,
              backend: string,
              exportFile: string,
              stylusTrace: string,
+             address: string,
+             socketPath: string,
              program: string,
              args: seq[string]): Trace =
   let detectedLang = detectLang(program, toLang(lang))
@@ -50,6 +52,12 @@ proc record*(lang: string,
   if stylusTrace != "":
     pargs.add("--stylus-trace")
     pargs.add(stylusTrace)
+  if address != "":
+    pargs.add("--address")
+    pargs.add(address)
+  if socketPath != "":
+    pargs.add("--socket")
+    pargs.add(socketPath)
 
   pargs.add(program)
   if args.len != 0:

--- a/src/ct/trace/run.nim
+++ b/src/ct/trace/run.nim
@@ -39,6 +39,8 @@ proc runWithRestart(
                              backend="",
                              exportFile="",
                              stylusTrace="",
+                             address="",
+                             socketPath="",
                              program=recordArgs[0],
                              args=recordArgs[1..^1])
     if not recordedTrace.isNil:


### PR DESCRIPTION
fixes #290

new `ct record` parameters: `-a/--address=<address>` and `--socket=<socket-path>` env vars (they were already existing and mostly functional): `CODETRACER_SHELL_ADDRESS`, `CODETRACER_SHELL_SOCKET`

we've mostly had this working in the past: `ct shell` was already sending those events with `ct record` internally, but now we want to directly support setting `ct record` to do it.

Actually, we also do have already env vars for that: `CODETRACER_SHELL_SOCKET` and `CODETRACER_SHELL_ADDRESS`, so this was also ready, but still we are adding the params(Nikola prefers env to make ct record calling in ci scripts easier though). For now they have higher priority than the env vars. (For now keeping them with those names for compatibility with `ct shell`, but we can rename the env vars if needed: `ct shell`, even if restored is not stable at all)

However we have removed the actual sendEvent code from the open sourced repo, so we are now just copy pasting it back from the rr-backend internal closed source repo.

We are again adding `curl` as a runtime dependency so this can work; it should work for the dev build;
however for the other builds (non-dev) this might need further work: TODO

another option is to make it optional and load `curl` from the environment if available.