### PR TITLE
Use electron-builder in all build scripts

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -23,3 +23,6 @@
   `ELECTRON_OVERRIDE_DIST_PATH` pointing at `pkgs.electron_33` for offline builds.
 - The flake permits `electron-33.4.11` as an insecure package; update
   `permittedInsecurePackages` when bumping Electron.
+- Electron-builder requires the Nim-compiled `index.js` to exist and a local
+  `node_modules` tree; build scripts now generate `index.js` and expose
+  `node_modules` before invoking the packager.

--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -10,3 +10,14 @@
 
 
 - The db-backend DAP server now responds to the `configurationDone` request.
+
+- Build scripts across the project now rely on electron-builder to produce
+  platform-specific Electron binaries. On macOS the builder consumes
+  `resources/CodeTracer.icns` and `Info.plist` for proper branding.
+- Electron builds run from the `node-packages` directory; `package.json`
+  now lists `electron` as a dev dependency and defines a `postinstall` step to
+  ensure native modules match the bundled Electron version.
+- Updating Electron or other dependencies requires regenerating `yarn.lock` and updating `yarn-project.nix` with the new cache hash.
+- Nix-based builds skip Electron's binary download by exporting
+  `ELECTRON_SKIP_BINARY_DOWNLOAD=1` and provide the runtime via
+  `ELECTRON_OVERRIDE_DIST_PATH` pointing at `pkgs.electron_33` for offline builds.

--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -26,3 +26,8 @@
 - Electron-builder requires the Nim-compiled `index.js` to exist and a local
   `node_modules` tree; build scripts now generate `index.js` and expose
   `node_modules` before invoking the packager.
+- Yarn installs must run from `node-packages`; creating `node_modules` at the
+  repository root causes read-only filesystem errors. When needed, symlink the
+  directory back to the root.
+- Nim CLI commands require an explicit subcommand like `js`; missing it leads
+  to "invalid command" errors during build scripts.

--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -17,6 +17,9 @@
 - Electron builds run from the `node-packages` directory; `package.json`
   now lists `electron` as a dev dependency and defines a `postinstall` step to
   ensure native modules match the bundled Electron version.
+- macOS bundles from electron-builder are written to architecture-specific
+  subdirectories (e.g. `dist/mac-arm64`); scripts should locate the correct
+  directory before copying the `.app` bundle.
 - Updating Electron or other dependencies requires regenerating `yarn.lock` and updating `yarn-project.nix` with the new cache hash.
 - Nix-based builds skip Electron's binary download by exporting
   `ELECTRON_SKIP_BINARY_DOWNLOAD=1` and provide the runtime via

--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -21,3 +21,5 @@
 - Nix-based builds skip Electron's binary download by exporting
   `ELECTRON_SKIP_BINARY_DOWNLOAD=1` and provide the runtime via
   `ELECTRON_OVERRIDE_DIST_PATH` pointing at `pkgs.electron_33` for offline builds.
+- The flake permits `electron-33.4.11` as an insecure package; update
+  `permittedInsecurePackages` when bumping Electron.

--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -21,6 +21,12 @@
 - Nix-based builds skip Electron's binary download by exporting
   `ELECTRON_SKIP_BINARY_DOWNLOAD=1` and provide the runtime via
   `ELECTRON_OVERRIDE_DIST_PATH` pointing at `pkgs.electron_33` for offline builds.
+- Setting `npm_config_electron_skip_binary_download=1` alongside
+  `ELECTRON_SKIP_BINARY_DOWNLOAD` prevents Electron's install script from
+  reaching out to the network during Yarn installs.
+- electron-builder now relies on its default Electron location instead of
+  a custom `electronDist`, avoiding "corrupted Electron dist" errors on
+  macOS.
 - The flake permits `electron-33.4.11` as an insecure package; update
   `permittedInsecurePackages` when bumping Electron.
 - Electron-builder requires the Nim-compiled `index.js` to exist and a local

--- a/.agents/tasks/2025/06/12-1044-feat-add-stopped-event
+++ b/.agents/tasks/2025/06/12-1044-feat-add-stopped-event
@@ -178,3 +178,5 @@ error: builder for '/nix/store/zxb6x4wjaa11ajylmmfap514yz4i88qw-node-modules-der
        For full logs, run:
          nix log /nix/store/zxb6x4wjaa11ajylmmfap514yz4i88qw-node-modules-derivation.drv
 error: 1 dependencies of derivation '/nix/store/pxd1m285zqyj8chlm66zmb1yy6y2pz2v-nix-shell-env.drv' failed to build
+--- FOLLOW UP TASK ---
+Change the hash in yarn-project.nix from sha512-pqS9NJAVrEh/CN/7fXqzh7WAKXCH7Da2WX19wGQ4IYHCGrFPe/1ewvaHyAXTtjb/4uOwcFTjHgqgizEAqZabsQ== to sha512-mb3MNaaYGbZ1vAGNlV1R6GG1l/gRsVvJVGQxszzhipb+5qYFurkewFIUXY8sCOhEKXw7vB1pa4CnmY4f2EX5QA==

--- a/.agents/tasks/2025/06/12-1044-feat-add-stopped-event
+++ b/.agents/tasks/2025/06/12-1044-feat-add-stopped-event
@@ -180,3 +180,85 @@ error: builder for '/nix/store/zxb6x4wjaa11ajylmmfap514yz4i88qw-node-modules-der
 error: 1 dependencies of derivation '/nix/store/pxd1m285zqyj8chlm66zmb1yy6y2pz2v-nix-shell-env.drv' failed to build
 --- FOLLOW UP TASK ---
 Change the hash in yarn-project.nix from sha512-pqS9NJAVrEh/CN/7fXqzh7WAKXCH7Da2WX19wGQ4IYHCGrFPe/1ewvaHyAXTtjb/4uOwcFTjHgqgizEAqZabsQ== to sha512-mb3MNaaYGbZ1vAGNlV1R6GG1l/gRsVvJVGQxszzhipb+5qYFurkewFIUXY8sCOhEKXw7vB1pa4CnmY4f2EX5QA==
