### PR TITLE
fix with Nedy: load terminal events for RR; fix loading label logic;

### DIFF
--- a/src/db-backend/src/handler.rs
+++ b/src/db-backend/src/handler.rs
@@ -1731,14 +1731,16 @@ impl Handler {
 
     pub fn load_terminal(&mut self, _req: dap::Request, sender: Sender<DapMessage>) -> Result<(), Box<dyn Error>> {
         let mut events_list: Vec<ProgramEvent> = vec![];
-        for (i, event_record) in self.db.events.iter().enumerate() {
-            if event_record.kind == EventLogKind::Write {
-                events_list.push(self.to_program_event(event_record, i));
+        if self.event_db.single_tables.len() > 0 {
+            for (_i, event_record) in self.event_db.single_tables[0].events.iter().enumerate() {
+                if event_record.kind == EventLogKind::Write {
+                    events_list.push(event_record.clone());
+                }
             }
-        }
 
-        let raw_event = self.dap_client.loaded_terminal_event(events_list)?;
-        sender.send(raw_event)?;
+            let raw_event = self.dap_client.loaded_terminal_event(events_list)?;
+            sender.send(raw_event)?;
+        }
 
         Ok(())
     }

--- a/src/frontend/renderer.nim
+++ b/src/frontend/renderer.nim
@@ -315,8 +315,8 @@ proc createUIComponents*(data: Data) =
 
 proc requestInitialPanelData*(data: Data) =
   ## Ask backend to resend panel data that isn't automatically replayed.
-  data.viewsApi.emit(CtLoadTerminal, EmptyArg())
   data.viewsApi.emit(CtEventLoad, EmptyArg())
+  data.viewsApi.emit(CtLoadTerminal, EmptyArg())
 
 # proc saveNew(data: Data, file: SaveFile) =
 #   ipc.send "CODETRACER::save-new", file

--- a/src/frontend/types.nim
+++ b/src/frontend/types.nim
@@ -580,6 +580,7 @@ type
     started*: bool
     ignoreOutput*: bool
     programEvents*: seq[ProgramEvent]
+    receivedUpdates*: bool
 
 
   DebugComponent* = ref object of Component
@@ -1893,6 +1894,9 @@ method onUpdatedTable*(self: Component, update: TableUpdate) {.base, async.} =
   discard
 
 method onUpdatedTrace*(self: Component, response: TraceUpdate) {.base, async.} =
+  discard
+
+method onUpdatedEvents*(self: EventLogComponent, response: seq[ProgramEvent]) {.base, async.} =
   discard
 
 method onLoadedTerminal*(self: Component, response: seq[ProgramEvent]) {.base, async.} =

--- a/src/frontend/ui/terminal_output.nim
+++ b/src/frontend/ui/terminal_output.nim
@@ -128,7 +128,9 @@ proc cacheAnsiToHtmlLines(self: TerminalOutputComponent, eventList: seq[ProgramE
             self.appendToTerminalLine(nextLineStart & tokens[^1], eventIndex)
 
 method onLoadedTerminal*(self: TerminalOutputComponent, eventList: seq[ProgramEvent]) {.async.} =
+  self.initialUpdate = false
   self.cacheAnsiToHtmlLines(eventList)
+  
 
 proc onTerminalEventClick(self: TerminalOutputComponent, eventElement: ProgramEvent) =
   self.api.emit(CtEventJump, eventElement)
@@ -183,7 +185,7 @@ proc terminalLineView(self: TerminalOutputComponent, i: int, lineEvents: seq[Ter
 method render*(self: TerminalOutputComponent): VNode  =
   if self.initialUpdate:
     self.getLines()
-    self.initialUpdate = false
+    # self.initialUpdate = false
 
   buildHtml(
     tdiv(class=componentContainerClass("terminal"))
@@ -194,7 +196,10 @@ method render*(self: TerminalOutputComponent): VNode  =
           terminalLineView(self, i, lineEvents)
       else:
         tdiv(class="empty-overlay"):
-          text "The current record does not print anything to the terminal."
+          if not self.initialUpdate:
+            text "The current record does not print anything to the terminal."
+          else:
+            text "Loading record output..."
 
 method register*(self: TerminalOutputComponent, api: MediatorWithSubscribers) =
   self.api = api


### PR DESCRIPTION
load from event_db not db in `db-backend`: however this requires the posibility of loading terminal request before load events, so we tried fixing initialUpdate logic; so terminal panel still tries to load again, if it hasn't received such an update(it doesn't if there are no "single tables" in event db yet)

newlines problem fixed/worked around in rr-backend

TODO: remaining loading case vs knowing there are no events problem text for event log: i hope ok to not solve it for now