### PR TITLE
feat: restore state/local panel watches with different query; auto-add watch for history address

### DIFF
--- a/examples/history.c
+++ b/examples/history.c
@@ -2,8 +2,8 @@
 
 int bug(int* a) {
     int original = *a;
-    int* a_address = a;
-    int* a_1_address = &a[1];
+    // int* a_address = a;
+    // int* a_1_address = &a[1];
     // in the scenario the author here thinks he is changing
     // a[0]
     a[1] = -50000;

--- a/src/common/common_types/language_features/value.nim
+++ b/src/common/common_types/language_features/value.nim
@@ -75,6 +75,7 @@ type
     # for easier compat between nim and rust code: 
     # NO_DEPTH_LIMIT = -1 for None for now
     depthLimit*: int 
+    watchExpressions*: seq[langstring]
     lang*: Lang
     
   CtLoadLocalsResponseBody* = ref object

--- a/src/db-backend/src/db.rs
+++ b/src/db-backend/src/db.rs
@@ -1169,7 +1169,7 @@ impl Replay for DbReplay {
         }
     }
 
-    fn load_locals(&mut self, _arg: CtLoadLocalsArguments) -> Result<Vec<VariableWithRecord>, Box<dyn Error>> {
+    fn load_locals(&mut self, arg: CtLoadLocalsArguments) -> Result<Vec<VariableWithRecord>, Box<dyn Error>> {
         let variables_for_step = self.db.variables[self.step_id].clone();
         let full_value_locals: Vec<VariableWithRecord> = variables_for_step
             .iter()
@@ -1196,6 +1196,13 @@ impl Replay for DbReplay {
                 }
             })
             .collect();
+
+        // TODO: watches require tracepoint-like evaluate_expression or would duplicate locals
+        // for now don't evaluate/support them for db traces: just ignoring
+        if arg.watch_expressions.len() > 0 {
+            warn!("watch expressions not supported for db traces currently");
+        }
+
         // based on https://stackoverflow.com/a/56490417/438099
         let mut locals: Vec<VariableWithRecord> = full_value_locals.into_iter().chain(value_tracking_locals).collect();
 

--- a/src/db-backend/src/task.rs
+++ b/src/db-backend/src/task.rs
@@ -26,6 +26,7 @@ pub struct CtLoadLocalsArguments {
     pub count_budget: i64,
     pub min_count_limit: i64,
     pub lang: Lang,
+    pub watch_expressions: Vec<String>,
     pub depth_limit: i64, // for easier compat with our nim code: NO_DEPTH_LIMIT = -1 for None for now
 }
 


### PR DESCRIPTION

restore the old watch input: it seems to work: maybe Niki/Nedy can improve it
  currently just no x/context menu option for removing it, we can add it as well
  iirc there was an edit inline interface, but i think
  it was a bit weird to use, at least in my impl, so for now i think we can not
  add it yet

auto-add it so we still see the history if we go to a frame where no local has or points to this address

also: for now watch expressions supported only in rr-traces; maybe we should hide the input for db traces(?)