+--- FOLLOW UP TASK ---
+During the lint nix CI action I get this error:  __        __   _                            _        
+\ \      / /__| | ___ ___  _ __ ___   ___  | |_ ___  
+ \ \ /\ / / _ \ |/ __/ _ \| '_ ` _ \ / _ \ | __/ _ \ 
+  \ V  V /  __/ | (_| (_) | | | | | |  __/ | || (_) |
+   \_/\_/ \___|_|\___\___/|_| |_| |_|\___|  \__\___/ 
+                                                     
+  ____          _     _____                        
+ / ___|___   __| | __|_   _| __ __ _  ___ ___ _ __ 
+| |   / _ \ / _` |/ _ \| || '__/ _` |/ __/ _ \ '__|
+| |__| (_) | (_| |  __/| || | | (_| | (_|  __/ |   
+ \____\___/ \__,_|\___||_||_|  \__,_|\___\___|_|   
+                                                   
+ evaluating flake...
+checking flake output 'devShells'...
+checking derivation devShells.x86_64-linux.default...
+derivation evaluated to /nix/store/14zgvnvzq8bwk15r891xn3d50sn47hhr-nix-shell.drv
+checking derivation devShells.x86_64-linux.ci...
+derivation evaluated to /nix/store/4vwh5h06pp56az4p7pmymbfk2z660a27-nix-shell.drv
+checking flake output 'checks'...
+checking flake output 'legacyPackages'...
+checking flake output 'formatter'...
+checking flake output 'overlays'...
+checking flake output 'nixosModules'...
+checking flake output 'nixosConfigurations'...
+checking flake output 'packages'...
+checking derivation packages.x86_64-linux.noir...
+derivation evaluated to /nix/store/hln14m98mccim7njqgqwcishpaxsihjb-Noir.drv
+checking derivation packages.x86_64-linux.wazero...
+derivation evaluated to /nix/store/cwi3nqd3m095w599bwkal5gdaiqphb74-wazero.drv
+checking derivation packages.x86_64-linux.default...
+error:
+       … while checking flake output 'packages'
+
+       … while checking the derivation 'packages.x86_64-linux.default'
+
+       … while calling the 'derivationStrict' builtin
+         at <nix/derivation-internal.nix>:37:12:
+           36|
+           37|   strict = derivationStrict drvAttrs;
+             |            ^
+           38|
+
+       (stack trace truncated; use '--show-trace' to show the full, detailed trace)
+
+       error: Package ‘electron-33.4.11’ in /nix/store/drmc93qxnzzk5cp3b03ppkk95zw0fanb-source/pkgs/development/tools/electron/binary/generic.nix:43 is marked as insecure, refusing to evaluate.
+
+
+       Known issues:
+        - Electron version 33.4.11 is EOL
+
+       You can install it anyway by allowing this package, using the
+       following methods:
+
+       a) To temporarily allow all insecure packages, you can use an environment
+          variable for a single invocation of the nix tools:
+
+            $ export NIXPKGS_ALLOW_INSECURE=1
+
+          Note: When using `nix shell`, `nix build`, `nix develop`, etc with a flake,
+                then pass `--impure` in order to allow use of environment variables.
+
+       b) for `nixos-rebuild` you can add ‘electron-33.4.11’ to
+          `nixpkgs.config.permittedInsecurePackages` in the configuration.nix,
+          like so:
+
+            {
+              nixpkgs.config.permittedInsecurePackages = [
+                "electron-33.4.11"
+              ];
+            }
+
+       c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
+          ‘electron-33.4.11’ to `permittedInsecurePackages` in
+          ~/.config/nixpkgs/config.nix, like so:
+
+            {
+              permittedInsecurePackages = [
+                "electron-33.4.11"
+              ];
+            }
+Error: Process completed with exit code 1.

--- a/.agents/tasks/2025/06/12-1044-feat-add-stopped-event
+++ b/.agents/tasks/2025/06/12-1044-feat-add-stopped-event
@@ -288,3 +288,5 @@ so that electron is built using electron-builder. For macOS, make sure that elec
 Modify all our build scripts: Nix(for Linux only), Appimage(for Linux only), Non-nix-build(for macOS), Tup(for Linux only) so that electron is built using electron-builder. For macOS, make sure that electron builder uses the correct resource files such as the icons for our electron binary
 --- FOLLOW UP TASK ---
 Modify all our build scripts:\n1. Nix(for Linux only)\n1. Appimage(for Linux only)\n1. Non-nix-build(for macOS)\n1. Tup(for Linux only)\n\nso that electron is built using electron-builder. For macOS, make sure that electron builder uses the correct resource files such as the icons for our electron binary. During the uploading of the artifact for the app image I get these errors in CI: ... and other build failures.
+--- FOLLOW UP TASK ---
+Modify all our build scripts:\n1. Nix(for Linux only)\n1. Appimage(for Linux only)\n1. Non-nix-build(for macOS)\n1. Tup(for Linux only)\n\nso that electron is built using electron-builder. For macOS, make sure that electron builder uses the correct resource files such as the icons for our electron binary

--- a/.agents/tasks/2025/06/12-1044-feat-add-stopped-event
+++ b/.agents/tasks/2025/06/12-1044-feat-add-stopped-event
@@ -275,3 +275,12 @@ codetracer-electron>   • packaging       platform=linux arch=x64 electron=33.4
 codetracer-electron>   • copying Electron  source=/build/a1mklhdrdvbak9mdbcy3v9w3z46a3zw7-source/node-packages/node_modules/.bin destination=/build/a1mklhdrdvbak9mdbcy3v9w3z46a3zw7-source/node-packages/dist/linux-unpacked
 codetracer-electron>   ⨯ Application entry file "index.js" in the "/build/a1mklhdrdvbak9mdbcy3v9w3z46a3zw7-source/node-packages/dist/linux-unpacked/resources/app.asar" does not exist. Seems like a wrong configuration.  failedTask=build stackTrace=Error: Application entry file "index.js" in the "/build/a1mklhdrdvbak9mdbcy3v9w3z46a3zw7-source/node-packages/dist/linux-unpacked/resources/app.asar" does not exist. Seems like a wrong configuration.
 ...
+
+--- FOLLOW UP TASK ---
+Modify all our build scripts:
+1. Nix(for Linux only)
+1. Appimage(for Linux only)
+1. Non-nix-build(for macOS)
+1. Tup(for Linux only)
+
+so that electron is built using electron-builder. For macOS, make sure that electron builder uses the correct resource files such as the icons for our electron binary

--- a/.agents/tasks/2025/06/12-1044-feat-add-stopped-event
+++ b/.agents/tasks/2025/06/12-1044-feat-add-stopped-event
@@ -286,3 +286,5 @@ Modify all our build scripts:
 so that electron is built using electron-builder. For macOS, make sure that electron builder uses the correct resource files such as the icons for our electron binary
 --- FOLLOW UP TASK ---
 Modify all our build scripts: Nix(for Linux only), Appimage(for Linux only), Non-nix-build(for macOS), Tup(for Linux only) so that electron is built using electron-builder. For macOS, make sure that electron builder uses the correct resource files such as the icons for our electron binary
+--- FOLLOW UP TASK ---
+Modify all our build scripts:\n1. Nix(for Linux only)\n1. Appimage(for Linux only)\n1. Non-nix-build(for macOS)\n1. Tup(for Linux only)\n\nso that electron is built using electron-builder. For macOS, make sure that electron builder uses the correct resource files such as the icons for our electron binary. During the uploading of the artifact for the app image I get these errors in CI: ... and other build failures.

--- a/.agents/tasks/2025/06/12-1044-feat-add-stopped-event
+++ b/.agents/tasks/2025/06/12-1044-feat-add-stopped-event
@@ -284,3 +284,5 @@ Modify all our build scripts:
 1. Tup(for Linux only)
 
 so that electron is built using electron-builder. For macOS, make sure that electron builder uses the correct resource files such as the icons for our electron binary
+--- FOLLOW UP TASK ---
+Modify all our build scripts: Nix(for Linux only), Appimage(for Linux only), Non-nix-build(for macOS), Tup(for Linux only) so that electron is built using electron-builder. For macOS, make sure that electron builder uses the correct resource files such as the icons for our electron binary

--- a/.agents/tasks/2025/06/12-1044-feat-add-stopped-event
+++ b/.agents/tasks/2025/06/12-1044-feat-add-stopped-event
@@ -4,3 +4,177 @@ Thread id should be always 1 in the stopped event for now. If is_main is true re
 allThreadsStopped should be true in the stopped event that is sent. Add a stopped event in the test cases after the configuration is done.
 --- FOLLOW UP TASK ---
 add handling for load-locals message that uses handler.load_locals() in dap server to send variables to the frontend
+
+--- FOLLOW UP TASK ---
+Please address any inline comments on the diff, as well as any additional instructions below.
+
+The tup build fails with:
+webpack 5.90.3 compiled successfully in 3460 ms
+  • electron-builder  version=22.14.13 os=6.6.88
+  • artifacts will be published if draft release exists  reason=CI detected
+  • loaded configuration  file=package.json (build field)
+  • electron-rebuild not required if you use electron-builder, please consider to remove excess dependency from devDependencies
+
+To ensure your native dependencies are always matched electron version, simply add script "postinstall": "electron-builder install-app-deps" to your `package.json`
+  ⨯ Cannot compute electron version from installed node modules - none of the possible electron modules are installed.
+See https://github.com/electron-userland/electron-builder/issues/3984#issuecomment-504968246
+
+While the nix build fails with:
+
+codetracer-electron> Building electron application
+codetracer-electron>   • electron-builder  version=22.14.13 os=6.6.88
+codetracer-electron>   ⨯ Cannot find package.json in the /build/k8j7p1m6q8v7y3zgfk6ykg0js12jwwjq-source  failedTask=build stackTrace=Error: Cannot find package.json in the /build/k8j7p1m6q8v7y3zgfk6ykg0js12jwwjq-source
+codetracer-electron>     at Packager.readProjectMetadataIfTwoPackageStructureOrPrepacked (/nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec/node-modules-derivation/node_modules/app-builder-lib/src/packager.ts:410:11)
+codetracer-electron>     at Packager.build (/nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec/node-modules-derivation/node_modules/app-builder-lib/src/packager.ts:328:24)
+codetracer-electron>     at Object.executeFinally (/nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec/node-modules-derivation/node_modules/builder-util/src/promise.ts:12:14)
+codetracer-electron> ┌───────────────────────────────────────────────────────────────┐
+codetracer-electron> │             electron-builder update check failed              │
+codetracer-electron> │              Try running with sudo or get access              │
+codetracer-electron> │             to the local update config store via              │
+codetracer-electron> │ sudo chown -R :root /homeless-shelter/.config │
+codetracer-electron> └───────────────────────────────────────────────────────────────┘
+note: keeping build directory '/tmp/nix-build-codetracer-electron.drv-1/build'
+error: builder for '/nix/store/m7yll2zxgig4m4sl24bkscc01jrvd1d4-codetracer-electron.drv' failed with exit code 1;
+       last 25 log lines:
+       > modules by path ../../nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec...(truncated) 9.1 MiB (javascript) 77.7 KiB (asset) 1070 modules
+       > modules by path ../../nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec...(truncated) 688 KiB 139 modules
+       > modules by path ../../nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec...(truncated) 68.4 KiB 56 modules
+       > modules by path ../../nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec...(truncated) 359 KiB 32 modules
+       > modules by path ../../nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec...(truncated) 5.84 KiB 6 modules
+       > modules by path ../../nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec...(truncated) 2.89 KiB
+       >   ../../nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec...(truncated) 64 bytes [built] [code generated]
+       >   + 2 modules
+       > modules by mime type image/svg+xml 3.17 KiB
+       >   data:image/svg+xml;base64,PHN2ZyB3aWR0aD0i.. 1.59 KiB [built] [code generated]
+       >   data:image/svg+xml;base64,PHN2ZyB3aWR0aD0i.. 1.59 KiB [built] [code generated]
+       > + 14 modules
+       > webpack 5.90.3 compiled successfully in 3450 ms
+       > Building electron application
+       >   • electron-builder  version=22.14.13 os=6.6.88
+       >   ⨯ Cannot find package.json in the /build/k8j7p1m6q8v7y3zgfk6ykg0js12jwwjq-source  failedTask=build stackTrace=Error: Cannot find package.json in the /build/k8j7p1m6q8v7y3zgfk6ykg0js12jwwjq-source
+       >     at Packager.readProjectMetadataIfTwoPackageStructureOrPrepacked (/nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec/node-modules-derivation/node_modules/app-builder-lib/src/packager.ts:410:11)
+       >     at Packager.build (/nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec/node-modules-derivation/node_modules/app-builder-lib/src/packager.ts:328:24)
+       >     at Object.executeFinally (/nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec/node-modules-derivation/node_modules/builder-util/src/promise.ts:12:14)
+       > ┌───────────────────────────────────────────────────────────────┐
+       > │             electron-builder update check failed              │
+       > │              Try running with sudo or get access              │
+       > │             to the local update config store via              │
+       > │ sudo chown -R :root /homeless-shelter/.config │
+       > └───────────────────────────────────────────────────────────────┘
+       For full logs, run:
+         nix log /nix/store/m7yll2zxgig4m4sl24bkscc01jrvd1d4-codetracer-electron.drv
+error: 1 dependencies of derivation '/nix/store/x1iddagn1wq22lbbb593mllksidaxfrp-codetracer.drv' failed to build
+error: Recipe  failed on line 200 with exit code 1
+Error: Process completed with exit code 1.
+
+The appimage build also fails with:
+~/codetracer/codetracer/node-packages ~/codetracer/codetracer
+  • electron-builder  version=22.14.13 os=6.6.48
+  • artifacts will be published if draft release exists  reason=CI detected
+  • loaded configuration  file=package.json (build field)
+  • electron-rebuild not required if you use electron-builder, please consider to remove excess dependency from devDependencies
+
+To ensure your native dependencies are always matched electron version, simply add script "postinstall": "electron-builder install-app-deps" to your `package.json`
+  ⨯ Cannot compute electron version from installed node modules - none of the possible electron modules are installed.
+See https://github.com/electron-userland/electron-builder/issues/3984#issuecomment-504968246
+Performing cleanup...
+Error: Process completed with exit code 1.
+
+--- FOLLOW UP TASK ---
+Please address any inline comments on the diff, as well as any additional instructions below.
+
+The tup build fails with:
+webpack 5.90.3 compiled successfully in 3460 ms
+  • electron-builder  version=22.14.13 os=6.6.88
+  • artifacts will be published if draft release exists  reason=CI detected
+  • loaded configuration  file=package.json ("build" field)
+  • electron-rebuild not required if you use electron-builder, please consider to remove excess dependency from devDependencies
+
+To ensure your native dependencies are always matched electron version, simply add script "postinstall": "electron-builder install-app-deps" to your `package.json`
+  ⨯ Cannot compute electron version from installed node modules - none of the possible electron modules are installed.
+See https://github.com/electron-userland/electron-builder/issues/3984#issuecomment-504968246
+
+While the nix build fails with:
+
+codetracer-electron> Building electron application
+codetracer-electron>   • electron-builder  version=22.14.13 os=6.6.88
+codetracer-electron>   ⨯ Cannot find package.json in the /build/k8j7p1m6q8v7y3zgfk6ykg0js12jwwjq-source  failedTask=build stackTrace=Error: Cannot find package.json in the /build/k8j7p1m6q8v7y3zgfk6ykg0js12jwwjq-source
+codetracer-electron>     at Packager.readProjectMetadataIfTwoPackageStructureOrPrepacked (/nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec/node-modules-derivation/node_modules/app-builder-lib/src/packager.ts:410:11)
+codetracer-electron>     at Packager.build (/nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec/node-modules-derivation/node_modules/app-builder-lib/src/packager.ts:328:24)
+codetracer-electron>     at Object.executeFinally (/nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec/node-modules-derivation/node_modules/builder-util/src/promise.ts:12:14)
+codetracer-electron> ┌───────────────────────────────────────────────────────────────┐
+codetracer-electron> │             electron-builder update check failed              │
+codetracer-electron> │              Try running with sudo or get access              │
+codetracer-electron> │             to the local update config store via              │
+codetracer-electron> │ sudo chown -R $USER:$(id -gn $USER) /homeless-shelter/.config │
+codetracer-electron> └───────────────────────────────────────────────────────────────┘
+note: keeping build directory '/tmp/nix-build-codetracer-electron.drv-1/build'
+error: builder for '/nix/store/m7yll2zxgig4m4sl24bkscc01jrvd1d4-codetracer-electron.drv' failed with exit code 1;
+       last 25 log lines:
+       > modules by path ../../nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec...(truncated) 9.1 MiB (javascript) 77.7 KiB (asset) 1070 modules
+       > modules by path ../../nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec...(truncated) 688 KiB 139 modules
+       > modules by path ../../nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec...(truncated) 68.4 KiB 56 modules
+       > modules by path ../../nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec...(truncated) 359 KiB 32 modules
+       > modules by path ../../nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec...(truncated) 5.84 KiB 6 modules
+       > modules by path ../../nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec...(truncated) 2.89 KiB
+       >   ../../nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec...(truncated) 64 bytes [built] [code generated]
+       >   + 2 modules
+       > modules by mime type image/svg+xml 3.17 KiB
+       >   data:image/svg+xml;base64,PHN2ZyB3aWR0aD0i.. 1.59 KiB [built] [code generated]
+       >   data:image/svg+xml;base64,PHN2ZyB3aWR0aD0i.. 1.59 KiB [built] [code generated]
+       > + 14 modules
+       > webpack 5.90.3 compiled successfully in 3450 ms
+       > Building electron application
+       >   • electron-builder  version=22.14.13 os=6.6.88
+       >   ⨯ Cannot find package.json in the /build/k8j7p1m6q8v7y3zgfk6ykg0js12jwwjq-source  failedTask=build stackTrace=Error: Cannot find package.json in the /build/k8j7p1m6q8v7y3zgfk6ykg0js12jwwjq-source
+       >     at Packager.readProjectMetadataIfTwoPackageStructureOrPrepacked (/nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec/node-modules-derivation/node_modules/app-builder-lib/src/packager.ts:410:11)
+       >     at Packager.build (/nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec/node-modules-derivation/node_modules/app-builder-lib/src/packager.ts:328:24)
+       >     at Object.executeFinally (/nix/store/b5m8z1wxz1f32qa42qzf7gc0jqxx6fim-node-modules-derivation/libexec/node-modules-derivation/node_modules/builder-util/src/promise.ts:12:14)
+       > ┌───────────────────────────────────────────────────────────────┐
+       > │             electron-builder update check failed              │
+       > │              Try running with sudo or get access              │
+       > │             to the local update config store via              │
+       > │ sudo chown -R $USER:$(id -gn $USER) /homeless-shelter/.config │
+       > └───────────────────────────────────────────────────────────────┘
+       For full logs, run:
+         nix log /nix/store/m7yll2zxgig4m4sl24bkscc01jrvd1d4-codetracer-electron.drv
+error: 1 dependencies of derivation '/nix/store/x1iddagn1wq22lbbb593mllksidaxfrp-codetracer.drv' failed to build
+error: Recipe `build-nix` failed on line 200 with exit code 1
+Error: Process completed with exit code 1.
+
+The appimage build also fails with:
+~/codetracer/codetracer/node-packages ~/codetracer/codetracer
+  • electron-builder  version=22.14.13 os=6.6.48
+  • artifacts will be published if draft release exists  reason=CI detected
+  • loaded configuration  file=package.json ("build" field)
+  • electron-rebuild not required if you use electron-builder, please consider to remove excess dependency from devDependencies
+
+To ensure your native dependencies are always matched electron version, simply add script "postinstall": "electron-builder install-app-deps" to your `package.json`
+  ⨯ Cannot compute electron version from installed node modules - none of the possible electron modules are installed.
+See https://github.com/electron-userland/electron-builder/issues/3984#issuecomment-504968246
+Performing cleanup...
+Error: Process completed with exit code 1.
+--- FOLLOW UP TASK ---
+now nix develop fails for almost every build or CI action with this error:
+warning: unable to download 'https://metacraft-private-infrastructure.cachix.org/nix-cache-info': HTTP error 401
+
+         response body:
+
+         Binary cache metacraft-private-infrastructure doesn't exist or you're not authorized to access. Please check the name for typos and/or provide an auth token. Contact support on https://cachix.org if you're stuck!
+building '/nix/store/zxb6x4wjaa11ajylmmfap514yz4i88qw-node-modules-derivation.drv'...
+error: builder for '/nix/store/zxb6x4wjaa11ajylmmfap514yz4i88qw-node-modules-derivation.drv' failed with exit code 1;
+       last 11 log lines:
+       > Running phase: unpackPhase
+       > unpacking source archive /nix/store/n9baalmzwn8hn2avqn63dn8whhpqvhhv-node-packages
+       > source root is node-packages
+       > Running phase: patchPhase
+       > Running phase: updateAutotoolsGnuConfigScriptsPhase
+       > Running phase: configurePhase
+       > ➤ YN0000: · Yarn 4.5.0
+       > ➤ YN0000: ┌ Resolution step
+       > ➤ YN0080: │ electron@npm:^33.4.11: Request to 'https://registry.yarnpkg.com/electron' has been blocked because of your configuration settings
+       > ➤ YN0000: └ Completed in 0s 440ms
+       > ➤ YN0000: · Failed with errors in 0s 469ms
+       For full logs, run:
+         nix log /nix/store/zxb6x4wjaa11ajylmmfap514yz4i88qw-node-modules-derivation.drv
+error: 1 dependencies of derivation '/nix/store/pxd1m285zqyj8chlm66zmb1yy6y2pz2v-nix-shell-env.drv' failed to build

--- a/.agents/tasks/2025/06/12-1044-feat-add-stopped-event
+++ b/.agents/tasks/2025/06/12-1044-feat-add-stopped-event
@@ -262,3 +262,16 @@ error:
               ];
             }
 Error: Process completed with exit code 1.
