### PR TITLE
[codex] ci: migrate CodeTracer cache operations to Attic

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -2,12 +2,6 @@ name: Setup Nix Environment
 description: Common steps for setting up the Nix environment
 
 inputs:
-  cachix-cache:
-    description: The name of the cachix cache to use
-    required: true
-  cachix-auth-token:
-    description: Cachix auth token
-    required: true
   trusted-public-keys:
     description: Trusted public keys
     required: false
@@ -23,10 +17,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: metacraft-labs/metacraft-github-actions/setup-nix@main
+    - uses: metacraft-labs/nixos-modules/.github/setup-nix@main
       with:
-        gh-token: ${{inputs.gh-token}}
-        cachix-cache: ${{inputs.cachix-cache}}
-        cachix-auth-token: ${{inputs.cachix-auth-token}}
-        substituters: ${{inputs.substituters}}
-        trusted-public-keys: ${{inputs.trusted-public-keys}}
+        push-to-cache: false
+        nix-github-token: ${{ inputs.gh-token }}
+        substituters: ${{ inputs.substituters }}
+        trusted-public-keys: ${{ inputs.trusted-public-keys }}

--- a/.github/workflows/beam-flow.yml
+++ b/.github/workflows/beam-flow.yml
@@ -68,10 +68,8 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ steps.app-token.outputs.token }}
 
       - name: Resolve sibling refs

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -799,10 +799,8 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
 
       - run: "nix develop .#devShells.x86_64-linux.default -c ./ci/lint/bash.sh"
@@ -819,10 +817,8 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
 
       - run: "nix develop .#devShells.x86_64-linux.default -c ./ci/lint/nim.sh"
@@ -839,10 +835,8 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
 
       - run: "nix develop .#devShells.x86_64-linux.default -c ./ci/lint/nix.sh"
@@ -947,10 +941,8 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
 
       - name: Allow direnv in cloned codetracer-native-recorder
@@ -1007,10 +999,8 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
 
       - name: Run Reprobuild macOS smoke
@@ -1027,10 +1017,8 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
 
       - name: Run Reprobuild Linux smoke
@@ -1064,10 +1052,8 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
 
       - name: Setup db-backend siblings
@@ -1105,10 +1091,8 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
 
       - name: Setup db-backend siblings
@@ -1241,10 +1225,8 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
 
       - run: "nix develop .#devShells.x86_64-linux.default --command ./ci/build/dev.sh"
@@ -1267,10 +1249,8 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
 
       - run: "nix develop .#devShells.x86_64-linux.default --command ./ci/build/nix.sh"
@@ -1549,10 +1529,8 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
 
       - name: "Import GPG key for signing commits"
@@ -1769,10 +1747,8 @@ jobs:
         if: matrix.platform == 'nixos'
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
 
       # --- macOS setup ---
@@ -2029,10 +2005,8 @@ jobs:
         if: matrix.platform == 'nixos'
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
 
       - name: Build CodeTracer (nix)
@@ -2231,38 +2205,24 @@ jobs:
         # ``.envrc`` does ``use flake``, so we need a working Nix
         # install on the runner first.
         #
-        # We bypass the shared ``setup-nix`` composite because it
-        # pins ``cachix/install-nix-action@v27`` which on
+        # We bypass the shared ``setup-nix`` composite because the
+        # install-nix action used by the regular setup path on
         # ``macos-latest`` (arm64) trips
         # ``eDSRecordAlreadyExists`` while creating the
         # ``_nixbld1`` build user -- the GitHub-hosted Apple Silicon
         # image carries leftover Nix state from its base snapshot
         # that the older installer can't recover from.
         # DeterminateSystems/nix-installer-action is the
-        # recommended workaround on that runner image; cachix on
-        # nixos / darwin self-hosted runners stays on v27 because
-        # those don't trip the same state issue.
+        # recommended workaround on that runner image; the regular
+        # setup path remains fine for nixos / darwin self-hosted
+        # runners because those don't trip the same state issue.
         if: matrix.platform == 'macos'
         uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |
             access-tokens = github.com=${{ steps.app-token.outputs.token }}
-            substituters = https://cache.nixos.org ${{ vars.SUBSTITUTERS }}
-            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ${{ vars.TRUSTED_PUBLIC_KEYS }}
-
-      - name: Configure Cachix (macOS)
-        if: matrix.platform == 'macos'
-        # The DeterminateSystems installer doesn't auto-configure
-        # Cachix substituters/auth.  Without this, ``scripts/build-
-        # siblings.sh`` re-evaluates each sibling's flake from
-        # source which (a) prints ``HTTP error 401`` against
-        # metacraft-labs-codetracer.cachix.org and (b) makes the
-        # cold ct-mcr build ~45 min instead of ~10 min.
-        uses: cachix/cachix-action@v15
-        with:
-          name: ${{ vars.CACHIX_CACHE }}
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          skipPush: true
+            substituters = https://cache.nixos.org ${{ vars.ATTIC_SUBSTITUTER }}
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
 
       - name: Build ct-mcr via codetracer-native-recorder nix develop (macOS)
         if: matrix.platform == 'macos'
