### PR TITLE
[codex] Migrate Cachix usage to Attic

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -2,12 +2,6 @@ name: Setup Nix Environment
 description: Common steps for setting up the Nix environment
 
 inputs:
-  cachix-cache:
-    description: The name of the cachix cache to use
-    required: true
-  cachix-auth-token:
-    description: Cachix auth token
-    required: true
   trusted-public-keys:
     description: Trusted public keys
     required: false
@@ -26,7 +20,5 @@ runs:
     - uses: metacraft-labs/metacraft-github-actions/setup-nix@main
       with:
         gh-token: ${{inputs.gh-token}}
-        cachix-cache: ${{inputs.cachix-cache}}
-        cachix-auth-token: ${{inputs.cachix-auth-token}}
         substituters: ${{inputs.substituters}}
         trusted-public-keys: ${{inputs.trusted-public-keys}}

--- a/.github/workflows/beam-flow.yml
+++ b/.github/workflows/beam-flow.yml
@@ -68,8 +68,6 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           gh-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -711,8 +711,6 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
@@ -731,8 +729,6 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
@@ -751,8 +747,6 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
@@ -859,8 +853,6 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
@@ -906,8 +898,6 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
@@ -935,8 +925,6 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
@@ -961,8 +949,6 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
@@ -1041,8 +1027,6 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
@@ -1067,8 +1051,6 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
@@ -1349,8 +1331,6 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
@@ -1569,8 +1549,6 @@ jobs:
         if: matrix.platform == 'nixos'
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
@@ -1678,8 +1656,6 @@ jobs:
         if: matrix.platform == 'nixos'
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
@@ -1881,14 +1857,14 @@ jobs:
         # install on the runner first.
         #
         # We bypass the shared ``setup-nix`` composite because it
-        # pins ``cachix/install-nix-action@v27`` which on
+        # pins ``Attic/install-nix-action@v27`` which on
         # ``macos-latest`` (arm64) trips
         # ``eDSRecordAlreadyExists`` while creating the
         # ``_nixbld1`` build user -- the GitHub-hosted Apple Silicon
         # image carries leftover Nix state from its base snapshot
         # that the older installer can't recover from.
         # DeterminateSystems/nix-installer-action is the
-        # recommended workaround on that runner image; cachix on
+        # recommended workaround on that runner image; Attic on
         # nixos / darwin self-hosted runners stays on v27 because
         # those don't trip the same state issue.
         if: matrix.platform == 'macos'
@@ -1898,20 +1874,6 @@ jobs:
             access-tokens = github.com=${{ steps.app-token.outputs.token }}
             substituters = https://cache.nixos.org ${{ vars.SUBSTITUTERS }}
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= ${{ vars.TRUSTED_PUBLIC_KEYS }}
-
-      - name: Configure Cachix (macOS)
-        if: matrix.platform == 'macos'
-        # The DeterminateSystems installer doesn't auto-configure
-        # Cachix substituters/auth.  Without this, ``scripts/build-
-        # siblings.sh`` re-evaluates each sibling's flake from
-        # source which (a) prints ``HTTP error 401`` against
-        # metacraft-labs-codetracer.cachix.org and (b) makes the
-        # cold ct-mcr build ~45 min instead of ~10 min.
-        uses: cachix/cachix-action@v15
-        with:
-          name: ${{ vars.CACHIX_CACHE }}
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          skipPush: true
 
       - name: Build ct-mcr via codetracer-native-recorder nix develop (macOS)
         if: matrix.platform == 'macos'
@@ -2049,8 +2011,6 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
@@ -2096,8 +2056,6 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
@@ -2277,14 +2235,14 @@ jobs:
         with:
           packages_dir: dist
 
-  push-to-cachix:
+  push-to-attic:
     runs-on: [self-hosted, nixos]
     needs:
       - test-non-gui
       - test-ui-tests
       - appimage-lib-check
       - dmg-lib-check
