### PR TITLE
Feat: autoimport traces in replay: pass raw traces directly to `ct replay -t=..`

### DIFF
--- a/src/ct/online_sharing/download.nim
+++ b/src/ct/online_sharing/download.nim
@@ -29,7 +29,7 @@ proc downloadTrace*(fileId, traceDownloadKey: string, key: array[32, byte], conf
   let traceMetadataPath = unzippedLocation / "trace_metadata.json"
   let metadataJson = parseJson(readFile(traceMetadataPath))
   let tracePathsMetadata = parseJson(readFile(unzippedLocation / "trace_paths.json"))
-  let isWasm = metadataJson{"program"}.getStr("").split("/")[^1].split(".")[^1] == "wasm" # Check if language is wasm
+  let isWasm = metadataJson{"program"}.getStr("").extractFilename.split(".")[^1] == "wasm" # Check if language is wasm
 
   var pathValue = ""
   for item in tracePathsMetadata:
@@ -37,7 +37,7 @@ proc downloadTrace*(fileId, traceDownloadKey: string, key: array[32, byte], conf
       pathValue = item.getStr("")
       break
 
-  let lang = detectLang(pathValue.split("/")[^1], LangUnknown, isWasm)
+  let lang = detectLang(pathValue.extractFilename, LangUnknown, isWasm)
   let recordPid = NO_PID # for now not processing the pid , but it can be 
   # accessed from trace metadata file if we need it in the future
   discard importDbTrace(traceMetadataPath, traceId, recordPid, lang, DB_SELF_CONTAINED_DEFAULT, traceDownloadKey)

--- a/src/ct/online_sharing/online_sharing_test.nim
+++ b/src/ct/online_sharing/online_sharing_test.nim
@@ -12,6 +12,9 @@ suite "Trace Sharing Commands":
     echo "Uploading"
     let traceId = 0
     let trace = findTraceForArgs(none(string), some(traceId), none(string))
+    if trace.isNil:
+      echo "ERROR: can't find trace in local database"
+      quit(1)
     let info = uploadTrace(trace, conf)
 
     check info.controlId.len > 0

--- a/src/ct/online_sharing/upload.nim
+++ b/src/ct/online_sharing/upload.nim
@@ -119,15 +119,19 @@ proc uploadCommand*(
     quit(1)
 
   var uploadInfo: UploadedInfo
-  var tracePath: Trace
+  var trace: Trace
 
   if interactive:
-    tracePath = interactiveTraceSelectMenu(StartupCommand.upload)
+    trace = interactiveTraceSelectMenu(StartupCommand.upload)
   else:
-    tracePath = findTraceForArgs(patternArg, traceIdArg, traceFolderArg)
+    trace = findTraceForArgs(patternArg, traceIdArg, traceFolderArg)
+
+  if trace.isNil:
+    echo "ERROR: can't find trace in local database"
+    quit(1)
 
   try:
-    uploadInfo = uploadTrace(tracePath, config)
+    uploadInfo = uploadTrace(trace, config)
   except CatchableError as e:
     echo e.msg
     quit(1)

--- a/src/ct/trace/replay.nim
+++ b/src/ct/trace/replay.nim
@@ -1,7 +1,8 @@
-import std/options,
+import std / [options, os],
   ../utilities/[ env ],
   ../cli/[ interactive_replay ],
-  ../../common/[ types ],
+  ../trace / storage_and_import,
+  ../../common/[ types, common_trace_index, lang ],
   ../codetracerconf,
   shell,
   run
@@ -20,4 +21,10 @@ proc replay*(
     trace = interactiveTraceSelectMenu(StartupCommand.replay);
   else:
     trace = findTraceForArgs(patternArg, traceIdArg, traceFolderArg)
+    
+    if trace.isNil and traceFolderArg.isSome:
+      trace = importDbTrace(traceFolderArg.get() / "trace_metadata.json", NO_TRACE_ID, NO_PID, LangUnknown)
+    if trace.isNil:
+      echo "ERROR: can't find or import trace"
+      quit(1)
   return runRecordedTrace(trace, test=false, recordCore=recordCore)

--- a/src/ct/trace/shell.nim
+++ b/src/ct/trace/shell.nim
@@ -34,15 +34,14 @@ proc findTraceForArgs*(
     patternArg: Option[string],
     traceIdArg: Option[int],
     traceFolderArg: Option[string]): Trace =
-  # if no trace found, direct error on screen and quit
+  # if no trace found, returning nil for now 
   if traceIdArg.isSome:
     let traceId = traceIdArg.get
     let trace = trace_index.find(traceId, test=false)
     if not trace.isNil:
       return trace
     else:
-      errorMessage fmt"error: trace with id {traceId} not found in local codetracer db"
-      quit(1)
+      return nil
   elif traceFolderArg.isSome:
     let folder = traceFolderArg.get
     var trace = trace_index.findByPath(expandFilename(folder), test=false)
@@ -51,8 +50,7 @@ proc findTraceForArgs*(
     if not trace.isNil:
       return trace
     else:
-      errorMessage fmt"error: trace with output folder {folder} not found in local codetracer db"
-      quit(1)
+      return nil
   else:
     assert patternArg.isSome
     let programPattern = patternArg.get
@@ -98,5 +96,4 @@ proc findTraceForArgs*(
     if not trace.isNil:
       return trace
     else:
-      errorMessage fmt"error: trace matching program with {programPattern} not found in local codetracer db"
-      quit(1)
+      return nil

--- a/src/ct/trace/storage_and_import.nim
+++ b/src/ct/trace/storage_and_import.nim
@@ -91,6 +91,7 @@ proc importDbTrace*(
   selfContained: bool = true,
   downloadKey: string = ""
 ): Trace =
+  
   let rawTraceMetadata = readFile(traceMetadataPath)
   let untypedJson = parseJson(rawTraceMetadata)
   let program = untypedJson{"program"}.getStr()
@@ -136,6 +137,11 @@ proc importDbTrace*(
   var paths: seq[string] = @[]
   if rawPaths.len > 0:
     paths = Json.decode(rawPaths, seq[string])
+
+  # var lang = langArg
+
+  # for path in paths:
+  #   path
 
   if selfContained and downloadKey == "":
     # for now assuming it happens on the original machine

--- a/src/ct/trace/storage_and_import.nim
+++ b/src/ct/trace/storage_and_import.nim
@@ -87,7 +87,7 @@ proc importDbTrace*(
   traceMetadataPath: string,
   traceIdArg: int,
   recordPid: int,
-  lang: Lang = LangNoir,
+  langArg: Lang = LangNoir,
   selfContained: bool = true,
   downloadKey: string = ""
 ): Trace =
@@ -138,10 +138,14 @@ proc importDbTrace*(
   if rawPaths.len > 0:
     paths = Json.decode(rawPaths, seq[string])
 
-  # var lang = langArg
+  var lang = langArg
 
-  # for path in paths:
-  #   path
+  if lang == LangUnknown:
+    for path in paths:
+      let traceLang = toLangFromFilename(path)
+      if traceLang != LangUnknown:
+        lang = traceLang
+        break # for now assume the first detected lang is ok
 
   if selfContained and downloadKey == "":
     # for now assuming it happens on the original machine

--- a/src/ct/trace/storage_and_import.nim
+++ b/src/ct/trace/storage_and_import.nim
@@ -156,8 +156,11 @@ proc importDbTrace*(
           lang = traceLang
         break # for now assume the first detected lang is ok
 
-  if selfContained and downloadKey == "":
-    # for now assuming it happens on the original machine
+  if existsDir(traceFolder / "files"):
+    copyDir(traceFolder / "files", outputFolder / "files")
+  elif selfContained and downloadKey == "":
+    # for now assuming if no `files/` dir already,
+    # it happens on the original machine
     # when the source files are still available and unchanged
     if paths.len > 0:
       storeTraceFiles(paths, outputFolder, lang)


### PR DESCRIPTION
make it possible to use `ct replay -t=<directly-created-by-recorder-trace>`