@@ -2400,10 +2360,8 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
 
       - name: Build CodeTracer
@@ -2456,10 +2414,8 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
 
       - name: Resolve codetracer-visual-replay ref
@@ -2637,7 +2593,7 @@ jobs:
         with:
           packages_dir: dist
 
-  push-to-cachix:
+  push-to-attic:
     runs-on: [self-hosted, nixos]
     needs:
       - test-non-gui
@@ -2655,17 +2611,19 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
 
-      - run: "nix develop .#devShells.x86_64-linux.default --command ./ci/deploy/build-nix-and-push-to-cachix.sh"
+      - run: "nix develop .#devShells.x86_64-linux.default --command ./ci/deploy/build-nix-and-push-to-attic.sh"
+        env:
+          ATTIC_ENDPOINT: ${{ vars.ATTIC_ENDPOINT }}
+          ATTIC_CACHE: ${{ vars.ATTIC_CACHE }}
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
 
   build-and-deploy-docs:
     runs-on: [self-hosted, nixos]
-    needs: [push-to-cachix]
+    needs: [push-to-attic]
     if: ${{ github.ref == 'refs/heads/main' && !github.event['codetracer-ci'] }}
     permissions:
       contents: "write"
@@ -2679,10 +2637,8 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
 
       - run: |
@@ -2710,10 +2666,8 @@ jobs:
       - name: Install Nix
         uses: metacraft-labs/nixos-modules/.github/install-nix@main
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
 
       - name: Configure Nix for private repos
         run: |
@@ -2754,10 +2708,8 @@ jobs:
       - name: Install Nix
         uses: metacraft-labs/nixos-modules/.github/install-nix@main
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
 
       - name: Configure Nix for private repos
         run: |

--- a/.github/workflows/cross-repo-tests.yml
+++ b/.github/workflows/cross-repo-tests.yml
@@ -45,10 +45,8 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
 
       - name: Resolve rr-backend ref
