### PR TITLE
fix(ct-test): scope workspace discovery, and make the ct-test gates actually gate

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -662,3 +662,39 @@ and a correlation marker's counterpart is by definition in another process.
     that returns GC-managed data needs the same hand-off (or `-d:useMalloc`,
     which sidesteps per-thread regions entirely but only protects the binaries
     that are built with it, not library consumers).
+
+- 2026-08-13 (ct-test discovery scoping + cost): `ct test discover --workspace`
+  fans out to ~38 providers, and EVERY provider used to answer "which files are
+  in this workspace?" with its own `walkDirRec(projectRoot)` plus an ad-hoc
+  reject list (`js_common` skipped `node_modules/`, `go_test` skipped `vendor/`,
+  `python_common` and `nim_unittest` skipped nothing). That produced ~16 full
+  recursive walks during `detect` alone, several of which READ every matching
+  file, and ~21 more during `discoverProject`.
+  Measured against the reprobuild workspace on the pre-fix build: 53,349 items
+  in 10m40s and 59 MB of JSON, of which 45,256 (84.8%) came from
+  `references/{llvm-project,buildxl,nix,spack,mold,wild,…}` — vendored upstream
+  source trees reported as that project's tests. After scoping: 8,093 items in
+  2.1s and 9.8 MB. Same binary, same workspace; a ~300x wall-clock difference
+  that is almost entirely "stop walking other people's repositories".
+  The rule now lives in ONE place, `src/ct_test/workspace_scope.nim`:
+  * `walkWorkspaceFiles(root)` is the drop-in for `walkDirRec` — new providers
+    MUST use it, otherwise they re-open the hole for their own language.
+  * The scope honours the workspace's OWN declaration rather than a ct_test
+    ignore file: `git ls-files --cached --others --exclude-standard`, run with
+    cwd = root (so `--workspace <subdir>` scopes itself). That gets the whole
+    `.gitignore` chain, stops at nested checkouts (a vendored tree is reported
+    as ONE directory entry, never descended into), and — the part that is easy
+    to break — keeps untracked-but-not-ignored files, so a test written seconds
+    ago is still discovered. Fallback for non-checkouts is a PRUNING walk
+    (prunes the descent, not the results) plus `VendorDirNames`.
+  * The resolved set is memoized in a `{.threadvar.}` because `TestProvider`'s
+    callbacks only receive `projectRoot: string`; `discovery.discover` calls
+    `invalidateWorkspaceScopes()` once per invocation, so one traversal is
+    shared by all 38 providers within a discovery and no state survives it.
+  * Escape hatch is opt-OUT, not opt-in: `--scope unscoped` / `CT_TEST_SCOPE`.
+    An `info` diagnostic (`discovery scope: N file(s) … excluded …`) reports
+    what was dropped, so the exclusion is never silent.
+  Regression guard: the last two cases in `src/ct_test/discovery_test.nim`.
+  Mutation-verified against 7 mutations (drop the nested-VCS prune, the
+  `VendorDirNames` prune in either mode, `--exclude-standard`, `--others`, the
+  `--scope unscoped` branch, and the summary diagnostic).

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -2731,6 +2731,160 @@ jobs:
           retention-days: 14
           if-no-files-found: ignore
 
