### PR TITLE
fix(build): resolve the docs book block's project path at package scope

### DIFF
--- a/repro.nim
+++ b/repro.nim
@@ -1338,9 +1338,9 @@ package codeTracer:
     # a workspace synced before that lands has no checkout to build against.
     block docsBookIsonim:
       let bookDir = "docs/book-isonim"
-      if not dirExists(projectRoot / bookDir):
+      if not dirExists(projectRootPath / bookDir):
         break docsBookIsonim
-      let ws = codeTracerWorkspaceRoot(projectRoot)
+      let ws = codeTracerWorkspaceRoot(projectRootPath)
       if ws.len == 0:
         break docsBookIsonim
 


### PR DESCRIPTION
## Problem

`repro.nim` fails to compile on `dev`:

```
repro.nim(1341, 24) Error: undeclared identifier: 'projectRoot'
```

The `docs/book-isonim` graph declaration references `projectRoot`, but that
name is a local of the `devEnv:` block. The book's targets are declared under
`build:`, a sibling scope, so the identifier is not visible there. The only
other bindings of that name are proc parameters.

This breaks any build that lowers the package's build graph. In particular it
fails reprobuild's `Test` check, which has a "Build codetracer ct (via
reprobuild)" step — so this currently blocks that check on every reprobuild PR.

## Fix

Use `projectRootPath`, the package-level binding the rest of the file already
uses for the repository root (including the entire `--path` set handed to the
Nim compiler). It is a compile-time constant derived from the source location,
so it is absolute and independent of the working directory the build runs from.

That property matters here, because the value is also passed to
`codeTracerWorkspaceRoot`, which walks parent directories looking for sibling
checkouts — a relative path would not resolve.

`codeTracerWorkspaceRoot` is kept rather than the plain `workspaceRootPath`: it
validates the candidate against known sibling directories and returns an empty
string when none are found, which is what lets the block skip itself cleanly in
a workspace with no book sources.

## Verification

- Reproduced the failure on the unmodified base and confirmed it is gone after
  the change, by compiling `repro.nim` with the package DSL on the Nim path in
  full (non-interface) mode, which is the mode that expands the `build:` block.
  Ran with `--errorMax:0`, so the clean result covers the whole file, not just
  the first error.
- Also compiles under `-d:reproInterfaceMode`.

Worth noting: interface mode does **not** expand the `build:` block, so it
compiles cleanly both before and after. A `-d:reproInterfaceMode` compile is
therefore not sufficient verification for changes to `build:`.

A full `repro build` could not be completed locally: it fails while linking its
own interface-extraction helper against `libxxhash`. That failure reproduces
identically on the unmodified base commit, so it is a local toolchain issue
rather than anything about this change.

## Scope

Reviewed the rest of the introducing commit and the one later commit touching
`repro.nim`; these two references are the only out-of-scope identifiers.

Not self-merging — flagging for a human since this is recent work by someone else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)