### PR TITLE
More robust handling of incompatible layout files

### DIFF
--- a/src/ct/codetracer.nim
+++ b/src/ct/codetracer.nim
@@ -6,16 +6,16 @@ import
   version
 
 try:
-  if not eventuallyWrapElectron():
-    # TODO: When confutils gets updated with nim 2 make sure to improve on the copyright banner, as newer versions
-    # support having prefix and postfix banners. The banner here is only a prefix banner
-    let conf = CodetracerConf.load(
-      version="CodeTracer version: " & version.CodeTracerVersionStr & (when defined(debug): "(debug)" else: ""),
-      copyrightBanner="CodeTracer - the user-friendly time-travelling debugger"
-    )
+  # TODO: When confutils gets updated with nim 2 make sure to improve on the copyright banner, as newer versions
+  # support having prefix and postfix banners. The banner here is only a prefix banner
+  let conf = CodetracerConf.load(
+    version="CodeTracer version: " & version.CodeTracerVersionStr & (when defined(debug): "(debug)" else: ""),
+    copyrightBanner="CodeTracer - the user-friendly time-travelling debugger"
+  )
+  if not eventuallyWrapElectron(conf):
     customValidateConfig(conf)
     runInitial(conf)
-except Exception as ex:
+except CatchableError as ex:
   echo "Error: Unhandled exception"
   echo getStackTrace(ex)
   echo "Unhandled " & ex.msg

--- a/src/ct/codetracerconf.nim
+++ b/src/ct/codetracerconf.nim
@@ -94,6 +94,18 @@ type
       defaultValue: @[]
     .} : seq[string]
 
