### PR TITLE
fix: try to stabilize new tracepoint sessions, fix current_step_id bug

### DIFF
--- a/src/db-backend/src/handler.rs
+++ b/src/db-backend/src/handler.rs
@@ -1399,6 +1399,16 @@ impl Handler {
         args: RunTracepointsArg,
         sender: Sender<DapMessage>,
     ) -> Result<(), Box<dyn Error>> {
+        if self.trace_kind == TraceKind::RR {
+            self.replay = Box::new(RRDispatcher::new(
+                "tracepoint",
+                self.tracepoint_rr_worker_index,
+                self.ct_rr_args.clone(),
+            ));
+            self.tracepoint_rr_worker_index += 1;
+        };
+        info!("run_tracepoints trace_kind {:?}", self.trace_kind);
+
         // Sort steps in StepId Ord
         self.setup_trace_session(req, args.clone(), sender.clone())?;
 


### PR DESCRIPTION
* ) start a new rr worker for now for each new tracepoint session, as we do for loading history
* ) fix a bug where we didn't ensure we have a started and setup rr worker for `current_step_id()`: hard to change all callsites to accept Result now, so for now returning NO_STEP_ID if there is a problem: this might require special handling too, but i hope for now as it is rr-specific, we should have those cases for other bigger rr ticks anyway(?) maybe still TODO: think/keep in mind separately:
* ) stop sleeping before setting up sockets: i think the problem we were trying to workaround was resolved with the fix of the threading deadlock, but i might be wrong