### PR TITLE
fix: fix a bug in `ct record`: store sensible source folders if not git repo

### DIFF
--- a/src/ct/launch/launch.nim
+++ b/src/ct/launch/launch.nim
@@ -29,7 +29,14 @@ proc runInitial*(conf: CodetracerConf) =
 
   case conf.cmd:
     of StartupCommand.install:
-      let rootDir = when defined(withTup): getGitTopLevel(".") & "/" else: linksPath & "/"
+      let rootDir = when defined(withTup):
+          let gitTopLevelResult = getGitTopLevel(".")
+          if gitTopLevelResult.isOk:
+            gitTopLevelResult.value & "/"
+          else:
+            raise newException(ValueError, "no valid git root: " & gitTopLevelResult.error)
+        else:
+          linksPath & "/"
 
       when defined(macosx):
         let

--- a/src/ct/utilities/git.nim
+++ b/src/ct/utilities/git.nim
@@ -1,6 +1,7 @@
 import std / [ os, osproc, streams, strutils ]
+import results
 
-proc getGitTopLevel*(dir: string): string =
+proc getGitTopLevel*(dir: string): Result[string, string] =
   try:
     let gitExe = findExe("git")
     let cmd = startProcess(
@@ -12,6 +13,6 @@ proc getGitTopLevel*(dir: string): string =
     let output = cmd.outputStream.readAll().strip()
     let exitCode = waitForExit(cmd)
     if exitCode == 0 and output.len > 0:
-      return output
+      return ok(output)
   except:
-    return ""
+    return err(getCurrentExceptionMsg())

--- a/src/frontend/index_config.nim
+++ b/src/frontend/index_config.nim
@@ -953,6 +953,7 @@ proc loadFile(
   var data: js
   var res: CodetracerFile
 
+  # echo "loadFile ", path, " ", depth, " ", index, " ", traceFilesPath, " ", selfContained
   if path.len == 0:
     return res
 


### PR DESCRIPTION

this fixes a bit of the filesystem panel: now showing `main.nr` again for something like `ct record /tmp/noir_test`, but still not Nargo.toml and others their logic seems more connected to the repo case? not sure when or if fix

use `Result` instead of "" for no git root

originally bug from Nikola for importing/patching such a trace