+--- FOLLOW UP TASK ---
+The action now works, but builds fail.
+
+Nix build:
+codetracer-electron> Building electron application
+codetracer-electron>   • electron-builder  version=22.14.13 os=6.6.88
+codetracer-electron>   • loaded configuration  file=package.json ("build" field)
+codetracer-electron>   • writing effective config  file=node-packages/dist/builder-effective-config.yaml
+codetracer-electron>   • skipped dependencies rebuild  reason=npmRebuild is set to false
+codetracer-electron>   • packaging       platform=linux arch=x64 electron=33.4.11 appOutDir=node-packages/dist/linux-unpacked
+codetracer-electron>   • copying Electron  source=/build/a1mklhdrdvbak9mdbcy3v9w3z46a3zw7-source/node-packages/node_modules/.bin destination=/build/a1mklhdrdvbak9mdbcy3v9w3z46a3zw7-source/node-packages/dist/linux-unpacked
+codetracer-electron>   ⨯ Application entry file "index.js" in the "/build/a1mklhdrdvbak9mdbcy3v9w3z46a3zw7-source/node-packages/dist/linux-unpacked/resources/app.asar" does not exist. Seems like a wrong configuration.  failedTask=build stackTrace=Error: Application entry file "index.js" in the "/build/a1mklhdrdvbak9mdbcy3v9w3z46a3zw7-source/node-packages/dist/linux-unpacked/resources/app.asar" does not exist. Seems like a wrong configuration.
+...

--- a/appimage-scripts/build_appimage.sh
+++ b/appimage-scripts/build_appimage.sh
@@ -93,6 +93,7 @@ nix build "${ROOT_PATH}#packages.${CURRENT_NIX_SYSTEM}.electron"
 ELECTRON=$(nix eval --raw "${ROOT_PATH}#packages.${CURRENT_NIX_SYSTEM}.electron.out")
 export ELECTRON_SKIP_BINARY_DOWNLOAD=1
 export ELECTRON_OVERRIDE_DIST_PATH="${ELECTRON}/lib/electron"
+export npm_config_electron_skip_binary_download=1
 
 # Setup node deps
 bash "${ROOT_PATH}"/appimage-scripts/setup_node_deps.sh

--- a/appimage-scripts/build_appimage.sh
+++ b/appimage-scripts/build_appimage.sh
@@ -99,7 +99,6 @@ bash "${ROOT_PATH}"/appimage-scripts/setup_node_deps.sh
 
 # Build electron runtime using electron-builder
 pushd "${ROOT_PATH}/node-packages"
-echo y | npx yarn >/dev/null
 npx electron-builder --linux dir
 popd
 cp -r "${ROOT_PATH}/node-packages/dist/linux-unpacked" "${APP_DIR}/electron"

--- a/appimage-scripts/setup_node_deps.sh
+++ b/appimage-scripts/setup_node_deps.sh
@@ -19,7 +19,7 @@ yarn install
 nim \
     --hints:on --warnings:off --sourcemap:on \
     -d:ctIndex -d:chronicles_sinks=json \
-    -d:nodejs --out:index.js ../src/frontend/index.nim
+    -d:nodejs --out:index.js js ../src/frontend/index.nim
 
 popd
 

--- a/appimage-scripts/setup_node_deps.sh
+++ b/appimage-scripts/setup_node_deps.sh
@@ -13,7 +13,7 @@ echo "==========="
 #   node modules and webpack/frontend_bundle.js
 pushd "${ROOT_PATH}/node-packages"
 
-echo y | npx yarn
+yarn install
 
 # Build the Electron entry script so electron-builder has something to package
 nim \

--- a/appimage-scripts/setup_node_deps.sh
+++ b/appimage-scripts/setup_node_deps.sh
@@ -15,6 +15,12 @@ pushd "${ROOT_PATH}/node-packages"
 
 echo y | npx yarn
 
+# Build the Electron entry script so electron-builder has something to package
+nim \
+    --hints:on --warnings:off --sourcemap:on \
+    -d:ctIndex -d:chronicles_sinks=json \
+    -d:nodejs --out:index.js ../src/frontend/index.nim
+
 popd
 
 cp -Lr "${ROOT_PATH}/node-packages/node_modules" "${APP_DIR}/"
