### PR TITLE
Fix clash between local and system ct

### DIFF
--- a/nix/shells/main.nix
+++ b/nix/shells/main.nix
@@ -260,8 +260,8 @@ mkShell {
     export NIX_CODETRACER_EXE_DIR=$ROOT_PATH/src/build-debug/
     export LINKS_PATH_DIR=$ROOT_PATH/src/build-debug/
     export CODETRACER_REPO_ROOT_PATH=$ROOT_PATH
-    export PATH=$PATH:$PWD/src/build-debug/bin
-    export PATH=$PATH:$ROOT_PATH/node_modules/.bin/
+    export PATH=$PWD/src/build-debug/bin:$PATH
+    export PATH=$ROOT_PATH/node_modules/.bin/:$PATH
     export CODETRACER_OPEN_DEV_TOOLS=1
     export CODETRACER_LOG_LEVEL=INFO
 


### PR DESCRIPTION
On Linux distributions where both both the ct appimage/package is installed and one tries to run ct locally from a dev shell the system ct is used. This should not be the case.