### PR TITLE
feat(frontend): terminate backend-manager on all app exits

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -10,3 +10,10 @@
 
 
 - The db-backend DAP server now responds to the `configurationDone` request.
+
+- Electron lifecycle: the backend-manager process is spawned in
+  `src/frontend/index.nim` during `ready()`. Previously, it was only stopped
+  via an explicit UI action. We now centralize cleanup with `stopBackendManager()`
+  and hook it to `app.on('before-quit')`, `app.on('window-all-closed')`, and
+  Node process signals (`SIGINT`, `SIGTERM`, `SIGHUP`) to ensure the process
+  is always terminated when the app exits.


### PR DESCRIPTION
  - Add stopBackendManager() to centralize and idempotently kill the backend-manager process.
  - Hook cleanup into Electron lifecycle: before-quit and window-all-closed.
  - Handle Node process signals (SIGINT, SIGTERM, SIGHUP) to stop backend-manager and quit.
  - Add process exit cleanup as a final safeguard.
  - Replace ad-hoc kill in onCloseApp with centralized cleanup.
  - Update codebase insights to document the lifecycle and cleanup strategy.