### PR TITLE
build: thread nim-shm-gset onto the ct compile path

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -70,6 +70,12 @@ addPathIfDir(getEnv("IO_MON_SRC"))
 addPathIfDir(workspaceRoot / "io-mon" / "src")
 addPathIfDir(getEnv("SHM_QUEUE_SRC"))
 addPathIfDir(workspaceRoot / "nim-shm-queue" / "src")
+# io-mon's writer now imports `shm_gset/transport` (the grow-only shared-memory
+# set that backs io-mon's Linux dependency-capture channel), in addition to
+# `shm_queue`. Thread nim-shm-gset onto the path the same way, or the `ct`
+# compile fails with `cannot open file: shm_gset/transport`.
+addPathIfDir(getEnv("SHM_GSET_SRC"))
+addPathIfDir(workspaceRoot / "nim-shm-gset" / "src")
 addPathIfDir(getEnv("NIM_STACKABLE_HOOKS_SRC"))
 addPathIfDir(workspaceRoot / "nim-stackable-hooks" / "src")
 


### PR DESCRIPTION
Newer io-mon (`io_mon/writer.nim`) imports `shm_gset/transport` from the **nim-shm-gset** sibling — the grow-only shared-memory set that backs io-mon's Linux dependency-capture channel — in addition to the existing `shm_queue` import.

`config.nims` threaded `IO_MON_SRC` and `SHM_QUEUE_SRC` onto the Nim path but not `SHM_GSET_SRC`, so building `ct` against a newer io-mon fails with `cannot open file: shm_gset/transport` (seen in reprobuild's CI when it builds `ct` via codetracer's `reprobuild.nim` recipe against an io-mon that carries the dlopen RUNPATH-transparency fix).

Fix mirrors the existing `SHM_QUEUE_SRC` handling: prefer `$SHM_GSET_SRC`, then the `../nim-shm-gset/src` workspace sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)