### PR TITLE
feat: binary trace format "version 1", based on CBOR and Zstd seekable compression

### DIFF
--- a/appimage-scripts/build_with_nim.sh
+++ b/appimage-scripts/build_with_nim.sh
@@ -15,6 +15,9 @@ pushd "$ROOT_PATH"
 echo "links path const:"
 echo "${APP_DIR}"
 
+
+    # --passL:"${APP_DIR}/lib/libsqlite3.so.0" \
+
 # codetracer
 nim -d:release \
     --d:asyncBackend=asyncdispatch \
@@ -25,7 +28,7 @@ nim -d:release \
     --dynlibOverride:"libzip" \
     --dynlibOverride:"libcrypto" \
     --dynlibOverride:"libssl" \
-    --passL:"${APP_DIR}/lib/libsqlite3.so.0" \
+    --passL:"-Wl,-Bstatic -lsqlite3 -Wl,-Bdynamic" \
     --passL:"${APP_DIR}/lib/libpcre.so.1" \
     --passL:"${APP_DIR}/lib/libzip.so.5" \
     --passL:"${APP_DIR}/lib/libcrypto.so" \
@@ -59,10 +62,11 @@ nim \
     -d:libcPath=libc \
     -d:builtWithNix \
     -d:ctEntrypoint \
+    --dynlibOverride:"libsqlite3" \
     --dynlibOverride:"sqlite3" \
     --dynlibOverride:"pcre" \
     --dynlibOverride:"libzip" \
-    --passL:"${APP_DIR}/lib/libsqlite3.so.0" \
+    --passL:"-Wl,-Bstatic -lsqlite3 -Wl,-Bdynamic" \
     --passL:"${APP_DIR}/lib/libpcre.so.1" \
     --passL:"${APP_DIR}/lib/libzip.so.5" \
     --nimcache:nimcache \

