### PR TITLE
fix: make tracepoint_interpreter tests nextest-compatible

### DIFF
--- a/justfile
+++ b/justfile
@@ -69,13 +69,7 @@ test-rust:
   pushd src/db-backend
   # Unit tests (inside the binary)
   cargo nextest run --release --bin db-backend
-  # Ignored tests require trace recording infrastructure (ruby recorder, etc.)
-  # which may not be fully functional on all CI platforms (e.g. macOS).
-  if [ "${CODETRACER_CI_PLATFORM:-}" != "macos" ]; then
-    cargo nextest run --release --bin db-backend --run-ignored ignored-only
-  else
-    echo "  NOTE: Skipping ignored tests on macOS CI (trace recording not available)"
-  fi
+  cargo nextest run --release --bin db-backend --run-ignored ignored-only
   # Integration tests (tests/*.rs): DAP protocol, flow tests, etc.
   # Flow tests that need ct-rr-support/rr skip automatically when unavailable.
   # Shell/JS flow tests require sibling repos (codetracer-shell-recorders, etc.)

--- a/src/db-backend/src/tracepoint_interpreter/tests.rs
+++ b/src/db-backend/src/tracepoint_interpreter/tests.rs
@@ -2,7 +2,6 @@
 #![allow(clippy::expect_used)]
 #![allow(clippy::panic)]
 
-use core::panic;
 use std::{
     env,
     error::Error,

--- a/src/db-backend/src/tracepoint_interpreter/tests.rs
+++ b/src/db-backend/src/tracepoint_interpreter/tests.rs
@@ -26,7 +26,6 @@ use crate::{
 use super::TracepointInterpreter;
 
 #[test]
-#[ignore]
 fn log_array() -> Result<(), Box<dyn Error>> {
     if find_ruby_recorder().is_none() {
         eprintln!("SKIPPED: Ruby recorder not found");
@@ -48,7 +47,6 @@ fn log_array() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-#[ignore]
 fn array_indexing() -> Result<(), Box<dyn Error>> {
     if find_ruby_recorder().is_none() {
         eprintln!("SKIPPED: Ruby recorder not found");

--- a/src/db-backend/src/tracepoint_interpreter/tests.rs
+++ b/src/db-backend/src/tracepoint_interpreter/tests.rs
@@ -6,11 +6,10 @@ use core::panic;
 use std::{
     env,
     error::Error,
-    fs::{create_dir, remove_dir_all},
+    fs::{create_dir_all, remove_dir_all},
     iter::zip,
     path::{Path, PathBuf},
     process::Command,
-    sync::{LazyLock, Mutex, Once},
 };
 
 use codetracer_trace_types::{StepId, TypeKind};
@@ -274,9 +273,13 @@ fn record_trace(program_dir: &Path, target_dir: &Path, lang: Lang) -> Result<(),
     Ok(())
 }
 
-static DIR_MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
-static CLEAN_TRACES: Once = Once::new();
-
+/// Load (or record) a test trace for the given program and language.
+///
+/// Each invocation records into a per-process temporary directory under
+/// `test-traces/`. This avoids the race condition that occurs with
+/// `cargo nextest`, which runs each test in a separate process — in-process
+/// `Mutex`/`Once` guards cannot synchronize across processes, so two tests
+/// that share a trace name would stomp on each other's output.
 fn load_test_trace(name: &str, lang: Lang) -> Result<Db, Box<dyn Error>> {
     let cwd = env::current_dir()?;
 
@@ -286,38 +289,21 @@ fn load_test_trace(name: &str, lang: Lang) -> Result<Db, Box<dyn Error>> {
         return Err("Can't find test programs. Please run 'cargo test' in src/db-backend.".into());
     }
 
-    let test_trace_path = cwd.join("test-traces");
+    // Use the PID to isolate each nextest worker process so parallel
+    // test invocations never share (and therefore never clobber) trace
+    // directories.
+    let pid = std::process::id();
+    let trace_dir = cwd
+        .join("test-traces")
+        .join(format!("pid-{pid}"))
+        .join(name)
+        .join(&lang_string);
 
-    let program_trace_path = test_trace_path.join(name);
-    let program_lang_path = program_trace_path.join(&lang_string);
-
-    {
-        let _guard = DIR_MUTEX.lock().unwrap();
-
-        // Clear old traces
-        CLEAN_TRACES.call_once(|| {
-            if test_trace_path.exists() {
-                if let Err(x) = remove_dir_all(&test_trace_path) {
-                    panic!("{}", x);
-                }
-            }
-        });
-
-        // Ensure parent directories
-        if !test_trace_path.exists() {
-            create_dir(&test_trace_path).unwrap();
-        }
-
-        if !program_trace_path.exists() {
-            create_dir(&program_trace_path).unwrap();
-        }
-
-        // Create trace if not already created
-        if !program_lang_path.exists() {
-            create_dir(&program_lang_path).unwrap();
-            record_trace(&program_dir, &program_lang_path, lang).unwrap();
-        }
+    if trace_dir.exists() {
+        remove_dir_all(&trace_dir)?;
     }
+    create_dir_all(&trace_dir)?;
+    record_trace(&program_dir, &trace_dir, lang)?;
 
-    Ok(load_db_for_trace(&program_lang_path))
+    Ok(load_db_for_trace(&trace_dir))
 }


### PR DESCRIPTION
## Summary
- Fix race condition in `tracepoint_interpreter` tests (`log_array`, `array_indexing`) that caused failures under `cargo nextest`
- The tests used in-process `Mutex`/`Once` guards to coordinate trace directory cleanup, but nextest runs each test in a separate process, making these guards ineffective
- Each test process now records into a PID-isolated directory under `test-traces/`, preventing parallel workers from clobbering each other's output
- Reverts the macOS CI workaround that skipped ignored tests, since the root cause is now fixed

## Test plan
- [ ] NixOS `test-non-gui` passes (including `--run-ignored`)
- [ ] macOS `test-non-gui` passes (previously failed with `log_array` trace file not found)
- [ ] All other CI checks remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)