### PR TITLE
Fix incorrect app name in ct help

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -52,10 +52,6 @@
 [submodule "libs/nim-result"]
 	path = libs/nim-result
 	url = https://github.com/metacraft-labs/nim-result.git
-[submodule "libs/nim-confutils"]
-	path = libs/nim-confutils
-	url = https://github.com/alehander92/nim-confutils
-	branch = rest-of-args-improvements
 [submodule "libs/runtime_tracing"]
 	path = libs/runtime_tracing
 	url = https://github.com/metacraft-labs/runtime_tracing.git
@@ -81,3 +77,6 @@
 [submodule "libs/vscode-debugadapter-node"]
 	path = libs/vscode-debugadapter-node
 	url = https://github.com/microsoft/vscode-debugadapter-node.git
+[submodule "libs/nim-confutils"]
+	path = libs/nim-confutils
+	url = https://github.com/metacraft-labs/nim-confutils


### PR DESCRIPTION
Currently, when we run `ct --help` subcommands are output like this:
```
ct_unwrapped start_backend [OPTIONS]...
```
To confutils this is the correct output, since the `ct` command is really just a shell wrapper over `ct_unwrapped` or `codetracer_depending_on_env_vars_in_tup`, however to the user and to us this is incorrect because the command should really be just `ct`.

Unfortunately, there is no way to override this confutils behaviour so I needed to patch confutils for it to work.

I fixed this issue by:

1. Forking @alehander92's fork of nim-confutils into the metacraft-labs organisation(should have probably been there to begin with)
1. Creating a new branch named `codetracer` for codetracer-specific patches
1. Patching confutils to return a hardcoded `ct` string: [3100398](https://github.com/metacraft-labs/nim-confutils/commit/3100398735c044440e7babd3e61474ba8cce5b4b)
1. Replacing the current git submodule with the newly forked and patched confutils

Now the output is:
```
ct start_backend [OPTIONS]...
```