+    # These options are recognized directly because Playwright injects them
+    # when launching Electron apps for testing. They get forwarded to Electron.
+    inspect* {.
+      name: "inspect"
+      desc: "Node.js inspector port (injected by Playwright for debugging)"
+    .} : Option[string]
+
+    remoteDebuggingPort* {.
+      name: "remote-debugging-port"
+      desc: "Chrome remote debugging port (injected by Playwright for debugging)"
+    .} : Option[string]
+
     case cmd* {.
       command,
       defaultValue: StartUpCommand.noCommand
@@ -557,7 +569,7 @@ type
     #     desc: "Warning message for sensative data"
     #   .} : bool
     of electron:
-      electronArgs* {.
+      electronAppArgs* {.
         restOfArgs
         defaultValue: @[]
         desc: "Arguments for electron",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -119,6 +119,15 @@ async function fsMkdirWithErr(directory: string, options: any): Promise<any> {
   return promise
 }
 
+async function fsUnlinkWithErr(path: string): Promise<any> {
+  var promise = new Promise<any>(resolve => {
+    fs.unlink(path, (err: any) => {
+        resolve(err)
+    })
+  })
+  return promise
+}
+
 async function childProcessExec(cmd: string, options: any = {}): Promise<{Field0: string, Field1: string, Field2: any}> {
     var promise = new Promise<{Field0: string, Field1: string, Field2: any}>(resolve => {
         options.maxBuffer = 5_000_000;
@@ -145,4 +154,4 @@ async function wait(ms: number): Promise<number> {
 
 var path = require('path')
 
-export {dbGet, dbAll, fsRead, fsOpen, fsReadFile, fsWriteFile, fsReadFileWithErr, fsWriteFileWithErr, fsReaddir, fsCopyFileWithErr, fsMkdirWithErr, childProcessExec, fs, wait}
+export {dbGet, dbAll, fsRead, fsOpen, fsReadFile, fsWriteFile, fsReadFileWithErr, fsWriteFileWithErr, fsReaddir, fsCopyFileWithErr, fsMkdirWithErr, fsUnlinkWithErr, childProcessExec, fs, wait}

--- a/tsc-ui-tests/lib/ct_helpers.ts
+++ b/tsc-ui-tests/lib/ct_helpers.ts
@@ -160,15 +160,24 @@ async function launchWelcomeScreen(): Promise<void> {
 async function launchEditMode(folderPath: string): Promise<void> {
   console.log(`# launching codetracer edit mode for ${folderPath}`);
 
-  process.env.CODETRACER_IN_UI_TEST = "1";
-  process.env.CODETRACER_TEST = "1";
-  process.env.CODETRACER_WRAP_ELECTRON = "1";
-  process.env.CODETRACER_START_INDEX = "1";
+  // Create a clean env like launchWelcomeScreen does
+  const cleanEnv = { ...process.env };
+  delete cleanEnv.CODETRACER_TRACE_ID;
+  delete cleanEnv.CODETRACER_CALLER_PID;
 
+  cleanEnv.CODETRACER_IN_UI_TEST = "1";
+  cleanEnv.CODETRACER_TEST = "1";
+  cleanEnv.CODETRACER_WRAP_ELECTRON = "1";
+  cleanEnv.CODETRACER_START_INDEX = "1";
+
+  // Launch ct directly with edit command.
+  // The ct binary handles Playwright's injected --inspect and
+  // --remote-debugging-port flags by forwarding them to Electron.
   electronApp = await electron.launch({
     executablePath: codetracerPath,
     cwd: codetracerInstallDir,
     args: ["edit", folderPath],
+    env: cleanEnv,
   });
 
   const firstWindow = await electronApp.firstWindow();

--- a/tsc-ui-tests/tests/layout/layout_resilience.spec.ts
+++ b/tsc-ui-tests/tests/layout/layout_resilience.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect } from "@playwright/test";
+import { page, ctEditMode, wait, codetracerInstallDir } from "../../lib/ct_helpers";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+// Use the test-programs directory as the folder to open in edit mode
+const testFolder = path.join(codetracerInstallDir, "test-programs");
+
+// Get the user layout directory (same logic as in frontend/config.nim)
+const userLayoutDir = path.join(
+  process.env.XDG_CONFIG_HOME ?? path.join(os.homedir(), ".config"),
+  "codetracer"
+);
+
+const defaultLayoutPath = path.join(userLayoutDir, "default_layout.json");
+const defaultEditLayoutPath = path.join(userLayoutDir, "default_edit_layout.json");
+const backupSuffix = ".backup_test";
+
+/**
+ * Helper to backup a layout file if it exists
+ */
+function backupLayoutFile(layoutPath: string): void {
+  if (fs.existsSync(layoutPath)) {
+    fs.copyFileSync(layoutPath, layoutPath + backupSuffix);
+  }
+}
+
+/**
+ * Helper to restore a layout file from backup
+ */
+function restoreLayoutFile(layoutPath: string): void {
+  const backupPath = layoutPath + backupSuffix;
+  if (fs.existsSync(backupPath)) {
+    fs.copyFileSync(backupPath, layoutPath);
+    fs.unlinkSync(backupPath);
+  }
+}
+
+/**
+ * Helper to corrupt a layout file with invalid JSON
+ */
+function corruptLayoutFile(layoutPath: string): void {
+  // Ensure directory exists
+  const dir = path.dirname(layoutPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  // Write invalid JSON that can't be parsed
+  fs.writeFileSync(layoutPath, "{ invalid json content without closing brace", "utf8");
+}
+
+/**
+ * Helper to create a layout file with valid JSON but invalid structure
+ */
+function createInvalidStructureLayoutFile(layoutPath: string): void {
+  const dir = path.dirname(layoutPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  // Write valid JSON but missing required 'root' property
+  const invalidLayout = {
+    settings: {
+      constrainDragToContainer: true,
+    },
+    dimensions: {
+      borderWidth: 2,
+    },
+    // Missing 'root' property - this should trigger validation failure
+    notRoot: {
+      type: "row",
+      content: [],
+    },
+  };
+  fs.writeFileSync(layoutPath, JSON.stringify(invalidLayout, null, 2), "utf8");
+}
+
+/**
+ * Helper to create a layout file with root but missing type
+ */
+function createMissingTypeLayoutFile(layoutPath: string): void {
+  const dir = path.dirname(layoutPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  const invalidLayout = {
+    settings: {},
+    root: {
+      // Missing 'type' property
+      content: [],
+    },
+  };
+  fs.writeFileSync(layoutPath, JSON.stringify(invalidLayout, null, 2), "utf8");
+}
+
+// Test: Normal operation with valid layout (sanity check)
+test.describe("Normal operation with valid layout", () => {
+  // Use default (hopefully valid) layout
+  ctEditMode(testFolder);
+
+  test("app loads normally with valid layout", async () => {
+    await page.waitForSelector(".lm_goldenlayout", { timeout: 30000 });
+
+    const layout = page.locator(".lm_goldenlayout");
+    await expect(layout).toBeVisible();
+
+    // Should have at least one panel/tab
+    const tabs = page.locator(".lm_tab");
+    const tabCount = await tabs.count();
+    expect(tabCount).toBeGreaterThan(0);
+  });
+
+  test("layout contains expected panels", async () => {
+    await page.waitForSelector(".lm_goldenlayout", { timeout: 30000 });
+    await wait(1000);
+
+    // Check for some expected panel types
+    const panels = page.locator(".lm_stack");
+    const panelCount = await panels.count();
+    expect(panelCount).toBeGreaterThan(0);
+  });
+
+  test("layout file exists and is valid JSON", async () => {
+    await wait(2000);
+
+    // Check that the layout file contains valid JSON
+    // Edit mode uses default_edit_layout.json, but falls back to default_layout.json
+    const layoutPath = fs.existsSync(defaultEditLayoutPath) ? defaultEditLayoutPath : defaultLayoutPath;
+
+    if (fs.existsSync(layoutPath)) {
+      const content = fs.readFileSync(layoutPath, "utf8");
+
+      // Should be valid JSON
+      expect(() => JSON.parse(content)).not.toThrow();
+
+      // Should have the required 'root' property
+      const parsed = JSON.parse(content);
+      expect(parsed).toHaveProperty("root");
+      expect(parsed.root).toHaveProperty("type");
+    }
+  });
+});

--- a/ui-tests/Execution/TestRegistry.cs
+++ b/ui-tests/Execution/TestRegistry.cs
@@ -170,6 +170,37 @@ internal sealed class TestRegistry : ITestRegistry
                 "NoirSpaceShip.ValueHistoryContextMenuOptions",
                 "Noir Space Ship / Value History Context Menu Options",
                 async context => await NoirSpaceShipTests.ValueHistoryContextMenuOptions(context.Page)));
+
+        // Layout resilience tests - verify app can recover from corrupt layout files
+        Register(
+            new UiTestDescriptor(
+                "Layout.RecoveryFromCorruptedJson",
+                "Layout Resilience / Recovery From Corrupted JSON",
+                async context => await LayoutResilienceTests.RecoveryFromCorruptedJsonInDebugMode(context.Page)));
+
+        Register(
+            new UiTestDescriptor(
+                "Layout.RecoveryFromInvalidStructure",
+                "Layout Resilience / Recovery From Invalid Structure",
+                async context => await LayoutResilienceTests.RecoveryFromInvalidStructure(context.Page)));
+
+        Register(
+            new UiTestDescriptor(
+                "Layout.RecoveryFromMissingType",
+                "Layout Resilience / Recovery From Missing Type",
+                async context => await LayoutResilienceTests.RecoveryFromMissingType(context.Page)));
+
+        Register(
+            new UiTestDescriptor(
+                "Layout.UiFunctionalityAfterRecovery",
+                "Layout Resilience / UI Functionality After Recovery",
+                async context => await LayoutResilienceTests.UiFunctionalityAfterRecovery(context.Page)));
+
+        Register(
+            new UiTestDescriptor(
+                "Layout.NormalOperationWithValidLayout",
+                "Layout Resilience / Normal Operation With Valid Layout",
+                async context => await LayoutResilienceTests.NormalOperationWithValidLayout(context.Page)));
     }
 
     public IReadOnlyCollection<UiTestDescriptor> All => _tests.Values.ToList();

--- a/ui-tests/Tests/ProgramAgnostic/LayoutResilienceTests.cs
+++ b/ui-tests/Tests/ProgramAgnostic/LayoutResilienceTests.cs
@@ -1,0 +1,318 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using UiTests.PageObjects;
+using UiTests.Utils;
+
+namespace UiTests.Tests.ProgramAgnostic;
+
+/// <summary>
+/// Tests for layout file resilience - verifying the app can recover from
+/// corrupt or invalid layout configuration files.
+/// </summary>
+public static class LayoutResilienceTests
+{
+    // Get the user layout directory (same logic as in frontend/config.nim)
+    private static string UserLayoutDir => Path.Combine(
+        Environment.GetEnvironmentVariable("XDG_CONFIG_HOME")
+            ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".config"),
+        "codetracer");
+
+    private static string DefaultLayoutPath => Path.Combine(UserLayoutDir, "default_layout.json");
+    private static string DefaultEditLayoutPath => Path.Combine(UserLayoutDir, "default_edit_layout.json");
+    private const string BackupSuffix = ".backup_test";
+
+    /// <summary>
+    /// Backup a layout file if it exists.
+    /// </summary>
+    private static void BackupLayoutFile(string layoutPath)
+    {
+        if (File.Exists(layoutPath))
+        {
+            File.Copy(layoutPath, layoutPath + BackupSuffix, overwrite: true);
+        }
+    }
+
+    /// <summary>
+    /// Restore a layout file from backup.
+    /// </summary>
+    private static void RestoreLayoutFile(string layoutPath)
+    {
+        var backupPath = layoutPath + BackupSuffix;
+        if (File.Exists(backupPath))
+        {
+            File.Copy(backupPath, layoutPath, overwrite: true);
+            File.Delete(backupPath);
+        }
+    }
+
+    /// <summary>
+    /// Corrupt a layout file with invalid JSON.
+    /// </summary>
+    private static void CorruptLayoutFile(string layoutPath)
+    {
+        // Ensure directory exists
+        var dir = Path.GetDirectoryName(layoutPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        // Write invalid JSON that can't be parsed
+        File.WriteAllText(layoutPath, "{ invalid json content without closing brace");
+    }
+
+    /// <summary>
+    /// Create a layout file with valid JSON but invalid structure (missing root).
+    /// </summary>
+    private static void CreateInvalidStructureLayoutFile(string layoutPath)
+    {
+        var dir = Path.GetDirectoryName(layoutPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        var invalidLayout = new
+        {
+            settings = new { constrainDragToContainer = true },
+            dimensions = new { borderWidth = 2 },
+            // Missing 'root' property - this should trigger validation failure
+            notRoot = new { type = "row", content = Array.Empty<object>() }
+        };
+        File.WriteAllText(layoutPath, JsonSerializer.Serialize(invalidLayout, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    /// <summary>
+    /// Create a layout file with root but missing type property.
+    /// </summary>
+    private static void CreateMissingTypeLayoutFile(string layoutPath)
+    {
+        var dir = Path.GetDirectoryName(layoutPath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+
+        var invalidLayout = new
+        {
+            settings = new { },
+            root = new
+            {
+                // Missing 'type' property
+                content = Array.Empty<object>()
+            }
+        };
+        File.WriteAllText(layoutPath, JsonSerializer.Serialize(invalidLayout, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    /// <summary>
+    /// Test that verifies the app can recover from a layout file with corrupted JSON.
+    /// This test should be run with a trace loaded (debug mode).
+    /// </summary>
+    public static async Task RecoveryFromCorruptedJsonInDebugMode(IPage page)
+    {
+        // Backup the current layout file
+        BackupLayoutFile(DefaultLayoutPath);
+
+        try
+        {
+            // Corrupt the layout file
+            CorruptLayoutFile(DefaultLayoutPath);
+
+            // Reload the page to trigger layout loading
+            await page.ReloadAsync();
+
+            // Wait for the layout to initialize (the app should recover)
+            await page.WaitForSelectorAsync(".lm_goldenlayout", new PageWaitForSelectorOptions { Timeout = 20000 });
+
+            // Verify the layout is visible
+            var layout = page.Locator(".lm_goldenlayout");
+            if (!await layout.IsVisibleAsync())
+            {
+                throw new Exception("Layout did not become visible after recovery from corrupted JSON");
+            }
+
+            // Verify layout content is present
+            var layoutContent = page.Locator(".lm_content");
+            if (!await layoutContent.IsVisibleAsync())
+            {
+                throw new Exception("Layout content is not visible after recovery");
+            }
+
+            // Verify the layout file was restored to valid JSON
+            await Task.Delay(2000); // Wait for file operations to complete
+
+            if (File.Exists(DefaultLayoutPath))
+            {
+                var content = await File.ReadAllTextAsync(DefaultLayoutPath);
+
+                // Should be valid JSON
+                try
+                {
+                    var parsed = JsonDocument.Parse(content);
+
+                    // Should have the required 'root' property
+                    if (!parsed.RootElement.TryGetProperty("root", out var root))
+                    {
+                        throw new Exception("Restored layout file is missing 'root' property");
+                    }
+
+                    if (!root.TryGetProperty("type", out _))
+                    {
+                        throw new Exception("Restored layout file root is missing 'type' property");
+                    }
+                }
+                catch (JsonException ex)
+                {
+                    throw new Exception($"Restored layout file is not valid JSON: {ex.Message}");
+                }
+            }
+        }
+        finally
+        {
+            // Restore the original layout file
+            RestoreLayoutFile(DefaultLayoutPath);
+        }
+    }
+
+    /// <summary>
+    /// Test that verifies the app can recover from a layout file with invalid structure.
+    /// </summary>
+    public static async Task RecoveryFromInvalidStructure(IPage page)
+    {
+        BackupLayoutFile(DefaultLayoutPath);
+
+        try
+        {
+            CreateInvalidStructureLayoutFile(DefaultLayoutPath);
+
+            await page.ReloadAsync();
+
+            await page.WaitForSelectorAsync(".lm_goldenlayout", new PageWaitForSelectorOptions { Timeout = 20000 });
+
+            var layout = page.Locator(".lm_goldenlayout");
+            if (!await layout.IsVisibleAsync())
+            {
+                throw new Exception("Layout did not become visible after recovery from invalid structure");
+            }
+        }
+        finally
+        {
+            RestoreLayoutFile(DefaultLayoutPath);
+        }
+    }
+
+    /// <summary>
+    /// Test that verifies the app can recover from a layout file missing the type property.
+    /// </summary>
+    public static async Task RecoveryFromMissingType(IPage page)
+    {
+        BackupLayoutFile(DefaultLayoutPath);
+
+        try
+        {
+            CreateMissingTypeLayoutFile(DefaultLayoutPath);
+
+            await page.ReloadAsync();
+
+            await page.WaitForSelectorAsync(".lm_goldenlayout", new PageWaitForSelectorOptions { Timeout = 20000 });
+
+            var layout = page.Locator(".lm_goldenlayout");
+            if (!await layout.IsVisibleAsync())
+            {
+                throw new Exception("Layout did not become visible after recovery from missing type");
+            }
+        }
+        finally
+        {
+            RestoreLayoutFile(DefaultLayoutPath);
+        }
+    }
+
+    /// <summary>
+    /// Test that verifies UI functionality is preserved after layout recovery.
+    /// </summary>
+    public static async Task UiFunctionalityAfterRecovery(IPage page)
+    {
+        BackupLayoutFile(DefaultLayoutPath);
+
+        try
+        {
+            CorruptLayoutFile(DefaultLayoutPath);
+
+            await page.ReloadAsync();
+
+            await page.WaitForSelectorAsync(".lm_goldenlayout", new PageWaitForSelectorOptions { Timeout = 20000 });
+            await Task.Delay(1000);
+
+            // Test that tabs are clickable
+            var tabs = page.Locator(".lm_tab");
+            var tabCount = await tabs.CountAsync();
+
+            if (tabCount > 0)
+            {
+                await tabs.First.ClickAsync();
+                await Task.Delay(500);
+
+                // Verify the layout is still responsive
+                var layout = page.Locator(".lm_goldenlayout");
+                if (!await layout.IsVisibleAsync())
+                {
+                    throw new Exception("Layout became non-responsive after clicking tabs");
+                }
+            }
+
+            // Test that splitters exist (for resize capability)
+            var splitters = page.Locator(".lm_splitter");
+            var splitterCount = await splitters.CountAsync();
+
+            if (splitterCount > 0)
+            {
+                var firstSplitter = splitters.First;
+                if (!await firstSplitter.IsVisibleAsync())
+                {
+                    throw new Exception("Splitters are not visible after recovery");
+                }
+            }
+        }
+        finally
+        {
+            RestoreLayoutFile(DefaultLayoutPath);
+        }
+    }
+
+    /// <summary>
+    /// Sanity check that normal operation works with a valid layout.
+    /// </summary>
+    public static async Task NormalOperationWithValidLayout(IPage page)
+    {
+        var layout = new LayoutPage(page);
+        await layout.WaitForAllComponentsLoadedAsync();
+
+        // Verify the layout is visible
+        var goldenLayout = page.Locator(".lm_goldenlayout");
+        if (!await goldenLayout.IsVisibleAsync())
+        {
+            throw new Exception("GoldenLayout is not visible");
+        }
+
+        // Should have at least one tab
+        var tabs = page.Locator(".lm_tab");
+        var tabCount = await tabs.CountAsync();
+        if (tabCount == 0)
+        {
+            throw new Exception("No tabs found in the layout");
+        }
+
+        // Should have at least one panel stack
+        var panels = page.Locator(".lm_stack");
+        var panelCount = await panels.CountAsync();
+        if (panelCount == 0)
+        {
+            throw new Exception("No panel stacks found in the layout");
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds validation and auto-reset for corrupted/incompatible layout JSON, forwards Playwright `--inspect`/`--remote-debugging-port` to Electron, and introduces layout resilience tests.
> 
> - **Frontend (Electron UI)**:
>   - Validate layout JSON via `isValidLayoutConfig` and auto-reset to bundled default with `resetLayoutToDefault` when corrupt/incompatible.
>   - Harden `loadLayoutConfig`/`loadEditLayoutConfig` with parse/structure checks and recovery; add `fsUnlinkWithErr` bridge in `helpers.ts` and bindings.
> - **CLI/Launch**:
>   - Add config options `inspect` and `remote-debugging-port`; `eventuallyWrapElectron(conf)` now forwards these to Electron.
>   - Refactor `wrapElectron(electronArgs, appArgs)` (posix) and adapt electron command to use `electronAppArgs`.
>   - Replace generic exception handlers with `CatchableError` in Nim entrypoints.
> - **Tests**:
>   - Add Playwright spec `tsc-ui-tests/tests/layout/layout_resilience.spec.ts` and C# UI tests `LayoutResilienceTests` with registry entries, plus cleaner env setup in `ct_helpers.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2426f92298b76ea232ba92630ba68118d5fb538f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->