+  # ---------------------------------------------------------------------------
+  # ct-test gates.
+  #
+  # `ci/test/m16-release-gate.sh` and `ci/test/ct-providers.sh` were real,
+  # maintained scripts that NO pipeline invoked: `.gitlab-ci.yml`'s only test
+  # jobs are `just test` (test-rust + test-nimsuggest + optional cross-repo) and
+  # `ci/test/ui-tests.sh`, and no workflow here named either script. They ran
+  # only when a human typed `just test-m16-release-gate` / `just
+  # test-ct-providers`. Every suite listed in them — not just the most recently
+  # added one — has therefore been in a gate that never gated.
+  #
+  # They are split across two jobs on purpose, because they have very different
+  # prerequisites and mixing them would let the harder one's infrastructure
+  # failures mask the easier one's test failures:
+  #
+  #   * `ct-test-release-gate` needs nothing but the codetracer dev shell. It is
+  #     the toolchain-light provider matrix plus the framework contract,
+  #     discovery, run-store and worker-pool suites.
+  #   * `ct-test-providers` drives real external toolchains AND three recorder
+  #     siblings (native/ct-mcr, JavaScript, Ruby), which have to be checked out
+  #     and built before the recording assertions can run.
+  #
+  # Neither job weakens what the scripts check: `CT_PROVIDERS_ALLOW_MISSING` and
+  # `CT_PROVIDERS_SKIP_SIBLINGS` are deliberately NOT set, so a recorder that is
+  # missing or fails to build fails the job instead of quietly turning the
+  # recording assertions into no-ops.
+  # ---------------------------------------------------------------------------
+  ct-test-release-gate:
+    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    name: ct-test release gate (M16 provider matrix)
+    steps:
+      - name: Mint installation token for cross-repo sibling access
+        # GitHub free plan restricts org-level secrets with visibility ALL from
+        # being readable inside private repos, so we mint per-run installation
+        # tokens from the repo-local CI_TOKEN_PROVIDER_APP_ID +
+        # CI_TOKEN_PROVIDER_PRIVATE_KEY secrets via the CI Token Provider App.
+        id: ci_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CI_TOKEN_PROVIDER_APP_ID }}
+          private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
+          owner: metacraft-labs
+
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          token: ${{ steps.ci_token.outputs.token }}
+
+      - name: Setup isonim siblings
+        # The gate's last two suites are ViewModel tests under
+        # src/frontend/viewmodel/, which build against ../isonim/src et al. via
+        # codetracer's top-level nim.cfg. Same prerequisite as `viewmodel-tests`.
+        uses: ./.github/actions/setup-isonim-siblings
+        with:
+          gh-token: ${{ steps.ci_token.outputs.token }}
+
+      - name: Install Nix
+        uses: ./.github/actions/setup-nix
+        with:
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
+
+      - name: Run the M16 ct-test release gate
+        # The ct_test sources import runquota_process; the dev shell exports
+        # RUNQUOTA_SRC (nix/shells/ci-base.nix) and src/ct_test/config.nims
+        # turns that into the --path set, so no runquota sibling checkout is
+        # needed here.
+        run: nix develop .#devShells.x86_64-linux.default --command just test-m16-release-gate
+
+  ct-test-providers:
+    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    name: ct-test cross-language provider gate
+    steps:
+      - name: Mint installation token for cross-repo sibling access
+        id: ci_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CI_TOKEN_PROVIDER_APP_ID }}
+          private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
+          owner: metacraft-labs
+          skip-token-revoke: false
+
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          token: ${{ steps.ci_token.outputs.token }}
+
+      - name: Setup dev env
+        # ci/test/ct-providers.sh requires three recorder siblings checked out
+        # at ../<repo> and builds each through its own pinned dev shell
+        # (scripts/build-siblings.sh -> `direnv exec <repo> just build`). Without
+        # them the script aborts in its very first suite, which is why it could
+        # never simply be dropped into an existing job.
+        #
+        # setup-dev-env clones them adjacent to this checkout at
+        # workspace-lock-pinned revisions — the same mechanism
+        # `visual-replay-regression-gate` and `test-non-gui` already use, so
+        # this is not new infrastructure. The trace-format / io-mon /
+        # stackable-hooks / nim-shm-queue entries are the native recorder's own
+        # build dependencies, mirroring the visual gate's sibling list.
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        with:
+          env-flavor: nix
+          gh-token: ${{ steps.ci_token.outputs.token }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          siblings: |
+            nim-everywhere
+            codetracer-trace-format
+            codetracer-trace-format-nim
+            io-mon
+            nim-shm-queue
+            nim-stackable-hooks
+            codetracer-native-recorder
+            codetracer-js-recorder
+            codetracer-ruby-recorder
+
+      - name: Allow direnv in the cloned recorder siblings
+        # scripts/build-siblings.sh runs every sibling build as
+        # `direnv exec <repo> …` so the repo's own flake pins its toolchain. A
+        # freshly cloned .envrc is in direnv's "blocked" state, so without this
+        # the build step fails (or silently falls back to the wrong PATH) —
+        # the same hazard `test-non-gui` handles for codetracer-beam-recorder.
+        run: |
+          set -euo pipefail
+          for sibling in codetracer-native-recorder codetracer-js-recorder codetracer-ruby-recorder; do
+            nix develop .#devShells.x86_64-linux.default -c \
+              direnv allow "${{ github.workspace }}/../${sibling}"
+          done
+
+      - name: Run the cross-language ct-test provider gate
+        # No CT_PROVIDERS_ALLOW_MISSING / CT_PROVIDERS_SKIP_SIBLINGS: a missing
+        # or unbuildable recorder must fail this job, not silently degrade the
+        # recording assertions into checks of nothing.
+        env:
+          CODETRACER_TRACE_FORMAT_NIM_SKIP_NIMBLE_INSTALL: "1"
+          CODETRACER_TRACE_FORMAT_NIM_EXTRA_PATHS: ${{ github.workspace }}/libs/nim-stew/stew:${{ github.workspace }}/libs/nim-stew
+        run: nix develop '.?submodules=1' --command just test-ct-providers
+
+      - name: Upload sibling build logs
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: ct-test-providers-sibling-logs
+          # scripts/build-siblings.sh captures each recorder build into
+          # .tools/build-siblings-logs/<repo>.log (LOG_DIR in that script);
+          # without them a sibling build failure reports only its exit code.
+          path: .tools/build-siblings-logs/
+          retention-days: 14
+          if-no-files-found: ignore
+
   publish-pypi:
     needs:
       - build-python-packages
@@ -3103,6 +3257,8 @@ jobs:
       - cross-process-linux
       - viewmodel-tests
       - visual-replay-regression-gate
+      - ct-test-release-gate
+      - ct-test-providers
       - windows-bootstrap-smoke
       - windows-named-pipe-tests
       - windows-rust-components

--- a/ci/test/ct-providers.sh
+++ b/ci/test/ct-providers.sh
@@ -19,6 +19,14 @@
 # fails the gate — recorder-dependent recording tests must never be skipped
 # silently.
 #
+# CI: the `ct-test-providers` job in .github/workflows/codetracer.yml runs this
+# script. That job checks the three recorder siblings out through setup-dev-env
+# at workspace-lock-pinned revisions and `direnv allow`s them, then invokes
+# `just test-ct-providers` with neither CT_PROVIDERS_SKIP_SIBLINGS nor
+# CT_PROVIDERS_ALLOW_MISSING set — a missing or unbuildable recorder fails the
+# job. The job is listed in ci/verdict/required-jobs.txt, so a run that skips it
+# is reported as lost coverage.
+#
 # Run this from inside the codetracer dev shell (which provides nim plus the
 # gtest/catch2/cmake/ninja toolchain and the CT_TEST_CC/CT_TEST_CXX +
 # CMAKE_PREFIX_PATH the C/C++ providers need):

--- a/ci/test/m16-release-gate.sh
+++ b/ci/test/m16-release-gate.sh
@@ -1,4 +1,16 @@
 #!/usr/bin/env bash
+# =============================================================================
+# M16 ct-test release gate: the toolchain-light provider matrix plus the
+# framework contract, discovery, run-store and worker-pool suites.
+#
+# CI: the `ct-test-release-gate` job in .github/workflows/codetracer.yml runs
+# this script. It needs only the codetracer dev shell (which exports
+# RUNQUOTA_SRC for the ct_test import paths) and the isonim siblings the two
+# ViewModel suites at the end build against — no recorder siblings. The
+# cross-language, recorder-dependent counterpart is ci/test/ct-providers.sh,
+# run by the `ct-test-providers` job. Both jobs are listed in
+# ci/verdict/required-jobs.txt.
+# =============================================================================
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"

--- a/ci/verdict/required-jobs.txt
+++ b/ci/verdict/required-jobs.txt
@@ -46,6 +46,13 @@ test-ui-tests-rr
 cross-process-linux
 viewmodel-tests
 visual-replay-regression-gate
+# ct-test's two gate scripts (ci/test/m16-release-gate.sh and
+# ci/test/ct-providers.sh) were maintained for months while no pipeline ran
+# either one, so "this suite is in the gate" was true while "the gate runs" was
+# false. Listing them here is what makes the second half true: a run in which
+# they are skipped or missing is reported as lost coverage, not as a pass.
+ct-test-release-gate
+ct-test-providers
 
 # --- platform lanes --------------------------------------------------
 windows-bootstrap-smoke

--- a/docs/ct-test-provider-guide.md
+++ b/docs/ct-test-provider-guide.md
@@ -31,6 +31,38 @@ in `newDefaultProviderRegistry()`. Capability flags must be exact:
 Conditional or toolchain-heavy providers must make the condition explicit in
 diagnostics and tests. Do not expose GUI actions for unsupported capabilities.
 
+## Enumerating Workspace Files
+
+A provider must **never** call `walkDirRec` (or any other unrestricted
+traversal) on the workspace root. Use `walkWorkspaceFiles(root)` from
+`src/ct_test/workspace_scope.nim` instead — `import ../discovery` re-exports it:
+
+```nim
+for path in walkWorkspaceFiles(projectRoot):
+  if isCandidateFile(path):
+    result.add path
+```
+
+Two reasons, both learned the expensive way:
+
+1. **Scope.** `walkWorkspaceFiles` yields only the files the workspace claims as
+   its own — it honours the project's `git ls-files --cached --others
+   --exclude-standard` inventory (full `.gitignore` chain, stops at nested
+   checkouts, keeps untracked-but-not-ignored files) and falls back to a pruning
+   filesystem walk elsewhere. A vendored upstream source tree such as
+   `references/llvm-project` is therefore invisible to every provider at once,
+   instead of each provider needing its own reject list — and forgetting.
+2. **Cost.** `discover --workspace` runs `detect` on every registered provider
+   and `discoverProject` on every one that claims the workspace. The scope is
+   resolved once per invocation and shared, so N providers cost one traversal
+   rather than N.
+
+A `detect` implementation that reads file *contents* to decide whether it owns
+the workspace is the most expensive probe in the registry. Prefer a project
+marker (`Cargo.toml`, `go.mod`, `package.json`, …) and treat the content scan as
+a last resort — and when you do scan, guard `readFile` so an unreadable file
+cannot abort discovery.
+
 ## Fixtures And Trace Smoke
 
 Every provider needs a representative fixture under `src/ct_test/fixtures/` or,
@@ -50,6 +82,9 @@ Use launcher-backed commands in docs and workflows:
 ```bash
 ct test discover --workspace . --json
 ct test discover --file path/to/test_file --json
+# Vendored/ignored trees are excluded by default. To reproduce the old
+# unrestricted enumeration (rarely what you want):
+ct test discover --workspace . --scope unscoped --json
 ct test run --test <selector>
 ct test record --test <selector>
 ```
@@ -66,6 +101,13 @@ Run:
 ```bash
 just test-m16-release-gate
 ```
+
+CI runs the same script in the `ct-test-release-gate` job of
+`.github/workflows/codetracer.yml`, and the cross-language counterpart
+(`just test-ct-providers`, which additionally builds the native/JS/Ruby
+recorder siblings) in `ct-test-providers`. Both are listed in
+`ci/verdict/required-jobs.txt`, so a run in which either is skipped is
+reported as lost coverage rather than as a pass.
 
 The gate fails on:
 

--- a/justfile
+++ b/justfile
@@ -663,6 +663,8 @@ test-visual-replay-gate:
   bash ci/test/visual-replay-gate.sh
 
 # Run the M16 ct-test provider matrix and release-gate checks.
+# CI runs this script in the required `ct-test-release-gate` job
+# (.github/workflows/codetracer.yml); it needs no recorder siblings.
 test-m16-release-gate:
   bash ci/test/m16-release-gate.sh
 
@@ -675,6 +677,9 @@ test-m16-release-gate:
 # already-built recorders. Run from inside the dev shell (it provides nim plus
 # the gtest/catch2/cmake/ninja toolchain and CMAKE_PREFIX_PATH / CT_TEST_C{C,XX}
 # the C/C++ providers need). See ci/test/ct-providers.sh.
+# CI runs this script in the required `ct-test-providers` job
+# (.github/workflows/codetracer.yml), which checks the recorder siblings out
+# via setup-dev-env first.
 test-ct-providers:
   bash ci/test/ct-providers.sh
 

--- a/src/ct_test/discovery.nim
+++ b/src/ct_test/discovery.nim
@@ -1,6 +1,9 @@
 import std/[algorithm, json, options, os, sha1, strutils, tables]
 
 import contracts
+import workspace_scope
+
+export workspace_scope
 
 type
   DiscoverScopeKind* = enum
@@ -12,6 +15,11 @@ type
     workspaceRoot*: string
     file*: string
     jsonOutput*: bool
+    scopeMode*: WorkspaceScopeMode
+      ## Which files discovery is allowed to look at. Defaults to ``wsmAuto``
+      ## (honour the workspace's VCS inventory, else a pruning walk); see
+      ## ``workspace_scope``. ``wsmUnscoped`` reproduces the pre-scoping
+      ## behaviour and must be asked for explicitly.
 
   DiscoverResponse* = object
     schemaVersion*: int
@@ -183,6 +191,26 @@ proc parseDiscoverArgs*(args: seq[string]): ProviderResult[DiscoverRequest] =
         inc i
     of "--json":
       request.jsonOutput = true
+    of "--scope":
+      # ``--scope <auto|vcs|walk|unscoped>``: opt OUT of the default scoping.
+      # There is deliberately no flag to opt *in* — a discovery surface whose
+      # default enumerates vendored upstream trees is a footgun, not a
+      # feature.
+      if i + 1 >= args.len:
+        diagnostics.add diagnostic(dsError, "missing value for --scope")
+      else:
+        let raw = args[i + 1]
+        if raw.strip.toLowerAscii notin
+            ["auto", "vcs", "walk", "unscoped", "off", "none"]:
+          diagnostics.add diagnostic(
+            dsError,
+            "invalid --scope value: " & raw &
+            " (expected auto, vcs, walk or unscoped)")
+        else:
+          request.scopeMode = parseWorkspaceScopeMode(raw)
+        inc i
+    of "--unscoped":
+      request.scopeMode = wsmUnscoped
     else:
       diagnostics.add diagnostic(
         dsError, "unknown discover argument: " & args[i])
@@ -239,6 +267,26 @@ proc discover*(
   if validationDiagnostics.len > 0:
     result.diagnostics = validationDiagnostics
     return
+
+  # Scoping is resolved ONCE per invocation and shared by every provider.
+  #
+  # ``wsmAuto`` means "no explicit request", so leave the thread-local mode
+  # cleared and let ``CT_TEST_SCOPE`` (if set) decide; anything else is an
+  # explicit caller decision that must win over the environment.
+  if request.scopeMode == wsmAuto:
+    clearWorkspaceScopeMode()
+  else:
+    setWorkspaceScopeMode(request.scopeMode)
+  invalidateWorkspaceScopes()
+
+  if request.scope == dskWorkspace:
+    # Report the scope before the providers run. A caller comparing this
+    # catalog against another runner's case list needs to see what discovery
+    # was allowed to look at, not just what it found.
+    let scope = workspaceScope(request.workspaceRoot)
+    result.diagnostics.add diagnostic(dsInfo, scope.scopeSummary)
+    for note in scope.notes:
+      result.diagnostics.add diagnostic(dsWarning, note)
 
   var supportedProviders = 0
   for provider in registry.providers:
@@ -372,7 +420,7 @@ proc fakeFileCatalog(providerInfo: TestProviderInfo; workspaceRoot,
 
 proc fakeProjectFiles(workspaceRoot: string): seq[string] =
   result = @[]
-  for path in walkDirRec(workspaceRoot):
+  for path in walkWorkspaceFiles(workspaceRoot):
     if fileExists(path) and path.endsWith(".fake") and
         splitFile(path).name != "ct-test":
       result.add path

--- a/src/ct_test/discovery_test.nim
+++ b/src/ct_test/discovery_test.nim
@@ -1,4 +1,4 @@
-import std/[json, os, osproc, strutils, tables, unittest]
+import std/[algorithm, json, os, osproc, strutils, tables, unittest]
 
 import contracts
 import discovery
@@ -323,6 +323,120 @@ quit(runCtTest(
     check second.catalogs.len == 0
     check messages(first).contains("provider parser failed")
     check messages(second).contains("provider parser failed")
+
+  test "workspace discovery excludes vendored subtrees and honours --scope":
+    ## Scoping regression guard.
+    ##
+    ## `ct test discover --workspace` used to hand every provider an
+    ## unrestricted `walkDirRec`, so a workspace that keeps vendored upstream
+    ## source trees in-tree had all of them enumerated as if they were its own
+    ## tests. On one real consumer that was 45,256 of 53,322 catalog items.
+    ##
+    ## The fixture reproduces the three shapes that produced those items:
+    ##   * `references/upstream/` — a nested VCS checkout (vendored source);
+    ##   * `node_modules/dep/`    — a package-manager dependency tree; and
+    ##   * `tests/own.fake`       — the workspace's actual test.
+    ## Only the last may appear in the catalog. The final leg re-runs the same
+    ## fixture with `--scope unscoped` and asserts the vendored items come
+    ## back: without it, an assertion that "the catalog has 1 item" would also
+    ## pass if discovery had simply stopped working.
+    let root = makeWorkspace("vendored")
+    defer: removeDir(root)
+    discard fakeFile(root, "tests/own.fake", markerLine = 1)
+    # A vendored upstream checkout: its own `.git` is what marks the boundary,
+    # exactly as `references/llvm-project` does in the real workspace.
+    createDir(root / "references" / "upstream" / ".git")
+    discard fakeFile(root, "references/upstream/tests/vendored.fake",
+      markerLine = 1)
+    discard fakeFile(root, "references/upstream/lib/deep/also_vendored.fake",
+      markerLine = 1)
+    # A dependency tree with no VCS metadata at all — caught by name.
+    discard fakeFile(root, "node_modules/dep/dep_test.fake", markerLine = 1)
+
+    let scoped = discover(
+      DiscoverRequest(scope: dskWorkspace, workspaceRoot: root,
+          jsonOutput: true),
+      m1Registry(newFakeProviderCounters()),
+      newDiscoveryCache())
+
+    check discoverExitCode(scoped) == 0
+    check scoped.catalogs.len == 1
+    var scopedFiles: seq[string] = @[]
+    for item in scoped.catalogs[0].items:
+      scopedFiles.add item.file
+    check scopedFiles == @["tests/own.fake"]
+    for path in scopedFiles:
+      check not path.startsWith("references/")
+      check not path.startsWith("node_modules/")
+    # The exclusion must be *reported*, not silent: a caller reconciling this
+    # catalog against another runner has to be able to see what was dropped.
+    let scopeMessages = messages(scoped)
+    check scopeMessages.contains("discovery scope:")
+    check scopeMessages.contains("references/upstream")
+    check scopeMessages.contains("node_modules")
+
+    let unscoped = discover(
+      DiscoverRequest(scope: dskWorkspace, workspaceRoot: root,
+          jsonOutput: true, scopeMode: wsmUnscoped),
+      m1Registry(newFakeProviderCounters()),
+      newDiscoveryCache())
+
+    check discoverExitCode(unscoped) == 0
+    check unscoped.catalogs.len == 1
+    var unscopedFiles: seq[string] = @[]
+    for item in unscoped.catalogs[0].items:
+      unscopedFiles.add item.file
+    unscopedFiles.sort(system.cmp[string])
+    check unscopedFiles == @[
+      "node_modules/dep/dep_test.fake",
+      "references/upstream/lib/deep/also_vendored.fake",
+      "references/upstream/tests/vendored.fake",
+      "tests/own.fake"]
+
+  test "workspace discovery honours the workspace's own VCS ignore rules":
+    ## The scoping rule deliberately does not invent a ct_test-specific ignore
+    ## file: it asks the workspace what it already considers its own, via
+    ## `git ls-files --cached --others --exclude-standard`. That buys the full
+    ## `.gitignore` chain (including nested files and negations) and — the
+    ## property this case pins — keeps *untracked but not ignored* files, so a
+    ## test written seconds ago is still discovered.
+    let root = makeWorkspace("vcs-ignore")
+    defer: removeDir(root)
+    let gitInit = execCmdEx("git init -q .", options = {poUsePath},
+      workingDir = root)
+    if gitInit.exitCode != 0:
+      skip()
+    else:
+      writeFixture(root / ".gitignore", "generated/\n*.tmp.fake\n")
+      discard fakeFile(root, "tests/tracked.fake", markerLine = 1)
+      discard fakeFile(root, "tests/untracked_but_visible.fake", markerLine = 1)
+      discard fakeFile(root, "generated/machine_written.fake", markerLine = 1)
+      discard fakeFile(root, "tests/scratch.tmp.fake", markerLine = 1)
+      # A dependency tree the workspace forgot to gitignore. The VCS inventory
+      # would happily list it (untracked, not ignored), so the built-in
+      # `VendorDirNames` prune has to apply to git-listed paths too — not only
+      # to the filesystem-walk fallback.
+      discard fakeFile(root, "node_modules/dep/vcs_dep.fake", markerLine = 1)
+      # Track only one of them: the others must still be classified correctly
+      # from their ignore status alone.
+      discard execCmdEx("git add tests/tracked.fake", options = {poUsePath},
+        workingDir = root)
+
+      let response = discover(
+        DiscoverRequest(scope: dskWorkspace, workspaceRoot: root,
+            jsonOutput: true),
+        m1Registry(newFakeProviderCounters()),
+        newDiscoveryCache())
+
+      check discoverExitCode(response) == 0
+      check response.catalogs.len == 1
+      var files: seq[string] = @[]
+      for item in response.catalogs[0].items:
+        files.add item.file
+      files.sort(system.cmp[string])
+      check files == @[
+        "tests/tracked.fake", "tests/untracked_but_visible.fake"]
+      check messages(response).contains("vcs-inventory")
 
   test "invalid workspace and file requests produce clear diagnostics":
     let root = makeWorkspace("invalid")

--- a/src/ct_test/frameworks/cpp_common.nim
+++ b/src/ct_test/frameworks/cpp_common.nim
@@ -61,7 +61,11 @@ proc isCppFile*(path: string): bool =
 proc cppFiles*(projectRoot: string): seq[string] =
   if not dirExists(projectRoot):
     return @[]
-  for path in walkDirRec(projectRoot):
+  # ``walkWorkspaceFiles`` (see ``workspace_scope``) yields only the files the
+  # workspace claims as its own, so vendored/ignored trees never reach the
+  # per-provider reject list below — which stays for build outputs the VCS
+  # inventory may still track.
+  for path in walkWorkspaceFiles(projectRoot):
     let rel = normalizedRelative(projectRoot, path)
     if rel.startsWith("build/") or rel.startsWith(".git/") or
         rel.startsWith("cmake-build-"):

--- a/src/ct_test/frameworks/crystal_spec.nim
+++ b/src/ct_test/frameworks/crystal_spec.nim
@@ -53,7 +53,7 @@ proc hasCrystalProject*(projectRoot: string): bool =
 proc crystalFiles*(projectRoot: string): seq[string] =
   if not dirExists(projectRoot):
     return @[]
-  for path in walkDirRec(projectRoot):
+  for path in walkWorkspaceFiles(projectRoot):
     let rel = normalizedRelative(projectRoot, path)
     if rel.startsWith("lib/") or rel.startsWith(".git/"):
       continue

--- a/src/ct_test/frameworks/d_unittest.nim
+++ b/src/ct_test/frameworks/d_unittest.nim
@@ -43,7 +43,7 @@ proc hasDProject*(projectRoot: string): bool =
 proc dFiles*(projectRoot: string): seq[string] =
   if not dirExists(projectRoot):
     return @[]
-  for path in walkDirRec(projectRoot):
+  for path in walkWorkspaceFiles(projectRoot):
     let rel = normalizedRelative(projectRoot, path)
     if rel.startsWith(".dub/") or rel.startsWith(".git/"):
       continue

--- a/src/ct_test/frameworks/go_test.nim
+++ b/src/ct_test/frameworks/go_test.nim
@@ -42,7 +42,7 @@ proc hasGoProject*(projectRoot: string): bool =
 proc goFiles*(projectRoot: string): seq[string] =
   if not dirExists(projectRoot):
     return @[]
-  for path in walkDirRec(projectRoot):
+  for path in walkWorkspaceFiles(projectRoot):
     let rel = normalizedRelative(projectRoot, path)
     if rel.startsWith("vendor/") or rel.startsWith(".git/"):
       continue

--- a/src/ct_test/frameworks/js_common.nim
+++ b/src/ct_test/frameworks/js_common.nim
@@ -81,7 +81,7 @@ proc isCandidateJsTestFile*(path: string): bool =
 proc jsFiles*(projectRoot: string): seq[string] =
   if not dirExists(projectRoot):
     return @[]
-  for path in walkDirRec(projectRoot):
+  for path in walkWorkspaceFiles(projectRoot):
     let rel = normalizedRelative(projectRoot, path)
     if rel.startsWith("node_modules/") or rel.startsWith("dist/") or
         rel.startsWith("build/"):

--- a/src/ct_test/frameworks/m12_fallback_common.nim
+++ b/src/ct_test/frameworks/m12_fallback_common.nim
@@ -82,7 +82,7 @@ proc isIgnored(spec: M12FallbackSpec; projectRoot, path: string): bool =
 proc sourceFiles*(spec: M12FallbackSpec; projectRoot: string): seq[string] =
   if not dirExists(projectRoot):
     return @[]
-  for path in walkDirRec(projectRoot):
+  for path in walkWorkspaceFiles(projectRoot):
     if fileExists(path) and spec.hasSupportedExtension(path) and
         not spec.isIgnored(projectRoot, path):
       result.add path

--- a/src/ct_test/frameworks/nim_unittest.nim
+++ b/src/ct_test/frameworks/nim_unittest.nim
@@ -480,7 +480,7 @@ proc isCandidateNimTestFile(path: string): bool =
   normalized.contains("/tests/") or filename.startsWith("test") or filename.endsWith("_test")
 
 proc nimProjectFiles(projectRoot: string): seq[string] =
-  for path in walkDirRec(projectRoot):
+  for path in walkWorkspaceFiles(projectRoot):
     if isCandidateNimTestFile(path):
       result.add path
   result.sort(system.cmp[string])
@@ -494,9 +494,22 @@ proc detectProject(projectRoot: string): ProviderResult[bool] =
   for kind, path in walkDir(projectRoot):
     if kind == pcFile and path.endsWith(".nimble"):
       return ProviderResult[bool](diagnostics: @[], value: true)
-  for path in walkDirRec(projectRoot):
+  # Last resort for a Nim workspace with no project marker at all: look for a
+  # unittest import in the sources themselves. This reads file contents, so it
+  # is the single most expensive probe in the registry — restricting it to the
+  # workspace's own files (rather than every ``.nim`` reachable from the root,
+  # vendored compiler checkouts included) is what keeps it affordable.
+  #
+  # A source file that cannot be read is not evidence either way; skipping it
+  # beats letting an ``IOError`` abort the whole discovery.
+  for path in walkWorkspaceFiles(projectRoot):
     if path.endsWith(".nim"):
-      let frameworks = detectFrameworksInContent(readFile(path))
+      var content = ""
+      try:
+        content = readFile(path)
+      except IOError, OSError:
+        continue
+      let frameworks = detectFrameworksInContent(content)
       if frameworks.len > 0:
         return ProviderResult[bool](diagnostics: @[], value: true)
   ProviderResult[bool](diagnostics: @[], value: false)

--- a/src/ct_test/frameworks/python_common.nim
+++ b/src/ct_test/frameworks/python_common.nim
@@ -1,5 +1,7 @@
 import std/[algorithm, os, sequtils, strutils, tables]
 
+import ../workspace_scope
+
 type
   PythonTestKind* = enum
     ptkClass
@@ -50,7 +52,10 @@ proc isCandidateUnittestFile*(path: string): bool =
 proc pythonFiles*(projectRoot: string; predicate: proc(path: string): bool {.gcsafe.}): seq[string] =
   if not dirExists(projectRoot):
     return @[]
-  for path in walkDirRec(projectRoot):
+  # This walk had NO exclusions at all, and ``isCandidateUnittestFile`` matches
+  # any name merely *containing* "test" — the combination is what turned a
+  # vendored LLVM checkout into tens of thousands of "the project's tests".
+  for path in walkWorkspaceFiles(projectRoot):
     if predicate(path):
       result.add path
   result.sort(system.cmp[string])

--- a/src/ct_test/frameworks/ruby_common.nim
+++ b/src/ct_test/frameworks/ruby_common.nim
@@ -88,7 +88,7 @@ proc rubyFiles*(projectRoot: string; predicate: proc(
     path: string): bool {.gcsafe.}): seq[string] =
   if not dirExists(projectRoot):
     return @[]
-  for path in walkDirRec(projectRoot):
+  for path in walkWorkspaceFiles(projectRoot):
     let rel = normalizedRelative(projectRoot, path)
     if rel.startsWith("vendor/") or rel.startsWith(".bundle/") or
         rel.startsWith("tmp/"):

--- a/src/ct_test/frameworks/rust_libtest.nim
+++ b/src/ct_test/frameworks/rust_libtest.nim
@@ -49,7 +49,7 @@ proc rustFiles*(projectRoot: string): seq[string] =
   for root in ["src", "tests"]:
     let dir = projectRoot / root
     if dirExists(dir):
-      for path in walkDirRec(dir):
+      for path in walkWorkspaceFiles(dir):
         if isRustFile(path):
           result.add path
   result.sort(system.cmp[string])

--- a/src/ct_test/frameworks/smart_contract_common.nim
+++ b/src/ct_test/frameworks/smart_contract_common.nim
@@ -167,7 +167,7 @@ proc fixtureFiles*(spec: SmartHarnessSpec; projectRoot: string): seq[string] =
     let root = repo / fixtureRoot
     if not dirExists(root):
       continue
-    for path in walkDirRec(root):
+    for path in walkWorkspaceFiles(root):
       if fileExists(path) and spec.hasExtension(path) and
           not spec.isIgnored(path):
         result.add path

--- a/src/ct_test/workspace_scope.nim
+++ b/src/ct_test/workspace_scope.nim
@@ -1,0 +1,389 @@
+## Shared, scoped enumeration of a workspace's *own* source files.
+##
+## Why this module exists
+## ---------------------
+## Every ct_test provider used to answer "which files are in this workspace?"
+## by calling ``std/os.walkDirRec(projectRoot)`` itself, each with its own
+## ad-hoc, inconsistent reject list (``js_common`` skipped ``node_modules/``,
+## ``go_test`` skipped ``vendor/``, ``python_common`` and ``nim_unittest``
+## skipped nothing at all). That had two consequences, both of which this
+## module exists to remove:
+##
+## 1. **Scope.** A workspace that keeps vendored upstream source trees in-tree
+##    — ``references/llvm-project``, ``references/buildxl``, … — had all of it
+##    enumerated as if it were the project's own test suite. On one real
+##    consumer that was 45,256 of 53,322 catalog items (84.9%): foreign code,
+##    reported as the project's tests, in a surface whose whole purpose is to
+##    tell a caller what this project's tests *are*.
+## 2. **Cost.** ``discover --workspace`` fans out to ~38 providers. With every
+##    provider running its own full recursive traversal (and several *reading
+##    every matching file* just to decide whether to claim the workspace), a
+##    single discovery performed dozens of full walks of a tree it had already
+##    walked. Sharing one pruned traversal collapses that to one.
+##
+## What counts as "the workspace's own files"
+## ------------------------------------------
+## Rather than invent a ct_test-specific ignore file that every project would
+## have to author and keep in sync, this module **honours the declaration the
+## workspace already maintains**: its version-control inventory.
+##
+## ``git ls-files --cached --others --exclude-standard`` is exactly the
+## question we want answered — "the files this project considers its own" —
+## and it comes with three properties no hand-rolled walk gets for free:
+##
+## * it applies the full ``.gitignore`` / ``.git/info/exclude`` /
+##   ``core.excludesFile`` chain, including negations and nested files;
+## * it stops at nested repository boundaries, so a vendored upstream checkout
+##   is reported as a single directory entry instead of being descended into
+##   (this is what excludes ``references/llvm-project`` even in a workspace
+##   that does not gitignore it); and
+## * it includes *untracked but not ignored* files, so a test written thirty
+##   seconds ago and not yet ``git add``-ed is still discovered — which a
+##   tracked-files-only query would have silently dropped.
+##
+## When the root is not inside a Git checkout (temp-dir fixtures, exported
+## tarballs, ``git`` unavailable), the module falls back to a pruning
+## filesystem walk that (a) refuses to descend into nested VCS checkouts and
+## (b) prunes a built-in list of directory names that never hold a project's
+## own tests (``VendorDirNames`` below). The built-in list is applied in *both*
+## modes, so an un-ignored ``node_modules`` is excluded either way.
+##
+## Escape hatch
+## ------------
+## Scoping is on by default — a default that enumerates 45k foreign items is a
+## footgun, and "remember to pass ``--exclude-vendored``" is not a fix. Callers
+## that genuinely want the old unscoped behaviour ask for it explicitly, via
+## ``setWorkspaceScopeMode(wsmUnscoped)`` (``ct-test test discover --unscoped``)
+## or the ``CT_TEST_SCOPE`` environment variable (``auto``/``vcs``/``walk``/
+## ``unscoped``).
+
+import std/[algorithm, os, sets, strutils, tables]
+
+import process_exec
+
+type
+  WorkspaceScopeMode* = enum
+    ## How the in-scope file set for a workspace root is decided.
+    wsmAuto = "auto"
+      ## VCS inventory when the root is inside a usable checkout, pruning
+      ## filesystem walk otherwise. The default.
+    wsmVcs = "vcs"
+      ## Require the VCS inventory; yield nothing rather than silently
+      ## widening to an unscoped walk. For callers that would rather see an
+      ## empty catalog than a wrong one.
+    wsmWalk = "walk"
+      ## Always use the pruning filesystem walk, even inside a checkout.
+    wsmUnscoped = "unscoped"
+      ## No scoping beyond skipping VCS metadata directories: the historical
+      ## ``walkDirRec`` behaviour, kept so a caller can reproduce it on purpose.
+
+  WorkspaceScopeSource* = enum
+    ## Which rule actually produced the file set (reported in diagnostics).
+    wssVcsInventory = "vcs-inventory"
+    wssFilesystemWalk = "filesystem-walk"
+    wssUnscopedWalk = "unscoped-walk"
+    wssUnavailable = "unavailable"
+
+  WorkspaceScope* = ref object
+    ## The resolved in-scope file set for one workspace root.
+    root*: string                 ## absolute, normalized
+    source*: WorkspaceScopeSource
+    files*: seq[string]           ## absolute paths, sorted, files only
+    excludedRoots*: seq[string]   ## root-relative subtrees that were pruned
+    notes*: seq[string]           ## human-readable scoping notes
+
+const
+  VendorDirNames*: array[28, string] = [
+    # Version-control metadata and nested-checkout markers.
+    ".git", ".hg", ".svn", ".jj", "_darcs",
+    # Dependency trees fetched by a package manager. Never first-party tests;
+    # ``vendor``/``third_party`` are the canonical in-tree vendoring names in
+    # Go, Ruby, PHP and C/C++ projects respectively.
+    "node_modules", "vendor", "third_party", "thirdparty", "nimbledeps",
+    # Language/tool caches.
+    "__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache",
+    ".tox", ".nox", ".eggs", "nimcache", ".cache",
+    # Virtual environments and per-directory environment managers.
+    ".venv", "venv", ".direnv", ".devenv",
+    # Editor/IDE and tool state.
+    ".idea", ".vs", ".vscode", ".gradle", ".terraform"]
+    ## Directory names pruned in every mode except ``wsmUnscoped``.
+    ##
+    ## Deliberately does NOT include build-output names (``build``, ``dist``,
+    ## ``target``, ``out``): those are already gitignored in real projects (so
+    ## the VCS inventory drops them anyway), several providers handle them
+    ## themselves, and they are plausible names for a first-party source
+    ## directory. Excluding them globally would trade one silent-wrong-answer
+    ## for another.
+
+  ScopeModeEnvVar* = "CT_TEST_SCOPE"
+    ## Environment override for the default mode, for embedders that cannot
+    ## reach ``setWorkspaceScopeMode`` (e.g. a provider suite invoked through a
+    ## shell wrapper).
+
+# ---------------------------------------------------------------------------
+# Process-wide (thread-local) state.
+#
+# ``TestProvider``'s callbacks receive only ``projectRoot: string``, so the
+# resolved scope cannot be threaded through them as a parameter without
+# changing the provider contract in ~30 modules. Instead the scope is
+# memoized here, keyed by absolute root, and ``discovery.discover`` calls
+# ``invalidateWorkspaceScopes`` once per invocation so a long-lived process
+# (the GUI's embedded ``ct test discover``) never serves a stale file set.
+#
+# Both are ``{.threadvar.}`` rather than plain globals: provider callbacks are
+# ``{.gcsafe.}``, and the run orchestrator executes them on a worker pool. A
+# thread-local memo is safe there by construction (no sharing, no lock), at the
+# cost of one extra ``git ls-files`` per thread that discovers.
+# ---------------------------------------------------------------------------
+var
+  scopeCache {.threadvar.}: Table[string, WorkspaceScope]
+  scopeModeOverride {.threadvar.}: WorkspaceScopeMode
+  scopeModeOverrideSet {.threadvar.}: bool
+
+proc parseWorkspaceScopeMode*(raw: string): WorkspaceScopeMode =
+  ## Parse a mode name; unknown values fall back to ``wsmAuto`` so a typo in
+  ## the environment degrades to the safe default instead of aborting.
+  case raw.strip.toLowerAscii
+  of "vcs": wsmVcs
+  of "walk": wsmWalk
+  of "unscoped", "off", "none": wsmUnscoped
+  else: wsmAuto
+
+proc setWorkspaceScopeMode*(mode: WorkspaceScopeMode) =
+  ## Pin the scoping mode for this thread and drop any memoized scopes
+  ## resolved under the previous mode.
+  scopeModeOverride = mode
+  scopeModeOverrideSet = true
+  scopeCache = initTable[string, WorkspaceScope]()
+
+proc clearWorkspaceScopeMode*() =
+  ## Return to ``CT_TEST_SCOPE``/``wsmAuto`` resolution. Exists so tests can
+  ## restore the default without leaking a pinned mode into the next case.
+  scopeModeOverrideSet = false
+  scopeCache = initTable[string, WorkspaceScope]()
+
+proc workspaceScopeMode*(): WorkspaceScopeMode =
+  if scopeModeOverrideSet: scopeModeOverride
+  else: parseWorkspaceScopeMode(getEnv(ScopeModeEnvVar, ""))
+
+proc invalidateWorkspaceScopes*() =
+  ## Drop every memoized scope. Called at the top of each ``discover`` so the
+  ## file set is re-resolved from the filesystem once per invocation while
+  ## still being shared by all providers within it.
+  scopeCache = initTable[string, WorkspaceScope]()
+
+proc isVendorDir(name: string): bool =
+  for vendored in VendorDirNames:
+    if name == vendored:
+      return true
+  false
+
+proc isNestedVcsRoot(path: string): bool =
+  ## A directory that carries its own VCS metadata is a separate checkout —
+  ## a vendored upstream tree, a submodule, or a ``repo``-tool sibling — not
+  ## part of the workspace under discovery. ``.git`` is a *file* for worktrees
+  ## and submodules, hence ``fileExists`` as well as ``dirExists``.
+  for marker in [".git", ".hg", ".svn", ".jj"]:
+    let candidate = path / marker
+    if dirExists(candidate) or fileExists(candidate):
+      return true
+  false
+
+proc relativeSlashPath(root, path: string): string =
+  relativePath(path, root).replace('\\', '/')
+
+proc walkPruned(root: string; prune: bool;
+                excluded: var seq[string]): seq[string] =
+  ## Iterative pre-order walk that *prunes the descent* rather than filtering
+  ## results after the fact. Pruning is the whole point: the previous
+  ## per-provider reject lists still paid to traverse ``node_modules`` and
+  ## every vendored checkout before discarding what they found.
+  result = @[]
+  var pending = @[root]
+  while pending.len > 0:
+    let dir = pending.pop()
+    var entries: seq[tuple[kind: PathComponent, path: string]] = @[]
+    try:
+      for kind, path in walkDir(dir):
+        entries.add (kind, path)
+    except OSError:
+      # An unreadable directory is not a reason to fail discovery; the caller
+      # sees a smaller file set and the note below explains nothing about it,
+      # so record it as an excluded root for visibility.
+      excluded.add relativeSlashPath(root, dir)
+      continue
+    for (kind, path) in entries:
+      case kind
+      of pcDir, pcLinkToDir:
+        let name = splitPath(path).tail
+        if prune and isVendorDir(name):
+          excluded.add relativeSlashPath(root, path)
+          continue
+        if name == ".git" or name == ".hg" or name == ".svn" or name == ".jj":
+          # Pruned even when ``prune`` is false: VCS metadata is never source.
+          continue
+        if prune and isNestedVcsRoot(path):
+          excluded.add relativeSlashPath(root, path)
+          continue
+        # Symlinked directories are not followed. ``walkDirRec``'s default
+        # ``followFilter`` is ``{pcDir}`` too, and following them turns a
+        # workspace with a self-referential link into an unbounded walk.
+        if kind == pcDir:
+          pending.add path
+      of pcFile:
+        result.add path
+      of pcLinkToFile:
+        # ``walkDirRec``'s default ``yieldFilter`` is ``{pcFile}``, which
+        # excludes symlinks; keep that so replacing the walk changes scope
+        # only, never the kind of entry a provider sees.
+        discard
+
+proc vcsInventory(root: string; excluded: var seq[string]):
+    tuple[ok: bool; files: seq[string]] =
+  ## Ask Git for the workspace's own files.
+  ##
+  ## ``git ls-files`` is scoped to the working directory it runs in, so a
+  ## ``--workspace`` pointing at a subdirectory of a checkout yields only that
+  ## subtree — no upward-walk heuristics needed here.
+  ##
+  ## ``-z`` because paths may contain anything but NUL (Git would otherwise
+  ## quote and escape non-ASCII names, and we would have to unescape them).
+  result = (ok: false, files: @[])
+  let run = execCaptured(
+    @["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+    cwd = root)
+  if run.exitCode != 0 or run.timedOut:
+    return
+  for raw in run.output.split('\0'):
+    if raw.len == 0:
+      continue
+    let absolute = root / raw
+    if dirExists(absolute):
+      # Git reports a nested checkout as a single directory entry rather than
+      # descending into it. That entry IS the vendored-tree boundary.
+      excluded.add raw.strip(trailing = true, chars = {'/'})
+      continue
+    if not fileExists(absolute):
+      # Deleted-but-still-indexed path; not something a provider can parse.
+      continue
+    var vendored = false
+    for segment in raw.split('/'):
+      if isVendorDir(segment):
+        vendored = true
+        break
+    if vendored:
+      continue
+    result.files.add normalizedPath(absolute)
+  result.ok = true
+
+proc resolveScope(root: string; mode: WorkspaceScopeMode): WorkspaceScope =
+  let normalizedRoot = normalizedPath(absolutePath(root))
+  result = WorkspaceScope(
+    root: normalizedRoot,
+    source: wssUnavailable,
+    files: @[],
+    excludedRoots: @[],
+    notes: @[])
+  if not dirExists(normalizedRoot):
+    result.notes.add "workspace scope: not a directory: " & normalizedRoot
+    return
+
+  if mode == wsmUnscoped:
+    result.source = wssUnscopedWalk
+    result.files = walkPruned(
+      normalizedRoot, prune = false, result.excludedRoots)
+    result.notes.add(
+      "workspace scope: unscoped walk requested; vendored and ignored trees " &
+      "are INCLUDED (" & $result.files.len & " files)")
+  else:
+    var usedVcs = false
+    if mode in {wsmAuto, wsmVcs}:
+      let inventory = vcsInventory(normalizedRoot, result.excludedRoots)
+      if inventory.ok and inventory.files.len > 0:
+        usedVcs = true
+        result.source = wssVcsInventory
+        result.files = inventory.files
+      elif inventory.ok and mode == wsmVcs:
+        # Explicitly asked for the VCS inventory and it is genuinely empty.
+        usedVcs = true
+        result.source = wssVcsInventory
+      elif inventory.ok:
+        # In a checkout, but it reports no files of its own — the usual cause
+        # is a workspace directory that its enclosing repository ignores.
+        # Widening to the filesystem walk beats reporting "no tests".
+        result.excludedRoots = @[]
+        result.notes.add(
+          "workspace scope: git reported no files under this root (is it " &
+          "ignored by an enclosing repository?); falling back to a pruning " &
+          "filesystem walk")
+      elif mode == wsmVcs:
+        result.notes.add(
+          "workspace scope: CT_TEST_SCOPE=vcs was requested but `git " &
+          "ls-files` did not succeed under " & normalizedRoot)
+        result.source = wssUnavailable
+        return
+
+    if not usedVcs:
+      result.excludedRoots = @[]
+      result.source = wssFilesystemWalk
+      result.files = walkPruned(
+        normalizedRoot, prune = true, result.excludedRoots)
+
+  result.files.sort(system.cmp[string])
+  result.excludedRoots.sort(system.cmp[string])
+  # Deduplicate: a path can be reported once per provider-visible route.
+  var seenFiles = initHashSet[string]()
+  var uniqueFiles: seq[string] = @[]
+  for path in result.files:
+    if not seenFiles.containsOrIncl(path):
+      uniqueFiles.add path
+  result.files = uniqueFiles
+  var seenExcluded = initHashSet[string]()
+  var uniqueExcluded: seq[string] = @[]
+  for path in result.excludedRoots:
+    if not seenExcluded.containsOrIncl(path):
+      uniqueExcluded.add path
+  result.excludedRoots = uniqueExcluded
+
+proc workspaceScope*(root: string): WorkspaceScope =
+  ## Resolve (and memoize for this thread) the in-scope file set for ``root``.
+  if scopeCache.len == 0:
+    scopeCache = initTable[string, WorkspaceScope]()
+  let key = normalizedPath(absolutePath(root))
+  if scopeCache.hasKey(key):
+    return scopeCache[key]
+  result = resolveScope(key, workspaceScopeMode())
+  scopeCache[key] = result
+
+proc scopeSummary*(scope: WorkspaceScope): string =
+  ## One-line, machine-greppable description of what discovery was allowed to
+  ## look at. Emitted as an ``info`` diagnostic by ``discovery.discover`` so a
+  ## caller comparing catalogs against another runner can see *why* a file set
+  ## is the size it is, instead of having to guess.
+  result = "discovery scope: " & $scope.files.len & " file(s) under " &
+    scope.root & " via " & $scope.source
+  if scope.excludedRoots.len > 0:
+    const MaxListed = 8
+    var listed: seq[string] = @[]
+    for i, path in scope.excludedRoots:
+      if i >= MaxListed:
+        listed.add "… and " & $(scope.excludedRoots.len - MaxListed) & " more"
+        break
+      listed.add path
+    result.add "; excluded vendored/nested trees: " & listed.join(", ")
+
+iterator walkWorkspaceFiles*(root: string): string =
+  ## Drop-in replacement for ``std/os.walkDirRec(root)`` restricted to the
+  ## workspace's own files.
+  ##
+  ## Providers call this instead of walking themselves, so (a) the traversal
+  ## happens once per root per discovery rather than once per provider, and
+  ## (b) a provider physically cannot enumerate a vendored tree even if it
+  ## forgets to add that tree to its own reject list.
+  ##
+  ## Yields absolute paths to *files* only (``walkDirRec`` yields directories
+  ## too under non-default flags; no ct_test caller used that).
+  let scope = workspaceScope(root)
+  for path in scope.files:
+    yield path