--- a/flake.lock
+++ b/flake.lock
@@ -1387,11 +1387,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1735471104,
-        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
+        "lastModified": 1753549186,
+        "narHash": "sha256-Znl7rzuxKg/Mdm6AhimcKynM7V3YeNDIcLjBuoBcmNs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
+        "rev": "17f6bd177404d6d43017595c5264756764444ab8",
         "type": "github"
       },
       "original": {

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -103,7 +103,8 @@
           paths = [
             pkgs.which
 
-            pkgs.nodejs-18_x
+            # pkgs.nodejs-18_x
+            pkgs.nodejs_20
             pkgs.nodePackages.npm
             pkgs.nodePackages.webpack-cli
             pkgs.bashInteractive
@@ -308,7 +309,7 @@
             codetracer-electron
             node-modules-derivation
             stdenv.cc
-            pkgs.electron_33
+            pkgs.electron
             pkgs.ruby
             indexJavascript
             uiJavascript
@@ -366,7 +367,7 @@
             project =
               pkgs.callPackage ../../node-packages/yarn-project.nix
                 {
-                  nodejs = pkgs.nodejs-18_x;
+                  nodejs = pkgs.nodejs_20;
                 }
                 {
                   src = ../../node-packages;
@@ -406,7 +407,8 @@
           inherit src;
 
           nativeBuildInputs = [
-            pkgs.nodejs-18_x
+            # pkgs.nodejs-18_x
+            pkgs.nodejs_20
             node-modules-derivation
           ];
 

--- a/nix/shells/main.nix
+++ b/nix/shells/main.nix
@@ -37,7 +37,7 @@ mkShell {
       electron
 
       # node and build tools
-      nodejs-18_x
+      nodejs_22
       nodePackages.webpack-cli
       corepack
 
@@ -227,7 +227,7 @@ mkShell {
 
     [ ! -f links/which ] && ln -s ${which.outPath}/bin/which links/which
     [ ! -f links/bash ] && ln -s ${bash.outPath}/bin/bash links/bash
-    [ ! -f links/node ] && ln -s ${nodejs-18_x.outPath}/bin/node links/node
+    [ ! -f links/node ] && ln -s ${nodejs_22.outPath}/bin/node links/node
     [ ! -f links/cmp ] && ln -s ${diffutils.outPath}/bin/cmp links/cmp
     [ ! -f links/ruby ] && ln -s ${ruby.outPath}/bin/ruby links/ruby
     [ ! -f links/nargo ] && ln -s ${ourPkgs.noir.outPath}/bin/nargo links/nargo

--- a/nix/shells/main.nix
+++ b/nix/shells/main.nix
@@ -34,7 +34,7 @@ mkShell {
       gcc
       binutils
 
-      electron_33
+      electron
 
       # node and build tools
       nodejs-18_x
@@ -232,7 +232,7 @@ mkShell {
     [ ! -f links/ruby ] && ln -s ${ruby.outPath}/bin/ruby links/ruby
     [ ! -f links/nargo ] && ln -s ${ourPkgs.noir.outPath}/bin/nargo links/nargo
     [ ! -f links/wazero ] && ln -s ${ourPkgs.wazero.outPath}/bin/wazero links/wazero
-    [ ! -f links/electron ] && ln -s ${electron_33.outPath}/bin/electron links/electron
+    [ ! -f links/electron ] && ln -s ${electron.outPath}/bin/electron links/electron
     [ ! -f links/ctags ] && ln -s ${universal-ctags.outPath}/bin/ctags links/ctags
     # TODO: try to add an option to link to libs/upstream-nim, libs/rr
     #   for faster iteration when patching them as Zahary suggested?

--- a/src/db-backend/Cargo.lock
+++ b/src/db-backend/Cargo.lock
@@ -134,11 +134,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbor4ii"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189a2a2e5eec2f203b2bb8bc4c2db55c7253770d2c6bf3ae5f79ace5a15c305f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -252,6 +263,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fscommon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "315ce685aca5ddcc5a3e7e436ef47d4a5d0064462849b6f0f628c28140103531"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +367,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +454,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom",
+ "libc",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,7 +507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
@@ -565,6 +607,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +644,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "redox_syscall"
@@ -637,18 +691,21 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "runtime_tracing"
-version = "0.12.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39742b6740382f844a1326d86f0840d8b14353a0b1c6ca4692e32c7d27ae4ee3"
+checksum = "bb39bbb7e2fe3f83c9020a2f871e7affd293e1ef5cc2f1c137012d9931611db6"
 dependencies = [
  "base64",
  "capnp",
  "capnpc",
+ "cbor4ii",
+ "fscommon",
  "num-derive",
  "num-traits",
  "serde",
  "serde_json",
  "serde_repr",
+ "zeekstd",
 ]
 
 [[package]]
@@ -878,6 +935,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,3 +1024,40 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "zeekstd"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ee50810d0fa308a167f17f08243378b36f0d9fd5e43e95c4943a1e51b7b8a5"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/src/db-backend/Cargo.toml
+++ b/src/db-backend/Cargo.toml
@@ -30,7 +30,7 @@ tokio = {version = "1.37.0", features=["full", "rt", "net", "signal"]}
 futures = "0.3.30"
 futures-timer = "3.0.3"
 clap = { version = "4.5.4", features = ["derive"] }
-runtime_tracing = "0.12.2" # { git = "https://github.com/metacraft-labs/runtime_tracing.git", branch = "feat-add-evm-event" }
+runtime_tracing = "0.14.0" # { git = "https://github.com/metacraft-labs/runtime_tracing.git", branch = "feat-add-evm-event" }
 tree-sitter-tracepoint = { path = "./tree-sitter-trace/" }
 num-bigint = "0.4.6"
 

--- a/src/db-backend/src/handler.rs
+++ b/src/db-backend/src/handler.rs
@@ -1405,8 +1405,7 @@ mod tests {
     // use futures::stream::Iter;
     use lang::Lang;
     use runtime_tracing::{
-        CallRecord, FieldTypeRecord, FunctionId, FunctionRecord, StepId, StepRecord, TraceLowLevelEvent, TraceMetadata,
-        Tracer, TypeId, TypeKind, TypeRecord, TypeSpecificInfo, ValueRecord, NONE_VALUE,
+        CallRecord, FieldTypeRecord, FunctionId, FunctionRecord, NonStreamingTraceWriter, StepId, StepRecord, TraceLowLevelEvent, TraceMetadata, TraceWriter, TypeId, TypeKind, TypeRecord, TypeSpecificInfo, ValueRecord, NONE_VALUE
     };
 
     use task::{TaskId, TaskKind, TraceSession, Tracepoint, TracepointMode};
@@ -1818,7 +1817,7 @@ mod tests {
 
     fn setup_db_with_calls() -> Db {
         // TODO: maybe source from a real program trace?
-        let mut tracer = Tracer::new("example.small", &[]);
+        let mut tracer = NonStreamingTraceWriter::new("example.small", &[]);
         let path = &PathBuf::from("/test/workdir/example.small");
         tracer.start(path, Line(1));
         tracer.register_step(path, Line(1));

--- a/src/db-backend/src/trace_processor.rs
+++ b/src/db-backend/src/trace_processor.rs
@@ -417,10 +417,9 @@ impl<'a> TraceProcessor<'a> {
 
 #[allow(clippy::panic)]
 pub fn load_trace_data(trace_file: &Path, file_format: runtime_tracing::TraceEventsFileFormat) -> Result<Vec<TraceLowLevelEvent>, Box<dyn Error>> {
-    let mut tracer = runtime_tracing::Tracer::new("", &[]);
-    tracer.load_trace_events(trace_file, file_format)?;
-
-    Ok(tracer.events)
+    let mut trace_reader = runtime_tracing::create_trace_reader(file_format);
+    let trace_events = trace_reader.load_trace_events(trace_file)?;
+    Ok(trace_events)
 }
 
 #[allow(clippy::panic)]


### PR DESCRIPTION
This brings support for the new "version 1" of the binary trace format, which is based on CBOR + Zstd compression. All the previous formats (binary "version 0", based on capnproto, and the JSON format) are still supported and should continue to work seamlessly. In the case of binary, the exact version of the format is detected from the file header.