### PR TITLE
ci/deploy/docs.sh: Fix failing deploy when worktree exists in git but...

### DIFF
--- a/ci/deploy/docs.sh
+++ b/ci/deploy/docs.sh
@@ -10,7 +10,11 @@ pushd docs/book/
 # for now depending on global project devshell 
 mdbook build # build output is in the `book` directory
 
-# If the worktree already exists at the given location it should be removed first
+# Prune any stale worktrees that no longer exist on disk
+git worktree prune
+
+# If the worktree directory still exists, remove it.
+# This handles the case where a previous run failed after creating the worktree.
 if [ -d "gh-pages" ]; then
     git worktree remove gh-pages
 fi


### PR DESCRIPTION
… not as a folder

Here's how to reproduce the error that we were getting in the CI. The following script would have failed before the change in this commit:

```sh
#!/usr/bin/env bash

# This script reproduces a CI error related to git worktrees.
# The error is: "fatal: 'docs/book/gh-pages' is a missing but already registered worktree"

set -e

echo "--- Setting up reproduction environment in docs/book/ ---"

# Navigate to the book directory where the CI script runs
if [ ! -d "docs/book" ]; then
    echo "Error: docs/book directory not found. Are you in the project root?"
    exit 1
fi
pushd docs/book/ > /dev/null

# --- Cleanup from previous runs of this script ---
echo "Cleaning up any previous state..."
# Use prune to remove stale worktrees, which is the core of the problem
git worktree prune &> /dev/null
# Remove the branch if it exists
if git show-ref --verify --quiet refs/heads/gh-pages; then
    git branch -D gh-pages
fi
if git show-ref --verify --quiet refs/heads/reproduce-bug-branch; then
    git branch -D reproduce-bug-branch
fi
# Remove the directory if it exists for some reason
if [ -d "gh-pages" ]; then
    rm -rf gh-pages
fi
echo "Cleanup complete."

# --- Create the inconsistent state ---
echo "Simulating the scenario that causes the error..."

# 1. Create a temporary branch and a worktree from it.
echo "1. Creating a temporary worktree named 'gh-pages'..."
git branch -f reproduce-bug-branch
git worktree add gh-pages reproduce-bug-branch

# 2. Remove the worktree's directory without telling git.
# This is what creates the "missing but already registered" state.
echo "2. Deleting the worktree directory ('gh-pages') without 'git worktree remove'..."
rm -rf gh-pages
echo "Inconsistent state created."

# --- Trigger the error ---
echo ""
echo "--- Attempting to reproduce the error ---"
echo "Running the command from the CI script that fails:"
echo "> git worktree add --orphan -B gh-pages gh-pages"
echo ""

# This command is expected to fail with the fatal error.
# The check `if [ -d "gh-pages" ]` in the CI script does not catch this
# because the directory is missing.
#git worktree add --orphan -B gh-pages gh-pages
popd > /dev/null
./ci/deploy/docs.sh

# This part will not be reached if the error is reproduced.
echo "If you see this, the error was NOT reproduced."
```