### PR TITLE
Use electron-builder in all build scripts

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -10,3 +10,7 @@
 
 
 - The db-backend DAP server now responds to the `configurationDone` request.
+
+- Build scripts across the project now rely on electron-builder to produce
+  platform-specific Electron binaries. On macOS the builder consumes
+  `resources/CodeTracer.icns` and `Info.plist` for proper branding.

--- a/appimage-scripts/build_appimage.sh
+++ b/appimage-scripts/build_appimage.sh
@@ -88,12 +88,26 @@ nix build "${ROOT_PATH}#packages.${CURRENT_NIX_SYSTEM}.libuv"
 LIBUV=$(nix eval --raw "${ROOT_PATH}#packages.${CURRENT_NIX_SYSTEM}.libuv.out")
 cp -L "${LIBUV}"/lib/libuv.so.1 "${APP_DIR}"/lib
 
-# Copy over electron
-# bash "${ROOT_PATH}"/appimage-scripts/install_electron_nix.sh
-bash "${ROOT_PATH}"/appimage-scripts/install_electron.sh
-
 # Setup node deps
 bash "${ROOT_PATH}"/appimage-scripts/setup_node_deps.sh
+
+# Build electron runtime using electron-builder
+pushd "${ROOT_PATH}/node-packages"
+echo y | npx yarn >/dev/null
+npx electron-builder --linux dir
+popd
+cp -r "${ROOT_PATH}/node-packages/dist/linux-unpacked" "${APP_DIR}/electron"
+rm -rf "${ROOT_PATH}/node-packages/node_modules"
+cat <<'EOF' > "${APP_DIR}/bin/electron"
+#!/usr/bin/env bash
+
+ELECTRON_DIR=${HERE:-..}/electron
+
+export LD_LIBRARY_PATH="${HERE}/ruby/lib:${HERE}/lib:/usr/lib/:/usr/lib64/:/usr/lib/x86_64-linux-gnu/:${LD_LIBRARY_PATH}"
+
+"${ELECTRON_DIR}/codetracer-electron" --no-sandbox "$@"
+EOF
+chmod +x "${APP_DIR}/bin/electron"
 
 # Build our css files
 bash "${ROOT_PATH}"/appimage-scripts/build_css.sh

--- a/ci/build/dev.sh
+++ b/ci/build/dev.sh
@@ -27,6 +27,11 @@ echo '##########################################################################
 
 node_modules/.bin/webpack
 
+pushd node-packages >/dev/null
+npx electron-builder --linux dir
+popd >/dev/null
+ln -sf "$(pwd)/node-packages/dist/linux-unpacked/codetracer-electron" src/links/electron
+
 pushd src
 
 # Use tup generate, because FUSE may not be supported on the runners

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -433,6 +433,10 @@
 
             echo "Packaging frontend using webpack"
             node $webpack
+
+            echo "Building electron application"
+            builder=${node-modules-derivation.out}/bin/node_modules/.bin/electron-builder
+            node $builder --linux dir
           '';
 
           installPhase = ''
@@ -469,6 +473,9 @@
 
             mkdir -p $out/config
             mv src/config/* $out/config/
+
+            # Include electron-builder output
+            cp -r dist/linux-unpacked/* $out/
           '';
         };
 

--- a/node-packages/package.json
+++ b/node-packages/package.json
@@ -107,6 +107,10 @@
       "target": [
         "AppImage"
       ]
+    },
+    "mac": {
+      "icon": "../resources/CodeTracer.icns",
+      "extendInfo": "../resources/Info.plist"
     }
   },
   "packageManager": "yarn@4.5.0"

--- a/non-nix-build/build_mac_app.sh
+++ b/non-nix-build/build_mac_app.sh
@@ -1,23 +1,14 @@
 #!/usr/bin/env bash
 set -e
 
-cd "$DIST_DIR"
+# Ensure icons are available for electron-builder
+iconutil -c icns "$ROOT_DIR/resources/Icon.iconset" --output "$ROOT_DIR/resources/CodeTracer.icns"
 
-mkdir -p "$DIST_DIR"/../Resources/
-iconutil -c icns "$ROOT_DIR"/resources/Icon.iconset --output "$DIST_DIR"/../Resources/CodeTracer.icns
-cp "$ROOT_DIR"/resources/Info.plist "$DIST_DIR"/..
+# Build the macOS application using electron-builder
+pushd "$ROOT_DIR/node-packages" >/dev/null
+npx electron-builder --mac dir
+popd >/dev/null
 
-# In the `public` folder, we have some symlinks to this awkwardly placed directory
-cd "$DIST_DIR"/..
-ln -s MacOS/node_modules ./
-
-# Hack because basically every OS-level string is labeled as Electron instead CodeTracer. Can be resolved by using a bundler
-cp "$ROOT_DIR"/resources/Info.plist "$(realpath MacOS/node_modules)"/electron/dist/Electron.app/Contents/Info.plist
-cp "$DIST_DIR"/../Resources/CodeTracer.icns "$(realpath MacOS/node_modules)"/electron/dist/Electron.app/Contents/Resources/
-
-# macOS uses core utils from FreeBSD so the additional "" is needed to execute this sed call.
-#
-# This sed call is needed because even though we replaced the entire plist file, the CodeTracer icon will not be displayed correctly
-# in the auto-generated about menu, if the correct executable isn't listed here. If it was left as "bin/ct" a big disabled icon would
-# be overlayed on top of the app icon
-sed -i "" "s/\<string\>bin\/ct/\<string\>Electron/g" "$(realpath MacOS/node_modules)"/electron/dist/Electron.app/Contents/Info.plist
+# Place the resulting .app where the DMG builder expects it
+rm -rf "$ROOT_DIR/non-nix-build/CodeTracer.app"
+cp -R "$ROOT_DIR/node-packages/dist/mac/CodeTracer.app" "$ROOT_DIR/non-nix-build/CodeTracer.app"


### PR DESCRIPTION
## Summary
- invoke electron-builder for Nix, AppImage, macOS, and Tup builds
- configure macOS build to use CodeTracer icon and Info.plist
- document the new electron-builder usage in codebase insights

## Testing
- `npm test` (ava: not found)
- `npm install` (dependency conflict)
- `cargo test` (missing capnp executable)


------
https://chatgpt.com/codex/tasks/task_b_68a74a0ebd208325ad8413f6c07e29b0