### PR TITLE
Synchronise the version in version.nim with the version in Info.plist

### DIFF
--- a/non-nix-build/build_mac_app.sh
+++ b/non-nix-build/build_mac_app.sh
@@ -5,6 +5,15 @@ cd "$DIST_DIR"
 
 mkdir -p "$DIST_DIR"/../Resources/
 iconutil -c icns "$ROOT_DIR"/resources/Icon.iconset --output "$DIST_DIR"/../Resources/CodeTracer.icns
+
+YEAR=$(grep "CodeTracerYear\*" "$ROOT_DIR"/src/ct/version.nim | sed "s/.*CodeTracerYear\* = //g")
+MONTH=$(printf '%02d' $(grep "CodeTracerMonth\*" "$ROOT_DIR"/src/ct/version.nim | sed "s/.*CodeTracerMonth\* = //g"))
+BUILD=$(grep "CodeTracerBuild\*" "$ROOT_DIR"/src/ct/version.nim | sed "s/.*CodeTracerBuild\* = //g")
+
+# macOS uses core utils from FreeBSD so the additional "" is needed to execute this sed call.
+sed -i "" "s/CFBundleShortVersionString.*/CFBundleShortVersionString<\/key><string>$YEAR.$MONTH.$BUILD<\/string>/g" "$ROOT_DIR"/resources/Info.plist
+sed -i "" "s/CFBundleVersion.*/CFBundleVersion<\/key><string>$YEAR.$MONTH.$BUILD<\/string>/g" "$ROOT_DIR"/resources/Info.plist
+
 cp "$ROOT_DIR"/resources/Info.plist "$DIST_DIR"/..
 
 # In the `public` folder, we have some symlinks to this awkwardly placed directory

--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -23,11 +23,10 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
 
-    <key>CFBundleShortVersionString</key>
-    <string>25.05.1</string>
+    <!-- CAUTION: DO NOT MOVE THE VALUE TO A NEW LINE!!! THIS NEEDS TO BE EDITABLE WITH SED! -->
+    <key>CFBundleShortVersionString</key><string>25.07.1</string>
 
-    <key>CFBundleVersion</key>
-    <string>25.05.1</string>
+    <key>CFBundleVersion</key><string>25.07.1</string>
 
     <key>DTCompiler</key>
     <string>com.apple.compilers.llvm.clang.1_0</string>


### PR DESCRIPTION
Currently we're not synchronising versions between `version.nim` and `Info.plist`. This patch replaces with the correct version on each build.