### PR DESCRIPTION
## Summary

`ct test discover --workspace` returned a catalog that was mostly other people's source code, took over ten minutes, and the two ct-test gate scripts that would have noticed were run by no pipeline.

## Defect 1 — discovery was unscoped

Every one of ~38 providers answered "which files are in this workspace?" with its own unrestricted `walkDirRec(projectRoot)` plus an ad-hoc reject list — `js_common` skipped `node_modules/`, `go_test` skipped `vendor/`, `python_common` and `nim_unittest` skipped nothing at all. That meant ~16 full recursive traversals during `detect` alone (several of which **read every matching file** to decide whether to claim the workspace) and ~21 more during `discoverProject`, with no sharing between them.

Measured against the `reprobuild` workspace, same binary, same providers:

| | before | after |
|---|---|---|
| catalogs | 10 | 3 |
| items | 53,349 | 8,093 |
| cases | — | 6,573 |
| from vendored `references/` | 45,256 (84.8%) | 0 |
| wall clock | 10m39.8s | ~2.3s |
| JSON | 59.4 MB | 9.8 MB |

The fix is one shared scope, resolved once per invocation, in `src/ct_test/workspace_scope.nim`. Rather than invent a ct_test ignore file that every project would have to author and keep in sync, it **honours the declaration the workspace already maintains**: `git ls-files --cached --others --exclude-standard`, run with cwd = the requested root. That brings

