### PR TITLE
feat(ui-tests-experimental): add selenium launcher

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -10,3 +10,4 @@
 
 
 - The db-backend DAP server now responds to the `configurationDone` request.
+- Experimental Selenium-based launcher added for driving the Electron UI via ChromeDriver.

--- a/ui-tests-experimental/Helpers/CodetracerLauncher.cs
+++ b/ui-tests-experimental/Helpers/CodetracerLauncher.cs
@@ -4,81 +4,119 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
 
-namespace UtTestsExperimentalConsoleAppication.Helpers
+namespace UtTestsExperimentalConsoleAppication.Helpers;
+
+internal static class CodetracerLauncher
 {
-    public static class PlaywrightCodetracerLauncher
+    public static readonly string RepoRoot =
+        Environment.GetEnvironmentVariable("CODETRACER_REPO_ROOT_PATH") ??
+        Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    public static string CtPath { get; } =
+        Environment.GetEnvironmentVariable("CODETRACER_E2E_CT_PATH") ??
+        Path.Combine(
+            Environment.GetEnvironmentVariable("NIX_CODETRACER_EXE_DIR") ??
+            Path.Combine(RepoRoot, "src", "build-debug"),
+            "bin", "ct");
+
+    public static string CtInstallDir { get; } = Path.GetDirectoryName(CtPath)!;
+
+    private static readonly string ProgramsDir = Path.Combine(RepoRoot, "ui-tests", "programs");
+
+    public static bool IsCtAvailable => File.Exists(CtPath);
+
+    public static int RecordProgram(string relativePath)
     {
-        private static readonly string RepoRoot =
-            Environment.GetEnvironmentVariable("CODETRACER_REPO_ROOT_PATH") ??
-            Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
-
-        public static string CtPath { get; } =
-            Environment.GetEnvironmentVariable("CODETRACER_E2E_CT_PATH") ??
-            Path.Combine(
-                Environment.GetEnvironmentVariable("NIX_CODETRACER_EXE_DIR") ??
-                Path.Combine(RepoRoot, "src", "build-debug"),
-                "bin", "ct");
-
-        private static readonly string CtInstallDir = Path.GetDirectoryName(CtPath)!;
-        private static readonly string ProgramsDir = Path.Combine(RepoRoot, "ui-tests", "programs");
-
-        public static bool IsCtAvailable => File.Exists(CtPath);
-
-        public static async Task<IPage> LaunchAsync(string programRelativePath)
+        var psi = new ProcessStartInfo(CtPath, $"record {Path.Combine(ProgramsDir, relativePath)}")
         {
-            if (!IsCtAvailable)
-                throw new FileNotFoundException($"ct executable not found at {CtPath}");
+            WorkingDirectory = CtInstallDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
 
-            int traceId = RecordProgram(programRelativePath);
-            StartCore(traceId, 1);
+        using var proc = Process.Start(psi)!;
+        proc.WaitForExit();
+        var lines = proc.StandardOutput.ReadToEnd().Trim().Split('\n');
+        var last = lines.Last();
+        return int.Parse(last.Split(':')[1].Trim());
+    }
 
-            var playwright = await Playwright.CreateAsync();
-            var app = await ((dynamic)playwright)._electron.LaunchAsync(new
-            {
-                executablePath = CtPath,
-                cwd = CtInstallDir,
-                env = new
-                {
-                    CODETRACER_CALLER_PID = "1",
-                    CODETRACER_TRACE_ID = traceId.ToString(),
-                    CODETRACER_IN_UI_TEST = "1",
-                    CODETRACER_TEST = "1",
-                    CODETRACER_WRAP_ELECTRON = "1",
-                    CODETRACER_START_INDEX = "1"
-                }
-            });
-
-            var firstWindow = await app.FirstWindowAsync();
-            return (await firstWindow.TitleAsync()) == "DevTools"
-                ? (await app.WindowsAsync())[1]
-                : firstWindow;
-        }
-
-        private static int RecordProgram(string relativePath)
+    public static void StartCore(int traceId, int runPid)
+    {
+        var psi = new ProcessStartInfo(CtPath, $"start_core {traceId} {runPid}")
         {
-            var psi = new ProcessStartInfo(CtPath, $"record {Path.Combine(ProgramsDir, relativePath)}")
-            {
-                WorkingDirectory = CtInstallDir,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false
-            };
-
-            using var proc = Process.Start(psi)!;
-            proc.WaitForExit();
-            var lines = proc.StandardOutput.ReadToEnd().Trim().Split('\n');
-            var last = lines.Last();
-            return int.Parse(last.Split(':')[1].Trim());
-        }
-
-        private static void StartCore(int traceId, int runPid)
-        {
-            var psi = new ProcessStartInfo(CtPath, $"start_core {traceId} {runPid}")
-            {
-                WorkingDirectory = CtInstallDir
-            };
-            Process.Start(psi);
-        }
+            WorkingDirectory = CtInstallDir
+        };
+        Process.Start(psi);
     }
 }