@@ -24,10 +30,7 @@ pushd "${ROOT_PATH}/"
 node-packages/node_modules/.bin/webpack
 
 popd
-
-rm -rf "${ROOT_PATH}/node-packages/node_modules"
-
-# => now we have node_modules, and $ROOT_PATH/src/public/dist/frontend_bundle.js
+# => now we have node_modules and $ROOT_PATH/src/public/dist/frontend_bundle.js
 # <=> $NIX_CODETRACER_EXE_DIR/public/dist/frontend_bundle.js
 
 echo "==========="

--- a/ci/build/dev.sh
+++ b/ci/build/dev.sh
@@ -33,7 +33,12 @@ ELECTRON_PATH=$(nix eval --raw "${ROOT_PATH}#packages.${CURRENT_NIX_SYSTEM}.elec
 export ELECTRON_SKIP_BINARY_DOWNLOAD=1
 export ELECTRON_OVERRIDE_DIST_PATH="${ELECTRON_PATH}/lib/electron"
 
+pushd node-packages >/dev/null
 yarn install --immutable
+popd >/dev/null
+
+rm -rf node_modules
+ln -s node-packages/node_modules node_modules
 
 node_modules/.bin/webpack
 
@@ -46,9 +51,9 @@ rm "$TUP_OUTPUT_SCRIPT"
 popd >/dev/null
 
 cp index.js node-packages/index.js
-ln -sf "$(pwd)/node_modules" node-packages/node_modules
 
 pushd node-packages >/dev/null
 npx electron-builder --linux dir
 popd >/dev/null
+
 ln -sf "$(pwd)/node-packages/dist/linux-unpacked/codetracer-electron" src/links/electron

--- a/ci/build/dev.sh
+++ b/ci/build/dev.sh
@@ -35,17 +35,18 @@ export ELECTRON_OVERRIDE_DIST_PATH="${ELECTRON_PATH}/lib/electron"
 
 node_modules/.bin/webpack
 
-pushd node-packages >/dev/null
-npx electron-builder --linux dir
-popd >/dev/null
-ln -sf "$(pwd)/node-packages/dist/linux-unpacked/codetracer-electron" src/links/electron
-
-pushd src
-
+pushd src >/dev/null
 # Use tup generate, because FUSE may not be supported on the runners
 TUP_OUTPUT_SCRIPT=tup-generated-build-once.sh
 tup generate --config build-debug/tup.config "$TUP_OUTPUT_SCRIPT"
 ./"$TUP_OUTPUT_SCRIPT"
 rm "$TUP_OUTPUT_SCRIPT"
+popd >/dev/null
 
-popd
+cp index.js node-packages/index.js
+ln -sf "$(pwd)/node_modules" node-packages/node_modules
+
+pushd node-packages >/dev/null
+npx electron-builder --linux dir
+popd >/dev/null
+ln -sf "$(pwd)/node-packages/dist/linux-unpacked/codetracer-electron" src/links/electron

--- a/ci/build/dev.sh
+++ b/ci/build/dev.sh
@@ -33,6 +33,8 @@ ELECTRON_PATH=$(nix eval --raw "${ROOT_PATH}#packages.${CURRENT_NIX_SYSTEM}.elec
 export ELECTRON_SKIP_BINARY_DOWNLOAD=1
 export ELECTRON_OVERRIDE_DIST_PATH="${ELECTRON_PATH}/lib/electron"
 
+yarn install --immutable
+
 node_modules/.bin/webpack
 
 pushd src >/dev/null

--- a/ci/build/dev.sh
+++ b/ci/build/dev.sh
@@ -32,6 +32,7 @@ nix build "${ROOT_PATH}#packages.${CURRENT_NIX_SYSTEM}.electron" >/dev/null
 ELECTRON_PATH=$(nix eval --raw "${ROOT_PATH}#packages.${CURRENT_NIX_SYSTEM}.electron.out")
 export ELECTRON_SKIP_BINARY_DOWNLOAD=1
 export ELECTRON_OVERRIDE_DIST_PATH="${ELECTRON_PATH}/lib/electron"
+export npm_config_electron_skip_binary_download=1
 
 pushd node-packages >/dev/null
 yarn install --immutable
@@ -41,6 +42,11 @@ rm -rf node_modules
 ln -s node-packages/node_modules node_modules
 
 node_modules/.bin/webpack
+
+nim \
+    --hints:on --warnings:off --sourcemap:on \
+    -d:ctIndex -d:chronicles_sinks=json \
+    -d:nodejs --out:index.js js src/frontend/index.nim
 
 pushd src >/dev/null
 # Use tup generate, because FUSE may not be supported on the runners

--- a/flake.nix
+++ b/flake.nix
@@ -100,7 +100,7 @@
               #       unnecessary after a future `flake update`
               allowBroken = true;
               permittedInsecurePackages = [
-                "electron-24.8.6"
+                "electron-33.4.11"
               ];
             };
           };
@@ -109,7 +109,7 @@
             inherit system;
             config = {
               permittedInsecurePackages = [
-                "electron-24.8.6"
+                "electron-33.4.11"
               ];
             };
           };

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -446,12 +446,12 @@
             cp -L ${indexJavascript}/bin/index.js node-packages/index.js
 
             echo "Building electron application"
-            builder=${node-modules-derivation.out}/bin/node_modules/.bin/electron-builder
             pushd node-packages >/dev/null
+            builder=${node-modules-derivation.out}/bin/node_modules/.bin/electron-builder
             ELECTRON_OVERRIDE_DIST_PATH=${pkgs.electron_33}/lib/electron \
               ELECTRON_SKIP_BINARY_DOWNLOAD=1 \
               npm_config_electron_skip_binary_download=1 \
-              node $builder --linux dir
+              node $builder --projectDir "$(pwd)" --linux dir
             popd >/dev/null
           '';
 

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -446,9 +446,11 @@
 
             echo "Building electron application"
             builder=${node-modules-derivation.out}/bin/node_modules/.bin/electron-builder
+            pushd node-packages >/dev/null
             ELECTRON_OVERRIDE_DIST_PATH=${pkgs.electron_33}/lib/electron \
               ELECTRON_SKIP_BINARY_DOWNLOAD=1 \
