### PR TITLE
Add Nix shell and relocate C# Playwright tests

### DIFF
--- a/ui-tests-experimental/.gitignore
+++ b/ui-tests-experimental/.gitignore
@@ -1,0 +1,5 @@
+bin/
+obj/
+TestResults/
+playwright-report/
+test-results/

--- a/ui-tests-experimental/GlobalUsings.cs
+++ b/ui-tests-experimental/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/ui-tests-experimental/Helpers/CodetracerLauncher.cs
+++ b/ui-tests-experimental/Helpers/CodetracerLauncher.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
+namespace UiTestsExperimental.Helpers
+{
+    public static class CodetracerLauncher
+    {
+        private static readonly string RepoRoot =
+            Environment.GetEnvironmentVariable("CODETRACER_REPO_ROOT_PATH") ??
+            Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+        public static string CtPath { get; } =
+            Environment.GetEnvironmentVariable("CODETRACER_E2E_CT_PATH") ??
+            Path.Combine(
+                Environment.GetEnvironmentVariable("NIX_CODETRACER_EXE_DIR") ??
+                Path.Combine(RepoRoot, "src", "build-debug"),
+                "bin", "ct");
+
+        private static readonly string CtInstallDir = Path.GetDirectoryName(CtPath)!;
+        private static readonly string ProgramsDir = Path.Combine(RepoRoot, "ui-tests", "programs");
+
+        public static bool IsCtAvailable => File.Exists(CtPath);
+
+        public static async Task<IPage> LaunchAsync(string programRelativePath)
+        {
+            if (!IsCtAvailable)
+                throw new FileNotFoundException($"ct executable not found at {CtPath}");
+
+            int traceId = RecordProgram(programRelativePath);
+            StartCore(traceId, 1);
+
+            var playwright = await Playwright.CreateAsync();
+            var app = await ((dynamic)playwright)._electron.LaunchAsync(new
+            {
+                executablePath = CtPath,
+                cwd = CtInstallDir,
+                env = new
+                {
+                    CODETRACER_CALLER_PID = "1",
+                    CODETRACER_TRACE_ID = traceId.ToString(),
+                    CODETRACER_IN_UI_TEST = "1",
+                    CODETRACER_TEST = "1",
+                    CODETRACER_WRAP_ELECTRON = "1",
+                    CODETRACER_START_INDEX = "1"
+                }
+            });
+
+            var firstWindow = await app.FirstWindowAsync();
+            return (await firstWindow.TitleAsync()) == "DevTools"
+                ? (await app.WindowsAsync())[1]
+                : firstWindow;
+        }
+
+        private static int RecordProgram(string relativePath)
+        {
+            var psi = new ProcessStartInfo(CtPath, $"record {Path.Combine(ProgramsDir, relativePath)}")
+            {
+                WorkingDirectory = CtInstallDir,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+
+            using var proc = Process.Start(psi)!;
+            proc.WaitForExit();
+            var lines = proc.StandardOutput.ReadToEnd().Trim().Split('\n');
+            var last = lines.Last();
+            return int.Parse(last.Split(':')[1].Trim());
+        }
+
+        private static void StartCore(int traceId, int runPid)
+        {
+            var psi = new ProcessStartInfo(CtPath, $"start_core {traceId} {runPid}")
+            {
+                WorkingDirectory = CtInstallDir
+            };
+            Process.Start(psi);
+        }
+    }
+}
+

--- a/ui-tests-experimental/Tests/MenuLogoTests.cs
+++ b/ui-tests-experimental/Tests/MenuLogoTests.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using NUnit.Framework;
+using UiTestsExperimental.Helpers;
+
+namespace UiTestsExperimental.Tests
+{
+    public class MenuLogoTests
+    {
+        [Test]
+        public async Task MenuLogoAppearsWithin10Seconds()
+        {
+            if (!CodetracerLauncher.IsCtAvailable)
+            {
+                Assert.Ignore($"ct executable not found at {CodetracerLauncher.CtPath}. Build CodeTracer or set CODETRACER_E2E_CT_PATH.");
+            }
+
+            var page = await CodetracerLauncher.LaunchAsync("noir_space_ship");
+            await page.WaitForSelectorAsync(".menu-logo-img", new() { Timeout = 10_000 });
+            Assert.Pass("The menu logo appeared within 10 seconds.");
+        }
+    }
+}

--- a/ui-tests-experimental/UiTestsExperimental.csproj
+++ b/ui-tests-experimental/UiTestsExperimental.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.54.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/ui-tests-experimental/flake.nix
+++ b/ui-tests-experimental/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "Dev shell for experimental C# Playwright UI tests";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in {
+        devShells.default = pkgs.mkShell {
+          packages = [
+            pkgs.dotnet-sdk_8
+            pkgs.nodejs_22
+            pkgs.playwright
+            pkgs.playwright-driver.browsers
+          ];
+          shellHook = ''
+            export PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers}
+            export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1
+          '';
+        };
+      });
+}


### PR DESCRIPTION
## Summary
- move `ui-tests-experimental` project to repository root
- add `flake.nix` providing dotnet, node, and Playwright for tests
- enhance `CodetracerLauncher` to locate `ct` via env vars and expose availability check
- skip C# Playwright test when `ct` executable is missing

## Testing
- `dotnet build`
- `dotnet test` *(skipped: ct executable not found)*
- `cargo build` *(failed: capnp executable missing)*
- `cargo test` *(failed: capnp executable missing)*
- `cargo clippy` *(failed: capnp executable missing)*

------
https://chatgpt.com/codex/tasks/task_b_68af00a27a40832ab857bbe43d59024a