### PR TITLE
Use the native window control buttons on macOS

### DIFF
--- a/src/frontend/index/window.nim
+++ b/src/frontend/index/window.nim
@@ -42,22 +42,35 @@ proc createMainWindow*: js =
 
     let iconPath = linksPath & "/resources/Icon.iconset/icon_256x256.png"
 
-    let win = jsnew electron.BrowserWindow(
-      js{
-        "title": cstring"CodeTracer",
-        "icon": iconPath,
-        "width": 1900,
-        "height": 1400,
-        "minWidth": 1050,
-        "minHeight": 600,
-        "webPreferences": js{
-          "nodeIntegration": true,
-          "contextIsolation": false,
-          "spellcheck": false
-        },
-        "frame": false,
-        "transparent": true,
-        })
+    var initInfo = newJsObject()
+    initInfo = js{
+      "title": cstring"CodeTracer",
+      "icon": iconPath,
+      "width": 1900,
+      "height": 1400,
+      "minWidth": 1050,
+      "minHeight": 600,
+      "webPreferences": js{
+        "nodeIntegration": true,
+        "contextIsolation": false,
+        "spellcheck": false
+      },
+    }
+
+    when defined(ctmacos):
+      initInfo["titleBarStyle"] = cstring"hidden"
+      initInfo["trafficLightPosition"] = js{
+        "x": 10,
+        "y": 12
+      }
+      initInfo["titleBarOverlay"] = js{
+        "height": 70
+      }
+    else:
+      initInfo["frame"] = false
+      initInfo["transparent"] = true
+
+    let win = jsnew electron.BrowserWindow(initInfo)
     win.on("maximize", proc() =
       win.webContents.executeJavaScript("document.body.style.backgroundColor = 'black';"))
     win.on("unmaximize", proc() =

--- a/src/frontend/renderer.nim
+++ b/src/frontend/renderer.nim
@@ -1021,7 +1021,9 @@ proc isWindowMaximized(): bool {.importjs: "(window.outerWidth == screen.availWi
   false
 
 proc windowMenu*(data: Data, fromWelcomeScreen: bool = false): VNode =
-  if inElectron:
+  # Only run when not in macOS, since there we render the native traffic light buttons instead of our own
+  # window control buttons.
+  if inElectron and not defined(ctmacos):
     return buildHtml(tdiv(class = "window-menu")):
       tdiv(
         class = "menu-button-svg minimize",

--- a/src/frontend/ui/debug.nim
+++ b/src/frontend/ui/debug.nim
@@ -227,11 +227,22 @@ method render*(self: DebugComponent): VNode =
   # let klass = if self.service.stableBusy and delta(now(), self.data.ui.lastRedraw) >= 1_000: "debug-button busy" else: "debug-button"
   let finished = if self.finished: cstring"debug-finished-background" else: cstring""
 
+  # On macOS we display the native traffic light buttons, which means that we need to give them some space.
+  # They use about 20px per button and 25 for side margin for the whole widget
+  let style = when defined(ctmacos):
+    style(StyleAttr.paddingLeft, cstring("85px"))
+  else:
+    style()
+
   result = buildHtml(
     tdiv()
   ):
     messageView(self)
-    tdiv(id="debug", class=finished):
+    tdiv(
+      id="debug",
+      class=finished,
+      style=style
+    ):
 
       proc debugStepButton(id: string, action: DebuggerAction, reverse: bool): VNode {.closure.} =
         # let klass = if self.service.stableBusy and delta(now(), self.data.ui.lastRedraw) >= 1_000:
@@ -303,7 +314,9 @@ method render*(self: DebugComponent): VNode =
               text tooltipText[id]
 
       if not self.finished:
-        separateBar()
+        # Looks ugly when rendering with the traffic light buttons
+        when not defined(ctmacos):
+          separateBar()
         debugButton("history-back")
         if self.listHistory:
           buildHistoryMenu(self)


### PR DESCRIPTION
Compared to Windows or Linux, window control buttons on macOS(also called the traffic light buttons) are generally ordered differently. This means that our current window control buttons on macOS are confusing to our macOS users. It is also a UX issue, since the maximisation button shows tiling assistance settings when hovered on, and we don't show this helper popup.

This PR uses electron settings to move the native traffic light buttons to our client-side bar in order to fix this issue.

Before this patch:

<img width="2056" height="120" alt="image" src="https://github.com/user-attachments/assets/176dbd34-dc92-4305-8c58-6348280521b6" />

After this patch:

<img width="2056" height="120" alt="image" src="https://github.com/user-attachments/assets/4f98a021-ea7a-48c9-91d9-8760c647f2fc" />