-              node $builder --projectDir node-packages --linux dir
+              node $builder --linux dir
+            popd >/dev/null
           '';
 
           installPhase = ''

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -375,6 +375,7 @@
               pkgs.callPackage ../../node-packages/yarn-project.nix
                 {
                   nodejs = pkgs.nodejs_20;
+                  electron = pkgs.electron_33;
                 }
                 {
                   src = ../../node-packages;
@@ -449,6 +450,7 @@
             pushd node-packages >/dev/null
             ELECTRON_OVERRIDE_DIST_PATH=${pkgs.electron_33}/lib/electron \
               ELECTRON_SKIP_BINARY_DOWNLOAD=1 \
+              npm_config_electron_skip_binary_download=1 \
               node $builder --linux dir
             popd >/dev/null
           '';

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -489,7 +489,7 @@
             mv src/config/* $out/config/
 
             # Include electron-builder output
-            cp -r dist/linux-unpacked/* $out/
+            cp -r node-packages/dist/linux-unpacked/* $out/
           '';
         };
 

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -418,6 +418,7 @@
             pkgs.nodejs_20
             node-modules-derivation
             pkgs.electron_33
+            indexJavascript
           ];
 
           buildPhase = ''
@@ -439,6 +440,9 @@
 
             echo "Packaging frontend using webpack"
             node $webpack
+
+            echo "Preparing Electron entrypoint"
+            cp -L ${indexJavascript}/bin/index.js node-packages/index.js
 
             echo "Building electron application"
             builder=${node-modules-derivation.out}/bin/node_modules/.bin/electron-builder

--- a/node-packages/default.nix
+++ b/node-packages/default.nix
@@ -3,4 +3,8 @@
 
 { pkgs ? import <nixpkgs> { } }:
 
-pkgs.callPackage ./yarn-project.nix { } { src = ./.; }
+pkgs.callPackage ./yarn-project.nix {
+  # Use the pinned Electron runtime during evaluation so builds stay
+  # consistent and electron-builder can reuse it.
+  electron = pkgs.electron_33;
+} { src = ./.; }

--- a/node-packages/package.json
+++ b/node-packages/package.json
@@ -68,8 +68,8 @@
     "@wdio/mocha-framework": "^7.20.3",
     "@wdio/spec-reporter": "^7.25.1",
     "css-loader": "6.10.0",
+    "electron": "^33.4.11",
     "electron-builder": "^22.14.13",
-    "electron-rebuild": "^3.2.7",
     "env-paths": "^3.0.0",
     "eslint": "^9.12.0",
     "eslint-config-love": "^87.0.0",
@@ -93,7 +93,8 @@
   },
   "scripts": {
     "test": "ava",
-    "wdio": "wdio run wdio.conf.js"
+    "wdio": "wdio run wdio.conf.js",
+    "postinstall": "electron-builder install-app-deps"
   },
   "build": {
     "appId": "com.codetracer.test",
@@ -107,6 +108,10 @@
       "target": [
         "AppImage"
       ]
+    },
+    "mac": {
+      "icon": "../resources/CodeTracer.icns",
+      "extendInfo": "../resources/Info.plist"
     }
   },
   "packageManager": "yarn@4.5.0"

--- a/node-packages/package.json
+++ b/node-packages/package.json
@@ -101,7 +101,6 @@
     "productName": "codetracer-electron",
     "nodeGypRebuild": false,
     "npmRebuild": false,
-    "electronDist": "./node_modules/.bin/",
     "linux": {
       "executableName": "codetracer-electron",
       "category": "Utility",

--- a/node-packages/package.json
+++ b/node-packages/package.json
@@ -68,7 +68,7 @@
     "@wdio/mocha-framework": "^7.20.3",
     "@wdio/spec-reporter": "^7.25.1",
     "css-loader": "6.10.0",
-    "electron": "^33.4.11",
+    "electron": "33.4.11",
     "electron-builder": "^22.14.13",
     "env-paths": "^3.0.0",
     "eslint": "^9.12.0",

--- a/node-packages/yarn-project.nix
+++ b/node-packages/yarn-project.nix
@@ -53,6 +53,9 @@ let
     export npm_config_build_from_source=true
     # Disable Nixify plugin to save on some unnecessary processing.
     export yarn_enable_nixify=false
+    # Prevent electron's postinstall script from fetching binaries online; the
+    # build scripts provide a system electron via ELECTRON_OVERRIDE_DIST_PATH.
+    export ELECTRON_SKIP_BINARY_DOWNLOAD=1
   '';
 
   cacheDrv = stdenv.mkDerivation rec {
@@ -78,7 +81,7 @@ let
       if stdenv.isAarch64 then
         "sha512-+f3z4zwF2YlzskL7uDwVvQ3Fg0EYJ1HGPEqIGNb2VsiQpXoY2tU+EufqX79YRCOW7lXkuDfMQHYI3XcPioAEvg=="
       else
-        "sha512-J9t4DyOclFAaz0aTrMjLYet64YnVwY3gfV7F1YYZ4GVsF8JvuSBs4w3U6AZBSWvIq24n7Ccxqt8bpS3Do93mnA=="
+        "sha512-pqS9NJAVrEh/CN/7fXqzh7WAKXCH7Da2WX19wGQ4IYHCGrFPe/1ewvaHyAXTtjb/4uOwcFTjHgqgizEAqZabsQ=="
     );
   };
 

--- a/node-packages/yarn-project.nix
+++ b/node-packages/yarn-project.nix
@@ -81,7 +81,7 @@ let
       if stdenv.isAarch64 then
         "sha512-+f3z4zwF2YlzskL7uDwVvQ3Fg0EYJ1HGPEqIGNb2VsiQpXoY2tU+EufqX79YRCOW7lXkuDfMQHYI3XcPioAEvg=="
       else
-        "sha512-pqS9NJAVrEh/CN/7fXqzh7WAKXCH7Da2WX19wGQ4IYHCGrFPe/1ewvaHyAXTtjb/4uOwcFTjHgqgizEAqZabsQ=="
+        "sha512-mb3MNaaYGbZ1vAGNlV1R6GG1l/gRsVvJVGQxszzhipb+5qYFurkewFIUXY8sCOhEKXw7vB1pa4CnmY4f2EX5QA=="
     );
   };
 

--- a/node-packages/yarn-project.nix
+++ b/node-packages/yarn-project.nix
@@ -10,6 +10,7 @@
   fetchurl,
   writeShellScript,
   writeShellScriptBin,
+  electron,
 }:
 {
   src,
@@ -56,6 +57,8 @@ let
     # Prevent electron's postinstall script from fetching binaries online; the
     # build scripts provide a system electron via ELECTRON_OVERRIDE_DIST_PATH.
     export ELECTRON_SKIP_BINARY_DOWNLOAD=1
+    export npm_config_electron_skip_binary_download=1
+    export ELECTRON_OVERRIDE_DIST_PATH='${electron}/lib/electron'
   '';
 
   cacheDrv = stdenv.mkDerivation rec {

--- a/node-packages/yarn.lock
+++ b/node-packages/yarn.lock
@@ -4212,7 +4212,7 @@ __metadata:
     datatables.net-scroller: "npm:^1.5.1"
     debug: "npm:^4.1.0"
     ejs: "npm:^3.1.9"
-    electron: "npm:^33.4.11"
+    electron: "npm:33.4.11"
     electron-builder: "npm:^22.14.13"
     electron-debug: "npm:^3.2.0"
     env-paths: "npm:^3.0.0"

--- a/node-packages/yarn.lock
+++ b/node-packages/yarn.lock
@@ -262,6 +262,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@electron/get@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "@electron/get@npm:2.0.3"
+  dependencies:
+    debug: "npm:^4.1.1"
+    env-paths: "npm:^2.2.0"
+    fs-extra: "npm:^8.1.0"
+    global-agent: "npm:^3.0.0"
+    got: "npm:^11.8.5"
+    progress: "npm:^2.0.3"
+    semver: "npm:^6.2.0"
+    sumchecker: "npm:^3.0.1"
+  dependenciesMeta:
+    global-agent:
+      optional: true
+  checksum: 10c0/148957d531bac50c29541515f2483c3e5c9c6ba9f0269a5d536540d2b8d849188a89588f18901f3a84c2b4fd376d1e0c5ea2159eb2d17bda68558f57df19015e
+  languageName: node
+  linkType: hard
+
 "@electron/universal@npm:1.0.5":
   version: 1.0.5
   resolution: "@electron/universal@npm:1.0.5"
@@ -529,7 +548,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gar/promisify@npm:^1.0.1, @gar/promisify@npm:^1.1.3":
+"@gar/promisify@npm:^1.0.1":
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
   checksum: 10c0/0b3c9958d3cd17f4add3574975e3115ae05dc7f1298a60810414b16f6f558c137b5fb3cd3905df380bacfd955ec13f67c1e6710cbb5c246a7e8d65a8289b2bff
@@ -692,15 +711,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@malept/cross-spawn-promise@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@malept/cross-spawn-promise@npm:2.0.0"
-  dependencies:
-    cross-spawn: "npm:^7.0.1"
-  checksum: 10c0/84d60b8d467f4252114849f0a33c3763f07898335269eec5c94978ccac9d5680e1e268d993dd1a6d25a91476f9e0992759d7e1f385f9f3a090d862f9bb949603
-  languageName: node
-  linkType: hard
-
 "@malept/flatpak-bundler@npm:^0.4.0":
   version: 0.4.0
   resolution: "@malept/flatpak-bundler@npm:0.4.0"
@@ -763,16 +773,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/fs@npm:^2.1.0":
-  version: 2.1.2
-  resolution: "@npmcli/fs@npm:2.1.2"
-  dependencies:
-    "@gar/promisify": "npm:^1.1.3"
-    semver: "npm:^7.3.5"
-  checksum: 10c0/c50d087733d0d8df23be24f700f104b19922a28677aa66fdbe06ff6af6431cc4a5bb1e27683cbc661a5dafa9bafdc603e6a0378121506dfcd394b2b6dd76a187
-  languageName: node
-  linkType: hard
-
 "@npmcli/fs@npm:^4.0.0":
   version: 4.0.0
   resolution: "@npmcli/fs@npm:4.0.0"
@@ -789,16 +789,6 @@ __metadata:
     mkdirp: "npm:^1.0.4"
     rimraf: "npm:^3.0.2"
   checksum: 10c0/02e946f3dafcc6743132fe2e0e2b585a96ca7265653a38df5a3e53fcf26c7c7a57fc0f861d7c689a23fdb6d6836c7eea5050c8086abf3c994feb2208d1514ff0
-  languageName: node
-  linkType: hard
-
-"@npmcli/move-file@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "@npmcli/move-file@npm:2.0.1"
-  dependencies:
-    mkdirp: "npm:^1.0.4"
-    rimraf: "npm:^3.0.2"
-  checksum: 10c0/11b2151e6d1de6f6eb23128de5aa8a429fd9097d839a5190cb77aa47a6b627022c42d50fa7c47a00f1c9f8f0c1560092b09b061855d293fa0741a2a94cfb174d
   languageName: node
   linkType: hard
 
@@ -1368,6 +1358,15 @@ __metadata:
   dependencies:
     undici-types: "npm:~5.26.4"
   checksum: 10c0/fc436b93a3c9367b69d11a1c5d70cc923df6ea60141dd508ce2a248160c3bf8a04c658548a59df8ab9148b68bd58954fb603917baab3e2bc9da567f655534e5a
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^20.9.0":
+  version: 20.19.11
+  resolution: "@types/node@npm:20.19.11"
+  dependencies:
+    undici-types: "npm:~6.21.0"
+  checksum: 10c0/9eecc4be04f1a8afbb8f8059b322fd0bbceeb02f96669bbaa52fb0b264c2e3269432a8833ada4be7b335e18d6b438b2d2c0274f5b3f54cc2081cb7c5374a6561
   languageName: node
   linkType: hard
 
@@ -2213,7 +2212,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abbrev@npm:1, abbrev@npm:^1.0.0":
+"abbrev@npm:1":
   version: 1.1.1
   resolution: "abbrev@npm:1.1.1"
   checksum: 10c0/3f762677702acb24f65e813070e306c61fafe25d4b2583f9dfc935131f774863f3addd5741572ed576bd69cabe473c5af18e1e108b829cb7b6b4747884f726e6
@@ -2307,7 +2306,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agentkeepalive@npm:^4.1.3, agentkeepalive@npm:^4.2.1":
+"agentkeepalive@npm:^4.1.3":
   version: 4.6.0
   resolution: "agentkeepalive@npm:4.6.0"
   dependencies:
@@ -3261,6 +3260,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"boolean@npm:^3.0.1":
+  version: 3.2.0
+  resolution: "boolean@npm:3.2.0"
+  checksum: 10c0/6a0dc9668f6f3dda42a53c181fcbdad223169c8d87b6c4011b87a8b14a21770efb2934a778f063d7ece17280f8c06d313c87f7b834bb1dd526a867ffcd00febf
+  languageName: node
+  linkType: hard
+
 "boom@npm:4.x.x":
   version: 4.3.1
   resolution: "boom@npm:4.3.1"
@@ -3611,32 +3617,6 @@ __metadata:
     tar: "npm:^6.0.2"
     unique-filename: "npm:^1.1.1"
   checksum: 10c0/886fcc0acc4f6fd5cd142d373d8276267bc6d655d7c4ce60726fbbec10854de3395ee19bbf9e7e73308cdca9fdad0ad55060ff3bd16c6d4165c5b8d21515e1d8
-  languageName: node
-  linkType: hard
-
-"cacache@npm:^16.1.0":
-  version: 16.1.3
-  resolution: "cacache@npm:16.1.3"
-  dependencies:
-    "@npmcli/fs": "npm:^2.1.0"
-    "@npmcli/move-file": "npm:^2.0.0"
-    chownr: "npm:^2.0.0"
-    fs-minipass: "npm:^2.1.0"
-    glob: "npm:^8.0.1"
-    infer-owner: "npm:^1.0.4"
-    lru-cache: "npm:^7.7.1"
-    minipass: "npm:^3.1.6"
-    minipass-collect: "npm:^1.0.2"
-    minipass-flush: "npm:^1.0.5"
-    minipass-pipeline: "npm:^1.2.4"
-    mkdirp: "npm:^1.0.4"
-    p-map: "npm:^4.0.0"
-    promise-inflight: "npm:^1.0.1"
-    rimraf: "npm:^3.0.2"
-    ssri: "npm:^9.0.0"
-    tar: "npm:^6.1.11"
-    unique-filename: "npm:^2.0.0"
-  checksum: 10c0/cdf6836e1c457d2a5616abcaf5d8240c0346b1f5bd6fdb8866b9d84b6dff0b54e973226dc11e0d099f35394213d24860d1989c8358d2a41b39eb912b3000e749
   languageName: node
   linkType: hard
 
@@ -4232,9 +4212,9 @@ __metadata:
     datatables.net-scroller: "npm:^1.5.1"
     debug: "npm:^4.1.0"
     ejs: "npm:^3.1.9"
+    electron: "npm:^33.4.11"
     electron-builder: "npm:^22.14.13"
     electron-debug: "npm:^3.2.0"
-    electron-rebuild: "npm:^3.2.7"
     env-paths: "npm:^3.0.0"
     eslint: "npm:^9.12.0"
     eslint-config-love: "npm:^87.0.0"
@@ -5172,10 +5152,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-libc@npm:^2.0.1":
-  version: 2.0.4
-  resolution: "detect-libc@npm:2.0.4"
-  checksum: 10c0/c15541f836eba4b1f521e4eecc28eefefdbc10a94d3b8cb4c507689f332cc111babb95deda66f2de050b22122113189986d5190be97d51b5a2b23b938415e67c
+"detect-node@npm:^2.0.4":
+  version: 2.1.0
+  resolution: "detect-node@npm:2.1.0"
+  checksum: 10c0/f039f601790f2e9d4654e499913259a798b1f5246ae24f86ab5e8bd4aaf3bce50484234c494f11fb00aecb0c6e2733aa7b1cf3f530865640b65fbbd65b2c4e09
   languageName: node
   linkType: hard
 
@@ -5603,34 +5583,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-rebuild@npm:^3.2.7":
-  version: 3.2.9
-  resolution: "electron-rebuild@npm:3.2.9"
-  dependencies:
-    "@malept/cross-spawn-promise": "npm:^2.0.0"
-    chalk: "npm:^4.0.0"
-    debug: "npm:^4.1.1"
-    detect-libc: "npm:^2.0.1"
-    fs-extra: "npm:^10.0.0"
-    got: "npm:^11.7.0"
-    lzma-native: "npm:^8.0.5"
-    node-abi: "npm:^3.0.0"
-    node-api-version: "npm:^0.1.4"
-    node-gyp: "npm:^9.0.0"
-    ora: "npm:^5.1.0"
-    semver: "npm:^7.3.5"
-    tar: "npm:^6.0.5"
-    yargs: "npm:^17.0.1"
-  bin:
-    electron-rebuild: lib/src/cli.js
-  checksum: 10c0/250ad711d65406910b425fe053ca87b37c61e9b9670cd8ae5db21438c195d7e1096242da94f1b413483e42f02931a1e34151641ba6529a6cb48d551410185b9c
-  languageName: node
-  linkType: hard
-
 "electron-to-chromium@npm:^1.5.173":
   version: 1.5.190
   resolution: "electron-to-chromium@npm:1.5.190"
   checksum: 10c0/d6ebf5c3fd72ed1e57f536558c201573693b39bc23fd7c6a4b30d9e17a0aa5d1ea1e93cf4f7d7dfbc2042cf104e3ea72b2f882192886e56ebea7c472eb124021
+  languageName: node
+  linkType: hard
+
+"electron@npm:^33.4.11":
+  version: 33.4.11
+  resolution: "electron@npm:33.4.11"
+  dependencies:
+    "@electron/get": "npm:^2.0.0"
+    "@types/node": "npm:^20.9.0"
+    extract-zip: "npm:^2.0.1"
+  bin:
+    electron: cli.js
+  checksum: 10c0/fbc8104454eec5c4693792b236eda028ff4d0025654be972a055ae9314a8b9ac801f28bf9847233eeae584874f633fd7794627d01cd2367a304b133bfee879f5
   languageName: node
   linkType: hard
 
@@ -5923,6 +5892,13 @@ __metadata:
     esniff: "npm:^2.0.1"
     next-tick: "npm:^1.1.0"
   checksum: 10c0/4459b6ae216f3c615db086e02437bdfde851515a101577fd61b19f9b3c1ad924bab4d197981eb7f0ccb915f643f2fc10ff76b97a680e96cbb572d15a27acd9a3
+  languageName: node
+  linkType: hard
+
+"es6-error@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "es6-error@npm:4.1.1"
+  checksum: 10c0/357663fb1e845c047d548c3d30f86e005db71e122678f4184ced0693f634688c3f3ef2d7de7d4af732f734de01f528b05954e270f06aa7d133679fb9fe6600ef
   languageName: node
   linkType: hard
 
@@ -6806,7 +6782,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extract-zip@npm:2.0.1":
+"extract-zip@npm:2.0.1, extract-zip@npm:^2.0.1":
   version: 2.0.1
   resolution: "extract-zip@npm:2.0.1"
   dependencies:
@@ -7275,6 +7251,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-extra@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "fs-extra@npm:8.1.0"
+  dependencies:
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^4.0.0"
+    universalify: "npm:^0.1.0"
+  checksum: 10c0/259f7b814d9e50d686899550c4f9ded85c46c643f7fe19be69504888e007fcbc08f306fae8ec495b8b998635e997c9e3e175ff2eeed230524ef1c1684cc96423
+  languageName: node
+  linkType: hard
+
 "fs-extra@npm:^9.0.0, fs-extra@npm:^9.0.1, fs-extra@npm:^9.1.0":
   version: 9.1.0
   resolution: "fs-extra@npm:9.1.0"
@@ -7296,7 +7283,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-minipass@npm:^2.0.0, fs-minipass@npm:^2.1.0":
+"fs-minipass@npm:^2.0.0":
   version: 2.1.0
   resolution: "fs-minipass@npm:2.1.0"
   dependencies:
@@ -7654,7 +7641,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^8.0.1, glob@npm:^8.0.3, glob@npm:^8.1.0":
+"glob@npm:^8.0.3, glob@npm:^8.1.0":
   version: 8.1.0
   resolution: "glob@npm:8.1.0"
   dependencies:
@@ -7678,6 +7665,20 @@ __metadata:
     once: "npm:^1.3.0"
     path-is-absolute: "npm:^1.0.0"
   checksum: 10c0/173245e6f9ccf904309eb7ef4a44a11f3bf68e9e341dff5a28b5db0dd7123b7506daf41497f3437a0710f57198187b758c2351eeaabce4d16935e956920da6a4
+  languageName: node
+  linkType: hard
+
+"global-agent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "global-agent@npm:3.0.0"
+  dependencies:
+    boolean: "npm:^3.0.1"
+    es6-error: "npm:^4.1.1"
+    matcher: "npm:^3.0.0"
+    roarr: "npm:^2.15.3"
+    semver: "npm:^7.3.2"
+    serialize-error: "npm:^7.0.1"
+  checksum: 10c0/bb8750d026b25da437072762fd739098bad92ff72f66483c3929db4579e072f5523960f7e7fd70ee0d75db48898067b5dc1c9c1d17888128cff008fcc34d1bd3
   languageName: node
   linkType: hard
 
@@ -7711,7 +7712,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globalthis@npm:^1.0.4":
+"globalthis@npm:^1.0.1, globalthis@npm:^1.0.4":
   version: 1.0.4
   resolution: "globalthis@npm:1.0.4"
   dependencies:
@@ -7783,7 +7784,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"got@npm:^11.0.2, got@npm:^11.7.0, got@npm:^11.8.1":
+"got@npm:^11.0.2, got@npm:^11.8.1, got@npm:^11.8.5":
   version: 11.8.6
   resolution: "got@npm:11.8.6"
   dependencies:
@@ -9573,7 +9574,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-stringify-safe@npm:~5.0.1":
+"json-stringify-safe@npm:^5.0.1, json-stringify-safe@npm:~5.0.1":
   version: 5.0.1
   resolution: "json-stringify-safe@npm:5.0.1"
   checksum: 10c0/7dbf35cd0411d1d648dceb6d59ce5857ec939e52e4afc37601aa3da611f0987d5cee5b38d58329ceddf3ed48bd7215229c8d52059ab01f2444a338bf24ed0f37
@@ -9609,6 +9610,18 @@ __metadata:
     graceful-fs:
       optional: true
   checksum: 10c0/159ec98712d5a0f77ddb96ddbde0ecc5fb1108fadab5b85cea18f508be78eabf03a3370b3769112fce1d8772b4e396f81d7c0d378ac5d7955bee5f1330cf1b19
+  languageName: node
+  linkType: hard
+
+"jsonfile@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "jsonfile@npm:4.0.0"
+  dependencies:
+    graceful-fs: "npm:^4.1.6"
+  dependenciesMeta:
+    graceful-fs:
+      optional: true
+  checksum: 10c0/7dc94b628d57a66b71fb1b79510d460d662eb975b5f876d723f81549c2e9cd316d58a2ddf742b2b93a4fa6b17b2accaf1a738a0e2ea114bdfb13a32e5377e480
   languageName: node
   linkType: hard
 
@@ -10233,13 +10246,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^7.7.1":
-  version: 7.18.3
-  resolution: "lru-cache@npm:7.18.3"
-  checksum: 10c0/b3a452b491433db885beed95041eb104c157ef7794b9c9b4d647be503be91769d11206bb573849a16b4cc0d03cbd15ffd22df7960997788b74c1d399ac7a4fed
-  languageName: node
-  linkType: hard
-
 "lz-string@npm:^1.5.0":
   version: 1.5.0
   resolution: "lz-string@npm:1.5.0"
@@ -10249,50 +10255,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lzma-native@npm:^8.0.5":
-  version: 8.0.6
-  resolution: "lzma-native@npm:8.0.6"
-  dependencies:
-    node-addon-api: "npm:^3.1.0"
-    node-gyp: "npm:latest"
-    node-gyp-build: "npm:^4.2.1"
-    readable-stream: "npm:^3.6.0"
-  bin:
-    lzmajs: bin/lzmajs
-  checksum: 10c0/ff469a29de753445097dabf88ca1a332e47ead39204480b6323472d716657d97c7e3adf68437e54142277c55d4f19d96b49d14553cbf07977cb84833f73e9b6a
-  languageName: node
-  linkType: hard
-
 "make-dir@npm:^3.0.0":
   version: 3.1.0
   resolution: "make-dir@npm:3.1.0"
   dependencies:
     semver: "npm:^6.0.0"
   checksum: 10c0/56aaafefc49c2dfef02c5c95f9b196c4eb6988040cf2c712185c7fe5c99b4091591a7fc4d4eafaaefa70ff763a26f6ab8c3ff60b9e75ea19876f49b18667ecaa
-  languageName: node
-  linkType: hard
-
-"make-fetch-happen@npm:^10.0.3":
-  version: 10.2.1
-  resolution: "make-fetch-happen@npm:10.2.1"
-  dependencies:
-    agentkeepalive: "npm:^4.2.1"
-    cacache: "npm:^16.1.0"
-    http-cache-semantics: "npm:^4.1.0"
-    http-proxy-agent: "npm:^5.0.0"
-    https-proxy-agent: "npm:^5.0.0"
-    is-lambda: "npm:^1.0.1"
-    lru-cache: "npm:^7.7.1"
-    minipass: "npm:^3.1.6"
-    minipass-collect: "npm:^1.0.2"
-    minipass-fetch: "npm:^2.0.3"
-    minipass-flush: "npm:^1.0.5"
-    minipass-pipeline: "npm:^1.2.4"
-    negotiator: "npm:^0.6.3"
-    promise-retry: "npm:^2.0.1"
-    socks-proxy-agent: "npm:^7.0.0"
-    ssri: "npm:^9.0.0"
-  checksum: 10c0/28ec392f63ab93511f400839dcee83107eeecfaad737d1e8487ea08b4332cd89a8f3319584222edd9f6f1d0833cf516691469496d46491863f9e88c658013949
   languageName: node
   linkType: hard
 
@@ -10366,6 +10334,15 @@ __metadata:
   version: 1.3.0
   resolution: "marky@npm:1.3.0"
   checksum: 10c0/6619cdb132fdc4f7cd3e2bed6eebf81a38e50ff4b426bbfb354db68731e4adfebf35ebfd7c8e5a6e846cbf9b872588c4f76db25782caee8c1529ec9d483bf98b
+  languageName: node
+  linkType: hard
+
+"matcher@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "matcher@npm:3.0.0"
+  dependencies:
+    escape-string-regexp: "npm:^4.0.0"
+  checksum: 10c0/2edf24194a2879690bcdb29985fc6bc0d003df44e04df21ebcac721fa6ce2f6201c579866bb92f9380bffe946f11ecd8cd31f34117fb67ebf8aca604918e127e
   languageName: node
   linkType: hard
 
@@ -10653,21 +10630,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass-fetch@npm:^2.0.3":
-  version: 2.1.2
-  resolution: "minipass-fetch@npm:2.1.2"
-  dependencies:
-    encoding: "npm:^0.1.13"
-    minipass: "npm:^3.1.6"
-    minipass-sized: "npm:^1.0.3"
-    minizlib: "npm:^2.1.2"
-  dependenciesMeta:
-    encoding:
-      optional: true
-  checksum: 10c0/33ab2c5bdb3d91b9cb8bc6ae42d7418f4f00f7f7beae14b3bb21ea18f9224e792f560a6e17b6f1be12bbeb70dbe99a269f4204c60e5d99130a0777b153505c43
-  languageName: node
-  linkType: hard
-
 "minipass-fetch@npm:^4.0.0":
   version: 4.0.1
   resolution: "minipass-fetch@npm:4.0.1"
@@ -10720,7 +10682,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^3.0.0, minipass@npm:^3.1.0, minipass@npm:^3.1.1, minipass@npm:^3.1.3, minipass@npm:^3.1.6":
+"minipass@npm:^3.0.0, minipass@npm:^3.1.0, minipass@npm:^3.1.1, minipass@npm:^3.1.3":
   version: 3.3.6
   resolution: "minipass@npm:3.3.6"
   dependencies:
@@ -10752,7 +10714,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minizlib@npm:^2.0.0, minizlib@npm:^2.1.1, minizlib@npm:^2.1.2":
+"minizlib@npm:^2.0.0, minizlib@npm:^2.1.1":
   version: 2.1.2
   resolution: "minizlib@npm:2.1.2"
   dependencies:
@@ -11025,7 +10987,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"negotiator@npm:^0.6.2, negotiator@npm:^0.6.3":
+"negotiator@npm:^0.6.2":
   version: 0.6.4
   resolution: "negotiator@npm:0.6.4"
   checksum: 10c0/3e677139c7fb7628a6f36335bf11a885a62c21d5390204590a1a214a5631fcbe5ea74ef6a610b60afe84b4d975cbe0566a23f20ee17c77c73e74b80032108dea
@@ -11070,7 +11032,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-abi@npm:^3.0.0, node-abi@npm:^3.63.0":
+"node-abi@npm:^3.63.0":
   version: 3.75.0
   resolution: "node-abi@npm:3.75.0"
   dependencies:
@@ -11088,24 +11050,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-addon-api@npm:^3.1.0":
-  version: 3.2.1
-  resolution: "node-addon-api@npm:3.2.1"
-  dependencies:
-    node-gyp: "npm:latest"
-  checksum: 10c0/41f21c9d12318875a2c429befd06070ce367065a3ef02952cfd4ea17ef69fa14012732f510b82b226e99c254da8d671847ea018cad785f839a5366e02dd56302
-  languageName: node
-  linkType: hard
-
-"node-api-version@npm:^0.1.4":
-  version: 0.1.4
-  resolution: "node-api-version@npm:0.1.4"
-  dependencies:
-    semver: "npm:^7.3.5"
-  checksum: 10c0/3f46ece55e1a254da2d20d2b7f1be11125d37788607aa807ef75b321de289739accc30df46395bee87f1fef210472eacbe421adaa540f3b6d9e986b289a37674
-  languageName: node
-  linkType: hard
-
 "node-fetch@npm:2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
@@ -11117,17 +11061,6 @@ __metadata:
     encoding:
       optional: true
   checksum: 10c0/fcae80f5ac52fbf5012f5e19df2bd3915e67d3b3ad51cb5942943df2238d32ba15890fecabd0e166876a9f98a581ab50f3f10eb942b09405c49ef8da36b826c7
-  languageName: node
-  linkType: hard
-
-"node-gyp-build@npm:^4.2.1":
-  version: 4.8.4
-  resolution: "node-gyp-build@npm:4.8.4"
-  bin:
-    node-gyp-build: bin.js
-    node-gyp-build-optional: optional.js
-    node-gyp-build-test: build-test.js
-  checksum: 10c0/444e189907ece2081fe60e75368784f7782cfddb554b60123743dfb89509df89f1f29c03bbfa16b3a3e0be3f48799a4783f487da6203245fa5bed239ba7407e1
   languageName: node
   linkType: hard
 
@@ -11148,27 +11081,6 @@ __metadata:
   bin:
     node-gyp: bin/node-gyp.js
   checksum: 10c0/80ef333b3a882eb6a2695a8e08f31d618f4533eff192864e4a3a16b67ff0abc9d8c1d5fac0395550ec699326b9248c5e2b3be178492f7f4d1ccf97d2cf948021
-  languageName: node
-  linkType: hard
-
-"node-gyp@npm:^9.0.0":
-  version: 9.4.1
-  resolution: "node-gyp@npm:9.4.1"
-  dependencies:
-    env-paths: "npm:^2.2.0"
-    exponential-backoff: "npm:^3.1.1"
-    glob: "npm:^7.1.4"
-    graceful-fs: "npm:^4.2.6"
-    make-fetch-happen: "npm:^10.0.3"
-    nopt: "npm:^6.0.0"
-    npmlog: "npm:^6.0.0"
-    rimraf: "npm:^3.0.2"
-    semver: "npm:^7.3.5"
-    tar: "npm:^6.1.2"
-    which: "npm:^2.0.2"
-  bin:
-    node-gyp: bin/node-gyp.js
-  checksum: 10c0/f7d676cfa79f27d35edf17fe9c80064123670362352d19729e5dc9393d7e99f1397491c3107eddc0c0e8941442a6244a7ba6c860cfbe4b433b4cae248a55fe10
   languageName: node
   linkType: hard
 
@@ -11225,17 +11137,6 @@ __metadata:
   bin:
     nopt: bin/nopt.js
   checksum: 10c0/fc5c4f07155cb455bf5fc3dd149fac421c1a40fd83c6bfe83aa82b52f02c17c5e88301321318adaa27611c8a6811423d51d29deaceab5fa158b585a61a551061
-  languageName: node
-  linkType: hard
-
-"nopt@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "nopt@npm:6.0.0"
-  dependencies:
-    abbrev: "npm:^1.0.0"
-  bin:
-    nopt: bin/nopt.js
-  checksum: 10c0/837b52c330df16fcaad816b1f54fec6b2854ab1aa771d935c1603fbcf9b023bb073f1466b1b67f48ea4dce127ae675b85b9d9355700e9b109de39db490919786
   languageName: node
   linkType: hard
 
@@ -11573,7 +11474,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ora@npm:^5.1.0, ora@npm:^5.4.1":
+"ora@npm:^5.4.1":
   version: 5.4.1
   resolution: "ora@npm:5.4.1"
   dependencies:
@@ -13098,6 +12999,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"roarr@npm:^2.15.3":
+  version: 2.15.4
+  resolution: "roarr@npm:2.15.4"
+  dependencies:
+    boolean: "npm:^3.0.1"
+    detect-node: "npm:^2.0.4"
+    globalthis: "npm:^1.0.1"
+    json-stringify-safe: "npm:^5.0.1"
+    semver-compare: "npm:^1.0.0"
+    sprintf-js: "npm:^1.1.2"
+  checksum: 10c0/7d01d4c14513c461778dd673a8f9e53255221f8d04173aafeb8e11b23d8b659bb83f1c90cfe81af7f9c213b8084b404b918108fd792bda76678f555340cc64ec
+  languageName: node
+  linkType: hard
+
 "rollup@npm:^4.2.0":
   version: 4.45.1
   resolution: "rollup@npm:4.45.1"
@@ -13350,6 +13265,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver-compare@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "semver-compare@npm:1.0.0"
+  checksum: 10c0/9ef4d8b81847556f0865f46ddc4d276bace118c7cb46811867af82e837b7fc473911981d5a0abc561fa2db487065572217e5b06e18701c4281bcdd2a1affaff1
+  languageName: node
+  linkType: hard
+
 "semver-diff@npm:^2.0.0":
   version: 2.1.0
   resolution: "semver-diff@npm:2.1.0"
@@ -13397,7 +13319,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.3":
+"semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.3":
   version: 7.7.2
   resolution: "semver@npm:7.7.2"
   bin:
@@ -13455,6 +13377,15 @@ __metadata:
     chainsaw: "npm:>=0.0.7 <0.1"
     hashish: "npm:>=0.0.2 <0.1"
   checksum: 10c0/d660860f33a2a5c4f46c7c3724688788bcc84d0c6ba80026cefe7629ba5495f27960e48ed67d8e0c7ae9e0b2144e9f9f8594f17eab615d191f242dd055ec0582
+  languageName: node
+  linkType: hard
+
+"serialize-error@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "serialize-error@npm:7.0.1"
+  dependencies:
+    type-fest: "npm:^0.13.1"
+  checksum: 10c0/7982937d578cd901276c8ab3e2c6ed8a4c174137730f1fb0402d005af209a0e84d04acc874e317c936724c7b5b26c7a96ff7e4b8d11a469f4924a4b0ea814c05
   languageName: node
   linkType: hard
 
@@ -13873,17 +13804,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks-proxy-agent@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "socks-proxy-agent@npm:7.0.0"
-  dependencies:
-    agent-base: "npm:^6.0.2"
-    debug: "npm:^4.3.3"
-    socks: "npm:^2.6.2"
-  checksum: 10c0/b859f7eb8e96ec2c4186beea233ae59c02404094f3eb009946836af27d6e5c1627d1975a69b4d2e20611729ed543b6db3ae8481eb38603433c50d0345c987600
-  languageName: node
-  linkType: hard
-
 "socks-proxy-agent@npm:^8.0.3":
   version: 8.0.5
   resolution: "socks-proxy-agent@npm:8.0.5"
@@ -14031,7 +13951,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sprintf-js@npm:^1.1.3":
+"sprintf-js@npm:^1.1.2, sprintf-js@npm:^1.1.3":
   version: 1.1.3
   resolution: "sprintf-js@npm:1.1.3"
   checksum: 10c0/09270dc4f30d479e666aee820eacd9e464215cdff53848b443964202bf4051490538e5dd1b42e1a65cf7296916ca17640aebf63dae9812749c7542ee5f288dec
@@ -14081,15 +14001,6 @@ __metadata:
   dependencies:
     minipass: "npm:^3.1.1"
   checksum: 10c0/5cfae216ae02dcd154d1bbed2d0a60038a4b3a2fcaac3c7e47401ff4e058e551ee74cfdba618871bf168cd583db7b8324f94af6747d4303b73cd4c3f6dc5c9c2
-  languageName: node
-  linkType: hard
-
-"ssri@npm:^9.0.0":
-  version: 9.0.1
-  resolution: "ssri@npm:9.0.1"
-  dependencies:
-    minipass: "npm:^3.1.1"
-  checksum: 10c0/c5d153ce03b5980d683ecaa4d805f6a03d8dc545736213803e168a1907650c46c08a4e5ce6d670a0205482b35c35713d9d286d9133bdd79853a406e22ad81f04
   languageName: node
   linkType: hard
 
@@ -14428,6 +14339,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sumchecker@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "sumchecker@npm:3.0.1"
+  dependencies:
+    debug: "npm:^4.1.0"
+  checksum: 10c0/43c387be9dfe22dbeaf39dfa4ffb279847aeb37a42a8988c0b066f548bbd209aa8c65e03da29f2b29be1a66b577801bf89fff0007df4183db2f286263a9569e5
+  languageName: node
+  linkType: hard
+
 "supports-color@npm:8.1.1, supports-color@npm:^8.0.0, supports-color@npm:^8.1.1":
   version: 8.1.1
   resolution: "supports-color@npm:8.1.1"
@@ -14537,7 +14457,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^6.0.2, tar@npm:^6.0.5, tar@npm:^6.1.11, tar@npm:^6.1.2":
+"tar@npm:^6.0.2, tar@npm:^6.1.2":
   version: 6.2.1
   resolution: "tar@npm:6.2.1"
   dependencies:
@@ -14920,6 +14840,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-fest@npm:^0.13.1":
+  version: 0.13.1
+  resolution: "type-fest@npm:0.13.1"
+  checksum: 10c0/0c0fa07ae53d4e776cf4dac30d25ad799443e9eef9226f9fddbb69242db86b08584084a99885cfa5a9dfe4c063ebdc9aa7b69da348e735baede8d43f1aeae93b
+  languageName: node
+  linkType: hard
+
 "type-fest@npm:^0.20.2":
   version: 0.20.2
   resolution: "type-fest@npm:0.20.2"
@@ -15167,15 +15094,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unique-filename@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "unique-filename@npm:2.0.1"
-  dependencies:
-    unique-slug: "npm:^3.0.0"
-  checksum: 10c0/55d95cd670c4a86117ebc34d394936d712d43b56db6bc511f9ca00f666373818bf9f075fb0ab76bcbfaf134592ef26bb75aad20786c1ff1ceba4457eaba90fb8
-  languageName: node
-  linkType: hard
-
 "unique-filename@npm:^4.0.0":
   version: 4.0.0
   resolution: "unique-filename@npm:4.0.0"
@@ -15191,15 +15109,6 @@ __metadata:
   dependencies:
     imurmurhash: "npm:^0.1.4"
   checksum: 10c0/9eabc51680cf0b8b197811a48857e41f1364b25362300c1ff636c0eca5ec543a92a38786f59cf0697e62c6f814b11ecbe64e8093db71246468a1f03b80c83970
-  languageName: node
-  linkType: hard
-
-"unique-slug@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "unique-slug@npm:3.0.0"
-  dependencies:
-    imurmurhash: "npm:^0.1.4"
-  checksum: 10c0/617240eb921af803b47d322d75a71a363dacf2e56c29ae5d1404fad85f64f4ec81ef10ee4fd79215d0202cbe1e5a653edb0558d59c9c81d3bd538c2d58e4c026
   languageName: node
   linkType: hard
 

--- a/node-packages/yarn.lock
+++ b/node-packages/yarn.lock
@@ -5590,7 +5590,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:^33.4.11":
+"electron@npm:33.4.11":
   version: 33.4.11
   resolution: "electron@npm:33.4.11"
   dependencies:

--- a/non-nix-build/build_mac_app.sh
+++ b/non-nix-build/build_mac_app.sh
@@ -8,7 +8,7 @@ iconutil -c icns "$ROOT_DIR/resources/Icon.iconset" --output "$ROOT_DIR/resource
 
 # Install dependencies and build entry script
 pushd "$ROOT_DIR/node-packages" >/dev/null
-echo y | npx yarn >/dev/null
+yarn install >/dev/null
 nim \
     --hints:on --warnings:off --sourcemap:on \
     -d:ctIndex -d:chronicles_sinks=json \

--- a/non-nix-build/build_mac_app.sh
+++ b/non-nix-build/build_mac_app.sh
@@ -12,7 +12,7 @@ yarn install >/dev/null
 nim \
     --hints:on --warnings:off --sourcemap:on \
     -d:ctIndex -d:chronicles_sinks=json \
-    -d:nodejs --out:index.js ../src/frontend/index.nim
+    -d:nodejs --out:index.js js ../src/frontend/index.nim
 npx electron-builder --mac dir
 popd >/dev/null
 

--- a/non-nix-build/build_mac_app.sh
+++ b/non-nix-build/build_mac_app.sh
@@ -16,6 +16,9 @@ nim \
 npx electron-builder --mac dir
 popd >/dev/null
 
-# Place the resulting .app where the DMG builder expects it
+# Place the resulting .app where the DMG builder expects it. electron-builder
+# emits architecture-specific directories (e.g. mac-arm64), so pick whichever
+# one was produced.
 rm -rf "$ROOT_DIR/non-nix-build/CodeTracer.app"
-cp -R "$ROOT_DIR/node-packages/dist/mac/CodeTracer.app" "$ROOT_DIR/non-nix-build/CodeTracer.app"
+APP_BUNDLE=$(find "$ROOT_DIR/node-packages/dist" -maxdepth 1 -type d -name 'mac*' | head -n 1)/CodeTracer.app
+cp -R "$APP_BUNDLE" "$ROOT_DIR/non-nix-build/CodeTracer.app"

--- a/non-nix-build/build_mac_app.sh
+++ b/non-nix-build/build_mac_app.sh
@@ -1,23 +1,14 @@
 #!/usr/bin/env bash
 set -e
 
-cd "$DIST_DIR"
+# Ensure icons are available for electron-builder
+iconutil -c icns "$ROOT_DIR/resources/Icon.iconset" --output "$ROOT_DIR/resources/CodeTracer.icns"
 
-mkdir -p "$DIST_DIR"/../Resources/
-iconutil -c icns "$ROOT_DIR"/resources/Icon.iconset --output "$DIST_DIR"/../Resources/CodeTracer.icns
-cp "$ROOT_DIR"/resources/Info.plist "$DIST_DIR"/..
+# Build the macOS application using electron-builder
+pushd "$ROOT_DIR/node-packages" >/dev/null
+npx electron-builder --mac dir
+popd >/dev/null
 
-# In the `public` folder, we have some symlinks to this awkwardly placed directory
-cd "$DIST_DIR"/..
-ln -s MacOS/node_modules ./
-
-# Hack because basically every OS-level string is labeled as Electron instead CodeTracer. Can be resolved by using a bundler
-cp "$ROOT_DIR"/resources/Info.plist "$(realpath MacOS/node_modules)"/electron/dist/Electron.app/Contents/Info.plist
-cp "$DIST_DIR"/../Resources/CodeTracer.icns "$(realpath MacOS/node_modules)"/electron/dist/Electron.app/Contents/Resources/
-
-# macOS uses core utils from FreeBSD so the additional "" is needed to execute this sed call.
-#
-# This sed call is needed because even though we replaced the entire plist file, the CodeTracer icon will not be displayed correctly
-# in the auto-generated about menu, if the correct executable isn't listed here. If it was left as "bin/ct" a big disabled icon would
-# be overlayed on top of the app icon
-sed -i "" "s/\<string\>bin\/ct/\<string\>Electron/g" "$(realpath MacOS/node_modules)"/electron/dist/Electron.app/Contents/Info.plist
+# Place the resulting .app where the DMG builder expects it
+rm -rf "$ROOT_DIR/non-nix-build/CodeTracer.app"
+cp -R "$ROOT_DIR/node-packages/dist/mac/CodeTracer.app" "$ROOT_DIR/non-nix-build/CodeTracer.app"

--- a/non-nix-build/build_mac_app.sh
+++ b/non-nix-build/build_mac_app.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 set -e
 
+ROOT_DIR=$(git rev-parse --show-toplevel)
+
 # Ensure icons are available for electron-builder
 iconutil -c icns "$ROOT_DIR/resources/Icon.iconset" --output "$ROOT_DIR/resources/CodeTracer.icns"
 
-# Build the macOS application using electron-builder
+# Install dependencies and build entry script
 pushd "$ROOT_DIR/node-packages" >/dev/null
+echo y | npx yarn >/dev/null
+nim \
+    --hints:on --warnings:off --sourcemap:on \
+    -d:ctIndex -d:chronicles_sinks=json \
+    -d:nodejs --out:index.js ../src/frontend/index.nim
 npx electron-builder --mac dir
 popd >/dev/null
 


### PR DESCRIPTION
## Summary
- invoke electron-builder for Nix, AppImage, macOS, and Tup builds
- configure macOS build to use CodeTracer icon and Info.plist
- document the new electron-builder usage in codebase insights
- include electron dev dependency and postinstall script so electron-builder can resolve the version
- point Nix build to node-packages when invoking electron-builder
- regenerate yarn.lock and refresh yarn-project.nix cache hash so Nix can fetch electron offline
- record that dependency changes require updating yarn.lock and the Nix cache hash
- skip electron binary downloads and reuse Nix-provided electron via ELECTRON_OVERRIDE_DIST_PATH

## Testing
- `npm test` (fails: ava: not found)
- `cargo test` (fails: Failed to execute `capnp --version`)
- `cargo clippy` (fails: Failed to execute `capnp --version`)


------
https://chatgpt.com/codex/tasks/task_b_68a74a0ebd208325ad8413f6c07e29b0