### PR TITLE
feat: embed default config assets

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -25,3 +25,4 @@
 - Interpreter overrides (e.g. `CODETRACER_PYTHON_INTERPRETER`) are now treated as authoritative; if the configured path cannot be resolved we error instead of silently falling back to PATH.
 - `ct record` verifies that `codetracer_python_recorder` is importable before launching the db backend and prints actionable guidance if the module is missing or broken.
 - Sudoku test-program datasets include intentionally invalid boards (e.g., examples #3 and #6) with duplicate digits inside a sub-grid; solvers should detect and report these gracefully.
+- Default config templates live in `src/config/defaults.nim` and are embedded with `staticRead`; installers write from the embedded string rather than copying from `linksPath`.

--- a/src/config/defaults.nim
+++ b/src/config/defaults.nim
@@ -1,0 +1,10 @@
+## Default configuration payloads embedded at compile time.
+##
+## Keeping the defaults in a dedicated module allows both CLI and frontend
+## components to share the same embedded assets without relying on runtime
+## filesystem access.
+
+const
+  defaultConfigFilename* = "default_config.yaml"
+  defaultConfigContent* = staticRead(defaultConfigFilename)
+

--- a/src/frontend/config.nim
+++ b/src/frontend/config.nim
@@ -2,13 +2,15 @@ import
   std / [json, strutils, sequtils, jsffi],
   types,
   lib/jslib,
-  .. / common / ct_logging
+  .. / common / ct_logging,
+  .. / config / defaults
 
 let
   configPath* = ".config.yaml"
   testConfigPath* = ".config.yaml"
   defaultConfigPath* = "default_config.yaml"
   defaultLayoutPath* = "default_layout.json"
+  defaultConfigContent* = defaults.defaultConfigContent
 
 when not defined(ctRenderer):
   import 
@@ -55,5 +57,4 @@ proc initShortcutMap*(map: InputShortcutMap): ShortcutMap =
   for key, value in conflicts:
     result.conflictList.add((key, value))
   return result
-
 

--- a/src/frontend/index/config.nim
+++ b/src/frontend/index/config.nim
@@ -193,15 +193,16 @@ proc loadConfig*(main: js, startOptions: StartOptions, home: cstring = cstring""
       errorPrint "mkdir for config folder error: exiting: ", errMkdir
       quit(1)
 
-    let errCopy = await fsCopyFileWithErr(
-      cstring(fmt"{configDir / defaultConfigPath}"),
-      cstring(fmt"{userConfigDir / configPath}")
+    # Persist the embedded default config when the user has no local file yet.
+    let errWrite = await fsWriteFileWithErr(
+      cstring(fmt"{userConfigDir / configPath}"),
+      cstring(defaultConfigContent)
     )
 
-    if not errCopy.isNil:
-      errorPrint "can't copy .config.yaml to user config dir:"
-      errorPrint "  tried to copy from: ", cstring(fmt"{configDir / defaultConfigPath}")
-      errorPrint "  to: ", fmt"{userConfigDir / configPath}"
+    if not errWrite.isNil:
+      errorPrint "can't write default .config.yaml to user config dir:"
+      errorPrint "  target: ", fmt"{userConfigDir / configPath}"
+      errorPrint "  error: ", errWrite
       quit(1)
 
   infoPrint "index: load config ", file

--- a/src/frontend/index_config.nim
+++ b/src/frontend/index_config.nim
@@ -1219,17 +1219,14 @@ proc loadConfig*(main: js, startOptions: StartOptions, home: cstring = j"", send
     if not errMkdir.isNil:
       errorPrint "mkdir for config folder error: exiting: ", errMkdir
       quit(1)
-    # thanks to Peter for the good advice to use copyFile instead of `cp`
-    # works around an issue i had with wrong libc version and nix
-    # and more clean
-    let errCopy = await fsCopyFileWithErr(
-      cstring(fmt"{configDir / defaultConfigPath}"),
-      cstring(fmt"{userConfigDir / configPath}"));
-     # cstring(&"cp {configDir}{defaultLayoutPath} {filename}"))
-    if not errCopy.isNil:
-      errorPrint "can't copy .config.yaml to user config dir:"
-      errorPrint "  tried to copy from: ", cstring(fmt"{configDir / defaultConfigPath}")
-      errorPrint "  to: ", fmt"{userConfigDir / configPath}"
+    # Persist the embedded default config when the user has no local file yet.
+    let errWrite = await fsWriteFileWithErr(
+      cstring(fmt"{userConfigDir / configPath}"),
+      cstring(defaultConfigContent))
+    if not errWrite.isNil:
+      errorPrint "can't write default .config.yaml to user config dir:"
+      errorPrint "  target: ", fmt"{userConfigDir / configPath}"
+      errorPrint "  error: ", errWrite
       quit(1)
 
   # TODO: maybe remove config test logic?


### PR DESCRIPTION
- Embedded default config via `staticRead` shared module.
- CLI/frontend installers write embedded defaults to user config.
- Updated developer insights with new default config location.

Generated by Codex