### PR TITLE
build: fix cleanup of appimage: fix perms so rm -rf/git clean can work

### DIFF
--- a/appimage-scripts/build_appimage.sh
+++ b/appimage-scripts/build_appimage.sh
@@ -12,6 +12,7 @@ set -e
 
 cleanup() {
   echo "Performing cleanup..."
+  chmod -R 777 "${APP_DIR}"
   rm -rf ./squashfs-root
 }
 


### PR DESCRIPTION
copied this `  chmod -R 777 "${APP_DIR}"` from another place in the build appimage script: cleanup worked ok locally in the end(after this line), but not when paused early: so it seems it fixes the permissions and we can put it in cleanup without sudo

debugged/discussed this problem together with @Madman10K 