### PR TITLE
fix: try to generate a more unique id in the trace archive filename when export folder is set

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -75,3 +75,6 @@
 [submodule "libs/jsony"]
 	path = libs/jsony
 	url = git@github.com:treeform/jsony.git
+[submodule "libs/nim-uuid4"]
+	path = libs/nim-uuid4
+	url = https://github.com/vtbassmatt/nim-uuid4.git

--- a/docs/book/src/misc/environment_variables.md
+++ b/docs/book/src/misc/environment_variables.md
@@ -10,7 +10,7 @@ for many of the flags, we expect "1" to enable them
 1. `CODETRACER_RECORD_CORE` - this does nothing as it is only related to the unreleased system backend
 1. `CODETRACER_SHELL_SOCKET` - this sets the socket path for sending events to the CI integration from `ct record`(or eventually `ct shell`)
 1. `CODETRACER_SHELL_ADDRESS` - this sets the address for sending events to the CI integration from `ct record`(or eventually `ct shell`)
-1. `CODETRACER_SHELL_EXPORT` - this enables export mode for `ct record` on: exporting the traces into zip files in the folder that is the value of this env variables; (similarly to the `ct record -e=<zippath>` option, but for all records while the variable is enabled)
+1. `CODETRACER_SHELL_EXPORT` - this enables export mode for `ct record` on: exporting the traces into zip files in the folder that is the value of this env variables; (similarly to the `ct record -e=<zippath>` option, but for all records while the variable is enabled). The trace archives try to use a globally unique id in their filenames, from `std/oids` in the nim stdlib: https://nim-lang.org/docs/oids.html
 1. `CODETRACER_DEBUG_CURL` - if "1", print debug output for the raw objects sent with curl for the CI integration from `ct record`(or eventually `ct shell`)
 
 ## CodeTracer Shell

--- a/nim.cfg
+++ b/nim.cfg
@@ -27,5 +27,6 @@ path:"libs/nim-confutils"
 path:"libs/nimcrypto"
 path:"libs/zip"
 path:"libs/jsony/src"
+path:"libs/nim-uuid4/src"
 
 gcc.options.debug = "-O0 -g3"

--- a/src/ct/db_backend_record.nim
+++ b/src/ct/db_backend_record.nim
@@ -1,5 +1,6 @@
-import std/[ os, osproc, strutils, strformat, sequtils, json, oids ],
+import std/[ os, osproc, strutils, strformat, sequtils, json ],
   json_serialization,
+  uuid4,
   ../common/[ lang, paths, types, trace_index ],
   utilities/[ env, language_detection, zip ],
   cli/[ logging, help ],
@@ -490,8 +491,8 @@ proc main*(): Trace =
     if isExported:
       # args override env vars, which exportFolder comes from
       if not isExportedWithArg and exportFolder.len > 0:
-        let oid = $genOid()
-        exportZipPath = exportFolder / fmt"trace-{oid}.zip"
+        let uuid = $uuid4()
+        exportZipPath = exportFolder / fmt"trace-{uuid}.zip"
         createDir(exportFolder)
       exportRecord(program, recordArgs, traceId, exportZipPath, outputFolder, cleanupOutputFolder)
 

--- a/src/ct/db_backend_record.nim
+++ b/src/ct/db_backend_record.nim
@@ -1,4 +1,4 @@
-import std/[ os, osproc, strutils, strformat, sequtils, json ],
+import std/[ os, osproc, strutils, strformat, sequtils, json, oids ],
   json_serialization,
   ../common/[ lang, paths, types, trace_index ],
   utilities/[ env, language_detection, zip ],
@@ -490,7 +490,8 @@ proc main*(): Trace =
     if isExported:
       # args override env vars, which exportFolder comes from
       if not isExportedWithArg and exportFolder.len > 0:
-        exportZipPath = exportFolder / fmt"trace-{traceId}.zip"
+        let oid = $genOid()
+        exportZipPath = exportFolder / fmt"trace-{oid}.zip"
         createDir(exportFolder)
       exportRecord(program, recordArgs, traceId, exportZipPath, outputFolder, cleanupOutputFolder)
 


### PR DESCRIPTION
Nikola proposed putting something like guid-s/uuid-s here, 
first we tried with`oid`, it is taken from nim stdlib `std/oids`: not sure if good enough for this case
it seems it wasn't maybe sure enough, so tried a library: hopefully this is valid uuid v4: 
https://github.com/vtbassmatt/nim-uuid4 credits to Matt Cooper its author

one case when this should work is when `CODETRACER_SHELL_EXPORT` is set to a non-empty folder name (of the target trace archives folder)