### PR TITLE
fix(ct-test): keep the parallel test runner alive, and gate it

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -623,3 +623,42 @@ and a correlation marker's counterpart is by definition in another process.
   `.../nan-payloads/legacy-encoding.ct`, made by a pre-M52 `ct-instrument` that
   cannot be rebuilt — it is excluded from that check and must never be
   regenerated.
+- 2026-08-11 (Nim ORC's allocator is per-thread, and the region dies with the
+  thread — `ct-test test run` SIGSEGV'd at 21+ workers): Nim ARC/ORC gives every
+  thread its own `MemRegion`, and that region lives in the thread's TLS
+  (`lib/system/mmdisp.nim`: `var allocator {.rtlThreadVar.}: MemRegion`). Every
+  string/seq payload is stamped with the allocating thread's region as its
+  owner. Cross-thread `dealloc` IS supported — `rawDealloc` sees
+  `c.owner != addr(a)` and hands the cell over via `addToSharedFreeList` — but
+  ONLY while the owning thread is still alive; that helper dereferences
+  `c.owner`. So "protected by a Lock" is NOT sufficient for sharing GC-managed
+  data with worker threads: you must also not let worker-allocated memory
+  outlive its worker. `run_orchestration.runUnits` returned worker-built
+  `RunUnitOutcome`s to its caller *after* `joinThreads`, and the caller's free
+  then walked a dangling `c.owner`. It looked fine below 21 workers purely
+  because glibc caches retired thread stacks (`stack_cache_maxsize`, 40 MiB
+  default) so the dead TLS stayed mapped — silent corruption, not safety. The
+  boundary is exact arithmetic, not folklore: Nim gives every thread a 2 MiB
+  stack of its own (`ThreadStackSize` in `std/typedthreads` is
+  `1024*256*sizeof(int) - 4096`; `ulimit -s` is irrelevant), so 40 MiB holds
+  exactly 20 retired stacks and worker 21 is the first whose region is
+  unmapped. Then the free segfaults, *after* the run has already printed a
+  correct summary (stdout says success, `$?` says 139).
+  Two things worth keeping:
+  * `GLIBC_TUNABLES=glibc.pthread.stack_cache_size=0` unmaps every worker's TLS
+    at join, so this whole bug class becomes deterministic at ONE worker instead
+    of probabilistic at 21. Measured on the pre-fix build: exit 139 at
+    `--threads 1`, and conversely a 1 GiB stack cache makes the pre-fix build
+    survive 64 workers — proof that thread count never made it safe, only quiet.
+    Reach for this tunable when stress-testing any threaded Nim code here; a
+    clean run without it is close to no evidence at all.
+  * `-d:useMalloc` is the independent cross-check: it removes the per-thread
+    regions, and the pre-fix build then passes at 64 workers even with the
+    cache disabled. If a crash survives `-d:useMalloc`, it is NOT this bug.
+  * The fix pattern is in `runUnits`' `ResultHandoff`: workers park on a
+    condvar after draining the queue, the spawning thread copies the results
+    into its own region and frees the worker-owned originals while the workers
+    are still alive, and only then releases and joins them. Any new worker pool
+    that returns GC-managed data needs the same hand-off (or `-d:useMalloc`,
+    which sidesteps per-thread regions entirely but only protects the binaries
+    that are built with it, not library consumers).

--- a/ci/test/ct-providers.sh
+++ b/ci/test/ct-providers.sh
@@ -125,7 +125,28 @@ run_nim_test src/ct_test/discovery_test.nim
 # The orchestration suite owns the `test run` worker pool, including the
 # high-thread-count worker-heap hand-off guard (it re-execs itself in a child
 # process and asserts the child's exit status). It needs no external toolchain.
-run_nim_test src/ct_test/run_orchestration_test.nim
+#
+# Run with glibc's retired-thread-stack cache disabled, scoped to this one
+# invocation. The guarded regression writes into a dead thread's TLS at *every*
+# thread count; only whether the page is still mapped decides whether the process
+# dies, and glibc's default 40 MiB cache keeps 20 of Nim's 2 MiB thread stacks
+# mapped. Left at the default, this guard silently depends on three unrelated
+# numbers holding still — glibc's cache size, Nim's ThreadStackSize, and the
+# suite's unit count staying above 21 (it runs min(threads, units) workers). Move
+# any one of them and the guard stops guarding while still reporting success.
+# With the cache gone the illegal write is fatal at the very first worker.
+#
+# That makes this gate deliberately stricter than production: an unmapped stack
+# can only expose a latent use-after-free, never invent one, so a failure seen
+# only here is a real bug in the code under test, not a gate artifact.
+#
+# The suite still makes its own unamplified 32-worker run, and that is what
+# proves the shipping configuration safe; the tunable is an amplifier on top of
+# it, not a replacement for it. Not exported script-wide on purpose: it is
+# glibc-only (a silent no-op on musl and macOS) and disabling the cache slows
+# down every thread-creating process.
+GLIBC_TUNABLES=glibc.pthread.stack_cache_size=0 \
+	run_nim_test src/ct_test/run_orchestration_test.nim
 run_nim_test src/ct_test/release_gate_test.nim
 
 echo "ct-providers: all provider suites passed"

--- a/ci/test/ct-providers.sh
+++ b/ci/test/ct-providers.sh
@@ -122,6 +122,10 @@ run_nim_test src/ct_test/ruby_providers_test.nim
 echo "ct-providers: running framework gate suites"
 run_nim_test src/ct_test/contracts_test.nim
 run_nim_test src/ct_test/discovery_test.nim
+# The orchestration suite owns the `test run` worker pool, including the
+# high-thread-count worker-heap hand-off guard (it re-execs itself in a child
+# process and asserts the child's exit status). It needs no external toolchain.
+run_nim_test src/ct_test/run_orchestration_test.nim
 run_nim_test src/ct_test/release_gate_test.nim
 
 echo "ct-providers: all provider suites passed"

--- a/ci/test/m16-release-gate.sh
+++ b/ci/test/m16-release-gate.sh
@@ -36,7 +36,28 @@ run_nim_test src/ct_test/discovery_test.nim
 run_nim_test src/ct_test/run_store_test.nim
 # Guards `ct-test test run` against the worker-heap hand-off regression that
 # made it dump core at high thread counts *after* printing a valid summary.
-run_nim_test src/ct_test/run_orchestration_test.nim
+#
+# Run with glibc's retired-thread-stack cache disabled, scoped to this one
+# invocation. That regression writes into a dead thread's TLS at *every* thread
+# count; only whether the page is still mapped decides whether the process dies,
+# and glibc's default 40 MiB cache keeps 20 of Nim's 2 MiB thread stacks mapped.
+# Left at the default, this guard silently depends on three unrelated numbers
+# holding still — glibc's cache size, Nim's ThreadStackSize, and the suite's unit
+# count staying above 21 (it runs min(threads, units) workers). Move any one of
+# them and the guard stops guarding while still reporting success. With the cache
+# gone the illegal write is fatal at the very first worker instead.
+#
+# That makes this gate deliberately stricter than production: an unmapped stack
+# can only expose a latent use-after-free, never invent one, so a failure seen
+# only here is a real bug in the code under test, not a gate artifact.
+#
+# The suite still makes its own unamplified 32-worker run, and that is what
+# proves the shipping configuration safe; the tunable is an amplifier on top of
+# it, not a replacement for it. Not exported script-wide on purpose: it is
+# glibc-only (a silent no-op on musl and macOS) and disabling the cache slows
+# down every thread-creating process.
+GLIBC_TUNABLES=glibc.pthread.stack_cache_size=0 \
+	run_nim_test src/ct_test/run_orchestration_test.nim
 run_nim_test src/ct_test/nim_unittest_provider_test.nim
 run_nim_test src/ct_test/python_providers_test.nim
 run_nim_test src/ct_test/rust_libtest_provider_test.nim

--- a/ci/test/m16-release-gate.sh
+++ b/ci/test/m16-release-gate.sh
@@ -34,6 +34,9 @@ echo "Running representative ct-test fixture providers"
 run_nim_test src/ct_test/contracts_test.nim
 run_nim_test src/ct_test/discovery_test.nim
 run_nim_test src/ct_test/run_store_test.nim
+# Guards `ct-test test run` against the worker-heap hand-off regression that
+# made it dump core at high thread counts *after* printing a valid summary.
+run_nim_test src/ct_test/run_orchestration_test.nim
 run_nim_test src/ct_test/nim_unittest_provider_test.nim
 run_nim_test src/ct_test/python_providers_test.nim
 run_nim_test src/ct_test/rust_libtest_provider_test.nim

--- a/repro.nim
+++ b/repro.nim
@@ -992,14 +992,23 @@ package codeTracer:
       target("replay-server", replayServer)
       codetracerActions.add(replayServer)
 
-    # Nim cache dirs. ``/tmp`` is POSIX-only; on Windows we resolve to
-    # ``%TEMP%/ct-nim-cache`` via getEnv. The nimcache path is consumed
-    # raw by nim.exe (not via bash), so backslash mixing is OK.
+    # Nim cache dirs. Both platforms derive the root from the ambient
+    # temporary directory (``%TEMP%`` on Windows, ``$TMPDIR`` on POSIX,
+    # falling back to ``/tmp`` when unset or empty) rather than hardcoding
+    # one host-global path. Hardcoding ``/tmp/ct-nim-cache`` made every
+    # checkout, worktree and sandboxed build on the machine share a single
+    # object directory keyed only by target name, so two builds of the same
+    # target from different source roots overwrote each other's ``.o`` files
+    # and produced undefined-reference link failures. Honouring ``$TMPDIR``
+    # lets a caller that already scopes its temp directory (test harnesses,
+    # CI runners, sandboxes) scope the nimcache with it. The nimcache path is
+    # consumed raw by nim.exe (not via bash), so backslash mixing is OK.
     let ctNimCacheRoot =
       when defined(windows):
         (getEnv("TEMP") / "ct-nim-cache").replace('\\', '/')
       else:
-        "/tmp/ct-nim-cache"
+        (if getEnv("TMPDIR").len > 0: getEnv("TMPDIR") else: "/tmp") /
+          "ct-nim-cache"
 
     if fileExists("src/ct/db_backend_record.nim"):
       let dbBackendRecord = ctNative(

--- a/repro.nim
+++ b/repro.nim
@@ -1062,11 +1062,14 @@ package codeTracer:
       #     usable from the `ct` binary, which is refc for the rest of
       #     CodeTracer's sake — use this binary for runs.)
       #
-      #     ORC is the precondition for the runner working, not the whole of
-      #     it: with enough workers the process still aborts in the allocator
-      #     while `runUnits` tears down, after the summary has been written.
-      #     Cap `--threads` until that is fixed; the collector is not what
-      #     fixes it.
+      #     ORC used to be only the precondition and not the whole of it: with
+      #     21 or more workers the process also aborted in the allocator while
+      #     `runUnits` tore down, after the summary had been written. That was
+      #     a lifetime bug, not a collector choice — worker-allocated results
+      #     were freed after their threads had exited — and it is fixed at the
+      #     source by `run_orchestration.runUnits`' `ResultHandoff`. No
+      #     `--threads` cap is needed or wanted: `test run` is expected to exit
+      #     0 at any thread count on this ORC build.
       #
       #   * no `NativeDefines`, no `NativePassL`, no `NativeDynlibOverrides`.
       #     Those carry `-lssl -lcrypto -lsqlite3 -lpcre -lzip` and the

--- a/repro.nim
+++ b/repro.nim
@@ -1026,6 +1026,74 @@ package codeTracer:
       target("ct", ct)
       codetracerActions.add(ct)
 
+    if fileExists("src/ct_test/ct_test.nim"):
+      # The standalone cross-language test driver (`ct-test test discover` /
+      # `ct-test test run`). The same engine is reachable as `ct test …`, but
+      # `ct` links the whole CodeTracer product (Electron-facing frontend
+      # plumbing, db-backend bridges, the recorder stack); consumers that only
+      # want discovery/run — CI, sibling repos, reprobuild's dev shell — should
+      # not have to build and ship that closure. Hence a separate, small
+      # binary from the same sources.
+      #
+      # NOTE: this target is deliberately NOT added to `codetracerActions`.
+      # That list feeds the `codetracer` aggregate (the default build action),
+      # and `ct-test` is an auxiliary tool, not part of the shipped product;
+      # adding it would put a second full Nim compile on every default build.
+      # Build it explicitly with `repro build ct-test`.
+      #
+      # The `target()` call below is not what makes that selector resolve —
+      # the output's basename already contributes the same implicit name, and
+      # `repro build ct-test` keeps working with the call renamed. It is here
+      # so the name this binary is built by is stated at its declaration
+      # rather than inferred from a path, and so renaming the output cannot
+      # silently rename the target.
+      #
+      # It does NOT go through `ctNative`, and both departures are load-bearing:
+      #
+      #   * `--mm:orc`, not `ctNative`'s `--mm:refc`. `test run` executes the
+      #     discovered tests on a worker pool (`run_orchestration.runUnits`),
+      #     and the workers share the `RunUnit`/`TestItem` sequences with the
+      #     spawning thread. Under refc every thread owns a private heap, so
+      #     that sharing is undefined behaviour — a refc build of this exact
+      #     source SIGSEGVs inside the worker loop on the first `test run`,
+      #     before a single result exists, while `test discover`
+      #     (single-threaded) survives. ORC shares one heap, so the workers run
+      #     and a summary comes out. (This is also why `ct test run` is not
+      #     usable from the `ct` binary, which is refc for the rest of
+      #     CodeTracer's sake — use this binary for runs.)
+      #
+      #     ORC is the precondition for the runner working, not the whole of
+      #     it: with enough workers the process still aborts in the allocator
+      #     while `runUnits` tears down, after the summary has been written.
+      #     Cap `--threads` until that is fixed; the collector is not what
+      #     fixes it.
+      #
+      #   * no `NativeDefines`, no `NativePassL`, no `NativeDynlibOverrides`.
+      #     Those carry `-lssl -lcrypto -lsqlite3 -lpcre -lzip` and the
+      #     chronicles/tup/ssl define set that the CodeTracer product needs;
+      #     `ct-test` links none of them (its whole non-stdlib dependency set
+      #     is `src/ct_test/**` plus runquota's process/host libraries). Pulling
+      #     them in only made this target unbuildable anywhere CodeTracer's full
+      #     native library set is absent — e.g. reprobuild's dev shell, which is
+      #     exactly where this tool is meant to run.
+      let ctTest = nim.c(
+        mm = "orc",
+        threadsOn = true,
+        hintsOff = true,
+        warningsOff = true,
+        disabledHints = DisabledNimHints,
+        disabledWarnings = DisabledCaseTransitionWarning,
+        debugInfo = true,
+        lineDirOn = true,
+        stacktraceOn = true,
+        linetraceOn = true,
+        boundChecksOn = true,
+        nimcache = ctNimCacheRoot & "/ct_test_codetracer_binary",
+        paths = CodeTracerNimPaths,
+        output = buildDebugPath("bin/ct-test" & (when defined(windows): ".exe" else: "")),
+        source = "src/ct_test/ct_test.nim")
+      target("ct-test", ctTest)
+
     if hasFrontendInputs and hasDbBackendRecordInput and hasCtInput:
       let codetracer = aggregate("codetracer",
         actions = codetracerActions,

--- a/src/ct/codetracer.nim
+++ b/src/ct/codetracer.nim
@@ -5,6 +5,7 @@ import
   ../frontend/viewmodel/agent_evidence,
   cli/e2e_tests,
   ../ct_test/incremental_cli,
+  ../ct_test/ct_test,
   codetracerconf, confutils,
   version
 
@@ -65,6 +66,20 @@ try:
       let testArgs = args[1 .. ^1]
       if testArgs.len > 0 and testArgs[0] == "--incremental":
         quit(runIncremental(testArgs[1 .. ^1]))
+      # M2 / Amendment A-2: `ct test discover` and `ct test run` are the
+      # cross-language ct_test surface (TestCatalog v1 discovery over the
+      # provider registry, plus the partitioned parallel runner). The engine
+      # already lived under src/ct_test but was reachable only through the
+      # standalone `ct-test` binary's `isMainModule` block; route the two
+      # implemented verbs here so `ct test …` exposes them too.
+      #
+      # Ordering matters: this dispatch sits AFTER the `--incremental`
+      # interception and BEFORE the `runE2eTestCli` fallback, and it triggers
+      # only on the two literal verbs, so `ct test --incremental …` and
+      # `ct test e2e …` keep their existing behaviour byte for byte.
+      # `runCtTestCli` wants the full vector including the leading "test".
+      if testArgs.len > 0 and testArgs[0] in ["discover", "run"]:
+        quit(runCtTestCli(args))
       quit(runE2eTestCli(testArgs))
 
     # M7 / M8: the help-delegate ``ct-complete`` / ``ct-completions``

--- a/src/ct_test/ct_test.nim
+++ b/src/ct_test/ct_test.nim
@@ -200,12 +200,14 @@ proc runCtTest*(args: seq[string]; registry: ProviderRegistry;
     # worker loop on the very first run, before a single result exists.
     # ORC/ARC share one heap, so the workers run and a summary is produced.
     #
-    # ORC/ARC are the precondition for the runner working, not proof that it
-    # always does: a separate teardown defect can still abort the process
-    # after the summary has been written, once the worker count is high
-    # enough. That is a different failure with a different remedy (cap
-    # ``--threads``); what this branch is about is refc producing no results
-    # at all.
+    # ORC/ARC alone were once not enough either: worker-allocated results used
+    # to be freed after the workers had been joined, which aborted the process
+    # in the allocator once the worker count was high enough — after a
+    # correct-looking summary had already been printed. That is fixed at the
+    # source in ``run_orchestration.runUnits`` (see its ``ResultHandoff``
+    # type); no thread-count cap is involved, and `run` is expected to exit 0
+    # at any ``--threads`` value on ORC/ARC. What this branch is about is refc
+    # producing no results at all.
     #
     # This is not hypothetical — the `ct` binary embeds this CLI and is built
     # `--mm:refc` for the rest of CodeTracer's sake, so `ct test run` would

--- a/src/ct_test/ct_test.nim
+++ b/src/ct_test/ct_test.nim
@@ -192,8 +192,36 @@ proc runCtTest*(args: seq[string]; registry: ProviderRegistry;
   if args.len >= 2 and args[0] == "test" and args[1] == "discover":
     return runDiscover(if args.len > 2: args[2 .. ^1] else: @[], registry, cache)
   if args.len >= 2 and args[0] == "test" and args[1] == "run":
-    var mutableRegistry = registry
-    return runRun(if args.len > 2: args[2 .. ^1] else: @[], mutableRegistry, cache)
+    # `run` executes the discovered tests on a worker pool
+    # (``run_orchestration.runUnits``), and the workers share the
+    # ``RunUnit``/``TestItem`` sequences with the spawning thread. Nim's refc
+    # collector gives every thread a PRIVATE heap, so that sharing is
+    # undefined behaviour: a refc build of this source SIGSEGVs inside the
+    # worker loop on the very first run, before a single result exists.
+    # ORC/ARC share one heap, so the workers run and a summary is produced.
+    #
+    # ORC/ARC are the precondition for the runner working, not proof that it
+    # always does: a separate teardown defect can still abort the process
+    # after the summary has been written, once the worker count is high
+    # enough. That is a different failure with a different remedy (cap
+    # ``--threads``); what this branch is about is refc producing no results
+    # at all.
+    #
+    # This is not hypothetical — the `ct` binary embeds this CLI and is built
+    # `--mm:refc` for the rest of CodeTracer's sake, so `ct test run` would
+    # crash where `ct test discover` (single-threaded) works fine. Refuse with
+    # the machine-readable error envelope every other `run` failure uses,
+    # rather than handing the caller a core dump. Compiled out entirely on
+    # ORC/ARC builds, which is what the standalone `ct-test` binary is.
+    when not defined(gcOrc) and not defined(gcArc):
+      return emitRunError(@[
+        "`test run` requires an ORC/ARC build: this binary was compiled with " &
+        "--mm:refc, whose per-thread heaps make the parallel runner unsafe. " &
+        "Use the standalone `ct-test` binary (built --mm:orc) for runs; " &
+        "`test discover` is supported here."])
+    else:
+      var mutableRegistry = registry
+      return runRun(if args.len > 2: args[2 .. ^1] else: @[], mutableRegistry, cache)
   let response = errorResponse(
     "usage: ct-test test (discover (--workspace <path> | --file <path>) --json " &
     "| run --workspace <path> [--file <f>] [--partition file:<path>] " &
@@ -201,8 +229,22 @@ proc runCtTest*(args: seq[string]; registry: ProviderRegistry;
   echo responseToJson(response).pretty
   discoverExitCode(response)
 
-when isMainModule:
+proc runCtTestCli*(args: seq[string]): int =
+  ## Convenience entry point for embedders that do not want to own the
+  ## provider registry or the discovery cache.
+  ##
+  ## ``runCtTest`` above deliberately takes both as parameters so a library
+  ## consumer can install a reduced/extended provider set and share a warm
+  ## cache across invocations. The two callers that just want "the default
+  ## ct_test CLI, please" — the standalone ``ct-test`` binary below and the
+  ## ``ct test discover|run`` route in ``src/ct/codetracer.nim`` — would
+  ## otherwise each duplicate the same two-line construction, so it lives
+  ## here once. ``args`` is the full ``test <verb> …`` vector, exactly as
+  ## ``runCtTest`` expects it.
   let
     registry = newDefaultProviderRegistry()
     cache = newDiscoveryCache()
-  quit(runCtTest(commandLineParams(), registry, cache))
+  runCtTest(args, registry, cache)
+
+when isMainModule:
+  quit(runCtTestCli(commandLineParams()))

--- a/src/ct_test/run_orchestration.nim
+++ b/src/ct_test/run_orchestration.nim
@@ -23,6 +23,13 @@
 ## ``Lock`` — mirroring ``ct_test_runner.nim``'s ``Queue`` / ``WorkerArgs``
 ## shape. The provider ``run`` procs are ``{.gcsafe.}`` so they are safe to
 ## invoke from the worker threads.
+##
+## Heap-ownership note (see ``ResultHandoff`` below): mutual exclusion is *not*
+## sufficient on its own. Nim's ARC/ORC allocator is per-thread, and a heap
+## block may only be freed while the thread that allocated it is still alive,
+## so ``runUnits`` additionally takes ownership of the workers' results — by
+## re-materialising them in the calling thread's heap — *before* the workers are
+## allowed to exit.
 
 import std/[cpuinfo, json, locks, options, os, sets, strutils, times]
 
@@ -230,6 +237,57 @@ type
     units: seq[RunUnit]
     pos: int
 
+  ResultHandoff = object
+    ## Ownership hand-off barrier between the workers and the spawning thread.
+    ##
+    ## **Why this exists.** Nim's ARC/ORC allocator is *per thread*: every
+    ## thread has its own ``MemRegion``, and that region lives in the thread's
+    ## thread-local storage (``lib/system/mmdisp.nim``:
+    ## ``var allocator {.rtlThreadVar.}: MemRegion``). Every ``string``/``seq``
+    ## payload a worker allocates is therefore stamped with that worker's region
+    ## as its owner (``PSmallChunk.owner``).
+    ##
+    ## Freeing such a block from a *different* thread is supported — but only
+    ## while the owning thread is still alive. ``rawDealloc``
+    ## (``lib/system/alloc.nim``) notices ``c.owner != addr(a)`` and hands the
+    ## cell to the owner via ``addToSharedFreeList``, which dereferences
+    ## ``c.owner`` to reach ``c.owner.sharedFreeLists[…]``. Once the worker has
+    ## exited, that dereference is a use-after-free: glibc only keeps a bounded
+    ## cache of retired thread stacks (``stack_cache_maxsize``, 40 MiB by
+    ## default) and unmaps the rest together with their static TLS blocks. Below
+    ## the cache limit the write silently lands in a retired region (leaking the
+    ## cell, or worse, resurfacing it in a *recycled* region); above it the
+    ## process dies with ``SIGSEGV`` inside ``addToSharedFreeList``.
+    ##
+    ## That is exactly what ``runUnits`` used to do: the aggregated
+    ## ``RunUnitOutcome``s were allocated by the workers, the workers were then
+    ## joined, and the caller freed the results afterwards — reliably crashing
+    ## once enough workers ran for their stacks to overflow glibc's cache. On
+    ## Linux/glibc that boundary is 21 workers, and the arithmetic is exact: Nim
+    ## gives every thread a 2 MiB stack of its own (``ThreadStackSize`` in
+    ## ``std/typedthreads`` is ``1024*256*sizeof(int) - 4096``, independent of
+    ## ``ulimit -s``), so glibc's 40 MiB default retains exactly 20 of them and
+    ## the 21st worker's region is unmapped by the time the caller frees.
+    ##
+    ## Below that boundary nothing is safe either — it is the same illegal
+    ## write, merely landing in a still-mapped retired region. Setting
+    ## ``GLIBC_TUNABLES=glibc.pthread.stack_cache_size=0`` disables the cache
+    ## and makes the defect fatal at a *single* worker, which is the only
+    ## trustworthy way to stress-test this code path.
+    ##
+    ## **The protocol.** Workers park here once the queue is drained instead of
+    ## returning from their thread proc. The spawning thread waits for all of
+    ## them to park, re-materialises the results in its *own* heap region
+    ## (``adoptOutcomes``), releases the worker-owned originals — still legal,
+    ## the workers are alive and parked — and only then lets the workers exit.
+    ## Post-condition: ``runUnits`` hands its caller memory that the calling
+    ## thread owns, and no worker-owned allocation outlives its worker.
+    lock: Lock
+    parked: Cond          ## workers → owner: "another worker has parked"
+    releaseCond: Cond     ## owner → workers: "results adopted, you may exit"
+    arrived: int          ## workers that have reached the barrier
+    released: bool        ## owner is done with the worker-owned results
+
   WorkerArgs = object
     ## Plain-pointer bundle passed by value to each worker thread. Pointers (not
     ## closures) keep the worker proc ``{.thread.}``-safe; every shared mutation
@@ -238,6 +296,7 @@ type
     registry: ptr ProviderRegistry
     resultsLock: ptr Lock
     outcomes: ptr seq[RunUnitOutcome]
+    handoff: ptr ResultHandoff
 
 proc resolveThreadCount*(requested: int): int =
   ## Resolve the effective worker-thread count. An explicit positive
@@ -312,10 +371,45 @@ proc workerLoop(args: WorkerArgs) =
     args.outcomes[].add outcome
     release(args.resultsLock[])
 
+proc parkUntilReleased(handoff: ptr ResultHandoff) =
+  ## Announce that this worker has finished producing results and block until
+  ## the spawning thread has taken ownership of them (see ``ResultHandoff``).
+  ##
+  ## Parking — rather than returning — is what keeps this worker's ``MemRegion``
+  ## mapped while the owner frees the blocks this worker allocated.
+  acquire(handoff.lock)
+  inc handoff.arrived
+  signal(handoff.parked)
+  while not handoff.released:
+    wait(handoff.releaseCond, handoff.lock)
+  release(handoff.lock)
+
 proc workerMain(args: WorkerArgs) {.thread.} =
   ## Top-level thread entry point. Worker threads cannot capture closures, so
   ## the per-thread state arrives by value as ``WorkerArgs``.
-  workerLoop(args)
+  ##
+  ## The barrier is reached from a ``finally`` so that a worker which dies on an
+  ## unexpected exception still (a) reports its arrival — the owner would
+  ## otherwise wait forever — and (b) keeps its heap region alive until the
+  ## owner has adopted whatever results it did manage to append.
+  try:
+    workerLoop(args)
+  finally:
+    parkUntilReleased(args.handoff)
+
+proc adoptOutcomes(source: seq[RunUnitOutcome]): seq[RunUnitOutcome] =
+  ## Re-materialise ``source`` in the **calling** thread's heap region.
+  ##
+  ## ``source`` is a borrowed (non-``sink``) parameter and stays live across the
+  ## loop, so the compiler cannot turn ``add source[i]`` into a move: it must
+  ## emit ``=copy``. ``RunUnitOutcome`` and everything it transitively contains
+  ## (``TestEvent``, ``TestDiagnostic``, ``TraceMetadata`` and its
+  ## ``Table[string, string]``) are pure value types with no ``ref`` fields, so
+  ## ``=copy`` is a genuine deep copy: every payload in the result is freshly
+  ## allocated here rather than aliased from a worker's region.
+  result = newSeqOfCap[RunUnitOutcome](source.len)
+  for i in 0 ..< source.len:
+    result.add source[i]
 
 proc runUnits*(
     registry: var ProviderRegistry;
@@ -349,6 +443,11 @@ proc runUnits*(
   initLock(resultsLock)
   var outcomes: seq[RunUnitOutcome] = @[]
 
+  var handoff = ResultHandoff(arrived: 0, released: false)
+  initLock(handoff.lock)
+  initCond(handoff.parked)
+  initCond(handoff.releaseCond)
+
   # Never spin up more workers than there are units to run; ``resolveThreadCount``
   # has already floored the request at 1.
   let workerCount = min(threadCount, selected.len)
@@ -358,19 +457,73 @@ proc runUnits*(
     queue: addr queue,
     registry: addr registry,
     resultsLock: addr resultsLock,
-    outcomes: addr outcomes)
+    outcomes: addr outcomes,
+    handoff: addr handoff)
 
   var workers = newSeq[Thread[WorkerArgs]](workerCount)
   let wallStart = epochTime()
-  for i in 0 ..< workerCount:
-    createThread(workers[i], workerMain, args)
-  joinThreads(workers)
+
+  # Track how many threads actually started: ``createThread`` raises when the
+  # OS refuses one, and both the barrier wait below and ``joinThread`` must be
+  # driven by the real count rather than the requested one.
+  var started = 0
+  try:
+    while started < workerCount:
+      createThread(workers[started], workerMain, args)
+      inc started
+  except CatchableError:
+    # The OS refused a thread (``ResourceExhaustedError``). Continue with the
+    # workers we did get rather than failing the whole run; if none started we
+    # fall back to draining the queue on this thread below.
+    discard
+
+  if started == 0:
+    # No worker could be started: drain the queue here instead of silently
+    # reporting zero outcomes. Everything is then allocated on this thread, so
+    # the hand-off below degrades to a plain (redundant) copy.
+    result.threads = 1
+    workerLoop(args)
+  else:
+    # Wait for every started worker to reach the barrier. At that point the
+    # queue is drained and ``outcomes`` is complete and stable.
+    acquire(handoff.lock)
+    while handoff.arrived < started:
+      wait(handoff.parked, handoff.lock)
+    release(handoff.lock)
+    result.threads = started
+
   result.wallTimeMs = int((epochTime() - wallStart) * 1000)
 
+  # Take ownership while the workers are still parked and their heap regions
+  # are still mapped: copy the results into this thread's region, then release
+  # every worker-owned allocation. Doing this after ``joinThreads`` is the
+  # use-after-free documented on ``ResultHandoff``. Both halves matter — moving
+  # instead of copying, or moving the ``reset`` below the joins, each restores
+  # the crash on its own.
+  result.outcomes = adoptOutcomes(outcomes)
+  reset(outcomes)
+
+  # Deliberately NOT wrapped in a ``try/finally``. Nothing from here to the
+  # joins can raise in practice (``std/locks`` only looks fallible to Nim's
+  # effect inference), and a ``finally`` would have to run the release+join on
+  # the *barrier-wait* failure path too — signalling the workers and freeing
+  # ``outcomes`` while they may still be appending to it, which is a worse
+  # failure than the one it would be guarding against. If an exception does
+  # escape here, the scope destructors still free the worker-owned results
+  # while the workers are parked and alive, so the lifetime rule above holds.
+  acquire(handoff.lock)
+  handoff.released = true
+  broadcast(handoff.releaseCond)
+  release(handoff.lock)
+
+  for i in 0 ..< started:
+    joinThread(workers[i])
+
+  deinitCond(handoff.parked)
+  deinitCond(handoff.releaseCond)
+  deinitLock(handoff.lock)
   deinitLock(queue.lock)
   deinitLock(resultsLock)
-
-  result.outcomes = outcomes
 
 # ---------------------------------------------------------------------------
 # Summary aggregation

--- a/src/ct_test/run_orchestration_test.nim
+++ b/src/ct_test/run_orchestration_test.nim
@@ -9,14 +9,23 @@
 ##   ``TestEvent`` streams is driven through the worker pool with and without a
 ##   partition file; exact executed/skipped/passed/failed counts and per-test
 ##   event kinds are asserted.
+## * runUnits (worker-heap hand-off) — a high-thread-count run is executed in a
+##   CHILD PROCESS and its exit status asserted, because the defect this guards
+##   is a fatal signal (see "worker-heap hand-off" below), which no in-process
+##   assertion can survive.
 ##
 ## The integration provider runs entirely in-process (no toolchain needed) so
 ## the test is self-contained and deterministic; it exercises the exact
 ## orchestration path real providers use (worker pool → provider.run(scope) →
 ## event aggregation), differing only in that the events are produced directly
-## rather than via execCaptured.
+## rather than via execCaptured. It is a fixture, not a mock of a collaborator:
+## nothing is stubbed out of ``run_orchestration`` itself — the real queue, the
+## real worker threads, the real aggregation and the real summary reduction all
+## run. Only the leaf ``TestProvider.run`` is supplied by the test, exactly as a
+## real language adapter would supply it, so the orchestration under test is
+## exercised end to end without depending on an external toolchain.
 
-import std/[json, options, os, sets, strutils, tables, unittest]
+import std/[json, options, os, osproc, sets, strutils, tables, unittest]
 
 import contracts
 import discovery
@@ -122,6 +131,105 @@ proc fixtureResponse(items: seq[TestItem]; workspaceRoot = "/tmp/ws"): DiscoverR
       items: items,
       diagnostics: @[])],
     diagnostics: @[])
+
+# ---------------------------------------------------------------------------
+# Worker-heap hand-off stress (regression guard)
+# ---------------------------------------------------------------------------
+#
+# Nim's ARC/ORC allocator is per-thread and each thread's ``MemRegion`` lives in
+# that thread's TLS. A heap block may only be freed while the thread that
+# allocated it is still alive — otherwise ``rawDealloc`` follows a dangling
+# ``PSmallChunk.owner`` into ``addToSharedFreeList`` and the process dies with
+# SIGSEGV. ``runUnits`` used to return worker-allocated results to its caller
+# *after* joining the workers, so `ct-test test run` reliably dumped core once
+# enough workers had run for glibc to stop caching their retired stacks — and it
+# did so only **after** printing a correct-looking summary, so stdout said
+# success while `$?` said 139.
+#
+# On Linux/glibc that boundary is exactly 21 workers: Nim gives every thread its
+# own 2 MiB stack (``ThreadStackSize`` in ``std/typedthreads``, independent of
+# `ulimit -s`), so glibc's 40 MiB `stack_cache_maxsize` retains exactly 20 of
+# them. Fewer workers is NOT safe, only quiet — the same illegal write lands in
+# a retired-but-still-mapped region. Running this binary under
+# `GLIBC_TUNABLES=glibc.pthread.stack_cache_size=0` removes the cache and makes
+# the defect fatal at a single worker; that is the amplifier to reach for when
+# stress-testing any threaded Nim code in this repo.
+#
+# The failure is a fatal signal, so it cannot be observed with ``check``: the
+# test binary would die too. The guard therefore re-executes THIS binary in a
+# child process and asserts the child's exit status, which is the property the
+# CLI contract actually needs ("exit 0 at the default thread count").
+
+const
+  StressChildFlag = "--ct-orch-heap-handoff-child"
+    ## argv[1] marker that turns this test binary into the stress child.
+  StressUnits = 200
+    ## Enough units that every worker gets several, and enough total payload
+    ## that worker allocations spread across many allocator chunks.
+  StressEventsPerUnit = 40
+  StressPayloadBytes = 200
+
+proc stressRun(scope: TestScope): ProviderResult[seq[TestEvent]] {.gcsafe.} =
+  ## Like ``fixtureRun`` but with a bulky event stream: the regression being
+  ## guarded is about *heap ownership*, so each unit must make its worker
+  ## allocate a non-trivial amount of string/seq payload that then has to
+  ## survive the hand-off back to the spawning thread.
+  let failed = scope.selector.endsWith("::fail")
+  var events: seq[TestEvent] = @[]
+  for i in 0 ..< StressEventsPerUnit:
+    events.add TestEvent(
+      schemaVersion: TestEventSchemaVersion, kind: tekOutput,
+      providerId: FixtureProviderId, runId: scope.testId, testId: scope.testId,
+      output: repeat("x", StressPayloadBytes) & $i & scope.selector)
+  events.add TestEvent(
+    schemaVersion: TestEventSchemaVersion, kind: tekTestFinished,
+    providerId: FixtureProviderId, runId: scope.testId, testId: scope.testId,
+    status: some(if failed: tsFailed else: tsPassed), durationMs: 1)
+  ProviderResult[seq[TestEvent]](diagnostics: @[], value: events)
+
+proc stressRegistry(): ProviderRegistry =
+  var provider = TestProvider(info: fixtureInfo(canRunSingle = true))
+  provider.run = stressRun
+  ProviderRegistry(providers: @[M1Provider(
+    provider: provider, relevantConfigFiles: @[])])
+
+proc stressUnits(registry: ProviderRegistry): seq[RunUnit] =
+  var items: seq[TestItem] = @[]
+  for i in 0 ..< StressUnits:
+    items.add fixtureItem("stress" & $i, i + 1, i mod 3 == 0)
+  enumerateRunUnits(fixtureResponse(items), registry)
+
+proc stableSummaryJson(summary: TestRunSummary): JsonNode =
+  ## The summary minus the two fields that legitimately vary with the worker
+  ## count, so a 32-thread run and a 1-thread run can be compared for equality.
+  result = summaryToJson(summary)
+  result.delete "wall_time_ms"
+  result.delete "threads"
+
+const StressSummaryMarker = "STRESS-SUMMARY "
+
+proc runStressChild(threads: int) =
+  ## Child-process body: run ``StressUnits`` units across ``threads`` workers,
+  ## report the summary, and then explicitly release the whole result — the
+  ## release is the operation that used to fault, so forcing it here makes the
+  ## failure land inside the child rather than depending on teardown timing.
+  var registry = stressRegistry()
+  let units = stressUnits(registry)
+  var runResult = runUnits(registry, units, emptyPartition(), threads = threads)
+  let summary = summarize(runResult)
+  echo StressSummaryMarker, $stableSummaryJson(summary)
+  echo "STRESS-THREADS ", runResult.threads
+  reset(runResult)
+  echo "STRESS-RELEASED"
+
+when isMainModule:
+  # Must run before any `suite` body executes, so the child does nothing but
+  # the stress run. Placed here (rather than at the end of the file) because
+  # `suite` blocks execute as the module body is evaluated.
+  let childArgs = commandLineParams()
+  if childArgs.len == 2 and childArgs[0] == StressChildFlag:
+    runStressChild(parseInt(childArgs[1]))
+    quit(0)
 
 proc tempPartitionFile(name, content: string): string =
   let path = getTempDir() / ("ct-orch-part-" & name & "-" &
@@ -359,6 +467,48 @@ suite "parallel run integration":
     check summary.executed == 2
     check summary.skippedByPartition == 3
     check runExitCode(summary) == 0
+
+  test "high worker counts return safely and match a single-threaded run":
+    # Regression guard for the worker-heap hand-off (see the block comment
+    # above ``StressChildFlag``). Pre-fix this child exits 139 with
+    # `SIGSEGV … addToSharedFreeList`; the summary it printed first was already
+    # correct, which is precisely why the exit status has to be asserted.
+    #
+    # 32 workers is above the 21-worker Linux/glibc threshold at which retired
+    # worker stacks (and the thread-local ``MemRegion``s inside them) stop being
+    # cached and start being unmapped, with enough headroom that the guard does
+    # not depend on the cache size to the byte. `countProcessors()` is folded in
+    # so it also covers "the default thread count on this machine", which is
+    # what the CLI uses when `--threads` is omitted.
+    #
+    # ``StressUnits`` must stay comfortably above this too: ``runUnits`` starts
+    # ``min(threads, units)`` workers, so a small unit count would silently cap
+    # the pool below the threshold and neuter the guard.
+    let threads = max(32, osproc.countProcessors())
+    let child = execCmdEx(
+      quoteShellCommand([getAppFilename(), StressChildFlag, $threads]))
+    checkpoint "child output:\n" & child.output
+    check child.exitCode == 0
+    check "STRESS-RELEASED" in child.output
+
+    # The parallel result must equal the serial one. A single-threaded run
+    # never leaves the calling thread, so it is the trustworthy reference.
+    var stressReg = stressRegistry()
+    let stressUnitList = stressUnits(stressReg)
+    let serial = summarize(
+      runUnits(stressReg, stressUnitList, emptyPartition(), threads = 1))
+
+    var childSummary = newJNull()
+    var childThreads = 0
+    for line in child.output.splitLines():
+      if line.startsWith(StressSummaryMarker):
+        childSummary = parseJson(line[StressSummaryMarker.len .. ^1])
+      elif line.startsWith("STRESS-THREADS "):
+        childThreads = parseInt(line["STRESS-THREADS ".len .. ^1].strip())
+    check childSummary == stableSummaryJson(serial)
+    check childSummary["executed"].getInt == StressUnits
+    # The run must actually have been concurrent, or it proves nothing.
+    check childThreads == threads
 
   test "empty partition skips everything and runs nothing":
     let path = tempPartitionFile("none", "# no ids here\n")


### PR DESCRIPTION
## Summary

Fixes a crash in `ct-test test run`, ships the cross-language test driver as its own binary, and puts the worker-pool suite under the CI gates that are supposed to catch this class of defect.

## What's here

- **`ct-test test run` no longer dies after a successful run.** Results were built on the worker threads and freed after those threads had exited, walking a pointer into unmapped thread-local storage. `run_orchestration.runUnits` now takes ownership of the results before the workers go away, so `run` exits 0 at any thread count on an ORC/ARC build.
- **The cross-language test driver builds as its own `ct-test` binary** (`--mm:orc`), with a `graph` target. The `ct` binary is built `--mm:refc` for the rest of CodeTracer's sake, so it now refuses `test run` with the same machine-readable error envelope every other `run` failure uses, rather than handing the caller a core dump. `test discover` is single-threaded and stays supported there.
- **`run_orchestration_test.nim` now runs in both provider gates.** It exercises the worker pool, needs no external toolchain, and previously appeared in neither gate.
- **The worker-pool guard runs without glibc's retired-stack cache.** The defect it guards against writes into a dead thread's TLS at every thread count; only whether the page is still mapped decides whether the process dies. Left on the default 40 MiB cache, the guard silently depended on three unrelated numbers holding still. Under `GLIBC_TUNABLES=glibc.pthread.stack_cache_size=0` the write is fatal at the first worker. The suite keeps its own unamplified 32-worker run, which is what shows the shipping configuration is safe.
- **Nim's object cache is scoped to the ambient temp directory**, and the stale `--threads` cap advice is dropped now that the underlying defect is fixed at its source.

## Verification

Rebased onto current `dev` and re-verified:

- `ci/test/m16-release-gate.sh` — green (95 checks, 0 failures)
- `nim c src/ct_test/ct_test.nim` — builds clean
- `run_orchestration_test.nim` — passes, including "high worker counts return safely and match a single-threaded run" under the amplifier
- `ct-test test discover` returns a valid catalog (exit 0); a `--mm:refc` build refuses `test run` with the error envelope and still serves `discover`
