### PR TITLE
env.ps1 + ensure-ttd.ps1: catch AppX "database disk image is malformed"

### DIFF
--- a/env.ps1
+++ b/env.ps1
@@ -205,7 +205,16 @@ function Invoke-AppxPackageQuery {
       ($msg -match "0x80131539") -or
       ($msg -match "not supported on this platform") -or
       ($msg -match "Appx") -or
-      ($msg -match "PackageManager")
+      ($msg -match "PackageManager") -or
+      # Windows Server 2022 / nested Windows guests sometimes ship with
+      # a broken AppX repository (SQLite database that never got the
+      # initial schema populated because no per-user App Installer ran).
+      # Get-AppxPackage then throws "The database disk image is
+      # malformed" (SQLite error 11).  Treat that the same way as the
+      # 0x80131539 platform-unsupported error: the box has no working
+      # AppX, degrade gracefully to "package unavailable" instead of
+      # blowing up env.ps1.
+      ($msg -match "database disk image is malformed")
     if ($isPlatformUnsupported) {
       return $null
     }

--- a/non-nix-build/windows/ensure-ttd.ps1
+++ b/non-nix-build/windows/ensure-ttd.ps1
@@ -20,7 +20,13 @@ function Invoke-AppxPackageQuery {
       ($msg -match "0x80131539") -or
       ($msg -match "not supported on this platform") -or
       ($msg -match "Appx") -or
-      ($msg -match "PackageManager")
+      ($msg -match "PackageManager") -or
+      # Windows Server 2022 / nested Windows guests: the AppX
+      # repository SQLite database is sometimes malformed on first
+      # boot (never got the initial schema populated), so
+      # Get-AppxPackage throws "The database disk image is malformed"
+      # (SQLite error 11). Treat that the same as 0x80131539.
+      ($msg -match "database disk image is malformed")
     if ($isPlatformUnsupported) { return $null }
     throw
   }


### PR DESCRIPTION
## Summary

Widen the `Invoke-AppxPackageQuery` `\$isPlatformUnsupported` fallback in both `env.ps1` and `non-nix-build/windows/ensure-ttd.ps1` to also match the `"database disk image is malformed"` error. Windows Server 2022 / nested Windows 11 guests sometimes ship with a corrupt AppX SQLite database, and `Get-AppxPackage` throws this specific message. Without the match, the catch re-throws, `env.ps1` crashes, and the whole windows-diy CI flow bails.

## Evidence

Observed today on `windows-runner-001` (self-hosted Windows CI runner) — invoking `. .\env.ps1` in a fresh pwsh session:

```
Get-AppxPackage: The database disk image is malformed
```

Cairo `ci-windows-diy` failed at `Setup dev env (windows-diy)` 13 seconds after the pwsh step started, with only `##[error]Process completed with exit code 1` in the CI output — no stack trace, because `\$ErrorActionPreference = 'Stop'` re-threw the caught exception and the invoking pwsh exited immediately.

## Fix

Add `($msg -match "database disk image is malformed")` to the OR chain in both files. The two `Invoke-AppxPackageQuery` bodies are intentional near-duplicates (their header comments cross-reference each other) so the change lands in both.

Semantics match the existing 0x80131539 fallback: the box has no working AppX, so `Get-AppxPackage` returns \$null and callers degrade to "package unavailable".

## Test plan

- [ ] Push a workspace lock for a cairo/dev commit that includes this codetracer SHA (once landed).
- [ ] Re-run cairo `ci-windows-diy` — expect the pwsh step to complete without throwing.

## Out of scope

Repairing the actual AppX database (`sfc /scannow` + `StartMenuExperienceHost` respawn, or re-provisioning the guest). That's a separate infra issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)