### PR TITLE
refactor: for now store diff & diff index files directly in trace; leave multitraces for the future

### DIFF
--- a/src/ct/codetracerconf.nim
+++ b/src/ct/codetracerconf.nim
@@ -420,9 +420,9 @@ type
       of listRecentTx:
         discard
     of `index-diff`:
-      indexDiffMultitracePath* {.
+      indexDiffTracePath* {.
         argument
-        desc: "Path to a multitrace: for now indexing only a single(the first) trace"
+        desc: "Path to a trace with diffs: for now indexing only a single trace"
       .}: string
 
     # of `import`:

--- a/src/ct/launch/launch.nim
+++ b/src/ct/launch/launch.nim
@@ -174,7 +174,7 @@ proc runInitial*(conf: CodetracerConf) =
         let res = Json.encode(transactions)
         echo res
     of StartupCommand.`index-diff`:
-      indexDiff(conf.indexDiffMultitracePath)
+      indexDiff(conf.indexDiffTracePath)
     # of StartupCommand.host:
     #   host(
     #     conf.hostPort,

--- a/src/ct/trace/multitrace.nim
+++ b/src/ct/trace/multitrace.nim
@@ -3,7 +3,7 @@ import json_serialization, result
 import .. / .. / common / trace_index
 import .. / .. / common / types
 import .. / utilities / [git, zip]
-import replay
+# import replay
 
 proc findDiff(diffSpecification: string): string =
   if diffSpecification.len > 0:
@@ -149,32 +149,38 @@ proc parseDiff(rawDiff: string): Diff =
         if chunk.previousFrom != 0:
           fileDiff.chunks.add(chunk)
 
-proc makeMultitraceArchive(traceFolders: seq[string], rawDiff: string, structuredDiff: Diff, outputPath: string) =
-  let folder = getTempDir() / "codetracer" / "multitrace-" & outputPath.extractFilename # TODO a more unique name?
-  removeDir(folder)
-  createDir(folder)
+# proc makeMultitraceArchive(traceFolders: seq[string], rawDiff: string, structuredDiff: Diff, outputPath: string) =
+#   let folder = getTempDir() / "codetracer" / "multitrace-" & outputPath.extractFilename # TODO a more unique name?
+#   removeDir(folder)
+#   createDir(folder)
 
-  for traceFolder in traceFolders:
-    copyDir(traceFolder, folder / traceFolder.extractFilename)
+#   for traceFolder in traceFolders:
+#     copyDir(traceFolder, folder / traceFolder.extractFilename)
 
-  writeFile(folder / "original_diff.patch", rawDiff)
-  writeFile(folder / "diff.json", Json.encode(structuredDiff, pretty=true))
-  # for now no diff_data.json or other format: eventually from diff-index
+#   writeFile(folder / "original_diff.patch", rawDiff)
+#   writeFile(folder / "diff.json", Json.encode(structuredDiff, pretty=true))
+#   # for now no diff_data.json or other format: eventually from diff-index
 
-  zipFolder(folder, outputPath)
+#   zipFolder(folder, outputPath)
 
   # TODO: decide here: only when flag archive? or always? removeDir(folder)
 
-proc makeMultitrace*(traceIdList: seq[int], diffSpecification: string, outputPath: string) =
-  # make a folder , copy those traces , find this diff, eventually parse it and store it
-  # TODO: eventually diff-index in the future
-  # in the future store as a new trace-id?
-  # for now in a custom place
+# proc makeMultitrace*(traceIdList: seq[int], diffSpecification: string, outputPath: string) =
+#   # make a folder , copy those traces , find this diff, eventually parse it and store it
+#   # TODO: eventually diff-index in the future
+#   # in the future store as a new trace-id?
+#   # for now in a custom place
   
-  # find the diff, parse
+#   # find the diff, parse
+#   let rawDiff = findDiff(diffSpecification)
+#   # echo rawDiff
+#   let structuredDiff = parseDiff(rawDiff)
+#   let traceFolders = traceIdList.mapIt(trace_index.find(it, test=false).outputFolder)
+#   makeMultitraceArchive(traceFolders, rawDiff, structuredDiff, outputPath)
+#   echo fmt"OK: created multitrace in {outputPath}"
+
+proc addDiffToTrace*(trace: Trace, diffSpecification: string) =
   let rawDiff = findDiff(diffSpecification)
-  # echo rawDiff
   let structuredDiff = parseDiff(rawDiff)
-  let traceFolders = traceIdList.mapIt(trace_index.find(it, test=false).outputFolder)
-  makeMultitraceArchive(traceFolders, rawDiff, structuredDiff, outputPath)
-  echo fmt"OK: created multitrace in {outputPath}"
+  writeFile(trace.outputFolder / "original_diff.patch", rawDiff)
+  writeFile(trace.outputFolder / "diff.json", Json.encode(structuredDiff, pretty=true))

--- a/src/ct/trace/record.nim
+++ b/src/ct/trace/record.nim
@@ -199,7 +199,8 @@ proc recordInternal(exe: string, args: seq[string], withDiff: string, configPath
       result = trace_index.find(traceId, test=false)
 
       if withDiff.len > 0:
-        makeMultitrace(@[traceId], withDiff, fmt"multitrace-with-diff-for-trace-{traceId}.zip")
+        # makeMultitrace(@[traceId], withDiff, fmt"multitrace-with-diff-for-trace-{traceId}.zip")
+        addDiffToTrace(result, withDiff)
 
 proc record*(lang: string,
              outputFolder: string,

--- a/src/ct/trace/replay.nim
+++ b/src/ct/trace/replay.nim
@@ -8,80 +8,112 @@ import std / [options, os, osproc, strutils, strformat ],
   run
 
 
-proc replayMultitrace*(archivePath: string, indexDiff: bool = false): bool =
-  # TODO: a more unique path? or is this enough
-  let fullArchivePath = expandFilename(expandTilde(archivePath))
-  let outputFolder = getTempDir() / "codetracer" / fullArchivePath.extractFilename.changeFileExt("")
-  unzipIntoFolder(fullArchivePath, outputFolder)
+# TODO: re-enable if restoring multitraces:
+# proc replayMultitrace*(archivePath: string, indexDiff: bool = false): bool =
+#   # TODO: a more unique path? or is this enough
+#   let fullArchivePath = expandFilename(expandTilde(archivePath))
+#   let outputFolder = getTempDir() / "codetracer" / fullArchivePath.extractFilename.changeFileExt("")
+#   unzipIntoFolder(fullArchivePath, outputFolder)
 
-  var traceDir = ""
-  for kind, file in walkDir(outputFolder, relative=true):
-    if kind == pcDir and file.startsWith("trace-"):
-      traceDir = outputFolder / file
-      # for now we start with supporting only 1 trace
-      # TODO: pass all the traces to the client
-      break
+#   var traceDir = ""
+#   for kind, file in walkDir(outputFolder, relative=true):
+#     if kind == pcDir and file.startsWith("trace-"):
+#       traceDir = outputFolder / file
+#       # for now we start with supporting only 1 trace
+#       # TODO: pass all the traces to the client
+#       break
   
-  if traceDir.len == 0:
-    echo "ERROR: a trace folder not found inside multitrace"
-    quit(1)
+#   if traceDir.len == 0:
+#     echo "ERROR: a trace folder not found inside multitrace"
+#     quit(1)
 
-  let trace = importDbTrace(traceDir / "trace_metadata.json", NO_TRACE_ID, NO_PID, LangUnknown)
-  if trace.isNil:
-    echo fmt"ERROR: couldn't import the trace with name {traceDir.extractFilename} from the multitrace"
-    quit(1)
+#   let trace = importDbTrace(traceDir / "trace_metadata.json", NO_TRACE_ID, NO_PID, LangUnknown)
+#   if trace.isNil:
+#     echo fmt"ERROR: couldn't import the trace with name {traceDir.extractFilename} from the multitrace"
+#     quit(1)
 
-  var structuredDiffPath = outputFolder / "diff.json"
-  var diffIndexPath = ""
+#   var structuredDiffPath = outputFolder / "diff.json"
+#   var diffIndexPath = ""
 
-  if indexDiff:
-    let backend = if trace.lang.isDbBased:
-        dbBackendExe
-      else:
-        let ctConfig = loadConfig(folder=getCurrentDir(), inTest=false)
-        if ctConfig.rrBackend.enabled:
-          ctConfig.rrBackend.path
-        else:
-          echo fmt"ERROR: rr backend not configured, but required for this trace lang: {trace.lang}"
-          quit(1)
+#   if indexDiff:
+#     let backend = if trace.lang.isDbBased:
+#         dbBackendExe
+#       else:
+#         let ctConfig = loadConfig(folder=getCurrentDir(), inTest=false)
+#         if ctConfig.rrBackend.enabled:
+#           ctConfig.rrBackend.path
+#         else:
+#           echo fmt"ERROR: rr backend not configured, but required for this trace lang: {trace.lang}"
+#           quit(1)
 
-    var eventualDiffIndexPath = outputFolder / "diff_index.json"
-    if not fileExists(eventualDiffIndexPath):
-      let process = startProcess(backend, args = @["index-diff", structuredDiffPath, traceDir, outputFolder], options={poParentStreams})
-      let exitCode = waitForExit(process)
+#     var eventualDiffIndexPath = outputFolder / "diff_index.json"
+#     if not fileExists(eventualDiffIndexPath):
+#       let process = startProcess(backend, args = @["index-diff", structuredDiffPath, traceDir, outputFolder], options={poParentStreams})
+#       let exitCode = waitForExit(process)
 
-      if exitCode == 0:
-        # replace with an archive with the indexed data
-        removeFile(archivePath)
-        zipFolder(outputFolder, archivePath)
-        diffIndexPath = eventualDiffIndexPath
-      else:
-        echo "WARN: a problem with indexing diff: no diff index"
-        diffIndexPath = "" # some kind of a problem        # indexDiffJson = ""
+#       if exitCode == 0:
+#         # replace with an archive with the indexed data
+#         removeFile(archivePath)
+#         zipFolder(outputFolder, archivePath)
+#         diffIndexPath = eventualDiffIndexPath
+#       else:
+#         echo "WARN: a problem with indexing diff: no diff index"
+#         diffIndexPath = "" # some kind of a problem        # indexDiffJson = ""
 
-    # if ok: trace patched, diff indexed: archive still accessible
-    # remove only the temp extracted folder: ok here for index-diff; not for `replay` in the next case for now
-    removeDir(outputFolder)
-    return false # this means it shouldn't restart: for now restart maybe supported in dev mode only for replays
-  else:
-    var eventualDiffIndexPath = outputFolder / "diff_index.json"
-    if fileExists(eventualDiffIndexPath):
-      diffIndexPath = eventualDiffIndexPath
-    else:
-      diffIndexPath = ""
+#     # if ok: trace patched, diff indexed: archive still accessible
+#     # remove only the temp extracted folder: ok here for index-diff; not for `replay` in the next case for now
+#     removeDir(outputFolder)
+#     return false # this means it shouldn't restart: for now restart maybe supported in dev mode only for replays
+#   else:
+#     var eventualDiffIndexPath = outputFolder / "diff_index.json"
+#     if fileExists(eventualDiffIndexPath):
+#       diffIndexPath = eventualDiffIndexPath
+#     else:
+#       diffIndexPath = ""
     
-    # trace imported, diff and eventually index copied: archive still accessible
-    # remove only the temp extracted folder?
-    # TODO: stopped removing it (or remove after replay):
-    #   decide what to do for this folder: for now depend on it for index/run: 
-    # removeDir(outputFolder)
+#     # trace imported, diff and eventually index copied: archive still accessible
+#     # remove only the temp extracted folder?
+#     # TODO: stopped removing it (or remove after replay):
+#     #   decide what to do for this folder: for now depend on it for index/run: 
+#     # removeDir(outputFolder)
 
-    let recordCore = envLoadRecordCore()
+#     let recordCore = envLoadRecordCore()
 
-    return runRecordedTrace(trace, test=false, structuredDiffPath=structuredDiffPath, indexDiffPath=diffIndexPath, recordCore=recordCore)
+#     return runRecordedTrace(trace, test=false, structuredDiffPath=structuredDiffPath, indexDiffPath=diffIndexPath, recordCore=recordCore)
 
-proc indexDiff*(multitracePath: string) =
-  discard replayMultitrace(multitracePath, indexDiff=true)
+# proc indexDiff*(multitracePath: string) =
+#   discard replayMultitrace(multitracePath, indexDiff=true)
+
+proc indexDiff*(tracePath: string) =
+  let trace = findTraceForArgs(none(string), none(int), some(tracePath))
+  if trace.isNil:
+    echo fmt"ERROR: can't find a trace with path {tracePath}"
+    quit(1)
+  var structuredDiffPath = trace.outputFolder / "diff.json"
+  let backend = dbBackendExe
+
+  var eventualDiffIndexPath = trace.outputFolder / "diff_index.json"
+  if not fileExists(eventualDiffIndexPath):
+    # db-backend index-diff writes in the trace the indexed flow
+    let process = startProcess(
+      backend,
+      args = @["index-diff", structuredDiffPath, trace.outputFolder],
+      options={poParentStreams, poEchoCmd})
+    let exitCode = waitForExit(process)
+
+    if exitCode == 0:
+      echo "OK"
+      quit(0)
+    else:
+      echo "ERROR: backend couldn't index diff: exit code ", exitCode
+      quit(exitCode)
+
+  else:
+    echo "WARN: trace already with indexed diff: not indexing again"
+    quit(0)
+
+  # discard runRecordedTrace(trace, test=false, recordCore=recordCore, indexDiff=true)
+  # discard replayMultitrace(multitracePath, indexDiff=true)
 
 proc replay*(
   patternArg: Option[string],
@@ -98,8 +130,9 @@ proc replay*(
     if traceFolderArg.isSome:
       let traceFolder = traceFolderArg.get
       let filename = traceFolder.extractFilename
-      if filename.startsWith("multitrace-") and filename.endsWith(".zip"):
-        return replayMultitrace(traceFolder)
+      # TODO: when restoring multitraces: 
+      # if filename.startsWith("multitrace-") and filename.endsWith(".zip"):
+        # return replayMultitrace(traceFolder)
 
     # not a multitrace:
 

--- a/src/ct/trace/run.nim
+++ b/src/ct/trace/run.nim
@@ -1,4 +1,4 @@
-import std/[osproc, strformat, sequtils],
+import std/[os, osproc, strformat, sequtils],
   ../../common/[ paths, lang, types ],
   ../launch/electron,
   ../utilities/[ env, language_detection ],
@@ -10,17 +10,20 @@ import std/[osproc, strformat, sequtils],
 proc runRecordedTrace*(
   trace: Trace,
   test: bool,
+  # TODO: we use those if we restore multitraces
   structuredDiffPath: string = "",
   indexDiffPath: string = "",
   recordCore: bool = false
 ): bool =
   var args = if test: @[$trace.id, "--test"] else: @[$trace.id]
-  if structuredDiffPath.len > 0:
+  let traceStructuredDiffPath = trace.outputFolder / "diff.json"
+  let traceIndexDiffPath = trace.outputFolder / "diff_index.json"
+  if existsFile(traceStructuredDiffPath):
     args.add("--diff")
-    args.add(structuredDiffPath)
-    if indexDiffPath.len > 0:
+    args.add(traceStructuredDiffPath)
+    if existsFile(traceIndexDiffPath):
       args.add("--diff-index")
-      args.add(indexDiffPath)
+      args.add(traceIndexDiffPath)
   return launchElectron(args, trace, ElectronLaunchMode.Default, recordCore, test)
 
 

--- a/src/db-backend/src/diff.rs
+++ b/src/db-backend/src/diff.rs
@@ -107,7 +107,7 @@ fn index_function_flow(_db: &Db, function_id: FunctionId) -> Result<(), Box<dyn 
 }
 
 
-pub fn index_diff(diff: Diff, trace_folder: &Path, multitrace_folder: &Path) -> Result<(), Box<dyn Error>> {
+pub fn index_diff(diff: Diff, trace_folder: &Path) -> Result<(), Box<dyn Error>> {
     info!("index_diff");
     let db = load_and_postprocess_trace(trace_folder)?;
 
@@ -149,6 +149,6 @@ pub fn index_diff(diff: Diff, trace_folder: &Path, multitrace_folder: &Path) -> 
     let flow_update = flow_preloader.load_diff_flow(diff_lines, &db);
 
     let raw = serde_json::to_string(&flow_update)?;
-    std::fs::write(multitrace_folder.join("diff_index.json"), raw)?;
+    std::fs::write(trace_folder.join("diff_index.json"), raw)?;
     Ok(())
 }

--- a/src/db-backend/src/expr_loader.rs
+++ b/src/db-backend/src/expr_loader.rs
@@ -424,9 +424,11 @@ impl ExprLoader {
         check_list: &HashMap<usize, BranchState>,
     ) -> HashMap<usize, BranchState> {
         let mut results: HashMap<usize, BranchState> = HashMap::default();
-        for branch in &self.processed_files[path].branch {
-            if !check_list.contains_key(&(branch.header_line.0 as usize)) && branch.status == BranchState::Unknown {
-                results.insert(branch.header_line.0 as usize, BranchState::NotTaken);
+        if self.processed_files.contains_key(path) {
+            for branch in &self.processed_files[path].branch {
+                if !check_list.contains_key(&(branch.header_line.0 as usize)) && branch.status == BranchState::Unknown {
+                    results.insert(branch.header_line.0 as usize, BranchState::NotTaken);
+                }
             }
         }
         results
@@ -545,7 +547,7 @@ impl ExprLoader {
     // pub fn load_loops(&mut self, )
 
     pub fn get_comment_positions(&self, path: &PathBuf) -> Vec<Position> {
-        self.processed_files.get(path).unwrap().comment_lines.clone()
+        self.processed_files.get(path).unwrap_or(&FileInfo::new("")).comment_lines.clone()
     }
 }
 

--- a/src/db-backend/src/main.rs
+++ b/src/db-backend/src/main.rs
@@ -67,7 +67,7 @@ enum Commands {
     IndexDiff {
         structured_diff_path: std::path::PathBuf,
         trace_folder: std::path::PathBuf,
-        multitrace_folder: std::path::PathBuf,
+        // TODO: multitrace_folder: std::path::PathBuf,
     },
 }
 
@@ -141,11 +141,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         Commands::IndexDiff {
             structured_diff_path,
             trace_folder,
-            multitrace_folder,
+            // multitrace_folder,
         } => {
             let raw = std::fs::read_to_string(structured_diff_path)?;
             let structured_diff = serde_json::from_str::<diff::Diff>(&raw)?;
-            diff::index_diff(structured_diff, &trace_folder, &multitrace_folder)?;
+            diff::index_diff(structured_diff, &trace_folder)?;
         }
     }
 


### PR DESCRIPTION


this way we can hope that they work directly with existing `ct import`, `ct host`, `ct upload`, `ct download`, `ct replay`