### PR TITLE
Build generated theme copies in dependency order

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -23,6 +23,8 @@ addPathIfDir(getEnv("CODETRACER_TRACE_FORMAT_NIM_SRC"))
 addPathIfDir(workspaceRoot / "codetracer-trace-format-nim" / "src")
 addPathIfDir(getEnv("IO_MON_SRC"))
 addPathIfDir(workspaceRoot / "io-mon" / "src")
+addPathIfDir(getEnv("SHM_QUEUE_SRC"))
+addPathIfDir(workspaceRoot / "nim-shm-queue" / "src")
 addPathIfDir(getEnv("NIM_STACKABLE_HOOKS_SRC"))
 addPathIfDir(workspaceRoot / "nim-stackable-hooks" / "src")
 

--- a/repro.nim
+++ b/repro.nim
@@ -816,12 +816,16 @@ package codeTracer:
       output = buildDebugPath("src/helpers.js"))
     target("frontend-src-helpers-js", frontendHelpersJs)
 
-    var styleActions: seq[BuildActionDef] = @[]
+    let defaultDarkThemeExtensionCss =
+      ctStylus("default_dark_theme_extension")
+    var styleActions: seq[BuildActionDef] = @[defaultDarkThemeExtensionCss]
     for name in StylusCssEntryPoints:
-      styleActions.add(ctStylus(name))
+      if name != "default_dark_theme_extension":
+        styleActions.add(ctStylus(name))
     let defaultDarkThemeCss = fs.copyFile(
       source = buildDebugPath("frontend/styles/default_dark_theme_extension.css"),
-      output = buildDebugPath("frontend/styles/default_dark_theme.css"))
+      output = buildDebugPath("frontend/styles/default_dark_theme.css"),
+      after = @[defaultDarkThemeExtensionCss])
     styleActions.add(defaultDarkThemeCss)
     let frontendStyles = aggregate("frontend-styles", actions = styleActions)
 


### PR DESCRIPTION
## Summary

- make the default dark theme copy explicitly depend on its generated CSS
- prevent parallel Reprobuild execution from racing the copy against Stylus

## Validation

- Reprobuild Windows build passes
- focused Linux CodeTracer integration validation is running against this commit