### PR TITLE
Use the current reprobuild diagnostics flag

### DIFF
--- a/scripts/build-once.sh
+++ b/scripts/build-once.sh
@@ -299,7 +299,7 @@ if [ -n "$ct_reprobuild_host" ]; then
 	"$repro_bin" "${CODETRACER_REPROBUILD_COMMAND:-build}" "${CODETRACER_REPROBUILD_TARGET:-.}" \
 		--tool-provisioning="${CODETRACER_REPROBUILD_TOOL_PROVISIONING:-$ct_tool_provisioning_default}" \
 		--progress="${CODETRACER_REPROBUILD_PROGRESS:-bar-line}" \
-		--diagnostics="${CODETRACER_REPROBUILD_DIAGNOSTICS:-.repro/build/reprobuild/build-diagnostics.log}" \
+		--write-diagnostics="${CODETRACER_REPROBUILD_DIAGNOSTICS:-.repro/build/reprobuild/build-diagnostics.log}" \
 		--log="${CODETRACER_REPROBUILD_LOG:-quiet}"
 	# post-build-setcap.sh re-applies BPF capabilities (cap_bpf +
 	# cap_perfmon + cap_dac_read_search) to the freshly built ct binary


### PR DESCRIPTION
`scripts/build-once.sh` passes `--diagnostics=` to `repro build`. That flag was
renamed to `--write-diagnostics=`, so it is now rejected outright:

```
repro build: error: unsupported build flag: --diagnostics=.repro/build/reprobuild/build-diagnostics.log
error: Recipe `build-once` failed on line 5 with exit code 1
```

The build stops before it starts, which also takes down any downstream job that
builds CodeTracer as a prerequisite.

This is the only call site in the repository using a superseded measurement
flag; the environment variable that supplies the value is unchanged, so the
override keeps working exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)