@@ -275,10 +273,8 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
-          substituters: ${{ vars.SUBSTITUTERS }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
 
       - name: Resolve shell-recorders ref

--- a/ci/deploy/build-nix-and-push-to-attic.sh
+++ b/ci/deploy/build-nix-and-push-to-attic.sh
@@ -1,31 +1,37 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
+
+: "${ATTIC_ENDPOINT:?ATTIC_ENDPOINT is required}"
+: "${ATTIC_CACHE:?ATTIC_CACHE is required}"
+: "${ATTIC_TOKEN:?ATTIC_TOKEN is required}"
+
+attic login --set-default codetracer-ci "$ATTIC_ENDPOINT" "$ATTIC_TOKEN"
 
 ###############################################################################
-# builds and pushes devshell to cachix
+# builds and pushes devshell to Attic
 ###############################################################################
 build_out=$(nix build --print-out-paths .#devShells.x86_64-linux.default)
 res=$?
 
 # Propagate error if nix build fails
 if [ $res -ne 0 ]; then
-	exit $res
+  exit $res
 fi
 
-cachix push metacraft-labs-codetracer "$build_out"
+attic push "$ATTIC_CACHE" "$build_out"
 ###############################################################################
 
 ###############################################################################
-# builds and pushes it to cachix
+# builds and pushes it to Attic
 ###############################################################################
 build_out=$(nix build --print-out-paths ".?submodules=1#codetracer")
 res=$?
 
 # Propagate error if nix build fails
 if [ $res -ne 0 ]; then
-	exit $res
+  exit $res
 fi
 
-cachix push metacraft-labs-codetracer "$build_out"
+attic push "$ATTIC_CACHE" "$build_out"
 ###############################################################################

--- a/docs/book/src/building_and_packaging/build_systems.md
+++ b/docs/book/src/building_and_packaging/build_systems.md
@@ -19,8 +19,8 @@ the most widely-used:
 1. `just build-once` - Just builds the project using Tup
 1. `just build-nix` - Builds the project and packages it for Nix
 1. `just build-docs` - Builds the documentation. More info can be found [here](https://dev-docs.codetracer.com/Misc/BuildDocs)
-1. `just cachix-push-nix-package` - Pushes nix package artefacts to cachix
-1. `just cachix-push-devshell` - Pushes the current dev shell to cachix
+1. `just attic-push-nix-package` - Pushes nix package artefacts to Attic
+1. `just attic-push-devshell` - Pushes the current dev shell to Attic
 1. `just reset-db` - Resets the local user's trace database
 1. `just clear-local-traces` - Clears the local user's traces
 1. `just reset-layout` - Resets the GUI window arrangements layout if your user's layout is incompatible with the latest version of CodeTracer. Further [documentation](https://dev-docs.codetracer.com/Introduction/Configuration)

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,9 @@
   description = "Code Tracer";
 
   nixConfig = {
-    extra-substituters = [ "https://metacraft-labs-codetracer.cachix.org" ];
+    extra-substituters = [ "https://cache.metacraft-labs.com/metacraft-codetracer" ];
     extra-trusted-public-keys = [
-      "metacraft-labs-codetracer.cachix.org-1:6p7pd81m6sIh59yr88yGPU9TFYJZkIrFZoFBWj/y4aE="
+      "metacraft-codetracer:9OV9wCDX560bt5/MrD4dlqnPpCitAEjpoqhNfQpWY3U="
     ];
   };
 
@@ -51,7 +51,7 @@
     # archive endpoint.
     noir = {
       # Bumped from 334c1ee9 to 5e98f904 (empty commit) to side-step
-      # the stale narinfo on metacraft-labs-codetracer.cachix.org +
+      # the stale narinfo in the legacy binary cache +
       # the per-runner fetcher-cache-v2.sqlite which both pin
       # 334c1ee9 to a NAR hash that no longer matches the actual
       # git content.  See CI-stabilization §4.

--- a/justfile
+++ b/justfile
@@ -719,11 +719,11 @@ tail pid_or_current_or_last kind process="default" instance_index="0":
 build-nix:
   nix build --print-build-logs '.?submodules=1#codetracer' --show-trace --keep-failed
 
-cachix-push-nix-package:
-  cachix push metacraft-labs-codetracer $(nix build --print-out-paths ".?submodules=1#codetracer")
+attic-push-nix-package:
+  attic push ${ATTIC_CACHE:?} $(nix build --print-out-paths ".?submodules=1#codetracer")
 
-cachix-push-devshell:
-  cachix push metacraft-labs-codetracer $(nix build --print-out-paths .#devShells.x86_64-linux.default)
+attic-push-devshell:
+  attic push ${ATTIC_CACHE:?} $(nix build --print-out-paths .#devShells.x86_64-linux.default)
 
 reset-db:
   rm -rf ~/.local/share/codetracer/trace_index.db

--- a/nix/shells/armShell.nix
+++ b/nix/shells/armShell.nix
@@ -105,8 +105,8 @@ mkShell {
     # github CLI
     gh
 
-    # cachix support
-    cachix
+    # Attic cache support
+    attic-client
 
     # ruby experimental support
     ruby

--- a/nix/shells/main.nix
+++ b/nix/shells/main.nix
@@ -174,8 +174,8 @@ mkShell {
     # github CLI
     gh
 
-    # cachix support
-    cachix
+    # Attic cache support
+    attic-client
 
     # ruby experimental support
     libyaml

--- a/node-packages/yarn-project.nix
+++ b/node-packages/yarn-project.nix
@@ -45,7 +45,7 @@ let
   # Our ``yarn.lock`` pins platform-specific optional dependencies (esbuild,
   # @parcel/watcher, ...) for every OS/CPU, so the resulting cache — and hence
   # the fixed-output hash — differs per build platform. Select the hash for the
-  # host system; the Linux hash is what CI / the Cachix cache is built against.
+  # host system; the Linux hash is what CI / the binary cache is built against.
   #
   # To add a new platform: build once, take the ``got:`` hash from the
   # "hash mismatch" error, and add it below.

--- a/reprobuild.nim
+++ b/reprobuild.nim
@@ -341,7 +341,7 @@ package codeTracer:
 
     # POSIX-only / Nix-only tools — guarded off the Windows branch.
     when not defined(windows):
-      "cachix >=0"
+      "attic-client >=0"
       "cargo-nextest >=0"
       "clang >=1"
       "ctags >=0"


### PR DESCRIPTION
## Summary
- replaces CodeTracer's Nix cache configuration with the metacraft-codetracer Attic cache
- switches workflow setup from Cachix inputs/actions to the nixos-modules setup-nix action with Attic vars
- renames the cache publish script/just recipes and uses `attic push` with `ATTIC_*` settings
- updates developer tooling/docs/comments from Cachix to Attic where they referred to cache operations

## Validation
- `rg -n 'cachix|Cachix|CACHIX' -S --glob '!flake.lock' .` leaves only `github:cachix/git-hooks.nix`, which is an upstream package input rather than binary-cache configuration
- `git diff --check`
- `bash -n ci/deploy/build-nix-and-push-to-attic.sh`
- PyYAML parse of `.github/actions/setup-nix/action.yml`, `.github/workflows/beam-flow.yml`, `.github/workflows/codetracer.yml`, and `.github/workflows/cross-repo-tests.yml`

## Deployment note
The public repo variables `ATTIC_ENDPOINT`, `ATTIC_CACHE`, `ATTIC_SUBSTITUTER`, and `ATTIC_TRUSTED_PUBLIC_KEY` have been set on `metacraft-labs/codetracer`. `ATTIC_TOKEN` still needs to be minted from Solunska with `AC_CACHE=metacraft-codetracer just configure-attic-cache-github-repo metacraft-labs/codetracer`; my local SSH auth to `solunska-server` failed with `Permission denied (publickey)`.