### PR TITLE
[codex] Use Attic for CodeTracer cache helpers

### DIFF
--- a/ci/deploy/build-nix-and-push-to-attic.sh
+++ b/ci/deploy/build-nix-and-push-to-attic.sh
@@ -3,7 +3,7 @@
 set -e
 
 ###############################################################################
-# builds and pushes devshell to cachix
+# builds and pushes devshell to Attic
 ###############################################################################
 build_out=$(nix build --print-out-paths .#devShells.x86_64-linux.default)
 res=$?
@@ -13,11 +13,11 @@ if [ $res -ne 0 ]; then
 	exit $res
 fi
 
-cachix push metacraft-labs-codetracer "$build_out"
+attic push metacraft-codetracer "$build_out"
 ###############################################################################
 
 ###############################################################################
-# builds and pushes it to cachix
+# builds and pushes it to Attic
 ###############################################################################
 build_out=$(nix build --print-out-paths ".?submodules=1#codetracer")
 res=$?
@@ -27,5 +27,5 @@ if [ $res -ne 0 ]; then
 	exit $res
 fi
 
-cachix push metacraft-labs-codetracer "$build_out"
+attic push metacraft-codetracer "$build_out"
 ###############################################################################

--- a/docs/book/src/building_and_packaging/build_systems.md
+++ b/docs/book/src/building_and_packaging/build_systems.md
@@ -19,8 +19,8 @@ the most widely-used:
 1. `just build-once` - Just builds the project using Tup
 1. `just build-nix` - Builds the project and packages it for Nix
 1. `just build-docs` - Builds the documentation. More info can be found [here](https://dev-docs.codetracer.com/Misc/BuildDocs)
-1. `just cachix-push-nix-package` - Pushes nix package artefacts to cachix
-1. `just cachix-push-devshell` - Pushes the current dev shell to cachix
+1. `just attic-push-nix-package` - Pushes nix package artefacts to Attic
+1. `just attic-push-devshell` - Pushes the current dev shell to Attic
 1. `just reset-db` - Resets the local user's trace database
 1. `just clear-local-traces` - Clears the local user's traces
 1. `just reset-layout` - Resets the GUI window arrangements layout if your user's layout is incompatible with the latest version of CodeTracer. Further [documentation](https://dev-docs.codetracer.com/Introduction/Configuration)

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,9 @@
   description = "Code Tracer";
 
   nixConfig = {
-    extra-substituters = [ "https://metacraft-labs-codetracer.cachix.org" ];
+    extra-substituters = [ "https://cache.metacraft-labs.com/metacraft-codetracer" ];
     extra-trusted-public-keys = [
-      "metacraft-labs-codetracer.cachix.org-1:6p7pd81m6sIh59yr88yGPU9TFYJZkIrFZoFBWj/y4aE="
+      "metacraft-codetracer:9OV9wCDX560bt5/MrD4dlqnPpCitAEjpoqhNfQpWY3U="
     ];
   };
 
@@ -51,7 +51,7 @@
     # archive endpoint.
     noir = {
       # Bumped from 334c1ee9 to 5e98f904 (empty commit) to side-step
-      # the stale narinfo on metacraft-labs-codetracer.cachix.org +
+      # the stale narinfo on the legacy CodeTracer binary cache +
       # the per-runner fetcher-cache-v2.sqlite which both pin
       # 334c1ee9 to a NAR hash that no longer matches the actual
       # git content.  See CI-stabilization §4.

--- a/justfile
+++ b/justfile
@@ -655,11 +655,11 @@ tail pid_or_current_or_last kind process="default" instance_index="0":
 build-nix:
   nix build --print-build-logs '.?submodules=1#codetracer' --show-trace --keep-failed
 
-cachix-push-nix-package:
-  cachix push metacraft-labs-codetracer $(nix build --print-out-paths ".?submodules=1#codetracer")
+attic-push-nix-package:
+  attic push metacraft-codetracer $(nix build --print-out-paths ".?submodules=1#codetracer")
 
-cachix-push-devshell:
-  cachix push metacraft-labs-codetracer $(nix build --print-out-paths .#devShells.x86_64-linux.default)
+attic-push-devshell:
+  attic push metacraft-codetracer $(nix build --print-out-paths .#devShells.x86_64-linux.default)
 
 reset-db:
   rm -rf ~/.local/share/codetracer/trace_index.db


### PR DESCRIPTION
## Summary

- replace CodeTracer flake Cachix trust with the metacraft-codetracer Attic cache
- rename the local Nix cache push helper from Cachix to Attic
- update just recipes and packaging docs to use `attic push`

## Validation

- `attic-migrate-flake`
- `git diff --check`
- `rg -n "cachix.org|cachix push|cachix-push|build-nix-and-push-to-cachix|metacraft-labs-codetracer.cachix|metacraft-labs-codetracer" flake.nix ci/deploy justfile docs/book/src/building_and_packaging/build_systems.md` returned no matches