### PR TITLE
Fix: Regressions for electron client after DAP integration

### DIFF
--- a/src/common/ct_event.nim
+++ b/src/common/ct_event.nim
@@ -63,7 +63,7 @@ type
     CtSetupTraceSession,
     InternalLastCompleteMove,
     InternalAddToScratchpad,
-    InternalAddToScratchpadWithExpression,
+    InternalAddToScratchpadFromExpression,
     InternalStatusUpdate,
     InternalNewOperation,
     

--- a/src/frontend/dap.nim
+++ b/src/frontend/dap.nim
@@ -103,7 +103,7 @@ const EVENT_KIND_TO_DAP_MAPPING: array[CtEventKind, cstring] = [
   CtSetupTraceSession: "ct/setup-trace-session",
   InternalLastCompleteMove: "internal/last-complete-move",
   InternalAddToScratchpad: "",
-  InternalAddToScratchpadWithExpression: "",
+  InternalAddToScratchpadFromExpression: "",
   InternalStatusUpdate: "",
   InternalNewOperation: "",
 ]

--- a/src/frontend/event_helpers.nim
+++ b/src/frontend/event_helpers.nim
@@ -12,4 +12,4 @@ proc ctSourceLineJump*(dap: DapApi, line: int, path: cstring, behaviour: JumpBeh
     dap.sendCtRequest(CtSourceLineJump, target.toJs)
 
 proc ctAddToScratchpad*(viewsApi: MediatorWithSubscribers, expression: cstring) {.exportc.} =
-    viewsApi.emit(InternalAddToScratchpadWithExpression, expression.toJs)
+    viewsApi.emit(InternalAddToScratchpadFromExpression, expression)

--- a/src/frontend/middleware.nim
+++ b/src/frontend/middleware.nim
@@ -72,7 +72,7 @@ proc setupMiddlewareApis*(dapApi: DapApi, viewsApi: MediatorWithSubscribers) {.e
     #     dapApi.completeMoveFunction(dapApi.editor, value, dapApi)
     # )
   viewsApi.subscribe(InternalAddToScratchpad, proc(kind: CtEventKind, value: ValueWithExpression, sub: Subscriber) = viewsApi.emit(InternalAddToScratchpad, value))
-  viewsApi.subscribe(InternalAddToScratchpadWithExpression, proc(kind: CtEventKind, value: cstring, sub: Subscriber) = viewsApi.emit(InternalAddToScratchpadWithExpression, value))
+  viewsApi.subscribe(InternalAddToScratchpadFromExpression, proc(kind: CtEventKind, value: cstring, sub: Subscriber) = viewsApi.emit(InternalAddToScratchpadFromExpression, value))
 
   when not defined(ctInExtension):
     dapApi.on(DapInitialized, proc(kind: CtEventKind, value: JsObject) = dapInitializationHandler())

--- a/src/frontend/types.nim
+++ b/src/frontend/types.nim
@@ -1669,7 +1669,7 @@ when defined(ctRenderer):
     else:
       component.data = data
       component.content = content
-      if not data.viewsApi.isNil:
+      if not data.viewsApi.isNil and component.api.isNil:
         let componentToMiddlewareApi = setupLocalViewToMiddlewareApi(cstring(fmt"{content} #{component.id} api"), data.viewsApi)
         component.register(componentToMiddlewareApi)
       echo "register component ", content, " ", component.id
@@ -1875,7 +1875,8 @@ method redrawForExtension*(self: Component) {.base.} =
     self.kxi.redraw()
 
 method redrawForSinglePage*(self: Component) {.base.} =
-  discard
+  if not self.kxi.isNil:
+    self.kxi.redraw()
 
 method redraw*(self: Component) {.base.} =
   if self.inExtension:

--- a/src/frontend/ui/calltrace.nim
+++ b/src/frontend/ui/calltrace.nim
@@ -904,18 +904,18 @@ proc eventuallyScroll(self: CalltraceComponent) =
 proc setCalltraceMutationObserver(self: CalltraceComponent) =
   let calltrace = "\"" & fmt"calltrace-data-label-{self.id}" & "\""
   let activeCalltrace = jq(fmt"[data-label={calltrace}]")
-
-  self.resizeObserver = createResizeObserver(proc(entries: seq[Element]) =
-    for entry in entries:
-      let timeout = setTimeout(proc =
-        self.startPositionX = -1
-        let index = self.scrollLineIndex()
-        self.startCallLineIndex = index
-        self.loadLines(fromScroll=false),
-        100
+  if not activeCalltrace.isNil:
+    self.resizeObserver = createResizeObserver(proc(entries: seq[Element]) =
+      for entry in entries:
+        let timeout = setTimeout(proc =
+          self.startPositionX = -1
+          let index = self.scrollLineIndex()
+          self.startCallLineIndex = index
+          self.loadLines(fromScroll=false),
+          100
+        )
       )
-    )
-  self.resizeObserver.observe(cast[Node](activeCalltrace))
+    self.resizeObserver.observe(cast[Node](activeCalltrace))
 
 proc redrawTraceLine(self: CalltraceComponent) =
   let localCalltraceElement = document.querySelector(".local-calltrace")

--- a/src/frontend/ui/flow.nim
+++ b/src/frontend/ui/flow.nim
@@ -1169,6 +1169,7 @@ proc createContextMenuItems(self: FlowComponent, name: cstring, beforeValue: Val
 proc ensureValueComponent(self: FlowComponent, id: cstring, name: cstring, value: Value) =
   self.modalValueComponent[id] =
     ValueComponent(
+      api: self.api,
       expanded: JsAssoc[cstring, bool]{$name: true},
       charts: JsAssoc[cstring, ChartComponent]{},
       showInLine: JsAssoc[cstring, bool]{},

--- a/src/frontend/ui/scratchpad.nim
+++ b/src/frontend/ui/scratchpad.nim
@@ -41,7 +41,7 @@ method register*(self: ScratchpadComponent, api: MediatorWithSubscribers) =
   api.subscribe(InternalAddToScratchpad, proc(kind: CtEventKind, response: ValueWithExpression, sub: Subscriber) =
     self.registerValue(response)
   )
-  api.subscribe(InternalAddToScratchpadWithExpression, proc(kind: CtEventKind, response: cstring, sub: Subscriber) =
+  api.subscribe(InternalAddToScratchpadFromExpression, proc(kind: CtEventKind, response: cstring, sub: Subscriber) =
     var found: Variable
     var foundIt = false
 

--- a/src/frontend/ui/show_code.nim
+++ b/src/frontend/ui/show_code.nim
@@ -32,4 +32,5 @@ proc showCode* (id: cstring, path: cstring, fromLine: int, toLine: int, codeLine
           li(): code(class = "excerpt-code"): text line
   else:
     # TODO: loading the actual file content if file not open
-    cwarn "TODO: showCode: for non-loaded files"
+    # cwarn "TODO: showCode: for non-loaded files"
+    discard

--- a/src/frontend/ui/value.nim
+++ b/src/frontend/ui/value.nim
@@ -1148,7 +1148,10 @@ proc view(
           tdiv(
             class = "add-to-scratchpad-button",
             onmousedown = proc(ev: Event, v: VNode) =
-              openValueInScratchpad((expression, value))
+              # TODO: Figure out a way to open panel if closed
+              # The logic for opening should be in the middleware later on
+              # openValueInScratchpad((expression, value))
+              self.api.emit(InternalAddToScratchpad, ValueWithExpression(expression: expression, value: value))
               self.redraw()
           ):
             tdiv(class = "custom-tooltip"):
@@ -1237,4 +1240,4 @@ method redraw*(self: ValueComponent) =
   if not self.state.isNil:
     self.state.redraw()
   else:
-    cast[Component](self).redraw()
+    procCall Component(self).redraw()

--- a/src/frontend/ui_js.nim
+++ b/src/frontend/ui_js.nim
@@ -630,8 +630,9 @@ when not defined(ctInExtension):
 
     for content, components in data.ui.componentMapping:
       for i, component in components:
-        let componentToMiddlewareApi = setupLocalViewToMiddlewareApi(cstring(fmt"{content} #{component.id} api"), data.viewsApi)
-        component.register(componentToMiddlewareApi)
+        if component.api.isNil:
+          let componentToMiddlewareApi = setupLocalViewToMiddlewareApi(cstring(fmt"{content} #{component.id} api"), data.viewsApi)
+          component.register(componentToMiddlewareApi)
 
     # discard windowSetTimeout(proc =
     #   data.dapApi.exampleDap.receiveOnMove(), 1_000)


### PR DESCRIPTION
- Fix minor issue with building for extension
- Fix mutation observer for calltrace #322 
- Fix scratchpad redraw issues #323
- Double component registration issue which might have been the issue with the slow golden layout movements #324 (more testing needs to be done on the matter)