-    if: "github.ref == 'refs/heads/main' && ${{ !github.event.codetracer-ci }}"
+    if: ${{ github.ref == 'refs/heads/main' && !github.event.codetracer-ci }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -2295,17 +2253,19 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
 
-      - run: "nix develop .#devShells.x86_64-linux.default --command ./ci/deploy/build-nix-and-push-to-cachix.sh"
+      - env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}
+          ATTIC_ENDPOINT: ${{ vars.ATTIC_ENDPOINT }}
+          ATTIC_CACHE: ${{ vars.ATTIC_CACHE }}
+        run: "nix develop .#devShells.x86_64-linux.default --command ./ci/deploy/build-nix-and-push-to-attic.sh"
 
   build-and-deploy-docs:
     runs-on: [self-hosted, nixos]
-    needs: [push-to-cachix]
+    needs: [push-to-attic]
     if: ${{ github.ref == 'refs/heads/main' && !github.event['codetracer-ci'] }}
     permissions:
       contents: "write"
@@ -2319,8 +2279,6 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
@@ -2350,8 +2308,6 @@ jobs:
       - name: Install Nix
         uses: metacraft-labs/nixos-modules/.github/install-nix@main
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
 
@@ -2394,8 +2350,6 @@ jobs:
       - name: Install Nix
         uses: metacraft-labs/nixos-modules/.github/install-nix@main
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
 

--- a/.github/workflows/cross-repo-tests.yml
+++ b/.github/workflows/cross-repo-tests.yml
@@ -45,8 +45,6 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}
@@ -275,8 +273,6 @@ jobs:
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
           trusted-public-keys: ${{ vars.TRUSTED_PUBLIC_KEYS }}
           substituters: ${{ vars.SUBSTITUTERS }}
           gh-token: ${{ secrets.GH_READ_METACRAFT_PRIVATE_REPOS }}

--- a/ci/deploy/build-nix-and-push-to-attic.sh
+++ b/ci/deploy/build-nix-and-push-to-attic.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+attic_cache="${ATTIC_CACHE:-metacraft-codetracer}"
+attic_endpoint="${ATTIC_ENDPOINT:-https://cache.metacraft-labs.com/}"
+
+: "${ATTIC_TOKEN:?ATTIC_TOKEN is required to push to Attic}"
+nix shell nixpkgs#attic-client -c attic login --set-default ci "$attic_endpoint" "$ATTIC_TOKEN"
+
 ###############################################################################
 # builds and pushes devshell to Attic
 ###############################################################################
@@ -13,7 +19,7 @@ if [ $res -ne 0 ]; then
 	exit $res
 fi
 
-attic push metacraft-codetracer "$build_out"
+nix shell nixpkgs#attic-client -c attic push --jobs 1 --ignore-upstream-cache-filter "$attic_cache" "$build_out"
 ###############################################################################
 
 ###############################################################################
@@ -27,5 +33,5 @@ if [ $res -ne 0 ]; then
 	exit $res
 fi
 
-attic push metacraft-codetracer "$build_out"
+nix shell nixpkgs#attic-client -c attic push --jobs 1 --ignore-upstream-cache-filter "$attic_cache" "$build_out"
 ###############################################################################

--- a/nix/shells/armShell.nix
+++ b/nix/shells/armShell.nix
@@ -105,8 +105,8 @@ mkShell {
     # github CLI
     gh
 
-    # cachix support
-    cachix
+    # Attic support
+    attic-client
 
     # ruby experimental support
     ruby

--- a/nix/shells/main.nix
+++ b/nix/shells/main.nix
@@ -174,8 +174,8 @@ mkShell {
     # github CLI
     gh
 
-    # cachix support
-    cachix
+    # Attic support
+    attic-client
 
     # ruby experimental support
     libyaml


### PR DESCRIPTION
## Summary
- replace Cachix cache/deploy usage with Attic cache configuration
- route Nix setup through the shared Attic-aware setup action or repo Attic variables
- remove legacy Cachix push/setup paths where this repo had them

## Validation
- parsed changed GitHub workflow YAML with yq
- parsed changed Nix files with nix-instantiate --parse
- ran git diff --check