- the full `.gitignore` / `.git/info/exclude` / `core.excludesFile` chain, including negations and nested files;
- nested-repository boundaries — a vendored upstream checkout is reported as a single directory entry and never descended into, which is what excludes `references/llvm-project` even in a workspace that does not gitignore it; and
- untracked-but-not-ignored files, so a test written seconds ago and not yet `git add`-ed is still discovered.

Outside a checkout (temp-dir fixtures, exported tarballs, no `git`) the fallback is a walk that **prunes the descent** rather than filtering results, refusing to enter nested VCS roots and a built-in list of dependency/cache directory names. That built-in list applies in both modes, so an un-ignored `node_modules` is excluded either way. It deliberately does *not* include build-output names (`build`, `dist`, `target`, `out`) — those are gitignored in practice, several providers handle them already, and they are plausible first-party source directory names.

Providers now call `walkWorkspaceFiles(root)` instead of walking themselves, so a provider physically cannot enumerate a vendored tree even if it forgets its own reject list. The docs section in `docs/ct-test-provider-guide.md` makes that a requirement for new providers.

Scoping is **opt-out, not opt-in**: `--scope auto|vcs|walk|unscoped` (or `CT_TEST_SCOPE`) restores the old enumeration for callers that want it. An `info` diagnostic reports what discovery was allowed to look at and which subtrees were dropped, so the exclusion is never silent:

```
discovery scope: 3784 file(s) under /…/reprobuild via vcs-inventory
```

### Regression test

Two cases at the end of `src/ct_test/discovery_test.nim` — already in both gate scripts, so they need no separate wiring. The first builds a fixture with a nested-`.git` vendored subtree and a `node_modules` tree and asserts neither reaches the catalog, that the exclusion is reported, and — the leg that stops "the catalog has 1 item" from passing because discovery broke — that `--scope unscoped` brings all four files back. The second pins the VCS-inventory path against a real `git init` fixture: gitignored files out, untracked-but-not-ignored files in.

Mutation-verified against 7 mutations, each caught:

| mutation | caught by |
|---|---|
| drop the nested-VCS prune | vendored files reappear in the catalog |
| drop the `VendorDirNames` prune (walk mode) | `node_modules` reappears |
| drop `--exclude-standard` | gitignored fixtures reappear |
| drop `--others` | the untracked-but-real test vanishes |
| ignore the `--scope unscoped` branch | escape hatch returns the scoped set |
| stop emitting the scope diagnostic | exclusion becomes silent |
| drop `VendorDirNames` on git-listed paths | *initially not caught* — test extended, then caught |

## Defect 2 — the gates were run by nothing

`ci/test/m16-release-gate.sh` and `ci/test/ct-providers.sh` are real, maintained scripts that no pipeline invoked. `.gitlab-ci.yml`'s only test jobs are `just test` (= `test-rust` + `test-nimsuggest` + optional cross-repo) and `ci/test/ui-tests.sh`; no GitHub workflow named either script. Every suite in them — not just the recently added one — has been in a gate that never gated.

