### PR TITLE
ci: drop Intel-mac (x86_64 macOS) build support

### DIFF
--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -1079,11 +1079,6 @@ jobs:
           #   arch: arm64
           #   plat_name: manylinux_2_17_aarch64
 
-          - name: macos-amd64
-            runner: eph-macos-arm64
-            target_os: macos
-            arch: amd64
-            plat_name: macosx_10_9_x86_64
           - name: macos-arm64
             runner: eph-macos-arm64
             target_os: macos


### PR DESCRIPTION
The recent runner migration collapsed the Intel-mac build leg onto Apple-Silicon (`eph-macos-arm64`), producing a redundant/mislabeled leg. This removes the Intel-mac (`macos-amd64`, x86_64 macOS) matrix entry from `build-python-packages` in `.github/workflows/codetracer.yml`.

- Removed the `macos-amd64` matrix include (target/plat_name x86_64 macOS, rid osx-x64).
- Kept the Apple-Silicon (`macos-arm64`) leg and the Linux leg.
- No dangling references: the built artifact is named `python-dist-${{ matrix.name }}` and consumed via `download-artifact` with `merge-multiple: true` (no hardcoded per-leg names); no `needs:`/`if:`/release-glob referenced the dropped leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)