+
+public static class PlaywrightCodetracerLauncher
+{
+    public static string CtPath => CodetracerLauncher.CtPath;
+    public static bool IsCtAvailable => CodetracerLauncher.IsCtAvailable;
+
+    public static async Task<IPage> LaunchAsync(string programRelativePath)
+    {
+        if (!IsCtAvailable)
+            throw new FileNotFoundException($"ct executable not found at {CtPath}");
+
+        int traceId = CodetracerLauncher.RecordProgram(programRelativePath);
+        CodetracerLauncher.StartCore(traceId, 1);
+
+        var playwright = await Playwright.CreateAsync();
+        var app = await ((dynamic)playwright)._electron.LaunchAsync(new
+        {
+            executablePath = CtPath,
+            cwd = CodetracerLauncher.CtInstallDir,
+            env = new
+            {
+                CODETRACER_CALLER_PID = "1",
+                CODETRACER_TRACE_ID = traceId.ToString(),
+                CODETRACER_IN_UI_TEST = "1",
+                CODETRACER_TEST = "1",
+                CODETRACER_WRAP_ELECTRON = "1",
+                CODETRACER_START_INDEX = "1"
+            }
+        });
+
+        var firstWindow = await app.FirstWindowAsync();
+        return (await firstWindow.TitleAsync()) == "DevTools"
+            ? (await app.WindowsAsync())[1]
+            : firstWindow;
+    }
+}
+
+public static class SeleniumCodetracerLauncher
+{
+    public static IWebDriver Launch(string programRelativePath)
+    {
+        if (!CodetracerLauncher.IsCtAvailable)
+            throw new FileNotFoundException($"ct executable not found at {CodetracerLauncher.CtPath}");
+
+        int traceId = CodetracerLauncher.RecordProgram(programRelativePath);
+        CodetracerLauncher.StartCore(traceId, 1);
+
+        var psi = new ProcessStartInfo(CodetracerLauncher.CtPath, "--remote-debugging-port=9222")
+        {
+            WorkingDirectory = CodetracerLauncher.CtInstallDir,
+            UseShellExecute = false
+        };
+        psi.Environment["CODETRACER_CALLER_PID"] = "1";
+        psi.Environment["CODETRACER_TRACE_ID"] = traceId.ToString();
+        psi.Environment["CODETRACER_IN_UI_TEST"] = "1";
+        psi.Environment["CODETRACER_TEST"] = "1";
+        psi.Environment["CODETRACER_WRAP_ELECTRON"] = "1";
+        psi.Environment["CODETRACER_START_INDEX"] = "1";
+        Process.Start(psi);
+
+        var options = new ChromeOptions();
+        options.DebuggerAddress = "127.0.0.1:9222";
+        return new ChromeDriver(options);
+    }
+}
+

--- a/ui-tests-experimental/Program.cs
+++ b/ui-tests-experimental/Program.cs
@@ -1,22 +1,33 @@
 using System;
 using System.Threading.Tasks;
-using Microsoft.Playwright;
+using OpenQA.Selenium;
 using UtTestsExperimentalConsoleAppication.Helpers;
 
 namespace UtTestsExperimentalConsoleAppication;
 
-// Console app launching CodeTracer via Playwright.
+// Console app launching CodeTracer via Selenium.
 class Program
 {
     public static async Task Main()
     {
-        if (!PlaywrightCodetracerLauncher.IsCtAvailable)
+        if (!CodetracerLauncher.IsCtAvailable)
         {
-            Console.WriteLine($"ct executable not found at {PlaywrightCodetracerLauncher.CtPath}. Build CodeTracer or set CODETRACER_E2E_CT_PATH.");
+            Console.WriteLine($"ct executable not found at {CodetracerLauncher.CtPath}. Build CodeTracer or set CODETRACER_E2E_CT_PATH.");
             return;
         }
 
-        var page = await PlaywrightCodetracerLauncher.LaunchAsync("noir_space_ship");
-        await page.WaitForSelectorAsync(".menu-logo-img", new() { Timeout = 10_000 });
+        using var driver = SeleniumCodetracerLauncher.Launch("noir_space_ship");
+        await Task.Delay(TimeSpan.FromSeconds(10));
+
+        bool isVisible = false;
+        try
+        {
+            var element = driver.FindElement(By.CssSelector(".menu-logo-img"));
+            isVisible = element.Displayed;
+        }
+        catch (NoSuchElementException)
+        {
+            // Element not found; isVisible remains false.
+        }
     }
 }


### PR DESCRIPTION
## Summary
- introduce shared launcher utilities and SeleniumCodetracerLauncher
- open CodeTracer via Selenium and query menu logo visibility
- document new Selenium launcher in codebase insights

## Testing
- `dotnet build ui-tests-experimental/ut-tests-experimental-console-appication.sln`

------
https://chatgpt.com/codex/tasks/task_b_68b0744af9dc832aaaafd32dc71037ad