They are now two jobs in `.github/workflows/codetracer.yml`, split because their prerequisites differ and mixing them would let the harder one's infrastructure failures mask the easier one's test failures:

- **`ct-test-release-gate`** — `just test-m16-release-gate`. Needs only the dev shell (which exports `RUNQUOTA_SRC`) plus the isonim siblings its two ViewModel suites build against.
- **`ct-test-providers`** — `just test-ct-providers`. Checks the three recorder siblings out through `setup-dev-env` at workspace-lock-pinned revisions (the same mechanism `visual-replay-regression-gate` and `test-non-gui` already use — not new infrastructure), `direnv allow`s them so `scripts/build-siblings.sh` can drive their own pinned dev shells, and uploads the per-recorder build logs on failure.

Neither job weakens what the scripts check: `CT_PROVIDERS_ALLOW_MISSING` and `CT_PROVIDERS_SKIP_SIBLINGS` are deliberately unset, so a missing or unbuildable recorder fails the job rather than hollowing the recording assertions out into checks of nothing.

Both are listed in `ci/verdict/required-jobs.txt` and in `ci-verdict`'s `needs:`, so a run in which either is skipped or missing is reported as lost coverage rather than as a pass. `ci/verdict/required-jobs-test.sh` passes, including its "every manifest job id exists in codetracer.yml" and "ci-verdict declares every manifest job in needs:" contracts.

