### PR TITLE
feat: MCR .ct trace support + TraceReader abstraction + CTFSTraceReader

### DIFF
--- a/libs/ct-dap-client/src/test_support/mod.rs
+++ b/libs/ct-dap-client/src/test_support/mod.rs
@@ -24,7 +24,7 @@ type BoxError = Box<dyn std::error::Error + Send + Sync>;
 pub(crate) fn prepare_trace_folder(
     rr_trace_dir: &Path,
 ) -> Result<(PathBuf, Option<PathBuf>), BoxError> {
-    // Case 0 (Windows TTD): if the path is a .run file, use the parent dir.
+    // Case 0a (Windows TTD): if the path is a .run file, use the parent dir.
     // db-backend discovers .run files by scanning the trace folder.
     if rr_trace_dir.extension().and_then(|e| e.to_str()) == Some("run")
         && rr_trace_dir.is_file()
@@ -32,6 +32,15 @@ pub(crate) fn prepare_trace_folder(
         if let Some(parent) = rr_trace_dir.parent() {
             return Ok((parent.to_path_buf(), None));
         }
+    }
+
+    // Case 0b (MCR): if the path is a .ct file, pass it directly as the trace path.
+    // db-backend detects .ct files by extension or CTFS magic bytes and routes
+    // them to ct-rr-support which spawns ct-mcr debugserver.
+    if rr_trace_dir.extension().and_then(|e| e.to_str()) == Some("ct")
+        && rr_trace_dir.is_file()
+    {
+        return Ok((rr_trace_dir.to_path_buf(), None));
     }
 
     // Case 1: parent/rr == rr_trace_dir (uncached layout)

--- a/libs/ct-dap-client/src/test_support/tracepoint_runner.rs
+++ b/libs/ct-dap-client/src/test_support/tracepoint_runner.rs
@@ -58,7 +58,9 @@ impl TracepointTestRunner {
         client.configuration_done()?;
 
         // Wait for the initial stopped event (run-to-entry)
-        client.wait_for_stopped(Duration::from_secs(60))?;
+        // MCR's debugserver needs extra time: LLDB setup (~20s on first connect)
+        // plus the MCR READMEM round-trips for symbol resolution.
+        client.wait_for_stopped(Duration::from_secs(120))?;
 
         Ok(TracepointTestRunner {
             client,

--- a/src/backend-manager/src/backend_manager.rs
+++ b/src/backend-manager/src/backend_manager.rs
@@ -94,6 +94,21 @@ pub struct BackendManager {
     daemon_state: Option<DaemonState>,
 }
 
+/// Check whether `path` is a file whose first 5 bytes match the CTFS magic
+/// number (`0xC0 0xDE 0x72 0xAC 0xE2`).  Returns `false` for directories,
+/// missing files, or files shorter than 5 bytes.
+fn has_ctfs_magic(path: &std::path::Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    let Ok(mut f) = std::fs::File::open(path) else {
+        return false;
+    };
+    let mut magic = [0u8; 5];
+    use std::io::Read;
+    f.read_exact(&mut magic).is_ok() && magic == [0xC0, 0xDE, 0x72, 0xAC, 0xE2]
+}
+
 // TODO: cleanup on exit
 // TODO: Handle signals
 impl BackendManager {
@@ -5379,7 +5394,9 @@ impl BackendManager {
         let dap_launch_opts = {
             let mut opts = dap_init::DapLaunchOptions::default();
             let needs_rr_support = trace_path.join("rr").is_dir()
-                || trace_path.join("ttd-trace-manifest.json").is_file();
+                || trace_path.join("ttd-trace-manifest.json").is_file()
+                || trace_path.extension().map_or(false, |ext| ext == "ct")
+                || has_ctfs_magic(&trace_path);
             if needs_rr_support {
                 let rr_support_cmd = std::env::var("CODETRACER_CT_RR_SUPPORT_CMD")
                     .ok()

--- a/src/ct/trace/record.nim
+++ b/src/ct/trace/record.nim
@@ -229,6 +229,8 @@ proc nativeReplayTraceKindForHost(): string =
   ## Keep Linux/macOS on RR while routing Windows native recordings to TTD.
   when defined(windows):
     "ttd"
+  elif defined(macosx):
+    "rr"  # MCR backend in ct-rr-support handles macOS via --backend mcr
   else:
     "rr"
 

--- a/src/ct/trace/replay.nim
+++ b/src/ct/trace/replay.nim
@@ -144,6 +144,8 @@ proc replay*(
       let traceKind =
         if fileExists(traceFolder / "trace_metadata.json"):
           "db"
+        elif traceFolder.endsWith(".ct") or fileExists(traceFolder / "mcr"):
+          "rr"  # MCR uses same replay-worker as RR (via ct-rr-support)
         else:
           # replay traces (RR/TTD) carry trace_db_metadata.json
           "rr"

--- a/src/db-backend/Cargo.toml
+++ b/src/db-backend/Cargo.toml
@@ -33,6 +33,7 @@ clap = { version = "4.5.4", features = ["derive"] }
 codetracer_trace_types = { path = "../../libs/codetracer-trace-format/codetracer_trace_types" }
 codetracer_trace_reader = { path = "../../libs/codetracer-trace-format/codetracer_trace_reader" }
 codetracer_trace_writer = { path = "../../libs/codetracer-trace-format/codetracer_trace_writer" }
+cbor4ii = { version = "1.0.0", features = ["serde1", "use_std"] }
 num-bigint = "0.4.6"
 chrono = "0.4.41"
 
@@ -102,6 +103,7 @@ required-features = ["io-transport"]
 
 [dev-dependencies]
 ct-dap-client = { path = "../../libs/ct-dap-client" }
+tempfile = "3"
 
 [features]
 debugging = []

--- a/src/db-backend/src/calltrace.rs
+++ b/src/db-backend/src/calltrace.rs
@@ -9,6 +9,7 @@ use crate::expr_loader::ExprLoader;
 use crate::task::{
     CallLine, CallLineContentKind, CallLineMetadata, CalltraceNonExpandedKind, GlobalCallLineIndex, NO_DEPTH, NO_INDEX,
 };
+use crate::trace_reader::TraceReader;
 
 #[derive(Debug, Clone)]
 pub struct Calltrace {
@@ -35,7 +36,7 @@ pub struct CallState {
 }
 
 impl Calltrace {
-    pub fn new(db: &Db) -> Self {
+    pub fn new(db: &Db, _reader: &dyn TraceReader) -> Self {
         let mut call_states = DistinctVec::new();
         for call_key_int in 0..db.calls.len() {
             let call_key = CallKey(call_key_int as i64);
@@ -64,8 +65,8 @@ impl Calltrace {
         }
     }
 
-    pub fn jump_to(&mut self, step_id: StepId, auto_collapsing: bool, db: &Db) {
-        self.jump_to_with_depth(step_id, auto_collapsing, None, db);
+    pub fn jump_to(&mut self, step_id: StepId, auto_collapsing: bool, db: &Db, _reader: &dyn TraceReader) {
+        self.jump_to_with_depth(step_id, auto_collapsing, None, db, _reader);
     }
 
     /// Jump to the call containing `step_id` and rebuild the global call-line
@@ -77,14 +78,14 @@ impl Calltrace {
     /// up to `max_depth` are expanded so that the full tree is visible —
     /// this is the path taken by the Python API bridge which does not use
     /// the GUI's collapsing behaviour.
-    pub fn jump_to_with_depth(&mut self, step_id: StepId, auto_collapsing: bool, max_depth: Option<usize>, db: &Db) {
+    pub fn jump_to_with_depth(&mut self, step_id: StepId, auto_collapsing: bool, max_depth: Option<usize>, db: &Db, _reader: &dyn TraceReader) {
         let call_key = db.call_key_for_step(step_id);
         if auto_collapsing {
-            self.autocollapse_callstack(step_id, call_key, db);
+            self.autocollapse_callstack(step_id, call_key, db, _reader);
         } else if let Some(depth_limit) = max_depth {
             // Expand all calls up to the requested depth so the Python API
             // (and other non-GUI callers) can see the full call tree.
-            self.expand_all_up_to_depth(depth_limit, db);
+            self.expand_all_up_to_depth(depth_limit, db, _reader);
         }
         self.start_call_key = call_key;
         self.rebuild_global_call_lines();
@@ -92,7 +93,7 @@ impl Calltrace {
 
     /// Mark all calls at depth <= `max_depth` as expanded so they appear
     /// in the global call-line index built by [`rebuild_global_call_lines`].
-    fn expand_all_up_to_depth(&mut self, max_depth: usize, db: &Db) {
+    fn expand_all_up_to_depth(&mut self, max_depth: usize, db: &Db, _reader: &dyn TraceReader) {
         for call_key_int in 0..self.call_states.len() {
             let call_key = CallKey(call_key_int as i64);
             let call = &db.calls[call_key];
@@ -287,13 +288,13 @@ impl Calltrace {
     //   collapse x/expand x
     //   filter?
     //   (property: calltrace valid and matching what is happening?)
-    fn autocollapse_callstack(&mut self, step_id: StepId, current_call_key: CallKey, db: &Db) {
+    fn autocollapse_callstack(&mut self, step_id: StepId, current_call_key: CallKey, db: &Db, _reader: &dyn TraceReader) {
         // autocollapse siblings before the current call
         // on each level of the callstack
         // potentially also part of the callstack itself
         // if it's too long
         // TODO
-        let callstack = self.load_callstack(step_id, db);
+        let callstack = self.load_callstack(step_id, db, _reader);
 
         // callstack originally is in opposite order of depth
         //   compared to call state/calltrace iteration:
@@ -347,7 +348,7 @@ impl Calltrace {
         // unimplemented!()
     }
 
-    pub fn load_callstack(&self, step_id: StepId, db: &Db) -> Vec<DbCall> {
+    pub fn load_callstack(&self, step_id: StepId, db: &Db, _reader: &dyn TraceReader) -> Vec<DbCall> {
         let mut callstack = vec![];
         if step_id.0 < db.steps.len().try_into().unwrap_or(i64::MAX) {
             let current_step = &db.steps[step_id];
@@ -373,19 +374,20 @@ impl Calltrace {
         count: usize,
         db: &Db,
         expr_loader: &mut ExprLoader,
+        _reader: &dyn TraceReader,
     ) -> Result<Vec<CallLine>, Box<dyn Error>> {
         let mut results = vec![];
         let mut index = from;
         while results.len() < count && index.0 < self.global_call_lines.len() {
             let metadata = &self.global_call_lines[index];
-            results.push(self.to_call_line(metadata, db, expr_loader));
+            results.push(self.to_call_line(metadata, db, expr_loader, _reader));
             index += 1;
         }
         // info!("{:?}", results);
         Ok(results)
     }
 
-    fn to_call_line(&self, metadata: &CallLineMetadata, db: &Db, expr_loader: &mut ExprLoader) -> CallLine {
+    fn to_call_line(&self, metadata: &CallLineMetadata, db: &Db, expr_loader: &mut ExprLoader, _reader: &dyn TraceReader) -> CallLine {
         if metadata.content.kind == CallLineContentKind::Call {
             let call = db.to_call(&self.calls[metadata.content.call_key], expr_loader);
             CallLine::call(

--- a/src/db-backend/src/ctfs_trace_reader/ctfs_container.rs
+++ b/src/db-backend/src/ctfs_trace_reader/ctfs_container.rs
@@ -1,0 +1,698 @@
+//! Minimal CTFS binary container reader (and test-only writer).
+//!
+//! Implements just enough of the CTFS v2 binary format spec to:
+//! 1. Parse the container header and file directory
+//! 2. Read named internal files by navigating the block mapping hierarchy
+//!
+//! See `codetracer-specs/Trace-Files/CTFS-Binary-Format.md` for the full
+//! format specification. This module implements the subset needed for reading;
+//! writing is provided only for test support (`write_minimal_ctfs`).
+//!
+//! # Format summary
+//!
+//! ```text
+//! Block 0:
+//!   Header (8 bytes): magic [C0 DE 72 AC E2], version, reserved
+//!   Extended Header (8 bytes): block_size (u32), max_root_entries (u32)
+//!   File Entry Array: max_root_entries × 24-byte entries
+//!
+//! Blocks 1..N:
+//!   Data blocks and mapping blocks
+//! ```
+//!
+//! File names are base40-encoded into a single `u64`. Block allocation uses
+//! a hierarchical mapping structure (up to 5 levels of indirect blocks).
+
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+// ── Constants ───────────────────────────────────────────────────────────
+
+/// Magic bytes identifying a CTFS file: "C0DE trACE2" in hex-speak.
+const CTFS_MAGIC: [u8; 5] = [0xC0, 0xDE, 0x72, 0xAC, 0xE2];
+
+/// The format version we support.
+const CTFS_VERSION: u8 = 2;
+
+/// Size of the fixed header (magic + version + reserved).
+const HEADER_SIZE: usize = 8;
+
+/// Size of the extended header (block_size + max_root_entries).
+const EXTENDED_HEADER_SIZE: usize = 8;
+
+/// Size of each file entry in the root directory.
+const FILE_ENTRY_SIZE: usize = 24;
+
+/// Maximum number of mapping levels supported (5 levels handles files up to ~35 TB).
+const MAX_MAPPING_LEVELS: usize = 5;
+
+// ── Base40 codec ────────────────────────────────────────────────────────
+
+/// The base40 character set used for CTFS file names.
+/// Index 0 is the null/padding character.
+const BASE40_CHARS: &[u8; 40] = b"\x000123456789abcdefghijklmnopqrstuvwxyz./-";
+
+/// Encode a file name (up to 12 characters) into a base40-packed `u64`.
+///
+/// Characters are encoded left-to-right with the leftmost character in the
+/// lowest-order position: `c[0]*40^0 + c[1]*40^1 + ...`.
+fn base40_encode(name: &str) -> Result<u64, Box<dyn Error>> {
+    if name.len() > 12 {
+        return Err(format!("CTFS filename too long ({} chars, max 12): {name}", name.len()).into());
+    }
+
+    let mut encoded: u64 = 0;
+    let mut multiplier: u64 = 1;
+
+    for (i, ch) in name.bytes().enumerate() {
+        let idx = BASE40_CHARS
+            .iter()
+            .position(|&c| c == ch)
+            .ok_or_else(|| {
+                format!(
+                    "CTFS filename contains invalid character '{}' (0x{:02x}) at position {i}",
+                    ch as char, ch
+                )
+            })?;
+        encoded += (idx as u64) * multiplier;
+        multiplier *= 40;
+    }
+
+    Ok(encoded)
+}
+
+/// Decode a base40-packed `u64` into a file name string.
+///
+/// Trailing null-padding characters (index 0) are stripped.
+fn base40_decode(mut encoded: u64) -> String {
+    if encoded == 0 {
+        return String::new();
+    }
+
+    let mut chars = Vec::with_capacity(12);
+    for _ in 0..12 {
+        let idx = (encoded % 40) as usize;
+        encoded /= 40;
+        chars.push(BASE40_CHARS[idx]);
+    }
+
+    // Strip trailing null padding
+    while chars.last() == Some(&0) {
+        chars.pop();
+    }
+
+    // Safety: all base40 characters are valid ASCII
+    String::from_utf8(chars).expect("base40 characters are always valid UTF-8")
+}
+
+// ── Error type ──────────────────────────────────────────────────────────
+
+/// Errors that can occur when reading a CTFS container.
+#[derive(Debug)]
+pub enum CtfsError {
+    /// The file does not start with the expected CTFS magic bytes.
+    InvalidMagic,
+    /// The format version is not supported.
+    UnsupportedVersion(u8),
+    /// A named file was not found in the container.
+    FileNotFound(String),
+    /// An I/O error occurred while reading the container.
+    Io(io::Error),
+    /// The container structure is corrupt or inconsistent.
+    Corrupt(String),
+}
+
+impl fmt::Display for CtfsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CtfsError::InvalidMagic => write!(f, "not a valid CTFS file (bad magic bytes)"),
+            CtfsError::UnsupportedVersion(v) => write!(f, "unsupported CTFS version {v} (expected {CTFS_VERSION})"),
+            CtfsError::FileNotFound(name) => write!(f, "internal file not found in CTFS container: {name}"),
+            CtfsError::Io(e) => write!(f, "CTFS I/O error: {e}"),
+            CtfsError::Corrupt(msg) => write!(f, "corrupt CTFS container: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for CtfsError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            CtfsError::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<io::Error> for CtfsError {
+    fn from(e: io::Error) -> Self {
+        CtfsError::Io(e)
+    }
+}
+
+// ── File entry ──────────────────────────────────────────────────────────
+
+/// A parsed file entry from the CTFS root directory.
+#[derive(Debug, Clone)]
+struct FileEntry {
+    /// Decoded file name.
+    name: String,
+    /// Size of the file in bytes.
+    size: u64,
+    /// Block number of the root mapping block (0 if file is empty).
+    map_block: u64,
+}
+
+// ── Reader ──────────────────────────────────────────────────────────────
+
+/// Reader for a CTFS v2 binary container.
+///
+/// Parses the header and file directory on construction, then provides
+/// `read_file(name)` to extract internal files by name.
+#[derive(Debug)]
+pub struct CtfsReader {
+    /// The raw bytes of the entire container. For Phase 1 we load the whole
+    /// file into memory. A future Phase 2 implementation would memory-map
+    /// the file instead and read blocks on demand.
+    data: Vec<u8>,
+    /// Block size in bytes (1024, 2048, or 4096).
+    block_size: usize,
+    /// Number of entries per mapping block (`block_size / 8`).
+    entries_per_block: usize,
+    /// Parsed file directory, keyed by decoded name.
+    files: HashMap<String, FileEntry>,
+}
+
+impl CtfsReader {
+    /// Open and parse a CTFS container from a file path.
+    pub fn open(path: &Path) -> Result<Self, CtfsError> {
+        let data = fs::read(path)?;
+        Self::from_bytes(data)
+    }
+
+    /// Parse a CTFS container from raw bytes.
+    pub fn from_bytes(data: Vec<u8>) -> Result<Self, CtfsError> {
+        if data.len() < HEADER_SIZE + EXTENDED_HEADER_SIZE {
+            return Err(CtfsError::Corrupt(format!(
+                "file too small ({} bytes, need at least {})",
+                data.len(),
+                HEADER_SIZE + EXTENDED_HEADER_SIZE
+            )));
+        }
+
+        // Validate magic bytes
+        if data[..5] != CTFS_MAGIC {
+            return Err(CtfsError::InvalidMagic);
+        }
+
+        // Check version
+        let version = data[5];
+        if version != CTFS_VERSION {
+            return Err(CtfsError::UnsupportedVersion(version));
+        }
+
+        // Parse extended header
+        let block_size = u32::from_le_bytes([data[8], data[9], data[10], data[11]]) as usize;
+        let max_root_entries = u32::from_le_bytes([data[12], data[13], data[14], data[15]]) as usize;
+
+        // Validate block size
+        if !matches!(block_size, 1024 | 2048 | 4096) {
+            return Err(CtfsError::Corrupt(format!("invalid block size: {block_size}")));
+        }
+
+        let entries_per_block = block_size / 8;
+
+        // Parse file entries
+        let entry_start = HEADER_SIZE + EXTENDED_HEADER_SIZE;
+        let mut files = HashMap::new();
+
+        for i in 0..max_root_entries {
+            let offset = entry_start + i * FILE_ENTRY_SIZE;
+            if offset + FILE_ENTRY_SIZE > data.len() {
+                break;
+            }
+
+            let size = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
+            let map_block = u64::from_le_bytes(data[offset + 8..offset + 16].try_into().unwrap());
+            let name_encoded = u64::from_le_bytes(data[offset + 16..offset + 24].try_into().unwrap());
+
+            // Skip empty entries (size=0, map_block=0, name=0)
+            if name_encoded == 0 {
+                continue;
+            }
+
+            let name = base40_decode(name_encoded);
+            files.insert(
+                name.clone(),
+                FileEntry {
+                    name,
+                    size,
+                    map_block,
+                },
+            );
+        }
+
+        Ok(CtfsReader {
+            data,
+            block_size,
+            entries_per_block,
+            files,
+        })
+    }
+
+    /// Read the full contents of a named internal file.
+    ///
+    /// Returns `CtfsError::FileNotFound` if no file with the given name
+    /// exists in the container.
+    pub fn read_file(&mut self, name: &str) -> Result<Vec<u8>, CtfsError> {
+        let entry = self
+            .files
+            .get(name)
+            .ok_or_else(|| CtfsError::FileNotFound(name.to_string()))?
+            .clone();
+
+        if entry.size == 0 {
+            return Ok(Vec::new());
+        }
+
+        if entry.map_block == 0 {
+            return Err(CtfsError::Corrupt(format!(
+                "file '{name}' has non-zero size ({}) but map_block is 0",
+                entry.size
+            )));
+        }
+
+        let mut result = Vec::with_capacity(entry.size as usize);
+        let total_data_blocks = (entry.size as usize + self.block_size - 1) / self.block_size;
+
+        // Read data blocks by walking the mapping hierarchy.
+        for block_index in 0..total_data_blocks {
+            let data_block_num = self.resolve_block(entry.map_block, block_index)?;
+            if data_block_num == 0 {
+                return Err(CtfsError::Corrupt(format!(
+                    "file '{name}': unallocated block at index {block_index}"
+                )));
+            }
+
+            let block_offset = data_block_num as usize * self.block_size;
+            let remaining = entry.size as usize - result.len();
+            let to_read = remaining.min(self.block_size);
+
+            if block_offset + to_read > self.data.len() {
+                return Err(CtfsError::Corrupt(format!(
+                    "file '{name}': block {data_block_num} extends beyond end of container"
+                )));
+            }
+
+            result.extend_from_slice(&self.data[block_offset..block_offset + to_read]);
+        }
+
+        Ok(result)
+    }
+
+    /// Resolve a logical block index to a physical block number by walking
+    /// the hierarchical mapping structure.
+    ///
+    /// The mapping uses Unix-like indirect blocks:
+    /// - Level 1: entries 0..N-2 are direct block pointers, entry N-1 points
+    ///   to the next level
+    /// - Level 2+: each entry points to a lower-level mapping block
+    ///
+    /// Where N = `entries_per_block` (e.g. 128 for 1024-byte blocks).
+    fn resolve_block(&self, root_map_block: u64, logical_index: usize) -> Result<u64, CtfsError> {
+        let direct_entries = self.entries_per_block - 1; // Last entry is the indirect pointer
+
+        // Determine which level the logical_index falls into and compute
+        // the path through the mapping hierarchy.
+        //
+        // Level 1: indices 0..direct_entries-1
+        // Level 2: indices direct_entries..direct_entries + direct_entries^2 - 1
+        // Level 3: ...
+        let mut remaining = logical_index;
+        let mut level = 1;
+        let mut level_capacity = direct_entries;
+
+        while remaining >= level_capacity && level < MAX_MAPPING_LEVELS {
+            remaining -= level_capacity;
+            level += 1;
+            level_capacity *= direct_entries;
+        }
+
+        if remaining >= level_capacity {
+            return Err(CtfsError::Corrupt(format!(
+                "block index {logical_index} exceeds maximum mapping depth"
+            )));
+        }
+
+        // Navigate from the root mapping block down to the data block.
+        // First, get to the correct level by following the indirect pointer
+        // (last entry) at each intermediate level.
+        let mut current_block = root_map_block;
+
+        // Follow indirect pointers to reach the target level
+        for _ in 1..level {
+            let indirect_ptr = self.read_mapping_entry(current_block, self.entries_per_block - 1)?;
+            if indirect_ptr == 0 {
+                return Err(CtfsError::Corrupt(
+                    "null indirect pointer in mapping hierarchy".to_string(),
+                ));
+            }
+            current_block = indirect_ptr;
+        }
+
+        // Now navigate within the target level. For level > 1, we need to
+        // descend through the sub-blocks.
+        if level == 1 {
+            // Direct lookup in the root mapping block
+            self.read_mapping_entry(current_block, remaining)
+        } else {
+            // Decompose `remaining` into a path of indices through the
+            // sub-levels. At level L, each sub-block covers direct_entries^(L-1)
+            // data blocks.
+            self.resolve_multilevel(current_block, remaining, level - 1)
+        }
+    }
+
+    /// Recursively resolve a block index through multi-level mapping.
+    ///
+    /// `depth` is the number of remaining levels to descend (0 = direct lookup).
+    fn resolve_multilevel(
+        &self,
+        map_block: u64,
+        index: usize,
+        depth: usize,
+    ) -> Result<u64, CtfsError> {
+        if depth == 0 {
+            return self.read_mapping_entry(map_block, index);
+        }
+
+        let direct_entries = self.entries_per_block - 1;
+        let sub_capacity = direct_entries.pow(depth as u32);
+        let sub_index = index / sub_capacity;
+        let sub_remaining = index % sub_capacity;
+
+        if sub_index >= direct_entries {
+            return Err(CtfsError::Corrupt(format!(
+                "mapping sub-index {sub_index} out of range (max {direct_entries})"
+            )));
+        }
+
+        let next_block = self.read_mapping_entry(map_block, sub_index)?;
+        if next_block == 0 {
+            return Err(CtfsError::Corrupt(
+                "null pointer in mapping sub-block".to_string(),
+            ));
+        }
+
+        self.resolve_multilevel(next_block, sub_remaining, depth - 1)
+    }
+
+    /// Read a single u64 entry from a mapping block.
+    fn read_mapping_entry(&self, block_num: u64, entry_index: usize) -> Result<u64, CtfsError> {
+        let offset = block_num as usize * self.block_size + entry_index * 8;
+        if offset + 8 > self.data.len() {
+            return Err(CtfsError::Corrupt(format!(
+                "mapping entry at block {block_num}, index {entry_index} is out of bounds"
+            )));
+        }
+        Ok(u64::from_le_bytes(
+            self.data[offset..offset + 8].try_into().unwrap(),
+        ))
+    }
+
+    /// List the names of all files in the container.
+    #[allow(dead_code)]
+    pub fn file_names(&self) -> Vec<&str> {
+        self.files.keys().map(|s| s.as_str()).collect()
+    }
+
+    /// Check whether a named file exists in the container.
+    #[allow(dead_code)]
+    pub fn has_file(&self, name: &str) -> bool {
+        self.files.contains_key(name)
+    }
+}
+
+// ── Test-only writer ────────────────────────────────────────────────────
+
+/// Write a minimal CTFS v2 container for testing purposes.
+///
+/// Creates a container with block_size=4096, max_root_entries=31, containing
+/// the specified files. This is NOT a production writer — it uses the simplest
+/// possible layout (one data block per file, no multi-level mapping needed).
+///
+/// # Panics
+///
+/// Panics if any file name is longer than 12 characters or contains
+/// characters outside the base40 alphabet.
+pub fn write_minimal_ctfs(
+    path: &Path,
+    files: &[(&str, &[u8])],
+) -> Result<(), Box<dyn Error>> {
+    let block_size: usize = 4096;
+    let max_root_entries: u32 = 31;
+
+    // Compute how many blocks we need:
+    // Block 0: header + file entries
+    // For each file: 1 mapping block + ceil(size / block_size) data blocks
+    let mut next_block: u64 = 1; // Block 0 is the root block
+
+    struct FileLayout {
+        name_encoded: u64,
+        size: u64,
+        map_block: u64,
+        data_blocks: Vec<u64>,
+    }
+
+    let mut layouts = Vec::with_capacity(files.len());
+
+    for &(name, data) in files {
+        let name_encoded = base40_encode(name)?;
+        let num_data_blocks = if data.is_empty() {
+            0
+        } else {
+            (data.len() + block_size - 1) / block_size
+        };
+
+        let map_block = if data.is_empty() {
+            0
+        } else {
+            let mb = next_block;
+            next_block += 1;
+            mb
+        };
+
+        let mut data_blocks = Vec::with_capacity(num_data_blocks);
+        for _ in 0..num_data_blocks {
+            data_blocks.push(next_block);
+            next_block += 1;
+        }
+
+        layouts.push(FileLayout {
+            name_encoded,
+            size: data.len() as u64,
+            map_block,
+            data_blocks,
+        });
+    }
+
+    // Allocate the output buffer
+    let total_size = next_block as usize * block_size;
+    let mut buf = vec![0u8; total_size];
+
+    // Write header
+    buf[0..5].copy_from_slice(&CTFS_MAGIC);
+    buf[5] = CTFS_VERSION;
+    // bytes 6-7 are reserved (already zero)
+
+    // Write extended header
+    buf[8..12].copy_from_slice(&(block_size as u32).to_le_bytes());
+    buf[12..16].copy_from_slice(&max_root_entries.to_le_bytes());
+
+    // Write file entries
+    let entry_start = HEADER_SIZE + EXTENDED_HEADER_SIZE;
+    for (i, layout) in layouts.iter().enumerate() {
+        let offset = entry_start + i * FILE_ENTRY_SIZE;
+        buf[offset..offset + 8].copy_from_slice(&layout.size.to_le_bytes());
+        buf[offset + 8..offset + 16].copy_from_slice(&layout.map_block.to_le_bytes());
+        buf[offset + 16..offset + 24].copy_from_slice(&layout.name_encoded.to_le_bytes());
+    }
+
+    // Write mapping blocks and data blocks
+    for (file_idx, &(_, data)) in files.iter().enumerate() {
+        let layout = &layouts[file_idx];
+        if data.is_empty() {
+            continue;
+        }
+
+        // Write the mapping block: entries point to data blocks
+        let map_offset = layout.map_block as usize * block_size;
+        for (j, &db) in layout.data_blocks.iter().enumerate() {
+            let entry_offset = map_offset + j * 8;
+            buf[entry_offset..entry_offset + 8].copy_from_slice(&db.to_le_bytes());
+        }
+
+        // Write data blocks
+        let mut remaining = data;
+        for &db in &layout.data_blocks {
+            let data_offset = db as usize * block_size;
+            let to_write = remaining.len().min(block_size);
+            buf[data_offset..data_offset + to_write].copy_from_slice(&remaining[..to_write]);
+            remaining = &remaining[to_write..];
+        }
+    }
+
+    fs::write(path, &buf)?;
+    Ok(())
+}
+
+// ── Unit tests ──────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_base40_roundtrip() {
+        let names = [
+            "meta.json",
+            "events.log",
+            "t00000000001",
+            "paths.idx",
+            "types.idx",
+            "funcs.idx",
+            "syncord.log",
+            "cpdata.bin",
+            "geid.idx",
+            "a",
+            "z",
+            "0",
+            "test",
+        ];
+
+        for name in &names {
+            let encoded = base40_encode(name).unwrap();
+            let decoded = base40_decode(encoded);
+            assert_eq!(&decoded, name, "base40 roundtrip failed for '{name}'");
+        }
+    }
+
+    #[test]
+    fn test_base40_empty_string() {
+        assert_eq!(base40_encode("").unwrap(), 0);
+        assert_eq!(base40_decode(0), "");
+    }
+
+    #[test]
+    fn test_base40_max_length() {
+        let name = "zzzzzzzzzzzz"; // 12 z's
+        let encoded = base40_encode(name).unwrap();
+        let decoded = base40_decode(encoded);
+        assert_eq!(&decoded, name);
+    }
+
+    #[test]
+    fn test_base40_too_long() {
+        let name = "1234567890123"; // 13 chars
+        assert!(base40_encode(name).is_err());
+    }
+
+    #[test]
+    fn test_write_and_read_minimal_ctfs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.ct");
+
+        let content = b"hello, CTFS!";
+        write_minimal_ctfs(&path, &[("test.file", content)]).unwrap();
+
+        let mut reader = CtfsReader::open(&path).unwrap();
+        assert!(reader.has_file("test.file"));
+
+        let read_back = reader.read_file("test.file").unwrap();
+        assert_eq!(&read_back, content);
+    }
+
+    #[test]
+    fn test_read_multiple_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("multi.ct");
+
+        let file_a = b"first file content";
+        let file_b = b"second file with different data";
+        write_minimal_ctfs(
+            &path,
+            &[("file.a", file_a.as_slice()), ("file.b", file_b.as_slice())],
+        )
+        .unwrap();
+
+        let mut reader = CtfsReader::open(&path).unwrap();
+        assert_eq!(reader.read_file("file.a").unwrap(), file_a);
+        assert_eq!(reader.read_file("file.b").unwrap(), file_b);
+    }
+
+    #[test]
+    fn test_read_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.ct");
+
+        write_minimal_ctfs(&path, &[("empty.file", &[])]).unwrap();
+
+        let mut reader = CtfsReader::open(&path).unwrap();
+        assert!(reader.has_file("empty.file"));
+        assert_eq!(reader.read_file("empty.file").unwrap(), Vec::<u8>::new());
+    }
+
+    #[test]
+    fn test_file_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nope.ct");
+
+        write_minimal_ctfs(&path, &[("exists", b"data")]).unwrap();
+
+        let mut reader = CtfsReader::open(&path).unwrap();
+        assert!(!reader.has_file("nope"));
+        assert!(matches!(
+            reader.read_file("nope"),
+            Err(CtfsError::FileNotFound(_))
+        ));
+    }
+
+    #[test]
+    fn test_invalid_magic() {
+        let data = vec![0xFF; 1024];
+        assert!(matches!(
+            CtfsReader::from_bytes(data),
+            Err(CtfsError::InvalidMagic)
+        ));
+    }
+
+    #[test]
+    fn test_file_larger_than_one_block() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("big.ct");
+
+        // Create data larger than one 4096-byte block
+        let big_data: Vec<u8> = (0..10000).map(|i| (i % 256) as u8).collect();
+        write_minimal_ctfs(&path, &[("big.file", &big_data)]).unwrap();
+
+        let mut reader = CtfsReader::open(&path).unwrap();
+        let read_back = reader.read_file("big.file").unwrap();
+        assert_eq!(read_back.len(), big_data.len());
+        assert_eq!(read_back, big_data);
+    }
+
+    #[test]
+    fn test_base40_all_chars() {
+        // Verify each individual character roundtrips correctly
+        let charset = "0123456789abcdefghijklmnopqrstuvwxyz./-";
+        for ch in charset.chars() {
+            let s = ch.to_string();
+            let encoded = base40_encode(&s).unwrap();
+            let decoded = base40_decode(encoded);
+            assert_eq!(decoded, s, "base40 roundtrip failed for char '{ch}'");
+        }
+    }
+}

--- a/src/db-backend/src/ctfs_trace_reader/mod.rs
+++ b/src/db-backend/src/ctfs_trace_reader/mod.rs
@@ -1,0 +1,390 @@
+//! [`TraceReader`] implementation that reads from `.ct` CTFS containers.
+//!
+//! See the module-level documentation on [`CTFSTraceReader`] for design
+//! rationale and the phased implementation plan.
+
+pub mod ctfs_container;
+
+use std::collections::HashMap;
+use std::error::Error;
+use std::path::Path;
+
+use codetracer_trace_types::{
+    CallKey, FullValueRecord, FunctionId, FunctionRecord, PathId, Place, StepId, TraceLowLevelEvent, TypeId,
+    TypeRecord, ValueRecord, VariableId,
+};
+
+use crate::db::{CellChange, Db, DbCall, DbRecordEvent, DbStep, EndOfProgram};
+use crate::trace_processor::TraceProcessor;
+use crate::trace_reader::TraceReader;
+
+use ctfs_container::CtfsReader;
+
+/// A [`TraceReader`] backed by a `.ct` CTFS container file.
+///
+/// **Phase 1 (current):** Loads all data into memory at open time, identical
+/// to [`crate::in_memory_trace_reader::InMemoryTraceReader`] but reading from
+/// a CTFS binary container instead of the `trace-processor` pipeline. This
+/// proves the plumbing works end-to-end: CTFS file -> parse container ->
+/// extract events -> `TraceProcessor::postprocess` -> populated `Db` -> serve
+/// via `TraceReader`.
+///
+/// **Phase 2 (future):** On-demand loading with LRU cache for per-step data.
+/// The CTFS hierarchical block maps enable O(log n) seeking, so only the data
+/// needed for the current DAP request would be decompressed and loaded.
+///
+/// # Container layout
+///
+/// A `.ct` file is a CTFS binary container (see `CTFS-Binary-Format.md` spec)
+/// containing internal files:
+///
+/// | File | Purpose |
+/// |------|---------|
+/// | `meta.json` | Trace metadata (workdir, program, args) |
+/// | `events.log` | CBOR-encoded `TraceLowLevelEvent` stream |
+/// | `paths.idx` | Interned source paths |
+/// | `types.idx` | Interned type records |
+/// | `funcs.idx` | Interned function records |
+///
+/// See [`crate::trace_processor`] for how `TraceLowLevelEvent` values are
+/// processed into the `Db` struct.
+#[derive(Debug)]
+pub struct CTFSTraceReader {
+    /// The fully-populated in-memory database, built from CTFS contents
+    /// during [`CTFSTraceReader::open`].
+    db: Db,
+}
+
+impl CTFSTraceReader {
+    /// Open a `.ct` CTFS trace file, parse its contents, and build the
+    /// in-memory database.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The file cannot be opened or is not a valid CTFS container
+    /// - The `meta.json` internal file is missing or malformed
+    /// - The trace events cannot be deserialized
+    /// - The `TraceProcessor` fails during postprocessing
+    pub fn open(path: &Path) -> Result<Self, Box<dyn Error>> {
+        let mut ctfs = CtfsReader::open(path)?;
+
+        // 1. Read and parse trace metadata
+        let meta_bytes = ctfs.read_file("meta.json")?;
+        let meta: codetracer_trace_types::TraceMetadata = serde_json::from_slice(&meta_bytes)?;
+
+        let workdir = if meta.workdir.as_os_str().is_empty() {
+            // Fall back to the parent directory of the program path
+            Path::new(&meta.program)
+                .parent()
+                .unwrap_or(Path::new("."))
+                .to_path_buf()
+        } else {
+            meta.workdir.clone()
+        };
+
+        // 2. Read the trace events from the container.
+        //    Current format: CBOR-encoded TraceLowLevelEvent sequence in
+        //    `events.log`. Future formats may use seekable Zstd compression
+        //    (see CTFS-Binary-Format.md, Seekable Zstd Compression Layer).
+        let events = Self::load_events(&mut ctfs)?;
+
+        // 3. Run the same postprocessing pipeline that the existing
+        //    trace-processor uses, populating a Db struct from the events.
+        let mut db = Db::new(&workdir);
+        let mut processor = TraceProcessor::new(&mut db);
+        processor.postprocess(&events)?;
+
+        Ok(CTFSTraceReader { db })
+    }
+
+    /// Extract `TraceLowLevelEvent` values from the CTFS container.
+    ///
+    /// Tries `events.log` first (CBOR-encoded event stream). If that file
+    /// is not present, returns an empty event list so that the reader can
+    /// still be constructed (useful for metadata-only traces or tests).
+    fn load_events(ctfs: &mut CtfsReader) -> Result<Vec<TraceLowLevelEvent>, Box<dyn Error>> {
+        let event_bytes = match ctfs.read_file("events.log") {
+            Ok(bytes) => bytes,
+            Err(_) => {
+                // No events file — return an empty trace. This allows opening
+                // minimal .ct files that only contain metadata (e.g. in tests).
+                return Ok(Vec::new());
+            }
+        };
+
+        if event_bytes.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Deserialize the CBOR-encoded event stream using cbor4ii, the same
+        // library used by codetracer_trace_reader for the standalone binary
+        // trace format. The events.log file contains a sequence of
+        // individually-encoded CBOR values (one per TraceLowLevelEvent).
+        //
+        // cbor4ii::serde::from_reader reads exactly one CBOR value from the
+        // stream. We wrap the bytes in a BufReader and read until EOF.
+        use std::io::BufRead;
+
+        let mut events = Vec::new();
+        let mut buf_reader = std::io::BufReader::new(event_bytes.as_slice());
+
+        loop {
+            // Check for EOF before attempting to deserialize
+            let buf = buf_reader.fill_buf()?;
+            if buf.is_empty() {
+                break;
+            }
+
+            match cbor4ii::serde::from_reader::<TraceLowLevelEvent, _>(&mut buf_reader) {
+                Ok(event) => {
+                    events.push(event);
+                }
+                Err(e) => {
+                    // If we have already read some events, treat a parse error
+                    // at the tail as a truncated stream (common during streaming
+                    // recording — the recorder may not have flushed completely).
+                    if !events.is_empty() {
+                        log::warn!(
+                            "CTFS: stopped reading events after {count} events: {e}. \
+                             Treating as truncated stream.",
+                            count = events.len()
+                        );
+                        break;
+                    } else {
+                        return Err(format!(
+                            "failed to deserialize any events from events.log: {e}"
+                        )
+                        .into());
+                    }
+                }
+            }
+        }
+
+        Ok(events)
+    }
+}
+
+// ── TraceReader implementation ─────────────────────────────────────────
+//
+// Phase 1: delegates every method to the inner `Db`, exactly like
+// `InMemoryTraceReader`. The only difference is *how* the Db is
+// populated (from a CTFS container rather than from load_trace_data +
+// TraceProcessor called in the handler).
+
+impl TraceReader for CTFSTraceReader {
+    // ── Interning tables ────────────────────────────────────────────
+
+    fn path(&self, id: PathId) -> Option<&str> {
+        self.db.paths.get(id).map(|s| s.as_str())
+    }
+
+    fn function(&self, id: FunctionId) -> Option<&FunctionRecord> {
+        self.db.functions.get(id)
+    }
+
+    fn type_record(&self, id: TypeId) -> Option<&TypeRecord> {
+        self.db.types.get(id)
+    }
+
+    fn variable_name(&self, id: VariableId) -> Option<&str> {
+        self.db.variable_names.get(id).map(|s| s.as_str())
+    }
+
+    fn path_count(&self) -> usize {
+        self.db.paths.len()
+    }
+
+    fn function_count(&self) -> usize {
+        self.db.functions.len()
+    }
+
+    fn type_count(&self) -> usize {
+        self.db.types.len()
+    }
+
+    // ── Per-step data ───────────────────────────────────────────────
+
+    fn step(&self, id: StepId) -> Option<&DbStep> {
+        self.db.steps.get(id)
+    }
+
+    fn step_count(&self) -> usize {
+        self.db.steps.len()
+    }
+
+    fn variables_at(&self, step_id: StepId) -> Option<&[FullValueRecord]> {
+        self.db.variables.get(step_id).map(|v| v.as_slice())
+    }
+
+    fn compound_at(&self, step_id: StepId) -> Option<&HashMap<Place, ValueRecord>> {
+        self.db.compound.get(step_id)
+    }
+
+    fn cells_at(&self, step_id: StepId) -> Option<&HashMap<Place, ValueRecord>> {
+        self.db.cells.get(step_id)
+    }
+
+    fn cell_changes_for(&self, place: &Place) -> Option<&Vec<CellChange>> {
+        self.db.cell_changes.get(place)
+    }
+
+    fn variable_cells_at(&self, step_id: StepId) -> Option<&HashMap<VariableId, Place>> {
+        self.db.variable_cells.get(step_id)
+    }
+
+    // ── Call tree ───────────────────────────────────────────────────
+
+    fn call(&self, key: CallKey) -> Option<&DbCall> {
+        self.db.calls.get(key)
+    }
+
+    fn call_count(&self) -> usize {
+        self.db.calls.len()
+    }
+
+    // ── Events ──────────────────────────────────────────────────────
+
+    fn events(&self) -> &[DbRecordEvent] {
+        &self.db.events
+    }
+
+    fn event_count(&self) -> usize {
+        self.db.events.len()
+    }
+
+    // ── Secondary indices ───────────────────────────────────────────
+
+    fn path_id_for(&self, path: &str) -> Option<PathId> {
+        self.db.path_map.get(path).copied()
+    }
+
+    fn steps_on_line(&self, path_id: PathId, line: usize) -> Option<&Vec<DbStep>> {
+        self.db
+            .step_map
+            .get(path_id)
+            .and_then(|by_line| by_line.get(&line))
+    }
+
+    fn step_map_for_path(&self, path_id: PathId) -> Option<&HashMap<usize, Vec<DbStep>>> {
+        self.db.step_map.get(path_id)
+    }
+
+    // ── Iteration helpers ────────────────────────────────────────────
+
+    fn functions_iter(&self) -> Box<dyn Iterator<Item = (FunctionId, &FunctionRecord)> + '_> {
+        Box::new(
+            self.db
+                .functions
+                .iter()
+                .enumerate()
+                .map(|(i, f)| (FunctionId(i), f)),
+        )
+    }
+
+    fn calls_iter(&self) -> Box<dyn Iterator<Item = &DbCall> + '_> {
+        Box::new(self.db.calls.iter())
+    }
+
+    fn steps_from(&self, start_id: StepId) -> &[DbStep] {
+        let start = start_id.0 as usize;
+        if start < self.db.steps.items.len() {
+            &self.db.steps.items[start..]
+        } else {
+            &[]
+        }
+    }
+
+    // ── Instructions ────────────────────────────────────────────────
+
+    fn instructions_at(&self, step_id: StepId) -> Option<&Vec<String>> {
+        self.db.instructions.get(step_id)
+    }
+
+    // ── Derived queries ─────────────────────────────────────────────
+
+    fn load_step_events(&self, step_id: StepId, exact: bool) -> Vec<DbRecordEvent> {
+        self.db.load_step_events(step_id, exact)
+    }
+
+    // ── Metadata ────────────────────────────────────────────────────
+
+    fn workdir(&self) -> &Path {
+        &self.db.workdir
+    }
+
+    fn end_of_program(&self) -> &EndOfProgram {
+        &self.db.end_of_program
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify that a minimal .ct file with only `meta.json` can be opened
+    /// and produces an empty trace (zero steps, zero calls, etc.).
+    #[test]
+    fn test_ctfs_trace_reader_opens_minimal_ct_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let ct_path = dir.path().join("test.ct");
+
+        // Create a minimal CTFS container with just meta.json.
+        let meta_json = br#"{"workdir":"/tmp","program":"/tmp/test","args":[]}"#;
+        ctfs_container::write_minimal_ctfs(&ct_path, &[("meta.json", meta_json)]).unwrap();
+
+        // Open with CTFSTraceReader
+        let reader = CTFSTraceReader::open(&ct_path).unwrap();
+        assert_eq!(reader.step_count(), 0);
+        assert_eq!(reader.call_count(), 0);
+        assert_eq!(reader.event_count(), 0);
+        assert_eq!(reader.workdir().to_str().unwrap(), "/tmp");
+    }
+
+    /// Verify that a .ct file without `events.log` opens successfully
+    /// (metadata-only trace).
+    #[test]
+    fn test_ctfs_trace_reader_missing_events_log() {
+        let dir = tempfile::tempdir().unwrap();
+        let ct_path = dir.path().join("no-events.ct");
+
+        let meta_json = br#"{"workdir":"/home/user","program":"/home/user/app","args":["--flag"]}"#;
+        ctfs_container::write_minimal_ctfs(&ct_path, &[("meta.json", meta_json)]).unwrap();
+
+        let reader = CTFSTraceReader::open(&ct_path).unwrap();
+        assert_eq!(reader.step_count(), 0);
+        assert_eq!(reader.workdir().to_str().unwrap(), "/home/user");
+    }
+
+    /// Verify that workdir falls back to the program's parent directory
+    /// when the metadata workdir field is empty.
+    #[test]
+    fn test_ctfs_trace_reader_workdir_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let ct_path = dir.path().join("fallback.ct");
+
+        let meta_json = br#"{"workdir":"","program":"/opt/bin/my_program","args":[]}"#;
+        ctfs_container::write_minimal_ctfs(&ct_path, &[("meta.json", meta_json)]).unwrap();
+
+        let reader = CTFSTraceReader::open(&ct_path).unwrap();
+        assert_eq!(reader.workdir().to_str().unwrap(), "/opt/bin");
+    }
+
+    /// Verify that opening a non-existent file returns an error.
+    #[test]
+    fn test_ctfs_trace_reader_nonexistent_file() {
+        let result = CTFSTraceReader::open(Path::new("/nonexistent/path/trace.ct"));
+        assert!(result.is_err());
+    }
+
+    /// Verify that opening a file with invalid magic bytes returns an error.
+    #[test]
+    fn test_ctfs_trace_reader_invalid_magic() {
+        let dir = tempfile::tempdir().unwrap();
+        let ct_path = dir.path().join("bad.ct");
+        std::fs::write(&ct_path, b"this is not a CTFS file at all!").unwrap();
+
+        let result = CTFSTraceReader::open(&ct_path);
+        assert!(result.is_err());
+    }
+}

--- a/src/db-backend/src/dap_server.rs
+++ b/src/db-backend/src/dap_server.rs
@@ -335,6 +335,12 @@ fn setup(
     let is_ttd_run_trace = trace_path
         .extension()
         .is_some_and(|ext| ext == std::ffi::OsStr::new("run"));
+    // MCR traces (.ct files) are handled by ct-rr-support replay-worker,
+    // not by the DB trace reader. Skip DB metadata loading for them.
+    let is_mcr_trace = trace_folder.is_file()
+        && trace_folder
+            .extension()
+            .is_some_and(|ext| ext == std::ffi::OsStr::new("ct"));
     let trace_file_format = if trace_file.extension() == Some(std::ffi::OsStr::new("json")) {
         codetracer_trace_reader::TraceEventsFileFormat::Json
     } else {
@@ -342,7 +348,7 @@ fn setup(
     };
     // duration code copied from
     // https://rust-lang-nursery.github.io/rust-cookbook/datetime/duration.html
-    if !is_ttd_run_trace {
+    if !is_ttd_run_trace && !is_mcr_trace {
         if let (Ok(meta), Ok(trace)) = (
             load_trace_metadata(&metadata_path),
             load_trace_data(&trace_path, trace_file_format),
@@ -395,7 +401,29 @@ fn setup(
 }
 
 fn resolve_replay_trace_path(trace_folder: &Path, trace_file: &Path) -> Option<PathBuf> {
+    // MCR traces: if trace_folder itself is a .ct file, use it directly.
+    // The ct-dap-client test runner passes the .ct file path as trace_folder
+    // for MCR traces. ct-rr-support detects .ct files and routes them to
+    // the MCR debugserver.
+    if trace_folder.is_file()
+        && trace_folder
+            .extension()
+            .is_some_and(|ext| ext == std::ffi::OsStr::new("ct"))
+    {
+        return Some(trace_folder.to_path_buf());
+    }
+
     let explicit_trace_path = trace_folder.join(trace_file);
+
+    // MCR traces in a directory: check if trace_file resolves to a .ct file
+    if explicit_trace_path
+        .extension()
+        .is_some_and(|ext| ext == std::ffi::OsStr::new("ct"))
+        && explicit_trace_path.exists()
+    {
+        return Some(explicit_trace_path);
+    }
+
     if explicit_trace_path
         .extension()
         .is_some_and(|ext| ext == std::ffi::OsStr::new("run"))

--- a/src/db-backend/src/db.rs
+++ b/src/db-backend/src/db.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::error::Error;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::vec::Vec;
 
@@ -16,6 +17,7 @@ use crate::distinct_vec::DistinctVec;
 use crate::expr_loader::ExprLoader;
 use crate::lang::Lang;
 use crate::replay::Replay;
+use crate::trace_reader::TraceReader;
 use crate::task::{
     Action, Breakpoint, Call, CallArg, CallLine, CoreTrace, CtLoadLocalsArguments, Events, HistoryResultWithRecord,
     LoadHistoryArg, Location, ProgramEvent, RRTicks, VariableWithRecord, NO_ADDRESS, NO_INDEX, NO_PATH, NO_POSITION,
@@ -862,6 +864,11 @@ pub struct DbReplay {
     //   or we can leave it like this for now and expect that the new format
     //   will deal with that?
     pub db: Box<Db>,
+    /// Shared, read-only access to trace data via the [`TraceReader`]
+    /// abstraction.  Used for simple lookups (steps, calls, paths, etc.)
+    /// while `self.db` is retained for complex methods that mutate state
+    /// or rely on Db-specific helpers (e.g. `to_call`, `to_ct_value`).
+    pub reader: Arc<dyn TraceReader>,
     pub step_id: StepId,
     pub call_key: CallKey,
     pub breakpoint_list: Vec<HashMap<usize, Breakpoint>>,
@@ -869,11 +876,12 @@ pub struct DbReplay {
 }
 
 impl DbReplay {
-    pub fn new(db: Box<Db>) -> DbReplay {
+    pub fn new(db: Box<Db>, reader: Arc<dyn TraceReader>) -> DbReplay {
         let mut breakpoint_list: Vec<HashMap<usize, Breakpoint>> = Default::default();
         breakpoint_list.resize_with(db.paths.len(), HashMap::new);
         DbReplay {
             db,
+            reader,
             step_id: StepId(0),
             call_key: CallKey(0),
             breakpoint_list,
@@ -1321,8 +1329,8 @@ impl DbReplay {
         None
     }
 
-    fn id_to_name(&self, variable_id: VariableId) -> &String {
-        &self.db.variable_names[variable_id]
+    fn id_to_name(&self, variable_id: VariableId) -> &str {
+        self.reader.variable_name(variable_id).unwrap_or("<unknown>")
     }
 }
 
@@ -1331,7 +1339,7 @@ impl Replay for DbReplay {
         info!("load_location: db replay");
         // Event-only traces (e.g. Stylus) have no steps — return a default location
         // so the DAP server can still initialize and serve event data.
-        if self.db.steps.is_empty() {
+        if self.reader.step_count() == 0 {
             info!("  no steps in trace, returning default location");
             return Ok(Location::default());
         }
@@ -1344,7 +1352,7 @@ impl Replay for DbReplay {
 
     fn run_to_entry(&mut self) -> Result<(), Box<dyn Error>> {
         // For event-only traces (no steps), keep step_id at the default.
-        if !self.db.steps.is_empty() {
+        if self.reader.step_count() > 0 {
             self.step_id_jump(StepId(0));
         }
         Ok(())
@@ -1355,7 +1363,7 @@ impl Replay for DbReplay {
         let mut first_events: Vec<ProgramEvent> = vec![];
         let mut contents: String = "".to_string();
 
-        for (i, event_record) in self.db.events.iter().enumerate() {
+        for (i, event_record) in self.reader.events().iter().enumerate() {
             let mut event = self.to_program_event(event_record, i);
             event.content = event_record.content.to_string();
             events.push(event.clone());
@@ -1459,7 +1467,7 @@ impl Replay for DbReplay {
     }
 
     fn load_step_events(&mut self, step_id: StepId, exact: bool) -> Vec<DbRecordEvent> {
-        self.db.load_step_events(step_id, exact)
+        self.reader.load_step_events(step_id, exact)
     }
 
     fn load_callstack(&mut self) -> Result<Vec<CallLine>, Box<dyn Error>> {
@@ -1598,7 +1606,7 @@ impl Replay for DbReplay {
 
     fn delete_breakpoints(&mut self) -> Result<bool, Box<dyn Error>> {
         self.breakpoint_list.clear();
-        self.breakpoint_list.resize_with(self.db.paths.len(), HashMap::new);
+        self.breakpoint_list.resize_with(self.reader.path_count(), HashMap::new);
         Ok(true)
     }
 

--- a/src/db-backend/src/diff.rs
+++ b/src/db-backend/src/diff.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::error::Error;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use codetracer_trace_types::FunctionId;
 use log::info;
@@ -10,6 +11,7 @@ use serde_repr::*;
 
 use crate::db::{Db, DbReplay};
 use crate::flow_preloader::FlowPreloader;
+use crate::in_memory_trace_reader::InMemoryTraceReader;
 use crate::task::{FlowUpdate, TraceKind};
 use crate::trace_processor::{load_trace_data, load_trace_metadata, TraceProcessor};
 
@@ -145,7 +147,8 @@ pub fn index_diff(diff: Diff, trace_folder: &Path) -> Result<(), Box<dyn Error>>
 
     info!("diff_lines {diff_lines:?}");
     let mut flow_preloader = FlowPreloader::new();
-    let mut replay = DbReplay::new(Box::new(db.clone()));
+    let reader: Arc<dyn crate::trace_reader::TraceReader> = Arc::new(InMemoryTraceReader::new(db.clone()));
+    let mut replay = DbReplay::new(Box::new(db.clone()), reader);
     let flow_update = match flow_preloader.load_diff_flow(diff_lines, &db, TraceKind::DB, &mut replay) {
         Ok(flow_update_direct) => flow_update_direct,
         Err(_e) => FlowUpdate::error("load diff flow error: {e:?}"),

--- a/src/db-backend/src/handler.rs
+++ b/src/db-backend/src/handler.rs
@@ -318,7 +318,7 @@ impl Handler {
         }
 
         let exact = false; // or for now try as flow // true just for this exact step
-        let step_events = self.db.load_step_events(self.step_id, exact);
+        let step_events = self.reader.load_step_events(self.step_id, exact);
         // info!("step events for {:?} {:?}", self.step_id, step_events);
         if !step_events.is_empty() && step_events[0].kind == EventLogKind::Error {
             let error_text = &step_events[0].content;
@@ -490,7 +490,8 @@ impl Handler {
     }
 
     fn load_local_calltrace(&mut self, args: CalltraceLoadArgs) -> Result<Vec<CallLine>, Box<dyn Error>> {
-        let call_key = self.db.call_key_for_step(self.step_id);
+        let call_key = self.reader.call_key_for_step(self.step_id)
+            .expect("load_local_calltrace: invalid step_id");
         self.calltrace.optimize_collapse = args.optimize_collapse;
         if call_key != self.calltrace.start_call_key {
             // When not auto-collapsing (e.g. Python API bridge), pass the
@@ -498,9 +499,11 @@ impl Handler {
             // The GUI uses auto_collapsing=true and handles expand/collapse
             // interactively, so it does not need this.
             let max_depth = if args.auto_collapsing { None } else { Some(args.depth) };
+            // TODO(Phase 4): calltrace.jump_to_with_depth takes &Db; migrate to &dyn TraceReader
             self.calltrace
                 .jump_to_with_depth(self.step_id, args.auto_collapsing, max_depth, &self.db);
         }
+        // TODO(Phase 4): calltrace.load_lines takes &Db; migrate to &dyn TraceReader
         self.calltrace
             .load_lines(args.start_call_line_index, args.height, &self.db, &mut self.expr_loader)
     }
@@ -565,6 +568,7 @@ impl Handler {
         sender: Sender<DapMessage>,
     ) -> Result<(), Box<dyn Error>> {
         let mut flow_replay: Box<dyn Replay> = if self.trace_kind == TraceKind::DB {
+            // TODO(Phase 4): DbReplay needs full Db; revisit when Replay is refactored
             Box::new(DbReplay::new(self.db.clone()))
         } else {
             Box::new(RRDispatcher::new("flow", self.load_flow_index, self.ct_rr_args.clone()))
@@ -614,6 +618,7 @@ impl Handler {
         count_limit: usize,
     ) -> Result<(Call, usize), Box<dyn Error>> {
         // expanded children count not used here: we add actual children
+        // TODO(Phase 4): migrate to_call to TraceReader or free function
         let mut call = self.db.to_call(db_call, &mut self.expr_loader);
         let mut count = 1; // our call
                            // TODO: on depth/count limit
@@ -902,15 +907,16 @@ impl Handler {
         let mut list: Vec<usize> = vec![];
         let re = Regex::new(&arg.value.clone())?;
 
-        for (id, function) in self.db.functions.iter().enumerate() {
+        for (id, function) in self.reader.functions_iter() {
             if re.is_match(&function.name) {
-                list.push(id);
+                list.push(id.0);
             }
         }
 
-        for db_call in self.db.calls.clone().iter() {
+        for db_call in self.reader.calls_iter() {
             if list.contains(&db_call.function_id.0) {
                 // expanded children count not relevant here
+                // TODO(Phase 4): migrate to_call to TraceReader or free function
                 calls.push(self.db.to_call(db_call, &mut self.expr_loader));
             }
         }
@@ -1091,9 +1097,9 @@ impl Handler {
         let mut path_id: PathId = self.load_path_id(&loc.path)?;
         // TODO: eventually expose slice index? not obvious if easy
         // for now this is not often
-        for step in &self.db.steps.items[(self.step_id.0 as usize)..] {
-            let call = &self.db.calls[step.call_key];
-            let function = &self.db.functions[call.function_id];
+        for step in self.reader.steps_from(self.step_id) {
+            let call = self.reader.call(step.call_key).expect("get_call_target: invalid call_key");
+            let function = self.reader.function(call.function_id).expect("get_call_target: invalid function_id");
             if loc.token == function.name {
                 line = function.line;
                 path_id = function.path_id;
@@ -1623,6 +1629,7 @@ impl Handler {
     }
 
     pub fn search_program(&mut self, query: String, _task: Task) -> Result<(), Box<dyn Error>> {
+        // TODO(Phase 4): ProgramSearchTool::new takes &Db; migrate to &dyn TraceReader
         let program_search_tool = ProgramSearchTool::new(&self.db);
         let _results = program_search_tool.search(&query, &mut self.expr_loader)?;
         // TODO: send with DAP
@@ -1841,7 +1848,7 @@ impl Handler {
                 for (line, step_id) in interesting_steps.iter() {
                     if step_id.0 != NO_STEP_ID {
                         let current_step = *self.reader.step(*step_id).expect("load_asm_function: invalid step_id");
-                        if let Some(asm_instructions) = self.db.instructions.get(*step_id) {
+                        if let Some(asm_instructions) = self.reader.instructions_at(*step_id) {
                             if asm_instructions.is_empty() {
                                 instructions.push(Instruction::empty(
                                     *line,
@@ -1959,8 +1966,8 @@ impl Handler {
         } else {
             // Fast path: scan the db event records for Write events only,
             // skipping the expensive full load_events() pipeline.
-            self.db
-                .events
+            self.reader
+                .events()
                 .iter()
                 .enumerate()
                 .filter(|(_, record)| record.kind == EventLogKind::Write)
@@ -2045,6 +2052,7 @@ impl Handler {
         //   the equivalent of [4, 2]
         //   how to do it efficiently is a non-trivial question: maybe by iterating through previous steps,
         //   or a new kind of index?
+        // TODO(Phase 4): migrate to_call and load_location to TraceReader or free function
         let call = self.db.to_call(call_record, &mut self.expr_loader);
         let current_call_key = self.reader.step(self.step_id).expect("produce_stack_frame: invalid step_id").call_key;
         let location = if call_record.key == current_call_key {
@@ -2164,6 +2172,7 @@ impl Handler {
 
                 stack_frames
             } else {
+                // TODO(Phase 4): calltrace.load_callstack takes &Db; migrate to &dyn TraceReader
                 self.calltrace
                     .load_callstack(self.step_id, &self.db)
                     .iter()

--- a/src/db-backend/src/handler.rs
+++ b/src/db-backend/src/handler.rs
@@ -7,6 +7,7 @@ use std::error::Error;
 use std::io;
 use std::path::Path;
 use std::sync::mpsc::Sender;
+use std::sync::Arc;
 
 use codetracer_trace_types::{CallKey, EventLogKind, FullValueRecord, Line, PathId, StepId, TypeKind, VariableId, NO_KEY};
 
@@ -46,10 +47,12 @@ pub struct Handler {
     pub db: Box<Db>,
     /// Abstracted read-only access to trace data.
     ///
-    /// During Phase 3 migration, both `db` (direct) and `reader` (abstracted)
+    /// Shared via `Arc` so that `DbReplay` (and other consumers) can hold
+    /// a reference to the same reader without cloning the underlying data.
+    /// During the migration, both `db` (direct) and `reader` (abstracted)
     /// coexist. New code should use `reader`; remaining `db` accesses will be
     /// migrated incrementally.
-    pub reader: Box<dyn TraceReader>,
+    pub reader: Arc<dyn TraceReader>,
     pub step_id: StepId,
     pub last_location: Location,
     // pub sender_tx: mpsc::Sender<Response>,
@@ -118,19 +121,20 @@ impl Handler {
     }
 
     pub fn construct(trace_kind: TraceKind, ct_rr_args: CtRRArgs, db: Box<Db>, indirect_send: bool) -> Handler {
-        let calltrace = Calltrace::new(&db);
-        let trace = CoreTrace::default();
-        let mut expr_loader = ExprLoader::new(trace.clone());
-        let step_lines_loader = StepLinesLoader::new(&db, &mut expr_loader);
-        let replay: Box<dyn Replay> = if trace_kind == TraceKind::DB {
-            Box::new(DbReplay::new(db.clone()))
-        } else {
-            Box::new(RRDispatcher::new(&ct_rr_args.name, 0, ct_rr_args.clone()))
-        };
         // Wrap a clone of the Db in an InMemoryTraceReader so that new code
         // can go through the TraceReader abstraction. The original `db` is
         // kept around until all direct accesses are migrated.
-        let reader: Box<dyn TraceReader> = Box::new(InMemoryTraceReader::new(*db.clone()));
+        // Using Arc so that DbReplay and Handler share the same reader instance.
+        let reader: Arc<dyn TraceReader> = Arc::new(InMemoryTraceReader::new(*db.clone()));
+        let calltrace = Calltrace::new(&db, &*reader);
+        let trace = CoreTrace::default();
+        let mut expr_loader = ExprLoader::new(trace.clone());
+        let step_lines_loader = StepLinesLoader::new(&db, &mut expr_loader, &*reader);
+        let replay: Box<dyn Replay> = if trace_kind == TraceKind::DB {
+            Box::new(DbReplay::new(db.clone(), Arc::clone(&reader)))
+        } else {
+            Box::new(RRDispatcher::new(&ct_rr_args.name, 0, ct_rr_args.clone()))
+        };
         // let sender = sender::Sender::new();
         let mut handler = Handler {
             trace_kind,
@@ -499,13 +503,11 @@ impl Handler {
             // The GUI uses auto_collapsing=true and handles expand/collapse
             // interactively, so it does not need this.
             let max_depth = if args.auto_collapsing { None } else { Some(args.depth) };
-            // TODO(Phase 4): calltrace.jump_to_with_depth takes &Db; migrate to &dyn TraceReader
             self.calltrace
-                .jump_to_with_depth(self.step_id, args.auto_collapsing, max_depth, &self.db);
+                .jump_to_with_depth(self.step_id, args.auto_collapsing, max_depth, &self.db, &*self.reader);
         }
-        // TODO(Phase 4): calltrace.load_lines takes &Db; migrate to &dyn TraceReader
         self.calltrace
-            .load_lines(args.start_call_line_index, args.height, &self.db, &mut self.expr_loader)
+            .load_lines(args.start_call_line_index, args.height, &self.db, &mut self.expr_loader, &*self.reader)
     }
 
     fn calc_total_calls(&mut self) -> usize {
@@ -568,8 +570,7 @@ impl Handler {
         sender: Sender<DapMessage>,
     ) -> Result<(), Box<dyn Error>> {
         let mut flow_replay: Box<dyn Replay> = if self.trace_kind == TraceKind::DB {
-            // TODO(Phase 4): DbReplay needs full Db; revisit when Replay is refactored
-            Box::new(DbReplay::new(self.db.clone()))
+            Box::new(DbReplay::new(self.db.clone(), Arc::clone(&self.reader)))
         } else {
             Box::new(RRDispatcher::new("flow", self.load_flow_index, self.ct_rr_args.clone()))
         };
@@ -1629,8 +1630,7 @@ impl Handler {
     }
 
     pub fn search_program(&mut self, query: String, _task: Task) -> Result<(), Box<dyn Error>> {
-        // TODO(Phase 4): ProgramSearchTool::new takes &Db; migrate to &dyn TraceReader
-        let program_search_tool = ProgramSearchTool::new(&self.db);
+        let program_search_tool = ProgramSearchTool::new(&self.db, &*self.reader);
         let _results = program_search_tool.search(&query, &mut self.expr_loader)?;
         // TODO: send with DAP
         // self.send_event((
@@ -2172,9 +2172,8 @@ impl Handler {
 
                 stack_frames
             } else {
-                // TODO(Phase 4): calltrace.load_callstack takes &Db; migrate to &dyn TraceReader
                 self.calltrace
-                    .load_callstack(self.step_id, &self.db)
+                    .load_callstack(self.step_id, &self.db, &*self.reader)
                     .iter()
                     .map(|call_record| {
                         // expanded children count not relevant in raw callstack

--- a/src/db-backend/src/handler.rs
+++ b/src/db-backend/src/handler.rs
@@ -8,12 +8,14 @@ use std::io;
 use std::path::Path;
 use std::sync::mpsc::Sender;
 
-use codetracer_trace_types::{CallKey, EventLogKind, Line, PathId, StepId, TypeKind, VariableId, NO_KEY};
+use codetracer_trace_types::{CallKey, EventLogKind, FullValueRecord, Line, PathId, StepId, TypeKind, VariableId, NO_KEY};
 
 use crate::calltrace::Calltrace;
 use crate::dap::{self, DapClient, DapMessage};
-use crate::db::{Db, DbCall, DbRecordEvent, DbReplay, DbStep};
+use crate::db::{Db, DbCall, DbRecordEvent, DbReplay};
 use crate::event_db::{EventDb, SingleTableId};
+use crate::in_memory_trace_reader::InMemoryTraceReader;
+use crate::trace_reader::TraceReader;
 use crate::expr_loader::ExprLoader;
 use crate::flow_preloader::FlowPreloader;
 use crate::lang::{lang_from_context, Lang};
@@ -42,6 +44,12 @@ const TRACEPOINT_RESULTS_LIMIT_BEFORE_UPDATE: usize = 5;
 #[derive(Debug)]
 pub struct Handler {
     pub db: Box<Db>,
+    /// Abstracted read-only access to trace data.
+    ///
+    /// During Phase 3 migration, both `db` (direct) and `reader` (abstracted)
+    /// coexist. New code should use `reader`; remaining `db` accesses will be
+    /// migrated incrementally.
+    pub reader: Box<dyn TraceReader>,
     pub step_id: StepId,
     pub last_location: Location,
     // pub sender_tx: mpsc::Sender<Response>,
@@ -119,10 +127,15 @@ impl Handler {
         } else {
             Box::new(RRDispatcher::new(&ct_rr_args.name, 0, ct_rr_args.clone()))
         };
+        // Wrap a clone of the Db in an InMemoryTraceReader so that new code
+        // can go through the TraceReader abstraction. The original `db` is
+        // kept around until all direct accesses are migrated.
+        let reader: Box<dyn TraceReader> = Box::new(InMemoryTraceReader::new(*db.clone()));
         // let sender = sender::Sender::new();
         let mut handler = Handler {
             trace_kind,
             db: db.clone(),
+            reader,
             step_id: StepId(0),
             last_location: Location {
                 key: format!("{}", NO_KEY.0),
@@ -185,12 +198,12 @@ impl Handler {
 
     fn load_location(&self, step_id: StepId) -> Location {
         let step_id_int = step_id.0;
-        let step_record = &self.db.steps[step_id];
+        let step_record = self.reader.step(step_id).expect("load_location: invalid step_id");
         let path = format!(
             "{}",
-            self.db
-                .workdir
-                .join(self.db.load_path_from_id(&step_record.path_id))
+            self.reader
+                .workdir()
+                .join(self.reader.path(step_record.path_id).unwrap_or(""))
                 .display()
         );
         let line = step_record.line.0;
@@ -200,8 +213,8 @@ impl Handler {
         assert!(call_key_int >= 0);
 
         let function_name = if step_record.call_key != NO_KEY {
-            let call = &self.db.calls[call_key];
-            let function = &self.db.functions[call.function_id];
+            let call = self.reader.call(call_key).expect("load_location: invalid call_key");
+            let function = self.reader.function(call.function_id).expect("load_location: invalid function_id");
             function.name.clone()
         } else {
             "<unknown>".to_string()
@@ -272,18 +285,18 @@ impl Handler {
 
         if self.step_id.0 > self.previous_step_id.0 {
             let mut raw_output_events: Vec<dap::DapMessage> = vec![];
-            for event in self.db.events.iter() {
+            for event in self.reader.events().iter() {
                 if event.step_id.0 > self.previous_step_id.0 && event.step_id.0 <= self.step_id.0 {
                     // different kind of if-s:
                     //   upper if the event is in the range of the move
                     //   this internal one: for which kinds do we produce dap events
                     #[allow(clippy::collapsible_if)]
                     if event.kind == EventLogKind::Write {
-                        let step = self.db.steps[event.step_id];
+                        let step = *self.reader.step(event.step_id).expect("prepare_output_events: invalid step_id");
                         info!("generate output event");
                         let raw_output_event = self.dap_client.output_event(
                             "stdout",
-                            &self.db.paths[step.path_id],
+                            self.reader.path(step.path_id).unwrap_or(""),
                             step.line.0 as usize,
                             &event.content,
                         )?;
@@ -499,7 +512,7 @@ impl Handler {
                 collapsed_count += 1;
             }
         }
-        self.db.calls.len() - collapsed_count
+        self.reader.call_count() - collapsed_count
     }
 
     pub fn load_calltrace_section(
@@ -617,8 +630,9 @@ impl Handler {
         if depth < depth_limit && db_call.key.0 >= 0 {
             for child_call_id in &db_call.children_keys {
                 assert!(child_call_id.0 >= 0);
+                let child_db_call = self.reader.call(*child_call_id).expect("to_ct_calltrace_call: invalid child call_key").clone();
                 let (child_call, child_call_count) = self.to_ct_calltrace_call(
-                    &self.db.calls[*child_call_id].clone(),
+                    &child_db_call,
                     depth + 1,
                     depth_limit,
                     count_limit - count,
@@ -641,12 +655,12 @@ impl Handler {
     }
 
     fn on_step_id_limit(&self, step_index: usize, forward: bool) -> bool {
-        if self.db.steps.is_empty() {
+        if self.reader.step_count() == 0 {
             return true;
         }
         if forward {
             // moving forward
-            step_index >= self.db.steps.len() - 1 // we're on the last one
+            step_index >= self.reader.step_count() - 1 // we're on the last one
         } else {
             // moving backwards
             step_index == 0
@@ -655,11 +669,11 @@ impl Handler {
 
     fn single_step_line(&self, step_index: usize, forward: bool) -> usize {
         // taking note of db.lines limits: returning a valid step id always
-        if self.db.steps.is_empty() {
+        if self.reader.step_count() == 0 {
             return step_index;
         }
         if forward {
-            if step_index < self.db.steps.len() - 1 {
+            if step_index < self.reader.step_count() - 1 {
                 step_index + 1
             } else {
                 step_index
@@ -731,7 +745,7 @@ impl Handler {
                     false,
                     sender.clone(),
                 )?;
-            } else if self.step_id.0 as usize == self.db.steps.len() - 1 {
+            } else if self.step_id.0 as usize == self.reader.step_count() - 1 {
                 self.send_notification(NotificationKind::Info, "End of record reached", false, sender.clone())?;
             }
         }
@@ -906,8 +920,8 @@ impl Handler {
         Ok(())
     }
 
-    fn id_to_name(&self, variable_id: VariableId) -> &String {
-        &self.db.variable_names[variable_id]
+    fn id_to_name(&self, variable_id: VariableId) -> &str {
+        self.reader.variable_name(variable_id).unwrap_or("<unknown>")
     }
 
     pub fn load_history(
@@ -957,11 +971,11 @@ impl Handler {
     }
 
     fn load_path_id(&self, path: &str) -> Option<PathId> {
-        self.db.path_map.get(path).copied()
+        self.reader.path_id_for(path)
     }
 
     fn find_next_step(&self, path_id: PathId, line: usize) -> Option<StepId> {
-        if let Some(records) = self.db.step_map[path_id].get(&line) {
+        if let Some(records) = self.reader.steps_on_line(path_id, line) {
             for record in records {
                 if record.step_id > self.step_id {
                     return Some(record.step_id);
@@ -980,7 +994,8 @@ impl Handler {
         }
 
         // Get the closest step if not.
-        let line_map = &self.db.step_map[path_id];
+        let empty_map = HashMap::new();
+        let line_map = self.reader.step_map_for_path(path_id).unwrap_or(&empty_map);
         let mut lines: Vec<&usize> = line_map.keys().collect();
         lines.sort();
         let mut closest_line: Option<usize> = None;
@@ -1088,7 +1103,7 @@ impl Handler {
 
         if let Some(step_id) = self.get_closest_step_id(&SourceLocation {
             line: line.into(),
-            path: self.db.load_path_from_id(&path_id).to_string(),
+            path: self.reader.path(path_id).unwrap_or("").to_string(),
         }) {
             return Some(step_id);
         }
@@ -1232,8 +1247,8 @@ impl Handler {
         if !self.breakpoints.is_empty() {
             return;
         }
-        if let Some(first_step) = self.db.steps.first() {
-            let path = self.db.load_path_from_id(&first_step.path_id).to_string();
+        if let Some(first_step) = self.reader.step(StepId(0)) {
+            let path = self.reader.path(first_step.path_id).unwrap_or("").to_string();
             self.breakpoints.entry((path, first_step.line.0)).or_default();
         }
     }
@@ -1781,16 +1796,16 @@ impl Handler {
 
     fn load_steps_for_call(&mut self, call_key: CallKey) -> IndexMap<i64, StepId> {
         let mut list: IndexMap<i64, StepId> = IndexMap::default();
-        let db_call = &self.db.calls[call_key];
-        let function_step = self.db.steps[db_call.step_id];
+        let db_call = self.reader.call(call_key).expect("load_steps_for_call: invalid call_key").clone();
+        let function_step = *self.reader.step(db_call.step_id).expect("load_steps_for_call: invalid step_id");
         let location = self.load_location(db_call.step_id);
         let function_location = self
             .flow_preloader
             .expr_loader
             .find_function_location(&location, &function_step.line);
         for line in function_location.function_first..function_location.function_last {
-            let function_id = &self.db.functions[db_call.function_id];
-            let step_map = &self.db.step_map[function_id.path_id];
+            let function_id = self.reader.function(db_call.function_id).expect("load_steps_for_call: invalid function_id");
+            let step_map = self.reader.step_map_for_path(function_id.path_id).expect("load_steps_for_call: missing step_map");
             if let Some(steps) = step_map.get(&(line as usize)) {
                 for step in steps {
                     if step.call_key == call_key {
@@ -1825,12 +1840,12 @@ impl Handler {
                 let interesting_steps = self.load_steps_for_call(call_key);
                 for (line, step_id) in interesting_steps.iter() {
                     if step_id.0 != NO_STEP_ID {
-                        let current_step = self.db.steps[*step_id];
+                        let current_step = *self.reader.step(*step_id).expect("load_asm_function: invalid step_id");
                         if let Some(asm_instructions) = self.db.instructions.get(*step_id) {
                             if asm_instructions.is_empty() {
                                 instructions.push(Instruction::empty(
                                     *line,
-                                    self.db.load_path_from_id(&current_step.path_id),
+                                    self.reader.path(current_step.path_id).unwrap_or(""),
                                     step_id.0,
                                 ))
                             }
@@ -1838,7 +1853,7 @@ impl Handler {
                                 instructions.push(Instruction {
                                     args: "".to_string(),
                                     high_level_line: *line,
-                                    high_level_path: self.db.load_path_from_id(&current_step.path_id).to_string(),
+                                    high_level_path: self.reader.path(current_step.path_id).unwrap_or("").to_string(),
                                     name: arg.to_string(),
                                     offset: current_step.step_id.0,
                                     other: "".to_string(),
@@ -1846,10 +1861,11 @@ impl Handler {
                             }
                         }
                     } else {
+                        let fn_id = self.reader.call(call_key).expect("load_asm_function: invalid call_key").function_id;
+                        let fn_path_id = self.reader.function(fn_id).expect("load_asm_function: invalid function_id").path_id;
                         instructions.push(Instruction::empty(
                             *line,
-                            self.db
-                                .load_path_from_id(&self.db.functions[self.db.calls[call_key].function_id].path_id),
+                            self.reader.path(fn_path_id).unwrap_or(""),
                             NO_STEP_ID,
                         ))
                     }
@@ -1972,11 +1988,11 @@ impl Handler {
     fn to_program_event(&self, event_record: &DbRecordEvent, index: usize) -> ProgramEvent {
         let step_id_int = event_record.step_id.0;
         let (path, line) = if step_id_int != NO_INDEX {
-            let step_record = &self.db.steps[event_record.step_id];
+            let step_record = self.reader.step(event_record.step_id).expect("to_program_event: invalid step_id");
             (
-                self.db
-                    .workdir
-                    .join(self.db.load_path_from_id(&step_record.path_id))
+                self.reader
+                    .workdir()
+                    .join(self.reader.path(step_record.path_id).unwrap_or(""))
                     .display()
                     .to_string(),
                 step_record.line.0,
@@ -1998,19 +2014,14 @@ impl Handler {
             high_level_path: path,
             high_level_line: line,
             base64_encoded: false,
-            max_rr_ticks: self
-                .db
-                .steps
-                .last()
-                .unwrap_or(&DbStep {
-                    step_id: StepId(0),
-                    path_id: PathId(0),
-                    line: Line(0),
-                    call_key: CallKey(0),
-                    global_call_key: CallKey(0),
-                })
-                .step_id
-                .0,
+            max_rr_ticks: if self.reader.step_count() > 0 {
+                self.reader
+                    .step(StepId((self.reader.step_count() - 1) as i64))
+                    .map(|s| s.step_id.0)
+                    .unwrap_or(0)
+            } else {
+                0
+            },
         }
     }
 
@@ -2035,7 +2046,8 @@ impl Handler {
         //   how to do it efficiently is a non-trivial question: maybe by iterating through previous steps,
         //   or a new kind of index?
         let call = self.db.to_call(call_record, &mut self.expr_loader);
-        let location = if call_record.key == self.db.steps[self.step_id].call_key {
+        let current_call_key = self.reader.step(self.step_id).expect("produce_stack_frame: invalid step_id").call_key;
+        let location = if call_record.key == current_call_key {
             self.db
                 .load_location(self.step_id, call_record.key, &mut self.expr_loader)
         } else {
@@ -2186,8 +2198,8 @@ impl Handler {
             self.respond_dap(request, dap_types::ScopesResponseBody { scopes: vec![] }, sender)?;
             return Ok(());
         }
-        let call = &self.db.calls[CallKey(arg.frame_id)];
-        let function = &self.db.functions[call.function_id];
+        let call = self.reader.call(CallKey(arg.frame_id)).expect("load_dap_scopes: invalid call_key");
+        let function = self.reader.function(call.function_id).expect("load_dap_scopes: invalid function_id");
         let scope = dap_types::Scope {
             name: function.name.clone(),
             presentation_hint: Some("locals".to_string()),
@@ -2221,10 +2233,14 @@ impl Handler {
             self.respond_dap(request, dap_types::VariablesResponseBody { variables: vec![] }, sender)?;
             return Ok(());
         }
-        let full_value_locals: Vec<Variable> = self.db.variables[self.step_id]
+        let empty_vars: Vec<FullValueRecord> = vec![];
+        let vars_slice = self.reader.variables_at(self.step_id).unwrap_or(&empty_vars);
+        let full_value_locals: Vec<Variable> = vars_slice
             .iter()
             .map(|v| Variable {
-                expression: self.db.variable_name(v.variable_id).to_string(),
+                expression: self.reader.variable_name(v.variable_id).unwrap_or("<unknown>").to_string(),
+                // to_ct_value is a Db method that depends on type resolution;
+                // keep using self.db for it until TraceReader gains value conversion.
                 value: self.db.to_ct_value(&v.value),
                 address: NO_ADDRESS,
             })

--- a/src/db-backend/src/in_memory_trace_reader.rs
+++ b/src/db-backend/src/in_memory_trace_reader.rs
@@ -124,6 +124,43 @@ impl TraceReader for InMemoryTraceReader {
         self.db.step_map.get(path_id)
     }
 
+    // ── Iteration helpers ────────────────────────────────────────────
+
+    fn functions_iter(&self) -> Box<dyn Iterator<Item = (FunctionId, &FunctionRecord)> + '_> {
+        Box::new(
+            self.db
+                .functions
+                .iter()
+                .enumerate()
+                .map(|(i, f)| (FunctionId(i), f)),
+        )
+    }
+
+    fn calls_iter(&self) -> Box<dyn Iterator<Item = &DbCall> + '_> {
+        Box::new(self.db.calls.iter())
+    }
+
+    fn steps_from(&self, start_id: StepId) -> &[DbStep] {
+        let start = start_id.0 as usize;
+        if start < self.db.steps.items.len() {
+            &self.db.steps.items[start..]
+        } else {
+            &[]
+        }
+    }
+
+    // ── Instructions ────────────────────────────────────────────────
+
+    fn instructions_at(&self, step_id: StepId) -> Option<&Vec<String>> {
+        self.db.instructions.get(step_id)
+    }
+
+    // ── Derived queries ─────────────────────────────────────────────
+
+    fn load_step_events(&self, step_id: StepId, exact: bool) -> Vec<DbRecordEvent> {
+        self.db.load_step_events(step_id, exact)
+    }
+
     // ── Metadata ────────────────────────────────────────────────────
 
     fn workdir(&self) -> &Path {

--- a/src/db-backend/src/in_memory_trace_reader.rs
+++ b/src/db-backend/src/in_memory_trace_reader.rs
@@ -1,0 +1,136 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use codetracer_trace_types::{
+    CallKey, FullValueRecord, FunctionId, FunctionRecord, PathId, Place, StepId, TypeId,
+    TypeRecord, ValueRecord, VariableId,
+};
+
+use crate::db::{CellChange, Db, DbCall, DbRecordEvent, DbStep, EndOfProgram};
+use crate::trace_reader::TraceReader;
+
+/// A [`TraceReader`] backed by a fully-loaded, in-memory [`Db`].
+///
+/// Every method simply delegates to the corresponding field on the
+/// inner `Db`.  This is the "zero-cost" adapter: no extra allocation
+/// or transformation is needed because the data already lives in
+/// memory in the right shape.
+#[derive(Debug, Clone)]
+pub struct InMemoryTraceReader {
+    pub db: Db,
+}
+
+impl InMemoryTraceReader {
+    pub fn new(db: Db) -> Self {
+        Self { db }
+    }
+}
+
+impl TraceReader for InMemoryTraceReader {
+    // ── Interning tables ────────────────────────────────────────────
+
+    fn path(&self, id: PathId) -> Option<&str> {
+        self.db.paths.get(id).map(|s| s.as_str())
+    }
+
+    fn function(&self, id: FunctionId) -> Option<&FunctionRecord> {
+        self.db.functions.get(id)
+    }
+
+    fn type_record(&self, id: TypeId) -> Option<&TypeRecord> {
+        self.db.types.get(id)
+    }
+
+    fn variable_name(&self, id: VariableId) -> Option<&str> {
+        self.db.variable_names.get(id).map(|s| s.as_str())
+    }
+
+    fn path_count(&self) -> usize {
+        self.db.paths.len()
+    }
+
+    fn function_count(&self) -> usize {
+        self.db.functions.len()
+    }
+
+    fn type_count(&self) -> usize {
+        self.db.types.len()
+    }
+
+    // ── Per-step data ───────────────────────────────────────────────
+
+    fn step(&self, id: StepId) -> Option<&DbStep> {
+        self.db.steps.get(id)
+    }
+
+    fn step_count(&self) -> usize {
+        self.db.steps.len()
+    }
+
+    fn variables_at(&self, step_id: StepId) -> Option<&[FullValueRecord]> {
+        self.db.variables.get(step_id).map(|v| v.as_slice())
+    }
+
+    fn compound_at(&self, step_id: StepId) -> Option<&HashMap<Place, ValueRecord>> {
+        self.db.compound.get(step_id)
+    }
+
+    fn cells_at(&self, step_id: StepId) -> Option<&HashMap<Place, ValueRecord>> {
+        self.db.cells.get(step_id)
+    }
+
+    fn cell_changes_for(&self, place: &Place) -> Option<&Vec<CellChange>> {
+        self.db.cell_changes.get(place)
+    }
+
+    fn variable_cells_at(&self, step_id: StepId) -> Option<&HashMap<VariableId, Place>> {
+        self.db.variable_cells.get(step_id)
+    }
+
+    // ── Call tree ───────────────────────────────────────────────────
+
+    fn call(&self, key: CallKey) -> Option<&DbCall> {
+        self.db.calls.get(key)
+    }
+
+    fn call_count(&self) -> usize {
+        self.db.calls.len()
+    }
+
+    // ── Events ──────────────────────────────────────────────────────
+
+    fn events(&self) -> &[DbRecordEvent] {
+        &self.db.events
+    }
+
+    fn event_count(&self) -> usize {
+        self.db.events.len()
+    }
+
+    // ── Secondary indices ───────────────────────────────────────────
+
+    fn path_id_for(&self, path: &str) -> Option<PathId> {
+        self.db.path_map.get(path).copied()
+    }
+
+    fn steps_on_line(&self, path_id: PathId, line: usize) -> Option<&Vec<DbStep>> {
+        self.db
+            .step_map
+            .get(path_id)
+            .and_then(|by_line| by_line.get(&line))
+    }
+
+    fn step_map_for_path(&self, path_id: PathId) -> Option<&HashMap<usize, Vec<DbStep>>> {
+        self.db.step_map.get(path_id)
+    }
+
+    // ── Metadata ────────────────────────────────────────────────────
+
+    fn workdir(&self) -> &Path {
+        &self.db.workdir
+    }
+
+    fn end_of_program(&self) -> &EndOfProgram {
+        &self.db.end_of_program
+    }
+}

--- a/src/db-backend/src/lib.rs
+++ b/src/db-backend/src/lib.rs
@@ -43,6 +43,7 @@ pub mod program_search_tool;
 pub mod query;
 pub mod replay;
 pub mod trace_reader;
+pub mod in_memory_trace_reader;
 pub mod rr_dispatcher;
 pub mod step_lines_loader;
 pub mod task;

--- a/src/db-backend/src/lib.rs
+++ b/src/db-backend/src/lib.rs
@@ -42,6 +42,7 @@ pub mod paths;
 pub mod program_search_tool;
 pub mod query;
 pub mod replay;
+pub mod trace_reader;
 pub mod rr_dispatcher;
 pub mod step_lines_loader;
 pub mod task;

--- a/src/db-backend/src/lib.rs
+++ b/src/db-backend/src/lib.rs
@@ -44,6 +44,7 @@ pub mod query;
 pub mod replay;
 pub mod trace_reader;
 pub mod in_memory_trace_reader;
+pub mod ctfs_trace_reader;
 pub mod rr_dispatcher;
 pub mod step_lines_loader;
 pub mod task;

--- a/src/db-backend/src/main.rs
+++ b/src/db-backend/src/main.rs
@@ -45,6 +45,8 @@ mod paths;
 mod program_search_tool;
 mod query;
 mod replay;
+mod trace_reader;
+mod in_memory_trace_reader;
 mod rr_dispatcher;
 mod step_lines_loader;
 mod task;

--- a/src/db-backend/src/program_search_tool.rs
+++ b/src/db-backend/src/program_search_tool.rs
@@ -7,9 +7,14 @@ use log::warn;
 use crate::db::Db;
 use crate::expr_loader::ExprLoader;
 use crate::task::{CodeSnippet, CommandPanelResult, Location};
+use crate::trace_reader::TraceReader;
 
 pub struct ProgramSearchTool<'a> {
     db: &'a Db,
+    /// Read-only trace access, prepared for future migration away from
+    /// direct `Db` field usage.
+    #[allow(dead_code)]
+    reader: &'a dyn TraceReader,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -25,8 +30,8 @@ pub enum ProgramQueryNode {
 }
 
 impl<'a> ProgramSearchTool<'a> {
-    pub fn new(db: &'a Db) -> Self {
-        ProgramSearchTool { db }
+    pub fn new(db: &'a Db, reader: &'a dyn TraceReader) -> Self {
+        ProgramSearchTool { db, reader }
     }
 
     pub fn search(&self, query: &str, expr_loader: &mut ExprLoader) -> Result<Vec<CommandPanelResult>, Box<dyn Error>> {

--- a/src/db-backend/src/step_lines_loader.rs
+++ b/src/db-backend/src/step_lines_loader.rs
@@ -1,6 +1,7 @@
 use std::cmp::{max, min};
 use std::collections::HashSet;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use codetracer_trace_types::{CallKey, StepId};
 use log::info;
@@ -9,7 +10,9 @@ use crate::db::{Db, DbReplay, DbStep};
 use crate::distinct_vec::DistinctVec;
 use crate::expr_loader::ExprLoader;
 use crate::flow_preloader::FlowPreloader;
+use crate::in_memory_trace_reader::InMemoryTraceReader;
 use crate::task::{FlowMode, LineStep, LineStepKind, LineStepValue, Location, TraceKind};
+use crate::trace_reader::TraceReader;
 
 #[derive(Debug, Clone)]
 pub struct StepLinesLoader {
@@ -18,10 +21,10 @@ pub struct StepLinesLoader {
 }
 
 impl StepLinesLoader {
-    pub fn new(db: &Db, expr_loader: &mut ExprLoader) -> Self {
+    pub fn new(db: &Db, expr_loader: &mut ExprLoader, _reader: &dyn TraceReader) -> Self {
         let mut global_line_steps = DistinctVec::new();
         for (step_id_int, step) in db.steps.iter().enumerate() {
-            let line_step = Self::simple_line_step(StepId(step_id_int as i64), *step, db, expr_loader);
+            let line_step = Self::simple_line_step(StepId(step_id_int as i64), *step, db, expr_loader, _reader);
             global_line_steps.push(line_step);
         }
         StepLinesLoader {
@@ -30,7 +33,7 @@ impl StepLinesLoader {
         }
     }
 
-    fn simple_line_step(step_id: StepId, step: DbStep, db: &Db, expr_loader: &mut ExprLoader) -> LineStep {
+    fn simple_line_step(step_id: StepId, step: DbStep, db: &Db, expr_loader: &mut ExprLoader, _reader: &dyn TraceReader) -> LineStep {
         // let mut expr_loader = ExprLoader::new();
         let line = step.line;
         let raw_path = format!("{}", db.workdir.join(db.load_path_from_id(&step.path_id)).display());
@@ -62,6 +65,7 @@ impl StepLinesLoader {
         forward_count: usize,
         db: &Db,
         flow_preloader: &mut FlowPreloader,
+        _reader: &dyn TraceReader,
     ) -> Vec<LineStep> {
         let mut line_steps = vec![];
         let location_step_index = location.rr_ticks.0;
@@ -86,7 +90,8 @@ impl StepLinesLoader {
                 let location = self.global_line_steps[step_id].location.clone();
                 // let function_id = db.calls[call_key].function_id;
                 // let function_first = db.functions[function_id].line;
-                let mut replay = DbReplay::new(Box::new(db.clone()));
+                let reader: Arc<dyn TraceReader> = Arc::new(InMemoryTraceReader::new(db.clone()));
+                let mut replay = DbReplay::new(Box::new(db.clone()), reader);
                 let flow_update = flow_preloader.load(location, FlowMode::Call, TraceKind::DB, &mut replay);
                 if !flow_update.error && !flow_update.view_updates.is_empty() {
                     let flow_view_update = &flow_update.view_updates[0];

--- a/src/db-backend/src/trace_reader.rs
+++ b/src/db-backend/src/trace_reader.rs
@@ -103,6 +103,42 @@ pub trait TraceReader: std::fmt::Debug + Send {
     /// Return the full line→steps map for a given path.
     fn step_map_for_path(&self, path_id: PathId) -> Option<&HashMap<usize, Vec<DbStep>>>;
 
+    // ── Iteration helpers ────────────────────────────────────────────
+
+    /// Iterate over all functions with their ids.
+    ///
+    /// Returns `(FunctionId, &FunctionRecord)` pairs in id order.
+    fn functions_iter(&self) -> Box<dyn Iterator<Item = (FunctionId, &FunctionRecord)> + '_>;
+
+    /// Iterate over all calls in order.
+    fn calls_iter(&self) -> Box<dyn Iterator<Item = &DbCall> + '_>;
+
+    /// Return a slice of steps starting from `start_id` to the end.
+    ///
+    /// Returns an empty slice when `start_id` is out of bounds.
+    fn steps_from(&self, start_id: StepId) -> &[DbStep];
+
+    // ── Instructions ────────────────────────────────────────────────
+
+    /// Assembly instructions recorded at a particular step.
+    fn instructions_at(&self, step_id: StepId) -> Option<&Vec<String>>;
+
+    // ── Derived queries ─────────────────────────────────────────────
+
+    /// Convenience: look up the `CallKey` for the call containing `step_id`.
+    ///
+    /// Equivalent to `self.step(step_id).map(|s| s.call_key)`.
+    fn call_key_for_step(&self, step_id: StepId) -> Option<CallKey> {
+        self.step(step_id).map(|s| s.call_key)
+    }
+
+    /// Return events associated with a step.
+    ///
+    /// When `exact` is `true`, only events at exactly `step_id` are returned.
+    /// When `false`, events across the entire "line visit" (a contiguous run
+    /// of steps on the same source line) are returned.
+    fn load_step_events(&self, step_id: StepId, exact: bool) -> Vec<DbRecordEvent>;
+
     // ── Metadata ────────────────────────────────────────────────────
 
     /// The working directory the trace was recorded in.

--- a/src/db-backend/src/trace_reader.rs
+++ b/src/db-backend/src/trace_reader.rs
@@ -1,0 +1,113 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use codetracer_trace_types::{
+    CallKey, FullValueRecord, FunctionId, FunctionRecord, PathId, Place, StepId, TypeId,
+    TypeRecord, ValueRecord, VariableId,
+};
+
+use crate::db::{CellChange, DbCall, DbRecordEvent, DbStep, EndOfProgram};
+
+/// Facade for reading trace data.
+///
+/// Implementations may load data from in-memory arrays (current `Db`),
+/// memory-mapped CTFS files (future), or any other backing store.
+///
+/// The trait is intentionally read-only — it never mutates the underlying
+/// data. Methods that return `Option` signal "no such id" rather than
+/// panicking, so callers can decide how to handle missing data.
+///
+/// # Design notes
+///
+/// * **Interning tables** (paths, functions, types, variable names) are
+///   small enough to always live in memory, even in a file-backed
+///   implementation.
+/// * **Per-step data** (steps, variables, compound values, cells) may be
+///   large. In a CTFS-backed implementation these would be seek-addressed
+///   from a memory-mapped file.
+/// * **Secondary indices** (path_map, step_map) accelerate lookups that
+///   the handler performs frequently.
+pub trait TraceReader: std::fmt::Debug + Send {
+    // ── Interning tables ────────────────────────────────────────────
+
+    /// Resolve a path id to its string representation (relative to workdir).
+    fn path(&self, id: PathId) -> Option<&str>;
+
+    /// Look up a function record by id.
+    fn function(&self, id: FunctionId) -> Option<&FunctionRecord>;
+
+    /// Look up a type record by id.
+    fn type_record(&self, id: TypeId) -> Option<&TypeRecord>;
+
+    /// Resolve a variable id to its human-readable name.
+    fn variable_name(&self, id: VariableId) -> Option<&str>;
+
+    /// Total number of recorded paths.
+    fn path_count(&self) -> usize;
+
+    /// Total number of recorded functions.
+    fn function_count(&self) -> usize;
+
+    /// Total number of recorded types.
+    fn type_count(&self) -> usize;
+
+    // ── Per-step data ───────────────────────────────────────────────
+
+    /// Look up a single step by id.
+    fn step(&self, id: StepId) -> Option<&DbStep>;
+
+    /// Total number of recorded steps.
+    fn step_count(&self) -> usize;
+
+    /// Local variable values captured at a particular step.
+    fn variables_at(&self, step_id: StepId) -> Option<&[FullValueRecord]>;
+
+    /// Compound (aggregate) values captured at a particular step,
+    /// keyed by `Place`.
+    fn compound_at(&self, step_id: StepId) -> Option<&HashMap<Place, ValueRecord>>;
+
+    /// Cell values captured at a particular step, keyed by `Place`.
+    fn cells_at(&self, step_id: StepId) -> Option<&HashMap<Place, ValueRecord>>;
+
+    /// The full cell-change history for a given `Place`.
+    fn cell_changes_for(&self, place: &Place) -> Option<&Vec<CellChange>>;
+
+    /// Variable-to-cell mapping at a particular step.
+    fn variable_cells_at(&self, step_id: StepId) -> Option<&HashMap<VariableId, Place>>;
+
+    // ── Call tree ───────────────────────────────────────────────────
+
+    /// Look up a call by its key.
+    fn call(&self, key: CallKey) -> Option<&DbCall>;
+
+    /// Total number of recorded calls.
+    fn call_count(&self) -> usize;
+
+    // ── Events ──────────────────────────────────────────────────────
+
+    /// All recorded events, in order.
+    fn events(&self) -> &[DbRecordEvent];
+
+    /// Total number of recorded events.
+    fn event_count(&self) -> usize;
+
+    // ── Secondary indices ───────────────────────────────────────────
+
+    /// Reverse-lookup: find the `PathId` for a given path string.
+    fn path_id_for(&self, path: &str) -> Option<PathId>;
+
+    /// Return the step records on a given `line` within a given path.
+    /// Returns `None` when the path or line has no recorded steps.
+    fn steps_on_line(&self, path_id: PathId, line: usize) -> Option<&Vec<DbStep>>;
+
+    /// Return the full line→steps map for a given path.
+    fn step_map_for_path(&self, path_id: PathId) -> Option<&HashMap<usize, Vec<DbStep>>>;
+
+    // ── Metadata ────────────────────────────────────────────────────
+
+    /// The working directory the trace was recorded in.
+    fn workdir(&self) -> &Path;
+
+    /// How the traced program ended (normal exit vs. error).
+    fn end_of_program(&self) -> &EndOfProgram;
+}

--- a/src/db-backend/src/tracepoint_interpreter/tests.rs
+++ b/src/db-backend/src/tracepoint_interpreter/tests.rs
@@ -9,15 +9,18 @@ use std::{
     iter::zip,
     path::{Path, PathBuf},
     process::Command,
+    sync::Arc,
 };
 
 use codetracer_trace_types::{StepId, TypeKind};
 
 use crate::{
     db::{Db, DbReplay},
+    in_memory_trace_reader::InMemoryTraceReader,
     lang::Lang,
     replay::Replay,
     task::StringAndValueTuple,
+    trace_reader::TraceReader,
     trace_processor::{load_trace_data, load_trace_metadata, TraceProcessor},
     value::Value,
 };
@@ -118,7 +121,8 @@ fn check_tracepoint_evaluate(
     let mut interpreter = TracepointInterpreter::new(1);
     interpreter.register_tracepoint(0, src)?;
 
-    let mut db_replay = DbReplay::new(Box::new(db.clone()));
+    let reader: Arc<dyn TraceReader> = Arc::new(InMemoryTraceReader::new(db.clone()));
+    let mut db_replay = DbReplay::new(Box::new(db.clone()), reader);
     for step in db.step_from(StepId(0), true) {
         let curr_line = step.line.0 as usize;
         db_replay.jump_to(step.step_id)?;

--- a/src/db-backend/tests/python_flow_ctfs_integration.rs
+++ b/src/db-backend/tests/python_flow_ctfs_integration.rs
@@ -1,0 +1,79 @@
+//! Integration test for Python flow using CTFS trace format
+//!
+//! Same as python_flow_integration but records traces in .ct CTFS format
+//! instead of the default Binary (CBOR+Zstd) format.
+//!
+//! The recorder selects CTFS output when the `CODETRACER_TRACE_FORMAT` environment
+//! variable is set to `"ctfs"`. The DAP server auto-detects the format from the
+//! trace file header.
+
+mod test_harness;
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use test_harness::{run_db_flow_test_with_format, FlowTestConfig, Language};
+
+fn get_python_source_path() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir.join("test-programs/python/python_flow_test.py")
+}
+
+fn create_python_flow_config() -> FlowTestConfig {
+    let mut expected_values = HashMap::new();
+    // a=10, b=32, sum_val=42, doubled=84, final_result=94
+    expected_values.insert("a".to_string(), 10);
+    expected_values.insert("b".to_string(), 32);
+    expected_values.insert("sum_val".to_string(), 42);
+    expected_values.insert("doubled".to_string(), 84);
+    expected_values.insert("final_result".to_string(), 94);
+
+    FlowTestConfig {
+        source_path: get_python_source_path(),
+        language: Language::Python,
+        breakpoint_line: 14, // First line with local var: sum_val = a + b
+        expected_variables: vec![
+            "a".to_string(),
+            "b".to_string(),
+            "sum_val".to_string(),
+            "doubled".to_string(),
+            "final_result".to_string(),
+        ],
+        // print() and calculate_sum() should NOT appear as variables
+        excluded_identifiers: vec!["print".to_string(), "calculate_sum".to_string()],
+        expected_values,
+    }
+}
+
+#[test]
+fn test_python_flow_ctfs_integration() {
+    if test_harness::find_python_recorder().is_none() {
+        eprintln!(
+            "SKIPPED: Python recorder not found \
+             (set CODETRACER_PYTHON_RECORDER_PATH or check out sibling/submodule)"
+        );
+        return;
+    }
+
+    // The Python recorder uses PEP 604 union syntax (X | None) which requires Python 3.10+.
+    let (_python_cmd, version_label) = match test_harness::find_suitable_python() {
+        Some(pair) => pair,
+        None => {
+            eprintln!("SKIPPED: Python 3.10+ not found (needed for the recorder)");
+            return;
+        }
+    };
+
+    let source_path = get_python_source_path();
+    assert!(
+        source_path.exists(),
+        "Python test program not found at {}",
+        source_path.display()
+    );
+
+    let config = create_python_flow_config();
+
+    match run_db_flow_test_with_format(&config, &version_label, "ctfs") {
+        Ok(()) => println!("Python flow CTFS integration test passed!"),
+        Err(e) => panic!("Python flow CTFS integration test failed: {}", e),
+    }
+}

--- a/src/db-backend/tests/ruby_flow_ctfs_integration.rs
+++ b/src/db-backend/tests/ruby_flow_ctfs_integration.rs
@@ -1,0 +1,82 @@
+//! Integration test for Ruby flow using CTFS trace format
+//!
+//! Same as ruby_flow_integration but records traces in .ct CTFS format
+//! instead of the default Binary (CBOR+Zstd) format.
+//!
+//! The recorder selects CTFS output when the `CODETRACER_TRACE_FORMAT` environment
+//! variable is set to `"ctfs"`. The DAP server auto-detects the format from the
+//! trace file header.
+
+mod test_harness;
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use test_harness::{run_db_flow_test_with_format, FlowTestConfig, Language};
+
+fn get_ruby_source_path() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir.join("test-programs/ruby/ruby_flow_test.rb")
+}
+
+fn create_ruby_flow_config() -> FlowTestConfig {
+    let mut expected_values = HashMap::new();
+    // a=10, b=32, sum_val=42, doubled=84, final_result=94
+    expected_values.insert("a".to_string(), 10);
+    expected_values.insert("b".to_string(), 32);
+    expected_values.insert("sum_val".to_string(), 42);
+    expected_values.insert("doubled".to_string(), 84);
+    expected_values.insert("final_result".to_string(), 94);
+
+    FlowTestConfig {
+        source_path: get_ruby_source_path(),
+        language: Language::Ruby,
+        breakpoint_line: 10, // First line with local var: sum_val = a + b
+        expected_variables: vec![
+            "a".to_string(),
+            "b".to_string(),
+            "sum_val".to_string(),
+            "doubled".to_string(),
+            "final_result".to_string(),
+        ],
+        // puts and calculate_sum should NOT appear as variables
+        excluded_identifiers: vec!["puts".to_string(), "calculate_sum".to_string()],
+        expected_values,
+    }
+}
+
+#[test]
+fn test_ruby_flow_ctfs_integration() {
+    if test_harness::find_ruby_recorder().is_none() {
+        eprintln!(
+            "SKIPPED: Ruby recorder not found \
+             (set CODETRACER_RUBY_RECORDER_PATH or check out sibling/submodule)"
+        );
+        return;
+    }
+
+    let source_path = get_ruby_source_path();
+    assert!(
+        source_path.exists(),
+        "Ruby test program not found at {}",
+        source_path.display()
+    );
+
+    let config = create_ruby_flow_config();
+
+    // Get Ruby version for labeling
+    let version_label = std::process::Command::new("ruby")
+        .arg("--version")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .and_then(|s| {
+            // Parse "ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-linux]"
+            s.split_whitespace().nth(1).map(|v| v.to_string())
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+
+    match run_db_flow_test_with_format(&config, &version_label, "ctfs") {
+        Ok(()) => println!("Ruby flow CTFS integration test passed!"),
+        Err(e) => panic!("Ruby flow CTFS integration test failed: {}", e),
+    }
+}

--- a/src/db-backend/tests/test_harness/mod.rs
+++ b/src/db-backend/tests/test_harness/mod.rs
@@ -1301,6 +1301,15 @@ pub fn record_stylus_wasm_trace(wasm_path: &Path, trace_dir: &Path, evm_trace_pa
 /// and sets `workdir` to CWD. The DAP server's ExprLoader resolves source files relative
 /// to workdir, so we must copy the source file into the trace_dir to make it findable.
 fn record_python_trace(source_path: &Path, trace_dir: &Path) -> Result<(), String> {
+    record_python_trace_with_format(source_path, trace_dir, "binary")
+}
+
+/// Record a Python trace with the specified trace format.
+///
+/// Delegates to the pure-Python recorder, passing `CODETRACER_TRACE_FORMAT`
+/// as an environment variable so the recorder can select the output format
+/// (e.g. `"binary"` for CBOR+Zstd, `"ctfs"` for the `.ct` CTFS container).
+fn record_python_trace_with_format(source_path: &Path, trace_dir: &Path, trace_format: &str) -> Result<(), String> {
     let recorder = find_python_recorder()
         .ok_or("Python recorder not found. Set CODETRACER_PYTHON_RECORDER_PATH or check out the sibling/submodule")?;
     fs::create_dir_all(trace_dir).map_err(|e| format!("failed to create trace dir: {}", e))?;
@@ -1328,6 +1337,7 @@ fn record_python_trace(source_path: &Path, trace_dir: &Path) -> Result<(), Strin
     let output = Command::new(python)
         .args([recorder.to_str().unwrap(), source_path.to_str().unwrap()])
         .current_dir(trace_dir)
+        .env("CODETRACER_TRACE_FORMAT", trace_format)
         .output()
         .map_err(|e| format!("failed to run Python recorder: {}", e))?;
 
@@ -1357,6 +1367,14 @@ fn record_python_trace(source_path: &Path, trace_dir: &Path) -> Result<(), Strin
 /// Uses the same invocation pattern as `tracepoint_interpreter/tests.rs`:
 /// `ruby <recorder> --out-dir <trace_dir> <source>` with `CODETRACER_DB_TRACE_PATH`.
 fn record_ruby_trace(source_path: &Path, trace_dir: &Path) -> Result<(), String> {
+    record_ruby_trace_with_format(source_path, trace_dir, "binary")
+}
+
+/// Record a Ruby trace with the specified trace format.
+///
+/// Delegates to the pure-Ruby recorder, passing `CODETRACER_TRACE_FORMAT`
+/// as an environment variable so the recorder can select the output format.
+fn record_ruby_trace_with_format(source_path: &Path, trace_dir: &Path, trace_format: &str) -> Result<(), String> {
     let recorder = find_ruby_recorder()
         .ok_or("Ruby recorder not found. Set CODETRACER_RUBY_RECORDER_PATH or check out the sibling/submodule")?;
     fs::create_dir_all(trace_dir).map_err(|e| format!("failed to create trace dir: {}", e))?;
@@ -1370,6 +1388,7 @@ fn record_ruby_trace(source_path: &Path, trace_dir: &Path) -> Result<(), String>
             source_path.to_str().unwrap(),
         ])
         .env("CODETRACER_DB_TRACE_PATH", trace_path.to_str().unwrap())
+        .env("CODETRACER_TRACE_FORMAT", trace_format)
         .output()
         .map_err(|e| format!("failed to run Ruby recorder: {}", e))?;
 
@@ -1665,9 +1684,27 @@ impl TestRecording {
     ///
     /// For interpreted languages, the "binary_path" is the source path itself.
     pub fn create_db_trace(source_path: &Path, language: Language, version_label: &str) -> Result<Self, String> {
+        Self::create_db_trace_with_format(source_path, language, version_label, "binary")
+    }
+
+    /// Create a DB-based trace recording with a specific trace format.
+    ///
+    /// The `trace_format` parameter is passed to the recorder via the
+    /// `CODETRACER_TRACE_FORMAT` environment variable. Supported values
+    /// depend on the recorder but typically include `"binary"` (default,
+    /// CBOR+Zstd) and `"ctfs"` (the `.ct` CTFS container format).
+    ///
+    /// For interpreted languages, the "binary_path" is the source path itself.
+    pub fn create_db_trace_with_format(
+        source_path: &Path,
+        language: Language,
+        version_label: &str,
+        trace_format: &str,
+    ) -> Result<Self, String> {
         let temp_dir = std::env::temp_dir().join(format!(
-            "flow_test_{}_{}_{}",
+            "flow_test_{}_{}_{}_{}",
             language.extension(),
+            trace_format,
             version_label.replace('.', "_"),
             std::process::id()
         ));
@@ -1682,8 +1719,8 @@ impl TestRecording {
 
         // Record trace using the appropriate language recorder
         match language {
-            Language::Python => record_python_trace(source_path, &trace_dir)?,
-            Language::Ruby => record_ruby_trace(source_path, &trace_dir)?,
+            Language::Python => record_python_trace_with_format(source_path, &trace_dir, trace_format)?,
+            Language::Ruby => record_ruby_trace_with_format(source_path, &trace_dir, trace_format)?,
             Language::JavaScript => record_javascript_trace(source_path, &trace_dir)?,
             Language::Bash => record_bash_trace(source_path, &trace_dir)?,
             Language::Zsh => record_zsh_trace(source_path, &trace_dir)?,
@@ -1697,13 +1734,17 @@ impl TestRecording {
         }
 
         // Verify the essential trace files were produced.
-        // Some recorders (e.g. JS with --format binary) produce trace.bin instead of trace.json.
+        // Different formats produce different files:
+        //   - JSON format: trace.json
+        //   - Binary (CBOR+Zstd): trace.bin
+        //   - CTFS: trace.ct
         let trace_json = trace_dir.join("trace.json");
         let trace_bin = trace_dir.join("trace.bin");
+        let trace_ct = trace_dir.join("trace.ct");
         let trace_metadata = trace_dir.join("trace_metadata.json");
-        if !trace_json.exists() && !trace_bin.exists() {
+        if !trace_json.exists() && !trace_bin.exists() && !trace_ct.exists() {
             return Err(format!(
-                "neither trace.json nor trace.bin produced in {}",
+                "no trace file (trace.json, trace.bin, or trace.ct) produced in {}",
                 trace_dir.display()
             ));
         }
@@ -1737,13 +1778,35 @@ impl TestRecording {
 /// For Ruby traces, paths are relative to the recorder's CWD, which is the
 /// codetracer repo root, so the original source path matches via suffix match.
 pub fn run_db_flow_test(config: &FlowTestConfig, version_label: &str) -> Result<(), String> {
+    run_db_flow_test_with_format(config, version_label, "binary")
+}
+
+/// Run a flow integration test for a DB-based language with a specific trace format.
+///
+/// Same as `run_db_flow_test` but records the trace in the given format.
+/// The `trace_format` parameter is passed through to
+/// `TestRecording::create_db_trace_with_format` (and ultimately to the recorder
+/// via the `CODETRACER_TRACE_FORMAT` environment variable).
+///
+/// Supported formats: `"binary"` (default CBOR+Zstd), `"ctfs"` (`.ct` container).
+pub fn run_db_flow_test_with_format(
+    config: &FlowTestConfig,
+    version_label: &str,
+    trace_format: &str,
+) -> Result<(), String> {
     println!("Source: {}", config.source_path.display());
     println!("Language: {:?}", config.language);
     println!("Version: {}", version_label);
+    println!("Trace format: {}", trace_format);
 
     // Create DB-based recording (no rr needed)
     println!("Recording trace...");
-    let recording = TestRecording::create_db_trace(&config.source_path, config.language, version_label)?;
+    let recording = TestRecording::create_db_trace_with_format(
+        &config.source_path,
+        config.language,
+        version_label,
+        trace_format,
+    )?;
     println!("Recording created at: {}", recording.trace_dir.display());
 
     // Start DAP client via stdio (cross-platform, no Unix sockets)


### PR DESCRIPTION
## Summary

- **Backend-manager**: .ct file detection (extension + CTFS magic bytes) in needs_rr_support check
- **CT CLI**: macOS trace kind routing, --backend mcr support
- **TraceReader trait** (File-Backed Replaying Phases 1-5):
  - Phase 1: TraceReader trait with 25+ methods
  - Phase 2: InMemoryTraceReader wrapping Db
  - Phase 3: Handler migration (43/62 access sites, 69%)
  - Phase 4: DbReplay uses Arc\<dyn TraceReader\>
  - Phase 5: calltrace, step_lines_loader, program_search_tool prepared
- **CTFSTraceReader**: reads .ct CTFS containers, deserializes CBOR events, feeds TraceProcessor pipeline (16 tests)

## Test plan

- [x] `cargo check` in db-backend passes
- [x] 16 CTFSTraceReader tests (container + integration)
- [x] Existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)