### PR TITLE
fix: fix a lang detection bug and improve lang detection logic

### DIFF
--- a/src/ct/utilities/language_detection.nim
+++ b/src/ct/utilities/language_detection.nim
@@ -43,33 +43,43 @@ const WASM_LANGS = {
 proc detectLang*(program: string, lang: Lang, isWasm: bool = false): Lang =
   # TODO: under a debug print flag?
   # echo "detectLang ", program, " ", lang, " isWasm: ", isWasm
+  if lang != LangUnknown:
+    return lang
+
+  result = LangUnknown # by default
+
   var possiblyExpandedPath = ""
   try:
     possiblyExpandedPath = expandFileName(program)
   except CatchableError:
     possiblyExpandedPath = program
 
-  if lang == LangUnknown:
-    if "." in possiblyExpandedPath:
-      let extension = rsplit(possiblyExpandedPath[1..^1], ".", 1)[1].toLowerAscii()
-      if not isWasm:
-        if LANGS.hasKey(extension):
-          result = LANGS[extension] # TODO detectLangFromTrace(traceId)
-      else:
-        if WASM_LANGS.hasKey(extension):
-          result = WASM_LANGS[extension]        
-    elif dirExists(program):
-      result = detectFolderLang(program)
-    else:
-      let ctConfig = loadConfig(folder=getCurrentDir(), inTest=false)
-      if ctConfig.rrBackend.enabled:
-        let rawLang = execProcess(
-          ctConfig.rrBackend.debugInfoToolPath,
-          args = @["lang", program],
-          options={}).strip
-        result = toLang(rawLang)
-      else:
-        result = LangUnknown
-  else:
-    result = lang
+  let filename = possiblyExpandedPath.extractFilename
+  let isFolder = dirExists(program)
+
+  if isFolder:
+    result = detectFolderLang(program)
+    if result != LangUnknown:
+      return result
+
+  if not isFolder and "." in filename:
+    let extension = rsplit(filename[1..^1], ".", 1)[1].toLowerAscii()
+
+    if isWasm and WASM_LANGS.hasKey(extension):
+      return WASM_LANGS[extension]
+
+    if LANGS.hasKey(extension):
+      result = LANGS[extension] # TODO detectLangFromTrace(traceId)
+      if result != LangUnknown:
+        return result
+
+  # try with the rr-backend
+  let ctConfig = loadConfig(folder=getCurrentDir(), inTest=false)
+  if ctConfig.rrBackend.enabled:
+    let rawLang = execProcess(
+      ctConfig.rrBackend.debugInfoToolPath,
+      args = @["lang", program],
+      options={}).strip
+    result = toLang(rawLang)
+
   # echo "detectLang result ", result


### PR DESCRIPTION
(alexander): the bug was that when we had a `.` in a parent-parent folder of `program` on Nikola's machine, we were detecting the next part of the path as an extension, and also returning a false LangC default
(`ct record` wasn't working for `ct record .` in such a noir folder)

overally the logic was messy, refactored a bit according to Nikola's suggestions