`.gitlab-ci.yml` is deliberately left alone: its last change to a test job was 2026-02, and adding a gate to a dormant pipeline would reproduce the defect being fixed rather than repair it.

## Claims checked

The claim at `justfile:661` — *"Run the MCR visual replay regression gate used by CI"* — is **correct as written**: `.github/workflows/codetracer.yml` runs `just test-visual-replay-gate` in the required `visual-replay-regression-gate` job, which is listed in `required-jobs.txt`. It was not corrected because there was nothing wrong with it. The neighbouring recipes made no CI claim; they now carry one, and it is true.

`docs/ct-test-provider-guide.md` described itself as "the release-gated checklist" while nothing enforced the gate; it now names the jobs that do.

## Verification

- `src/ct_test/discovery_test.nim` — 10/10, including the two new scoping cases
- `contracts_test`, `nim_unittest_provider_test`, `python_providers_test`, `rust_libtest_provider_test`, `playwright_provider_test`, `run_store_test`, `release_gate_test` — all green
- `nim c src/ct_test/ct_test.nim` — builds clean; no new warnings (the unused-import set is byte-identical to `dev`)
- `bash ci/verdict/required-jobs-test.sh` — 12/12 contracts hold
- `shellcheck` clean on both edited gate scripts
- Before/after discovery measured end-to-end on the `reprobuild` workspace with binaries built from `dev` and from this branch

## Not fixed here

`assembly-fallback` claims two `.s` files under `tests/fixtures/` as test cases, and `python_common.isCandidateUnittestFile` matches any filename merely *containing* "test". Those are provider heuristics, not scoping, and are left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
