### PR TITLE
fix: small fixes for raw diff index & db-backend test

### DIFF
--- a/src/db-backend/src/diff.rs
+++ b/src/db-backend/src/diff.rs
@@ -67,6 +67,7 @@ pub struct DiffLine {
 
 // loop shape 1:
 pub fn load_and_postprocess_trace(trace_folder: &Path) -> Result<Db, Box<dyn Error>> {
+    info!("load_and_postprocess_trace {:?}", trace_folder.display());
     let mut trace_path = trace_folder.join("trace.json");
     let mut trace_file_format = runtime_tracing::TraceEventsFileFormat::Json;
     if !trace_path.exists() {
@@ -107,6 +108,7 @@ fn index_function_flow(_db: &Db, function_id: FunctionId) -> Result<(), Box<dyn 
 
 
 pub fn index_diff(diff: Diff, trace_folder: &Path, multitrace_folder: &Path) -> Result<(), Box<dyn Error>> {
+    info!("index_diff");
     let db = load_and_postprocess_trace(trace_folder)?;
 
     // breakpoint on each diff line or at least track it for db-backend

--- a/src/db-backend/src/flow_preloader.rs
+++ b/src/db-backend/src/flow_preloader.rs
@@ -41,6 +41,7 @@ impl FlowPreloader {
     }
 
     pub fn load_diff_flow(&mut self, diff_lines: HashSet<(PathBuf, i64)>, db: &Db) -> FlowUpdate {
+        info!("load_diff_flow");
         for diff_line in &diff_lines {
             match self.expr_loader.load_file(&diff_line.0) {
                 Ok(_) => {

--- a/src/db-backend/src/main.rs
+++ b/src/db-backend/src/main.rs
@@ -65,7 +65,7 @@ enum Commands {
         stdio: bool,
     },
     IndexDiff {
-        structured_diff_path: std::path::PathBuf,
+        structured_diff_raw: String, // _path: std::path::PathBuf,
         trace_folder: std::path::PathBuf,
         multitrace_folder: std::path::PathBuf,
     },
@@ -139,13 +139,13 @@ fn main() -> Result<(), Box<dyn Error>> {
             };
         }
         Commands::IndexDiff {
-            structured_diff_path,
+            structured_diff_raw,
             trace_folder,
             multitrace_folder,
         } => {
-            let raw = std::fs::read_to_string(structured_diff_path)?;
-            info!("raw {raw:?}");
-            let structured_diff = serde_json::from_str::<diff::Diff>(&raw)?;
+            // TODO: eventually structured diff path? big diff-s might not fit into CLI args
+            // let raw = std::fs::read_to_string(structured_diff_path)?;
+            let structured_diff = serde_json::from_str::<diff::Diff>(&structured_diff_raw)?;
             diff::index_diff(structured_diff, &trace_folder, &multitrace_folder)?;
         }
     }

--- a/src/db-backend/tests/dap_backend_server.rs
+++ b/src/db-backend/tests/dap_backend_server.rs
@@ -39,7 +39,6 @@ fn test_backend_dap_server() {
     let trace_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("trace");
 
     let socket_path = dap_server::socket_path_for(std::process::id() as usize);
-    let mut child = Command::new(bin).arg("dap-server").arg(&socket_path).spawn().unwrap();
 
     if let Some(dir) = socket_path.parent() {
         fs::create_dir_all(dir).unwrap_or_else(|err| panic!("failed to create socket directory {dir:?}: {err}"));
@@ -63,7 +62,7 @@ fn test_backend_dap_server() {
     // use std::os::unix::fs::PermissionsExt;
     // fs::set_permissions(&socket_path, fs::Permissions::from_mode(0o600))?;
 
-    let mut child = Command::new(bin).arg(&socket_path).spawn().unwrap();
+    let mut child = Command::new(bin).arg("dap-server").arg(&socket_path).spawn().unwrap();
     println!("Bin: {}", bin);
 
     println!("Socket path: {}", socket_path.to_str().unwrap());


### PR DESCRIPTION
small fixes after rebase; however also a `main.rs` fix, because we were handling structured diff CLI arg, as path, but it was the source not sure how this ever worked
also a small fix for the dap server test (putting the new way to called the binary in the right place, sorry)

copying commit message from original raw_diff_index commit by me and Nedy for context:

(a624ea0875269d8cae9184bce5555473d475d77d):
```

  fix: try to pass raw diff index content to db-backend instead of hardcoding path

    Part of a pairing session with Nedy;
    TODO: (alexander: i decided for now to go with passing it directly with CLI for
    faster prototype/working version)
    still hacky as CLI args have limited size/memory, but for initial internal version
    hopefully ok
    ```