### PR TITLE
fix(ci): provision cross-repo siblings without an external lock lookup

### DIFF
--- a/.github/actions/setup-db-backend-siblings/action.yml
+++ b/.github/actions/setup-db-backend-siblings/action.yml
@@ -25,9 +25,13 @@ runs:
   using: composite
   steps:
     - name: Setup dev env (clone db-backend siblings + install Nix)
-      # setup-dev-env resolves each sibling's revision from the per-commit
-      # repo-workspaces workspace lock (the single approved source of sibling
-      # revisions) and clones it to ../<name>. codetracer-native-recorder /
+      # setup-dev-env clones each sibling to ../<name> at its pinned `dev`
+      # ref. The refs are explicit because a bare entry resolves through a
+      # per-commit workspace lock in the shared manifests repo, which has
+      # published nothing since 2026-08-02 -- see the note at the top of
+      # .github/workflows/codetracer.yml. This composite is used by six jobs,
+      # and every one of them died in this step until the refs were pinned.
+      # codetracer-native-recorder /
       # codetracer-trace-format / codetracer-trace-format-nim have no
       # .gitmodules; the recursive-submodule update is best-effort and a
       # no-op for them. The bespoke "direnv allow" fixup that used to live
@@ -40,6 +44,6 @@ runs:
         substituters: ${{ inputs.substituters }}
         trusted-public-keys: ${{ inputs.trusted-public-keys }}
         siblings: |
-          codetracer-trace-format
-          codetracer-trace-format-nim
-          codetracer-native-recorder
+          codetracer-trace-format=dev
+          codetracer-trace-format-nim=dev
+          codetracer-native-recorder=dev

--- a/.github/workflows/beam-flow.yml
+++ b/.github/workflows/beam-flow.yml
@@ -33,11 +33,11 @@ on:
   workflow_dispatch:
     inputs:
       beam_recorder_ref:
-        description: 'codetracer-beam-recorder ref (default: workspace lock)'
+        description: 'codetracer-beam-recorder ref (default: dev)'
         required: false
         default: ''
       trace_format_ref:
-        description: 'codetracer-trace-format ref (default: workspace lock)'
+        description: 'codetracer-trace-format ref (default: dev)'
         required: false
         default: ''
 
@@ -66,12 +66,12 @@ jobs:
       - name: Setup dev env
         # setup-dev-env installs Nix (with the Attic substituter/keys) and
         # clones the cross-repo siblings adjacent to this checkout at the
-        # workspace-lock-pinned revisions, replacing the former
+        # pinned `dev` refs, replacing the former
         # Checkout-manifests / Resolve-lock / Resolve-refs / clone-repo
         # machinery. The beam_recorder_ref / trace_format_ref
-        # workflow_dispatch inputs override the locked revisions (empty =>
-        # lock). codetracer-trace-format is also cloned as a sibling here so
-        # its workspace-locked SHA is available for the in-repo
+        # workflow_dispatch inputs override the refs (empty => `dev`).
+        # codetracer-trace-format is also cloned as a sibling here so
+        # its pinned SHA is available for the in-repo
         # libs/codetracer-trace-format swap below (the beam recorder reads
         # the in-repo path, not the sibling).
         uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
@@ -81,13 +81,13 @@ jobs:
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
           siblings: |
-            codetracer-beam-recorder=${{ github.event.inputs.beam_recorder_ref }}
-            codetracer-trace-format=${{ github.event.inputs.trace_format_ref }}
+            codetracer-beam-recorder=${{ github.event.inputs.beam_recorder_ref || 'dev' }}
+            codetracer-trace-format=${{ github.event.inputs.trace_format_ref || 'dev' }}
 
       - name: Swap libs/codetracer-trace-format for the pinned sibling clone
         # The beam recorder's trace shim reuses the shared CTFS writer at
         # the in-repo path libs/codetracer-trace-format. setup-dev-env
-        # cloned codetracer-trace-format at the workspace-locked (or
+        # cloned codetracer-trace-format at the pinned `dev` (or
         # dispatch-overridden) revision adjacent to this checkout; mirror
         # it into libs/ so the recorder build picks up the pinned source
         # instead of the submodule-pinned copy.

--- a/.github/workflows/beam-flow.yml
+++ b/.github/workflows/beam-flow.yml
@@ -50,18 +50,33 @@ jobs:
     runs-on: eph-linux-x64  # CIP-5: nix job → eph-linux-x64
 
     steps:
-      - name: Checkout codetracer
-        uses: actions/checkout@v5
-        with:
-          submodules: recursive
-
       - name: Generate CI token
+        # MUST precede the checkout. `submodules: recursive` pulls
+        # `libs/tree-sitter-nim`, which is PRIVATE, so an unauthenticated
+        # checkout cannot see it and the whole step dies before anything else
+        # in this workflow runs:
+        #
+        #   remote: Repository not found.
+        #   fatal: clone of 'https://github.com/metacraft-labs/tree-sitter-nim.git'
+        #     into submodule path '.../libs/tree-sitter-nim' failed
+        #
+        # This workflow is path-filtered onto BEAM-related files, so it had not
+        # been triggered in the window where anyone was watching; the ordering
+        # defect meant it could never have checked out if it had been.
+        # `cross-repo-tests.yml` already mints its token first and passes it —
+        # this is that same shape.
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ vars.CI_TOKEN_PROVIDER_APP_ID }}
           private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
           owner: metacraft-labs
+
+      - name: Checkout codetracer
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup dev env
         # setup-dev-env installs Nix (with the Attic substituter/keys) and

--- a/.github/workflows/beam-flow.yml
+++ b/.github/workflows/beam-flow.yml
@@ -95,9 +95,32 @@ jobs:
           gh-token: ${{ steps.app-token.outputs.token }}
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          # codetracer-trace-format-nim is the second half of a MATCHED FFI PAIR
+          # and must be provisioned wherever codetracer-trace-format is built.
+          # codetracer-beam-recorder's Cargo.toml path-depends on
+          # `../codetracer-trace-format/codetracer_trace_writer_nim`, and that
+          # crate's build.rs resolves the Nim entry point as a SIBLING of
+          # codetracer-trace-format, hard-erroring when it is absent:
+          #
+          #   Nim FFI entry point not found at
+          #   .../codetracer-trace-format-nim/src/codetracer_trace_writer_ffi.nim
+          #   -- is the codetracer-trace-format-nim repo checked out as a sibling?
+          #
+          # Not yet observed in THIS job only because it currently dies earlier,
+          # at `cargo: command not found` (run 31719867251, job 94513828329); the
+          # build that would hit it never starts. It is observed in the identical
+          # path-dep from codetracer-shell-recorders (run 31719867246, job
+          # 94513828226, step "Build shell trace writer").
+          #
+          # Pinned `=dev` rather than reusing `trace_format_ref`: that input names
+          # a ref in the *Rust* repo and must not be applied to a different
+          # repository. A dispatch overriding trace_format_ref therefore still
+          # moves only one half of the pair -- a pre-existing gap in this
+          # workflow's dispatch interface, recorded rather than silently widened.
           siblings: |
             codetracer-beam-recorder=${{ github.event.inputs.beam_recorder_ref || 'dev' }}
             codetracer-trace-format=${{ github.event.inputs.trace_format_ref || 'dev' }}
+            codetracer-trace-format-nim=dev
 
       - name: Swap libs/codetracer-trace-format for the pinned sibling clone
         # The beam recorder's trace shim reuses the shared CTFS writer at

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -2515,9 +2515,23 @@ jobs:
           gh-token: ${{ steps.app-token.outputs.token }}
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          # MATCHED FFI PAIR. The "Build codetracer-beam-recorder (nixos)" step
+          # below already documents that this recorder "transitively
+          # path-depends on codetracer-trace-format/codetracer_trace_writer_nim"
+          # -- that crate's build.rs also needs the Nim half checked out as a
+          # SIBLING of codetracer-trace-format, and hard-errors without it:
+          #
+          #   Nim FFI entry point not found at
+          #   .../codetracer-trace-format-nim/src/codetracer_trace_writer_ffi.nim
+          #
+          # Observed via the identical path-dep from codetracer-shell-recorders
+          # (run 31719867246, job 94513828226). Pinned by the
+          # "codetracer-trace-format implies codetracer-trace-format-nim"
+          # assertion in ci/test/sibling-provisioning-test.sh.
           siblings: |
             codetracer-beam-recorder=dev
             codetracer-trace-format=dev
+            codetracer-trace-format-nim=dev
 
       - name: Allow direnv in cloned codetracer-beam-recorder
         # ``elixir_flow_dap_test.rs`` / ``erlang_flow_dap_test.rs``

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -3760,3 +3760,73 @@ jobs:
         run: |
           printf '%s' "$NEEDS_JSON" > "${RUNNER_TEMP}/needs.json"
           bash ci/verdict/required-jobs.sh --needs-json "${RUNNER_TEMP}/needs.json"
+
+  workspace-lock-freshness:
+    # Alarm, not a gate: is the shared manifests repo still receiving workspace
+    # locks for this repo's commits?
+    #
+    # Until 2026-08-04 that question was answered as a side effect —
+    # `setup-dev-env` resolved every cross-repo sibling from the per-commit
+    # lock, so an unlocked commit could not get past `Setup dev env`. That
+    # coupling was a terrible gate (six jobs dead in their first real step, nine
+    # more `skipped`, for eight days) and the `siblings:` entries above now name
+    # their refs explicitly so it cannot recur. But it was also the only thing
+    # anyone was watching, and the condition it was accidentally reporting is
+    # not small: nothing has been committed to the manifests repo, for ANY repo,
+    # since 2026-08-02. Those locks are what make a published workspace state
+    # reproducible, so the stall means no reproducible snapshot exists for any
+    # commit in that window.
+    #
+    # Fixing the pipeline must not be the thing that hides that. Hence a job
+    # with its own name, red on every run while the stall lasts.
+    #
+    # NOTHING declares `needs:` on this job, and it is deliberately absent from
+    # `ci/verdict/required-jobs.txt`. A red check here must never be able to
+    # skip a test job — coupling lock publication to the test suite is exactly
+    # the defect being undone, and re-introducing it as a gate would trade an
+    # eight-day outage for the next one. Loud, and structurally incapable of
+    # cascading.
+    #
+    # Stock ubuntu-latest, bash + git only: like `ci-verdict`, a watchdog must
+    # not share the failure mode it watches for.
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Mint installation token for the manifests repo
+        id: ci_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CI_TOKEN_PROVIDER_APP_ID }}
+          private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
+          owner: metacraft-labs
+
+      - name: Checkout
+        # depth 2 so HEAD's first parent is present: that is the second
+        # candidate, and the one that kept `dev` resolvable for exactly one
+        # commit after publication stopped.
+        uses: actions/checkout@v5
+        with:
+          submodules: false
+          fetch-depth: 2
+
+      - name: Clone the manifests repo
+        env:
+          GH_TOKEN: ${{ steps.ci_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          git clone --quiet --branch latest \
+            "https://x-access-token:${GH_TOKEN}@github.com/metacraft-labs/metacraft-manifests.git" \
+            "${RUNNER_TEMP}/metacraft-manifests"
+
+      - name: Assert this commit has a published workspace lock
+        run: |
+          set -uo pipefail
+          # HEAD plus its first parent — the same two candidates clone-siblings
+          # probes. `git rev-parse HEAD^` is empty for a root commit or if the
+          # fetch depth did not reach the parent; the script ignores empty and
+          # all-zero candidates.
+          PARENT="$(git rev-parse --verify --quiet HEAD^ || true)"
+          bash ci/verdict/workspace-lock-freshness.sh \
+            --manifest-dir "${RUNNER_TEMP}/metacraft-manifests" \
+            --sha "${GITHUB_SHA}" \
+            --sha "${PARENT}"

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -3275,6 +3275,26 @@ jobs:
         # this is not new infrastructure. The trace-format / io-mon /
         # stackable-hooks / nim-shm-queue entries are the native recorder's own
         # build dependencies, mirroring the visual gate's sibling list.
+        #
+        # codetracer-native-backend is listed for the NATIVE RECORDER's sake,
+        # not this job's: `build-siblings.sh` runs `just build-ct-mcr`, whose
+        # `build-license-ffi` recipe opens with
+        # `cd ../codetracer-native-backend && ...` to build `ct_license_ffi` out
+        # of the backend checkout. Without it:
+        #
+        #   sh: line 1: cd: ../codetracer-native-backend: No such file or directory
+        #   error: could not find `Cargo.toml` in `.../codetracer-native-recorder`
+        #   error: Recipe `build-license-ffi` failed on line 123 with exit code 101
+        #
+        # The recipe `&&`-chains only its first link and uses `;` after, so the
+        # failed `cd` does not abort it -- cargo just runs in the recorder root,
+        # which has no root Cargo.toml, and the error names the wrong repo.
+        #
+        # A gap in this list, not in the lock: the recipe is byte-identical at
+        # the last lock-pinned recorder revision (196f95c9, 2026-07-07) and at
+        # today's `dev`, and neither revision has a root Cargo.toml, so the
+        # lock-pinned build would have failed the same way. It stayed invisible
+        # because this job could not get past `Setup dev env` to reach it.
         uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
         with:
           env-flavor: nix
@@ -3291,6 +3311,7 @@ jobs:
             codetracer-native-recorder=dev
             codetracer-js-recorder=dev
             codetracer-ruby-recorder=dev
+            codetracer-native-backend=dev
 
       - name: Allow direnv in the cloned recorder siblings
         # scripts/build-siblings.sh runs every sibling build as

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -3138,6 +3138,7 @@ jobs:
             codetracer-trace-format-nim=dev
             io-mon=dev
             nim-shm-queue=dev
+            nim-shm-gset=dev
             nim-stackable-hooks=dev
             codetracer-visual-replay=dev
             codetracer-native-backend=dev
@@ -3415,6 +3416,7 @@ jobs:
             codetracer-trace-format-nim=dev
             io-mon=dev
             nim-shm-queue=dev
+            nim-shm-gset=dev
             nim-stackable-hooks=dev
             codetracer-native-recorder=dev
             codetracer-js-recorder=dev

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -2711,9 +2711,40 @@ jobs:
           cp -a "$SRC" "$DEST"
 
       # --- NixOS setup ---
+
+      - name: Stage codetracer-trace-format-nim into libs/
+        # codetracer-trace-format and codetracer-trace-format-nim are a MATCHED
+        # PAIR across an FFI boundary, and must move together or not at all.
+        # `codetracer-trace-format/codetracer_trace_writer_nim/src/lib.rs` is the
+        # Rust caller; `codetracer-trace-format-nim/src/codetracer_trace_writer_ffi.nim`
+        # is the Nim provider. Overriding only the first one links the newer
+        # caller against the older provider:
+        #
+        #   libcodetracer_trace_writer_nim...rcgu.o: in function
+        #     `codetracer_trace_writer_nim::NimTraceReaderHandle::event_metadata':
+        #     undefined reference to `ct_reader_event_metadata'
+        #   error: could not compile `replay-server` (bin "replay-server")
+        #
+        # `ct_reader_event_metadata` was added to the Nim side on 2026-08-07;
+        # flake.lock pins that repo at 839ed880 (2026-06-24), which does not
+        # define it.
+        #
+        # This is what the per-commit workspace lock was actually buying: not a
+        # pinned SHA, but COORDINATION across repos -- it moved both halves to
+        # one consistent revision. Pinning each sibling independently to `dev`
+        # keeps them current and loses that coordination, so the pair has to be
+        # overridden together, explicitly.
+        shell: bash
+        run: |
+          set -euo pipefail
+          SRC="${{ github.workspace }}/../codetracer-trace-format-nim"
+          DEST="${{ github.workspace }}/libs/codetracer-trace-format-nim"
+          rm -rf "$DEST"
+          cp -a "$SRC" "$DEST"
+
       - name: Build CodeTracer (nix)
         if: matrix.platform == 'nixos'
-        run: nix build --print-build-logs '.?submodules=1#codetracer' --override-input codetracer-trace-format path:./libs/codetracer-trace-format
+        run: nix build --print-build-logs '.?submodules=1#codetracer' --override-input codetracer-trace-format path:./libs/codetracer-trace-format --override-input codetracer-trace-format-nim path:./libs/codetracer-trace-format-nim
 
       # --- macOS setup ---
       # The macOS leg is the explicitly non-nix build path on the hosted
@@ -2934,6 +2965,7 @@ jobs:
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
           siblings: |
             codetracer-trace-format=dev
+            codetracer-trace-format-nim=dev
 
       - name: Stage codetracer-trace-format into libs/
         # The flake override below points at ./libs/codetracer-trace-format;
@@ -2946,8 +2978,39 @@ jobs:
           rm -rf "$DEST"
           cp -a "$SRC" "$DEST"
 
+
+      - name: Stage codetracer-trace-format-nim into libs/
+        # codetracer-trace-format and codetracer-trace-format-nim are a MATCHED
+        # PAIR across an FFI boundary, and must move together or not at all.
+        # `codetracer-trace-format/codetracer_trace_writer_nim/src/lib.rs` is the
+        # Rust caller; `codetracer-trace-format-nim/src/codetracer_trace_writer_ffi.nim`
+        # is the Nim provider. Overriding only the first one links the newer
+        # caller against the older provider:
+        #
+        #   libcodetracer_trace_writer_nim...rcgu.o: in function
+        #     `codetracer_trace_writer_nim::NimTraceReaderHandle::event_metadata':
+        #     undefined reference to `ct_reader_event_metadata'
+        #   error: could not compile `replay-server` (bin "replay-server")
+        #
+        # `ct_reader_event_metadata` was added to the Nim side on 2026-08-07;
+        # flake.lock pins that repo at 839ed880 (2026-06-24), which does not
+        # define it.
+        #
+        # This is what the per-commit workspace lock was actually buying: not a
+        # pinned SHA, but COORDINATION across repos -- it moved both halves to
+        # one consistent revision. Pinning each sibling independently to `dev`
+        # keeps them current and loses that coordination, so the pair has to be
+        # overridden together, explicitly.
+        shell: bash
+        run: |
+          set -euo pipefail
+          SRC="${{ github.workspace }}/../codetracer-trace-format-nim"
+          DEST="${{ github.workspace }}/libs/codetracer-trace-format-nim"
+          rm -rf "$DEST"
+          cp -a "$SRC" "$DEST"
+
       - name: Build CodeTracer
-        run: nix build --print-build-logs '.?submodules=1#codetracer' --override-input codetracer-trace-format path:./libs/codetracer-trace-format
+        run: nix build --print-build-logs '.?submodules=1#codetracer' --override-input codetracer-trace-format path:./libs/codetracer-trace-format --override-input codetracer-trace-format-nim path:./libs/codetracer-trace-format-nim
 
       - name: Setup rr-backend
         # `ci/setup-rr-backend.sh` resolves codetracer-native-backend's revision

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -12,6 +12,45 @@ permissions:
   id-token: write
 
 jobs:
+  # WHY EVERY `siblings:` ENTRY CARRIES AN EXPLICIT `=dev` REF.
+  #
+  # `metacraft-github-actions/setup-dev-env` clones cross-repo siblings via its
+  # `clone-siblings` sub-action. A bare entry (`codetracer-trace-format`) asks
+  # that action to resolve the revision from a *workspace lock* — a per-commit
+  # snapshot published to `metacraft-labs/metacraft-manifests@latest` by the
+  # workspace tooling's pre-push hook. An entry of the form `name=ref` skips
+  # that lookup and clones `ref` directly.
+  #
+  # Lock publication for this repo stopped on 2026-08-02 (last entry:
+  # `locks/dev/codetracer/784c9bda…​.xml`). `clone-siblings` probes the pushed
+  # commit and its parent only (`--no-walk`), so `dev` stayed resolvable for
+  # exactly one more commit and then broke: 8d587343 (parent 784c9bda) was the
+  # last green `Setup dev env`; 3583cd6b (run 30951549711, 2026-08-04) was the
+  # first red one, and every push since has failed the same way:
+  #
+  #   ##[error]No workspace lock for codetracer (candidates: <sha> <parent>).
+  #   Neither a repo-workspaces locks/<project>/codetracer/<sha>.xml nor a
+  #   reprobuild locks/<project>/codetracer/<sha>.toml exists in
+  #   metacraft-labs/metacraft-manifests@latest.
+  #
+  # That took out `lint-rust`, `test-non-gui`, `test-ui-tests` (both legs),
+  # `test-ui-tests-rr`, `visual-replay-regression-gate` and `ct-test-providers`
+  # in their first real step, which in turn left nine jobs declaring `needs:` on
+  # them `skipped` — the exact "the tests never ran" state `ci-verdict` exists
+  # to name.
+  #
+  # Restoring lock publication is an infrastructure task outside this repo (the
+  # workspace moved from repo-workspaces to reprobuild and the manifests repo
+  # has received nothing since). Until it is restored, siblings are pinned to
+  # the branch the lock itself recorded for every one of them (`upstream="dev"`
+  # in 784c9bda's lock), which is also what the lock-free paths in this file
+  # already do — `.github/actions/setup-isonim-siblings` and the `clone-repo`
+  # steps in `viewmodel-tests` / `test-non-gui` all clone `ref: dev`.
+  #
+  # This changes WHERE a revision comes from, not WHICH repos are provisioned
+  # or what any job asserts. When locks are published again, dropping the
+  # `=dev` suffixes restores per-commit pinning.
+  #
   # NOTE (CIP-5 Wave 4): the whole Windows platform was migrated as a single
   # unit (honoring the prior "move the whole platform or none of it" rule) from
   # the GitHub-hosted `windows-latest` onto the self-hosted `eph-win-x64`
@@ -728,7 +767,7 @@ jobs:
 
       - name: Setup dev env
         # setup-dev-env (windows-diy) clones the cross-repo siblings adjacent
-        # to this checkout at the workspace-lock-pinned revisions and sources
+        # to this checkout at their pinned `dev` refs and sources
         # env.ps1, whose ensure-* helpers provision the Windows toolchain
         # (capnp / cargo / nim / nimble), persisting the env to GITHUB_ENV /
         # GITHUB_PATH for subsequent steps. This replaces the former
@@ -740,9 +779,9 @@ jobs:
           env-flavor: windows-diy
           gh-token: ${{ steps.app-token.outputs.token }}
           siblings: |
-            codetracer-trace-format
-            codetracer-trace-format-nim
-            codetracer-native-recorder
+            codetracer-trace-format=dev
+            codetracer-trace-format-nim=dev
+            codetracer-native-recorder=dev
 
       - name: Remove WSL bash stub from System32
         # db-backend's build.rs runs ``Command::new("bash") ...
@@ -952,7 +991,7 @@ jobs:
 
       - name: Setup dev env
         # setup-dev-env clones the cross-repo siblings adjacent to this
-        # checkout at the workspace-lock-pinned revisions and sources
+        # checkout at their pinned `dev` refs and sources
         # env.ps1 (windows-diy flavor), persisting the resulting env to
         # GITHUB_ENV/GITHUB_PATH for subsequent steps — replacing the former
         # Checkout-manifests / Resolve-lock / per-sibling clone-repo steps
@@ -965,9 +1004,9 @@ jobs:
           gh-token: ${{ steps.app-token.outputs.token }}
           env-ps1-path: ./env.ps1
           siblings: |
-            codetracer-native-recorder
-            codetracer-trace-format
-            codetracer-trace-format-nim
+            codetracer-native-recorder=dev
+            codetracer-trace-format=dev
+            codetracer-trace-format-nim=dev
 
       - name: Install Nim dependencies
         shell: bash
@@ -1150,7 +1189,7 @@ jobs:
       - name: Setup dev env
         # setup-dev-env installs Nix (with the Attic substituter/keys) and
         # clones the cross-repo siblings adjacent to this checkout at the
-        # workspace-lock-pinned revisions, replacing the former
+        # pinned `dev` refs, replacing the former
         # Checkout-manifests / Resolve-lock / per-sibling clone-repo / Install
         # Nix steps. The direnv-allow + ct_emulator nimble steps below remain
         # bespoke because they operate inside the cloned native-recorder
@@ -1162,9 +1201,9 @@ jobs:
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
           siblings: |
-            codetracer-trace-format
-            codetracer-trace-format-nim
-            codetracer-native-recorder
+            codetracer-trace-format=dev
+            codetracer-trace-format-nim=dev
+            codetracer-native-recorder=dev
 
       - name: Allow direnv in cloned codetracer-native-recorder
         # src/db-backend/build.rs invokes ``direnv exec <recorder-root>
@@ -2380,8 +2419,57 @@ jobs:
         if: matrix.platform == 'macos'
         run: curl -LsSf https://get.nexte.st/latest/mac | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
+      - name: Clone codetracer-trace-format (macOS)
+        # ``./non-nix-build/build.sh`` -> ``env.sh`` -> ``build_trace_writer_ffi.sh``
+        # builds ``codetracer_trace_writer_ffi`` out of a codetracer-trace-format
+        # checkout, defaulting to the workspace sibling
+        # ``$ROOT_DIR/../codetracer-trace-format``.  That used to be the in-repo
+        # submodule ``libs/codetracer-trace-format``; e901eb6c8 (2026-05-12,
+        # "migrate codetracer-trace-format from submodule to sibling repo") made
+        # it a sibling, and nothing on THIS leg ever started providing it -- the
+        # job's ``Setup dev env`` (which clones siblings) is
+        # ``if: matrix.platform == 'nixos'``.  So every macOS run since has died
+        # here with
+        #
+        #   ERROR: codetracer-trace-format checkout not found at
+        #   .../non-nix-build/../../codetracer-trace-format.
+        #
+        # Its sibling job ``test-ui-tests`` runs the same script on the same
+        # runner and does not hit this, because its ``Setup dev env`` has no
+        # platform ``if:``.  (This leg was already red at ``Build (non-nix)``
+        # before e901eb6c8 -- its last green run anywhere is 24457842335, main,
+        # 2026-04-15, and it has never been green on ``dev`` -- so this may
+        # expose an older failure rather than turn the leg green.  It is
+        # ``continue-on-error`` on macOS either way.)  Clone the sibling here
+        # with the same ``clone-repo``
+        # + ``ref: dev`` pattern this job already uses for the python / ruby /
+        # BEAM recorders, rather than dropping the platform ``if:`` off
+        # ``Setup dev env``: this leg is deliberately the *non-nix* build path
+        # and must not acquire a nix dev env as a side effect.
+        if: matrix.platform == 'macos'
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        with:
+          repo: metacraft-labs/codetracer-trace-format
+          # `dev` is where this repo's work lands; its default branch is
+          # `stable`, and the last published workspace lock recorded
+          # upstream="dev" for it.
+          ref: dev
+          path: ${{ github.workspace }}/../codetracer-trace-format
+          gh-token: ${{ steps.ci_token.outputs.token }}
+
       - name: Build (non-nix)
         if: matrix.platform == 'macos'
+        # Mirror the environment ``test-ui-tests``' macOS leg passes to this
+        # same script: ``install_nim_osx.sh`` bootstraps Nim without nimble, so
+        # ``codetracer_trace_writer_nim``'s build.rs must skip its
+        # ``nimble install --depsOnly`` and take stew/results from the in-repo
+        # submodules instead; and macos-latest has no direnv for db-backend's
+        # build.rs to wrap ``build_native_api.sh`` in.
+        env:
+          CT_EMULATOR_EXTRA_NIM_PATHS: ${{ github.workspace }}/libs/nim-stew/stew:${{ github.workspace }}/libs/nim-stew:${{ github.workspace }}/libs/nim-result
+          CODETRACER_TRACE_FORMAT_NIM_SKIP_NIMBLE_INSTALL: "1"
+          CODETRACER_TRACE_FORMAT_NIM_EXTRA_PATHS: ${{ github.workspace }}/libs/nim-stew/stew:${{ github.workspace }}/libs/nim-stew
+          CODETRACER_DB_BACKEND_SKIP_DIRENV: "1"
         run: ./non-nix-build/build.sh
 
       - name: Clone python-recorder (macOS)
@@ -2415,7 +2503,7 @@ jobs:
       #
       # setup-dev-env clones the BEAM recorder + codetracer-trace-format
       # (the recorder's CTFS path-dep) adjacent to this checkout at the
-      # workspace-lock-pinned revisions, replacing the former
+      # pinned `dev` refs, replacing the former
       # Checkout-manifests / Resolve-lock / per-sibling clone-repo steps.
       # Nix is already installed by the earlier "Install Nix" step on the
       # nixos leg; setup-dev-env's nix install is idempotent.
@@ -2428,8 +2516,8 @@ jobs:
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
           siblings: |
-            codetracer-beam-recorder
-            codetracer-trace-format
+            codetracer-beam-recorder=dev
+            codetracer-trace-format=dev
 
       - name: Allow direnv in cloned codetracer-beam-recorder
         # ``elixir_flow_dap_test.rs`` / ``erlang_flow_dap_test.rs``
@@ -2582,7 +2670,7 @@ jobs:
         # the workaround for the hosted-macOS ``eDSRecordAlreadyExists``
         # failure that the older installer trips on the GitHub-hosted Apple
         # Silicon image) and clones the cross-repo siblings adjacent to this
-        # checkout (``../<name>``) at the workspace-lock-pinned revisions. This
+        # checkout (``../<name>``) at their pinned `dev` refs. This
         # replaces the former Checkout-manifests / Resolve-lock / per-sibling
         # clone-repo steps (both legs), the nixos ``Install Nix`` (setup-nix),
         # and the bespoke macOS ``Install Nix (… for ct_cli build)`` Determinate
@@ -2602,17 +2690,17 @@ jobs:
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
           nix-develop-args: '.?submodules=1'
           siblings: |
-            codetracer-trace-format
-            codetracer-trace-format-nim
-            codetracer-native-recorder
-            nim-stackable-hooks
-            codetracer-visual-replay
-            codetracer-native-backend
+            codetracer-trace-format=dev
+            codetracer-trace-format-nim=dev
+            codetracer-native-recorder=dev
+            nim-stackable-hooks=dev
+            codetracer-visual-replay=dev
+            codetracer-native-backend=dev
 
       - name: Stage codetracer-trace-format into libs/
         # The nix flake build below overrides the codetracer-trace-format input
         # with the in-repo path ./libs/codetracer-trace-format; mirror the
-        # lock-pinned sibling clone (placed at ../codetracer-trace-format by
+        # sibling clone (placed at ../codetracer-trace-format by
         # setup-dev-env) there.
         shell: bash
         run: |
@@ -2661,7 +2749,7 @@ jobs:
       # NOTE: codetracer-trace-format, codetracer-trace-format-nim,
       # codetracer-native-recorder, nim-stackable-hooks, codetracer-visual-replay and
       # codetracer-native-backend are now cloned adjacent to this checkout
-      # (``../<name>``) at workspace-lock-pinned revisions by the
+      # (``../<name>``) at their pinned `dev` refs by the
       # ``Setup dev env`` step above. The macOS cargo path deps
       # (``../../../codetracer-trace-format/...``), the trace-format-nim FFI
       # entry point, the native-recorder canonicalize, the ct_cli
@@ -2833,7 +2921,7 @@ jobs:
       - name: Setup dev env
         # setup-dev-env installs Nix (with the Attic substituter/keys) and
         # clones codetracer-trace-format adjacent to this checkout at the
-        # workspace-lock-pinned revision, replacing the former
+        # pinned `dev` ref, replacing the former
         # Checkout-manifests / Resolve-lock / clone-repo / Install Nix steps.
         # The flake build below reads the in-repo path
         # libs/codetracer-trace-format, so the sibling clone is mirrored
@@ -2845,11 +2933,11 @@ jobs:
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
           siblings: |
-            codetracer-trace-format
+            codetracer-trace-format=dev
 
       - name: Stage codetracer-trace-format into libs/
         # The flake override below points at ./libs/codetracer-trace-format;
-        # mirror the lock-pinned sibling clone there.
+        # mirror the sibling clone there.
         shell: bash
         run: |
           set -euo pipefail
@@ -2925,7 +3013,7 @@ jobs:
       - name: Setup dev env
         # setup-dev-env installs Nix (with the Attic substituter/keys) and
         # clones every source dependency used by the visual gate adjacent to
-        # this checkout at workspace-lock-pinned revisions. That includes the
+        # this checkout at their pinned `dev` refs. That includes the
         # frontend's IsoNim/agent libraries, the incremental runner's trace and
         # I/O libraries, and visual replay's own native siblings. A missing
         # lock entry fails loudly before the build starts.
@@ -2936,21 +3024,21 @@ jobs:
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
           siblings: |
-            isonim
-            nim-everywhere
-            nim-acp
-            nim-agent-harbor
-            nim-agents
-            codetracer-trace-format
-            codetracer-trace-format-nim
-            io-mon
-            nim-shm-queue
-            nim-stackable-hooks
-            codetracer-visual-replay
-            codetracer-native-backend
-            codetracer-native-recorder
-            codetracer-native-test-programs
-            codetracer-visual-replay-fixtures
+            isonim=dev
+            nim-everywhere=dev
+            nim-acp=dev
+            nim-agent-harbor=dev
+            nim-agents=dev
+            codetracer-trace-format=dev
+            codetracer-trace-format-nim=dev
+            io-mon=dev
+            nim-shm-queue=dev
+            nim-stackable-hooks=dev
+            codetracer-visual-replay=dev
+            codetracer-native-backend=dev
+            codetracer-native-recorder=dev
+            codetracer-native-test-programs=dev
+            codetracer-visual-replay-fixtures=dev
 
       - name: Run visual replay regression gate
         env:
@@ -3171,7 +3259,7 @@ jobs:
         # never simply be dropped into an existing job.
         #
         # setup-dev-env clones them adjacent to this checkout at
-        # workspace-lock-pinned revisions — the same mechanism
+        # pinned `dev` refs — the same mechanism
         # `visual-replay-regression-gate` and `test-non-gui` already use, so
         # this is not new infrastructure. The trace-format / io-mon /
         # stackable-hooks / nim-shm-queue entries are the native recorder's own
@@ -3183,15 +3271,15 @@ jobs:
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
           siblings: |
-            nim-everywhere
-            codetracer-trace-format
-            codetracer-trace-format-nim
-            io-mon
-            nim-shm-queue
-            nim-stackable-hooks
-            codetracer-native-recorder
-            codetracer-js-recorder
-            codetracer-ruby-recorder
+            nim-everywhere=dev
+            codetracer-trace-format=dev
+            codetracer-trace-format-nim=dev
+            io-mon=dev
+            nim-shm-queue=dev
+            nim-stackable-hooks=dev
+            codetracer-native-recorder=dev
+            codetracer-js-recorder=dev
+            codetracer-ruby-recorder=dev
 
       - name: Allow direnv in the cloned recorder siblings
         # scripts/build-siblings.sh runs every sibling build as
@@ -3631,6 +3719,17 @@ jobs:
         # -- which matters, because the Windows lane had no signal at all
         # for the months this went unnoticed.
         run: bash ci/test/windows-runner-bootstrap-test.sh
+
+      - name: Assert no job's siblings depend on a published workspace lock
+        # A bare `siblings:` entry resolves its revision from a workspace lock
+        # in metacraft-labs/metacraft-manifests, which has published nothing
+        # for this repo since 2026-08-02. Six jobs died in their first real
+        # step for eight days because of it, and nine more were reported
+        # `skipped` in consequence -- the state the verdict step below exists
+        # to name. Like the Windows contract above this is a static check over
+        # this workflow file, so it runs here, from a stock runner, where it
+        # cannot be taken down by the outage it watches for.
+        run: bash ci/test/sibling-provisioning-test.sh
 
       - name: Self-test the private-registry credential preflight
         # This suite is also run by `visual-replay-regression-gate`, but that

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -3097,6 +3097,23 @@ jobs:
         with:
           submodules: recursive
           token: ${{ steps.ci_token.outputs.token }}
+          # Do not leave `http.https://github.com/.extraHeader` behind in
+          # `.git/config`. That persisted header prefix-matches every URL, which
+          # is what forced `visual-replay-private-cargo-preflight.sh` to weaken
+          # its `auth-header-url-boundary` check from "no header matches at all"
+          # to "the lldb-sys credential does not widen"; see the long comment
+          # there. Nothing downstream needs it:
+          #   * `Setup dev env` gets the same token explicitly via `gh-token`.
+          #   * `submodules: recursive` is unaffected — actions/checkout fetches
+          #     submodules under a temporary *global* auth config it installs
+          #     regardless of this setting, and only strips the credential in
+          #     its `finally` block, after submodules are checked out.
+          #   * The gate itself does no network git against this checkout. Its
+          #     one authenticated fetch (`git ls-remote` on lldb-sys, in the
+          #     preflight) uses the process-scoped `GIT_CONFIG_KEY_0`
+          #     extraHeader; every other git-touching step runs with its working
+          #     directory inside a *sibling* repo provisioned by setup-dev-env.
+          persist-credentials: false
 
       - name: Setup dev env
         # setup-dev-env installs Nix (with the Attic substituter/keys) and

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -2950,8 +2950,19 @@ jobs:
         run: nix build --print-build-logs '.?submodules=1#codetracer' --override-input codetracer-trace-format path:./libs/codetracer-trace-format
 
       - name: Setup rr-backend
+        # `ci/setup-rr-backend.sh` resolves codetracer-native-backend's revision
+        # from `$RR_BACKEND_REF` first and otherwise from the workspace lock via
+        # `scripts/resolve-sibling-rev.sh`. That second route cannot work on a
+        # runner: the resolver locates the locks/ tree by walking up for a
+        # `.repro/manifests` or `.repo/manifests` directory, and a CI checkout
+        # has neither (nothing sets `$CT_MANIFEST_DIR` here either), so it exits
+        # 3 with "cannot locate the manifest repo locks/ tree" -- the same
+        # lock dependency the `siblings:` entries above were pinned to avoid,
+        # reached one step later. Take the documented explicit override, which
+        # keeps the script's lock path intact for workspace use.
         env:
           GH_TOKEN: ${{ steps.ci_token.outputs.token }}
+          RR_BACKEND_REF: dev
         run: ./ci/setup-rr-backend.sh
 
       - name: Run TypeScript Playwright UI tests (RR-based only)

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -3295,6 +3295,20 @@ jobs:
         # today's `dev`, and neither revision has a root Cargo.toml, so the
         # lock-pinned build would have failed the same way. It stayed invisible
         # because this job could not get past `Setup dev env` to reach it.
+        #
+        # codetracer-visual-replay is here for the same reason, one layer on:
+        # once the backend is present, `build-license-ffi` succeeds and the
+        # build reaches `cd ct_cli && nimble build`, which imports
+        # `gfx_stream/ctfs_visual` -- a module that lives in
+        # codetracer-visual-replay/src/gfx_stream, not in the recorder:
+        #
+        #   ct_cli/src/ct_cli/extract_gfx_cmd.nim(39, 18)
+        #     Error: cannot open file: gfx_stream/ctfs_visual
+        #   error: Recipe `build-ct-mcr` failed on line 43 with exit code 1
+        #
+        # `visual-replay-regression-gate` already lists it. Same missing-sibling
+        # class as the backend above, uncovered only because fixing the first
+        # one let the build run far enough to hit the second.
         uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
         with:
           env-flavor: nix
@@ -3312,6 +3326,7 @@ jobs:
             codetracer-js-recorder=dev
             codetracer-ruby-recorder=dev
             codetracer-native-backend=dev
+            codetracer-visual-replay=dev
 
       - name: Allow direnv in the cloned recorder siblings
         # scripts/build-siblings.sh runs every sibling build as

--- a/.github/workflows/cross-repo-tests.yml
+++ b/.github/workflows/cross-repo-tests.yml
@@ -229,9 +229,31 @@ jobs:
           gh-token: ${{ steps.ci_token.outputs.token }}
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          # codetracer-trace-format-nim is the second half of a MATCHED FFI
+          # PAIR and is required whenever codetracer-trace-format is BUILT, not
+          # only when something imports the Nim library directly.
+          # `crates/ct-shell-trace-writer` path-depends on
+          # `codetracer-trace-format/codetracer_trace_writer_nim`, whose
+          # build.rs resolves the Nim entry point as a SIBLING of
+          # codetracer-trace-format and hard-errors when it is absent:
+          #
+          #   error: failed to run custom build command for
+          #     `codetracer_trace_writer_nim v0.1.0`
+          #   Nim FFI entry point not found at
+          #     .../codetracer-trace-format-nim/src/codetracer_trace_writer_ffi.nim
+          #     -- is the codetracer-trace-format-nim repo checked out as a
+          #     sibling? (override with CODETRACER_TRACE_FORMAT_NIM_DIR)
+          #
+          # Observed in run 31719867246, job 94513828226, step "Build shell
+          # trace writer" -- reached only because the `=dev` pins here got this
+          # job past `Setup dev env` for the first time since 2026-08-04.
+          # Pinned by the "codetracer-trace-format implies
+          # codetracer-trace-format-nim" assertion in
+          # ci/test/sibling-provisioning-test.sh.
           siblings: |
             codetracer-shell-recorders=${{ github.event.inputs.shell_recorders_ref || 'dev' }}
             codetracer-trace-format=dev
+            codetracer-trace-format-nim=dev
 
       - name: Build shell trace writer
         run: |

--- a/.github/workflows/cross-repo-tests.yml
+++ b/.github/workflows/cross-repo-tests.yml
@@ -17,11 +17,11 @@ on:
   workflow_dispatch:
     inputs:
       rr_backend_ref:
-        description: 'rr-backend git ref to test against (default: workspace lock)'
+        description: 'rr-backend git ref to test against (default: dev)'
         required: false
         default: ''
       shell_recorders_ref:
-        description: 'shell-recorders git ref to test against (default: workspace lock)'
+        description: 'shell-recorders git ref to test against (default: dev)'
         required: false
         default: ''
 
@@ -55,12 +55,12 @@ jobs:
 
       - name: Setup dev env
         # setup-dev-env installs Nix (with the Attic substituter/keys) and
-        # clones the cross-repo siblings adjacent to this checkout at the
-        # workspace-lock-pinned revisions (recursive submodules), replacing
+        # clones the cross-repo siblings adjacent to this checkout at their
+        # pinned `dev` refs (recursive submodules), replacing
         # the former Checkout-manifests / Resolve-lock / per-sibling
         # clone-repo machinery. The rr_backend_ref workflow_dispatch input
-        # overrides codetracer-native-backend's locked revision (empty =>
-        # lock). The native-backend submodule unfold below is still bespoke
+        # overrides codetracer-native-backend's ref (empty => `dev`).
+        # The native-backend submodule unfold below is still bespoke
         # because the path:-flake-input visibility fix is specific to this
         # repo's flake.
         uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
@@ -70,10 +70,10 @@ jobs:
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
           siblings: |
-            codetracer-native-backend=${{ github.event.inputs.rr_backend_ref }}
-            codetracer-trace-format
-            codetracer-trace-format-nim
-            codetracer-native-recorder
+            codetracer-native-backend=${{ github.event.inputs.rr_backend_ref || 'dev' }}
+            codetracer-trace-format=dev
+            codetracer-trace-format-nim=dev
+            codetracer-native-recorder=dev
 
       - name: Unfold native-backend submodules into parent index
         # codetracer-native-backend's flake.nix has
@@ -206,10 +206,10 @@ jobs:
       - name: Setup dev env
         # setup-dev-env installs Nix (with the Attic substituter/keys) and
         # clones codetracer-shell-recorders adjacent to this checkout at the
-        # workspace-lock-pinned revision, replacing the former
+        # pinned `dev` ref, replacing the former
         # Checkout-manifests / Resolve-lock / clone-repo steps. The
-        # shell_recorders_ref workflow_dispatch input overrides the locked
-        # revision (empty => lock).
+        # shell_recorders_ref workflow_dispatch input overrides the ref
+        # (empty => `dev`).
         uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
         with:
           env-flavor: nix
@@ -217,7 +217,7 @@ jobs:
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
           siblings: |
-            codetracer-shell-recorders=${{ github.event.inputs.shell_recorders_ref }}
+            codetracer-shell-recorders=${{ github.event.inputs.shell_recorders_ref || 'dev' }}
 
       - name: Build shell trace writer
         run: |

--- a/.github/workflows/cross-repo-tests.yml
+++ b/.github/workflows/cross-repo-tests.yml
@@ -210,6 +210,19 @@ jobs:
         # Checkout-manifests / Resolve-lock / clone-repo steps. The
         # shell_recorders_ref workflow_dispatch input overrides the ref
         # (empty => `dev`).
+        #
+        # codetracer-trace-format is listed because the shell recorders' Cargo
+        # workspace path-depends on it:
+        #
+        #   error: failed to load manifest for workspace member
+        #     `.../codetracer-shell-recorders/crates/ct-shell-trace-writer`
+        #   Caused by: failed to load manifest for dependency `codetracer_trace_types`
+        #   Caused by: failed to read `.../codetracer-trace-format/codetracer_trace_types/Cargo.toml`
+        #   Caused by: No such file or directory (os error 2)
+        #
+        # It was missing from this list, not from the lock — the `rr-backend-tests`
+        # job above already names it for the same reason. The gap was invisible
+        # while this job could not get past `Setup dev env` at all.
         uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
         with:
           env-flavor: nix
@@ -218,6 +231,7 @@ jobs:
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
           siblings: |
             codetracer-shell-recorders=${{ github.event.inputs.shell_recorders_ref || 'dev' }}
+            codetracer-trace-format=dev
 
       - name: Build shell trace writer
         run: |

--- a/.github/workflows/elixir-flow-dap.yml
+++ b/.github/workflows/elixir-flow-dap.yml
@@ -8,11 +8,11 @@ on:
   workflow_dispatch:
     inputs:
       beam_recorder_ref:
-        description: 'codetracer-beam-recorder ref (default: workspace lock)'
+        description: 'codetracer-beam-recorder ref (default: dev)'
         required: false
         default: ''
       trace_format_ref:
-        description: 'codetracer-trace-format ref (default: workspace lock)'
+        description: 'codetracer-trace-format ref (default: dev)'
         required: false
         default: ''
 

--- a/ci/test/sibling-provisioning-test.sh
+++ b/ci/test/sibling-provisioning-test.sh
@@ -313,6 +313,69 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 1c. MATCHED PAIR: io-mon implies nim-shm-gset.
+#
+# The same defect class as 1b, found by asking the question 1b answers for one
+# pair of every other provisioned sibling.
+#
+#   io-mon/src/io_mon.nim
+#     -> io_mon/writer     imports `shm_gset/transport`
+#     -> io_mon/fs_snoop   imports `shm_gset` and `shm_gset/transport`
+#
+# `shm_gset` is the grow-only shared-memory set backing io-mon's Linux
+# dependency-capture channel. As with the trace-format pair, the dependency is
+# invisible from either manifest: io-mon resolves it as a plain sibling through
+# its `config.nims` `SHM_GSET_SRC` default (`../nim-shm-gset/src`), and
+# codetracer's repo-root `config.nims` mirrors that with
+#
+#     addPathIfDir(workspaceRoot / "nim-shm-gset" / "src")
+#
+# `addPathIfDir` is SILENT when the directory is absent. So an io-mon-only
+# `siblings:` block provisions successfully, and the omission surfaces much
+# later, in the `ct` compile, as
+#
+#     cannot open file: shm_gset/transport
+#
+# with nothing pointing back at the sibling list. Note the sibling clone WINS
+# over the `IO_MON_SRC` flake input here -- Nim searches `--path` entries
+# newest-first and the repo-root config adds the workspace sibling after it --
+# so pinning `io-mon=dev` is exactly what makes the newer `shm_gset` import
+# reachable, and exactly what makes the missing sibling fatal. Currency without
+# coordination again.
+#
+# NOT YET OBSERVED IN CI. Both jobs that provision io-mon
+# (`visual-replay-regression-gate`, `ct-test-providers`) have been dying earlier
+# than the `ct` compile for the whole period this was reachable, so this is a
+# static finding, not a reproduction. It is asserted anyway; the mechanism is
+# the one already paid for twice in 1b.
+# ---------------------------------------------------------------------------
+unpaired=()
+for _i in "${!BLOCK_REPOS[@]}"; do
+	_repos=" ${BLOCK_REPOS[$_i]} "
+	case "$_repos" in
+	*" io-mon "*)
+		case "$_repos" in
+		*" nim-shm-gset "*) ;;
+		*)
+			unpaired+=("${BLOCK_WHERE[$_i]}: provisions io-mon without nim-shm-gset")
+			;;
+		esac
+		;;
+	esac
+done
+unset _i _repos
+
+if [ "${#unpaired[@]}" -eq 0 ]; then
+	ok "every block provisioning io-mon also provisions nim-shm-gset"
+else
+	fail "every block provisioning io-mon also provisions nim-shm-gset" \
+		"io_mon's writer/fs_snoop import shm_gset; the repo-root config.nims adds the" \
+		"sibling with addPathIfDir, which is silent when absent, so the omission only" \
+		"surfaces later as 'cannot open file: shm_gset/transport' from the ct compile" \
+		"${unpaired[@]}"
+fi
+
+# ---------------------------------------------------------------------------
 # 2. Every `./non-nix-build/build.sh` invocation has codetracer-trace-format
 #    provisioned earlier in its own job.
 #
@@ -443,7 +506,7 @@ fi
 # this script reporting success on fewer checks than it claims.
 # ---------------------------------------------------------------------------
 echo
-readonly EXPECTED_ASSERTIONS=6
+readonly EXPECTED_ASSERTIONS=7
 if [ "$assertions" -ne "$EXPECTED_ASSERTIONS" ]; then
 	printf 'FAIL: ran %d assertions, expected %d\n' "$assertions" "$EXPECTED_ASSERTIONS"
 	failures=$((failures + 1))

--- a/ci/test/sibling-provisioning-test.sh
+++ b/ci/test/sibling-provisioning-test.sh
@@ -65,6 +65,14 @@
 #      lock" -- the bare-entry failure wearing a costume.
 #   3. The `siblings:` block set is non-empty (a rename of the input must not
 #      turn this suite into a vacuous pass).
+#
+#      Scope is `.github/workflows/*.yml` AND `.github/actions/*/action.yml`.
+#      The composite actions matter as much as the workflows and are easier to
+#      forget: `.github/actions/setup-db-backend-siblings/action.yml` carries
+#      its own `siblings:` block, is used by six jobs, and kept every one of
+#      them failing after the workflows themselves had been fixed -- this
+#      suite's first version only walked the workflow directory and waved it
+#      straight through.
 #   4. Every workflow step that runs `./non-nix-build/build.sh` is preceded, in
 #      its own job, by a step that provisions `codetracer-trace-format`.
 #   5. Every workflow step that runs `ci/setup-rr-backend.sh` sets
@@ -91,6 +99,20 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 readonly REPO_ROOT
 WORKFLOW_DIR="${1:-$REPO_ROOT/.github/workflows}"
 readonly WORKFLOW_DIR
+ACTIONS_DIR="${2:-$REPO_ROOT/.github/actions}"
+readonly ACTIONS_DIR
+
+# Every file that may declare a `siblings:` block: the workflows, plus each
+# composite action. A composite is a workflow step by another name and the
+# action input it passes is the same one.
+declare -a SIBLING_SOURCE_FILES=()
+for _wf in "$WORKFLOW_DIR"/*.yml "$WORKFLOW_DIR"/*.yaml; do
+	[ -f "$_wf" ] && SIBLING_SOURCE_FILES+=("$_wf")
+done
+for _act in "$ACTIONS_DIR"/*/action.yml "$ACTIONS_DIR"/*/action.yaml; do
+	[ -f "$_act" ] && SIBLING_SOURCE_FILES+=("$_act")
+done
+unset _wf _act
 
 # GitHub Actions' own expression syntax, quoted verbatim -- this is the literal
 # text a sibling ref must not contain without a `||` fallback beside it.
@@ -131,8 +153,7 @@ sibling_blocks=0
 bad_entries=()
 entry_count=0
 
-for wf in "$WORKFLOW_DIR"/*.yml; do
-	[ -f "$wf" ] || continue
+for wf in "${SIBLING_SOURCE_FILES[@]}"; do
 	wf_name="${wf##*/}"
 	in_block=0
 	key_indent=0
@@ -215,8 +236,7 @@ echo "non-nix build legs provision codetracer-trace-format"
 build_sites=0
 missing_sites=()
 
-for wf in "$WORKFLOW_DIR"/*.yml; do
-	[ -f "$wf" ] || continue
+for wf in "${SIBLING_SOURCE_FILES[@]}"; do
 	wf_name="${wf##*/}"
 	job=""
 	seen_trace_format=0
@@ -281,8 +301,7 @@ echo "rr-backend setup overrides the ref explicitly"
 rr_sites=0
 rr_missing=()
 
-for wf in "$WORKFLOW_DIR"/*.yml; do
-	[ -f "$wf" ] || continue
+for wf in "${SIBLING_SOURCE_FILES[@]}"; do
 	wf_name="${wf##*/}"
 	step_has_override=0
 	line_no=0

--- a/ci/test/sibling-provisioning-test.sh
+++ b/ci/test/sibling-provisioning-test.sh
@@ -73,6 +73,12 @@
 #      them failing after the workflows themselves had been fixed -- this
 #      suite's first version only walked the workflow directory and waved it
 #      straight through.
+#   3b. Any `siblings:` block that provisions `codetracer-trace-format` also
+#      provisions `codetracer-trace-format-nim`. They are the two halves of one
+#      FFI boundary and are only ever correct together; the dependency is
+#      invisible from either repo's own manifest, so it keeps being missed.
+#      See the assertion's own comment for the two failure modes already paid
+#      for (absent half -> build.rs error; stale half -> link error).
 #   4. Every workflow step that runs `./non-nix-build/build.sh` is preceded, in
 #      its own job, by a step that provisions `codetracer-trace-format`.
 #   5. Every workflow step that runs `ci/setup-rr-backend.sh` sets
@@ -152,12 +158,17 @@ echo "siblings: entries pin an explicit ref"
 sibling_blocks=0
 bad_entries=()
 entry_count=0
+# Per-block record of which repos each `siblings:` block provisions, used by
+# the matched-pair assertion further down. One space-delimited entry per block.
+declare -a BLOCK_REPOS=()
+declare -a BLOCK_WHERE=()
 
 for wf in "${SIBLING_SOURCE_FILES[@]}"; do
 	wf_name="${wf##*/}"
 	in_block=0
 	key_indent=0
 	line_no=0
+	block_repos=""
 	while IFS= read -r line || [ -n "$line" ]; do
 		line_no=$((line_no + 1))
 		stripped="${line#"${line%%[![:space:]]*}"}"
@@ -166,7 +177,17 @@ for wf in "${SIBLING_SOURCE_FILES[@]}"; do
 		if [ "$in_block" -eq 1 ]; then
 			if [ -z "$stripped" ] || [ "$indent" -le "$key_indent" ]; then
 				in_block=0
+				BLOCK_REPOS+=("$block_repos")
+				block_repos=""
 			else
+				# `clone-siblings` strips a `#` comment from each line before
+				# tokenising ("Both accept '#' comments and whitespace/newline
+				# separation" -- clone-siblings/action.yml). Model that here, or
+				# this scanner rejects a configuration the action accepts.
+				stripped="${stripped%%#*}"
+				stripped="${stripped%"${stripped##*[![:space:]]}"}"
+				[ -z "$stripped" ] && continue
+				block_repos="$block_repos ${stripped%%=*}"
 				entry_count=$((entry_count + 1))
 				case "$stripped" in
 				*=*)
@@ -199,10 +220,16 @@ for wf in "${SIBLING_SOURCE_FILES[@]}"; do
 		'siblings: |'*)
 			in_block=1
 			key_indent=$indent
+			block_repos=""
+			BLOCK_WHERE+=("$wf_name:$line_no")
 			sibling_blocks=$((sibling_blocks + 1))
 			;;
 		esac
 	done <"$wf"
+	# A block that runs to EOF never hits the dedent that closes it.
+	if [ "$in_block" -eq 1 ]; then
+		BLOCK_REPOS+=("$block_repos")
+	fi
 done
 
 if [ "${#bad_entries[@]}" -eq 0 ]; then
@@ -221,6 +248,68 @@ else
 	fail "the workflows still declare cross-repo siblings" \
 		"no 'siblings: |' block was found -- either the input was renamed or the" \
 		"scanner no longer matches it, and this suite is passing vacuously"
+fi
+
+# ---------------------------------------------------------------------------
+# 1b. MATCHED PAIR: codetracer-trace-format implies codetracer-trace-format-nim.
+#
+# These two repos are the two halves of one FFI boundary and are only ever
+# correct together:
+#
+#   codetracer-trace-format/codetracer_trace_writer_nim/src/lib.rs      caller
+#   codetracer-trace-format-nim/src/codetracer_trace_writer_ffi.nim     provider
+#
+# The dependency is not visible from a repo's own manifest, which is why it
+# keeps being missed. Anything that path-depends on the
+# `codetracer_trace_writer_nim` crate -- codetracer-shell-recorders'
+# `crates/ct-shell-trace-writer`, codetracer-beam-recorder, codetracer's own
+# db-backend -- drags in a build.rs that resolves the Nim entry point as a
+# SIBLING OF codetracer-trace-format and hard-errors when it is absent:
+#
+#   Nim FFI entry point not found at
+#   .../codetracer-trace-format-nim/src/codetracer_trace_writer_ffi.nim
+#   -- is the codetracer-trace-format-nim repo checked out as a sibling?
+#
+# So provisioning the Rust half alone is never right. Two forms of the same
+# defect have now been paid for:
+#
+#   * the Nim half ABSENT      -> the build.rs error above
+#                                 (run 31719867246, job 94513828226)
+#   * the Nim half STALE       -> a link error against the older provider,
+#                                 `undefined reference to ct_reader_event_metadata`
+#                                 (fixed in 32a9de3c7 by overriding both)
+#
+# This is also the general lesson of the lock outage: a per-commit workspace
+# lock bought COORDINATION across repos, not merely a pinned SHA. Pinning each
+# sibling independently to `dev` keeps them current and silently discards that
+# coordination. For independent siblings that is invisible; for a matched pair
+# it is a build failure. Where coordination is required it now has to be stated
+# explicitly -- and this assertion is where "explicitly" is enforced.
+# ---------------------------------------------------------------------------
+unpaired=()
+for _i in "${!BLOCK_REPOS[@]}"; do
+	_repos=" ${BLOCK_REPOS[$_i]} "
+	case "$_repos" in
+	*" codetracer-trace-format "*)
+		case "$_repos" in
+		*" codetracer-trace-format-nim "*) ;;
+		*)
+			unpaired+=("${BLOCK_WHERE[$_i]}: provisions codetracer-trace-format without codetracer-trace-format-nim")
+			;;
+		esac
+		;;
+	esac
+done
+unset _i _repos
+
+if [ "${#unpaired[@]}" -eq 0 ]; then
+	ok "every block provisioning codetracer-trace-format also provisions its -nim half"
+else
+	fail "every block provisioning codetracer-trace-format also provisions its -nim half" \
+		"the two repos are one FFI boundary; the Rust half alone fails in build.rs with" \
+		"'Nim FFI entry point not found ... is the codetracer-trace-format-nim repo" \
+		"checked out as a sibling?'" \
+		"${unpaired[@]}"
 fi
 
 # ---------------------------------------------------------------------------
@@ -354,7 +443,7 @@ fi
 # this script reporting success on fewer checks than it claims.
 # ---------------------------------------------------------------------------
 echo
-readonly EXPECTED_ASSERTIONS=5
+readonly EXPECTED_ASSERTIONS=6
 if [ "$assertions" -ne "$EXPECTED_ASSERTIONS" ]; then
 	printf 'FAIL: ran %d assertions, expected %d\n' "$assertions" "$EXPECTED_ASSERTIONS"
 	failures=$((failures + 1))

--- a/ci/test/sibling-provisioning-test.sh
+++ b/ci/test/sibling-provisioning-test.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Contract: no CI job's sibling checkout depends on a published workspace lock,
+# and the macOS non-nix build leg provisions the sibling its build script reads.
+#
+# # Why this file exists
+#
+# `metacraft-github-actions/setup-dev-env` clones cross-repo siblings through
+# its `clone-siblings` sub-action. Each entry of its `siblings:` input is
+# either
+#
+#     name          -> resolve the revision from a WORKSPACE LOCK
+#     name=ref      -> clone `ref` directly
+#
+# The lock is a per-commit snapshot published to
+# `metacraft-labs/metacraft-manifests@latest` by the workspace tooling's
+# pre-push hook. Publication for this repo stopped on 2026-08-02 -- the last
+# entry is `locks/dev/codetracer/784c9bda....xml`. `clone-siblings` probes the
+# pushed commit and its parent only (it passes `--no-walk` to the resolver), so
+# `dev` survived exactly one more commit and then broke:
+#
+#   8d587343 (parent 784c9bda)   last green `Setup dev env`   2026-08-02
+#   3583cd6b (parent 8d587343)   first red one, run 30951549711, 2026-08-04
+#
+#     ##[error]No workspace lock for codetracer (candidates: <sha> <parent>).
+#     Neither a repo-workspaces locks/<project>/codetracer/<sha>.xml nor a
+#     reprobuild locks/<project>/codetracer/<sha>.toml exists in
+#     metacraft-labs/metacraft-manifests@latest.
+#
+# Six jobs -- lint-rust, test-non-gui, test-ui-tests (both legs),
+# test-ui-tests-rr, visual-replay-regression-gate, ct-test-providers -- died in
+# their first real step for eight days, and the nine jobs that `needs:` them
+# were reported `skipped`, which is the "the tests never ran" state that
+# `ci/verdict/required-jobs.sh` exists to name out loud.
+#
+# A bare entry is not a syntax error and not a lint failure; it is a live
+# dependency on a repository this one does not control. This contract makes
+# adding one a test failure instead of an outage.
+#
+# The second half of the file covers the same class of defect reached from the
+# other direction. `test-non-gui`'s macOS leg runs `./non-nix-build/build.sh`,
+# which (via `env.sh` -> `build_trace_writer_ffi.sh`) needs a
+# codetracer-trace-format checkout at `../codetracer-trace-format`. That was an
+# in-repo submodule until e901eb6c8 (2026-05-12) made it a sibling repo, and
+# this leg's `Setup dev env` -- the step that clones siblings -- carries
+# `if: matrix.platform == 'nixos'`, so the macOS leg never got one:
+#
+#     ERROR: codetracer-trace-format checkout not found at
+#     .../non-nix-build/../../codetracer-trace-format.
+#
+# Independent of the lock outage above, and invisible for months because the
+# leg is `continue-on-error: ${{ matrix.platform == 'macos' }}`. Note this leg
+# was ALREADY failing at `Build (non-nix)` before e901eb6c8 -- the last green
+# run of it anywhere is 24457842335 (main, 2026-04-15) and it has never been
+# green on `dev` at all -- so clearing the missing sibling may expose an older
+# failure underneath rather than turning the leg green. This contract is about
+# the sibling, not about the leg's overall health.
+#
+# # What is asserted
+#
+#   1. Every `siblings:` entry in every workflow carries an explicit `=ref`.
+#   2. An entry whose ref is a `${{ }}` expression supplies a non-empty
+#      fallback. `name=${{ github.event.inputs.foo }}` on a push evaluates to a
+#      trailing `=`, which `clone-siblings` documents as "fall back to the
+#      lock" -- the bare-entry failure wearing a costume.
+#   3. The `siblings:` block set is non-empty (a rename of the input must not
+#      turn this suite into a vacuous pass).
+#   4. Every workflow step that runs `./non-nix-build/build.sh` is preceded, in
+#      its own job, by a step that provisions `codetracer-trace-format`.
+#
+# # No mocks
+#
+# The workflow files themselves are the input. Nothing is stubbed, generated or
+# reconstructed: the parse runs over `.github/workflows/*.yml` as committed,
+# which is the artefact GitHub executes.
+#
+# Run: bash ci/test/sibling-provisioning-test.sh
+# Lane: a step of the `ci-verdict` job (stock ubuntu-latest, bash only -- no
+#       Nix, no dev shell), alongside the verdict gate's own self-test.
+# =============================================================================
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+readonly REPO_ROOT
+WORKFLOW_DIR="${1:-$REPO_ROOT/.github/workflows}"
+readonly WORKFLOW_DIR
+
+# GitHub Actions' own expression syntax, quoted verbatim -- this is the literal
+# text a sibling ref must not contain without a `||` fallback beside it.
+# shellcheck disable=SC2016
+readonly ACTIONS_EXPR_OPEN='${{'
+
+assertions=0
+failures=0
+
+ok() {
+	assertions=$((assertions + 1))
+	printf '  ok   %s\n' "$1"
+}
+
+fail() {
+	assertions=$((assertions + 1))
+	failures=$((failures + 1))
+	printf '  FAIL %s\n' "$1"
+	if [ "$#" -gt 1 ]; then
+		shift
+		printf '         %s\n' "$@"
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# 1. Every `siblings:` entry names an explicit ref.
+#
+# Deliberately a small, explicit scanner rather than a YAML library: this must
+# run on a stock runner with bash and nothing else, in the same spirit as
+# ci/test/windows-runner-bootstrap-test.sh.
+#
+# A `siblings: |` block is a YAML literal scalar; its entries are the lines
+# indented deeper than the key, up to the first line that is not.
+# ---------------------------------------------------------------------------
+echo "siblings: entries pin an explicit ref"
+
+sibling_blocks=0
+bad_entries=()
+entry_count=0
+
+for wf in "$WORKFLOW_DIR"/*.yml; do
+	[ -f "$wf" ] || continue
+	wf_name="${wf##*/}"
+	in_block=0
+	key_indent=0
+	line_no=0
+	while IFS= read -r line || [ -n "$line" ]; do
+		line_no=$((line_no + 1))
+		stripped="${line#"${line%%[![:space:]]*}"}"
+		indent=$((${#line} - ${#stripped}))
+
+		if [ "$in_block" -eq 1 ]; then
+			if [ -z "$stripped" ] || [ "$indent" -le "$key_indent" ]; then
+				in_block=0
+			else
+				entry_count=$((entry_count + 1))
+				case "$stripped" in
+				*=*)
+					# An expression-valued ref must not be able to evaluate to
+					# the empty string; `name=` is the lock fallback.
+					ref="${stripped#*=}"
+					case "$ref" in
+					'')
+						bad_entries+=("$wf_name:$line_no: '$stripped' (empty ref falls back to the workspace lock)")
+						;;
+					*"$ACTIONS_EXPR_OPEN"*)
+						case "$ref" in
+						*'||'*) ;;
+						*)
+							bad_entries+=("$wf_name:$line_no: '$stripped' (expression ref with no || fallback evaluates to empty on push)")
+							;;
+						esac
+						;;
+					esac
+					;;
+				*)
+					bad_entries+=("$wf_name:$line_no: '$stripped' (bare name resolves through the workspace lock)")
+					;;
+				esac
+				continue
+			fi
+		fi
+
+		case "$stripped" in
+		'siblings: |'*)
+			in_block=1
+			key_indent=$indent
+			sibling_blocks=$((sibling_blocks + 1))
+			;;
+		esac
+	done <"$wf"
+done
+
+if [ "${#bad_entries[@]}" -eq 0 ]; then
+	ok "all $entry_count sibling entries across $sibling_blocks blocks pin an explicit ref"
+else
+	fail "all sibling entries pin an explicit ref" \
+		"each entry below resolves through a workspace lock in" \
+		"metacraft-labs/metacraft-manifests, which has published nothing for this" \
+		"repo since 2026-08-02; the step fails with 'No workspace lock for codetracer'" \
+		"${bad_entries[@]}"
+fi
+
+if [ "$sibling_blocks" -gt 0 ]; then
+	ok "the workflows still declare cross-repo siblings ($sibling_blocks blocks)"
+else
+	fail "the workflows still declare cross-repo siblings" \
+		"no 'siblings: |' block was found -- either the input was renamed or the" \
+		"scanner no longer matches it, and this suite is passing vacuously"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Every `./non-nix-build/build.sh` invocation has codetracer-trace-format
+#    provisioned earlier in its own job.
+#
+# Job boundaries are two-space-indented keys under `jobs:`; anything deeper
+# belongs to the job above it.
+# ---------------------------------------------------------------------------
+echo
+echo "non-nix build legs provision codetracer-trace-format"
+
+build_sites=0
+missing_sites=()
+
+for wf in "$WORKFLOW_DIR"/*.yml; do
+	[ -f "$wf" ] || continue
+	wf_name="${wf##*/}"
+	job=""
+	seen_trace_format=0
+	line_no=0
+	while IFS= read -r line || [ -n "$line" ]; do
+		line_no=$((line_no + 1))
+		stripped_line="${line#"${line%%[![:space:]]*}"}"
+		case "$line" in
+		'  '[a-zA-Z0-9_-]*':'*)
+			case "$line" in
+			'   '*) ;;
+			*)
+				job="${line#  }"
+				job="${job%%:*}"
+				seen_trace_format=0
+				;;
+			esac
+			;;
+		esac
+		case "$line" in
+		*'metacraft-labs/codetracer-trace-format'* | *'codetracer-trace-format='*)
+			seen_trace_format=1
+			;;
+		esac
+		# Only real invocations, not the many comment lines that name the
+		# script; a comment mentioning it must not create a phantom call site.
+		case "$stripped_line" in
+		'run: ./non-nix-build/build.sh'* | './non-nix-build/build.sh'*)
+			build_sites=$((build_sites + 1))
+			if [ "$seen_trace_format" -eq 0 ]; then
+				missing_sites+=("$wf_name:$line_no: job '$job' runs ./non-nix-build/build.sh with no codetracer-trace-format checkout before it")
+			fi
+			;;
+		esac
+	done <"$wf"
+done
+
+if [ "$build_sites" -gt 0 ]; then
+	ok "the workflows still run the non-nix build ($build_sites call sites)"
+else
+	fail "the workflows still run the non-nix build" \
+		"no './non-nix-build/build.sh' step was found -- either the macOS lane was" \
+		"removed or the scanner no longer matches it, and this check is vacuous"
+fi
+
+if [ "${#missing_sites[@]}" -eq 0 ]; then
+	ok "every non-nix build leg provisions codetracer-trace-format first"
+else
+	fail "every non-nix build leg provisions codetracer-trace-format first" \
+		"build.sh -> env.sh -> build_trace_writer_ffi.sh reads the repo root's" \
+		"../codetracer-trace-format and exits 1 with" \
+		"'ERROR: codetracer-trace-format checkout not found at ...' when it is absent" \
+		"${missing_sites[@]}"
+fi
+
+# ---------------------------------------------------------------------------
+# Self-accounting: a contract that is deleted or short-circuited must not leave
+# this script reporting success on fewer checks than it claims.
+# ---------------------------------------------------------------------------
+echo
+readonly EXPECTED_ASSERTIONS=4
+if [ "$assertions" -ne "$EXPECTED_ASSERTIONS" ]; then
+	printf 'FAIL: ran %d assertions, expected %d\n' "$assertions" "$EXPECTED_ASSERTIONS"
+	failures=$((failures + 1))
+fi
+
+if [ "$failures" -ne 0 ]; then
+	printf '%d of %d assertions failed\n' "$failures" "$assertions"
+	exit 1
+fi
+printf 'all %d assertions passed\n' "$assertions"

--- a/ci/test/sibling-provisioning-test.sh
+++ b/ci/test/sibling-provisioning-test.sh
@@ -67,6 +67,13 @@
 #      turn this suite into a vacuous pass).
 #   4. Every workflow step that runs `./non-nix-build/build.sh` is preceded, in
 #      its own job, by a step that provisions `codetracer-trace-format`.
+#   5. Every workflow step that runs `ci/setup-rr-backend.sh` sets
+#      `RR_BACKEND_REF`. That script's other route to a revision is the same
+#      workspace lock, reached through `scripts/resolve-sibling-rev.sh`, which
+#      locates the locks/ tree by walking up for `.repro/manifests` or
+#      `.repo/manifests` -- neither of which exists in a CI checkout. Without
+#      the override the step exits 3 with "cannot locate the manifest repo
+#      locks/ tree", one step after `Setup dev env` was made to survive.
 #
 # # No mocks
 #
@@ -266,11 +273,69 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 3. Every `ci/setup-rr-backend.sh` step overrides the ref explicitly.
+# ---------------------------------------------------------------------------
+echo
+echo "rr-backend setup overrides the ref explicitly"
+
+rr_sites=0
+rr_missing=()
+
+for wf in "$WORKFLOW_DIR"/*.yml; do
+	[ -f "$wf" ] || continue
+	wf_name="${wf##*/}"
+	step_has_override=0
+	line_no=0
+	while IFS= read -r line || [ -n "$line" ]; do
+		line_no=$((line_no + 1))
+		stripped_line="${line#"${line%%[![:space:]]*}"}"
+		case "$stripped_line" in
+		'- name: '* | '- uses: '* | '- run: '*)
+			# A new step: the override must be declared inside the step that
+			# runs the script, so reset at every step boundary.
+			step_has_override=0
+			;;
+		esac
+		case "$stripped_line" in
+		'RR_BACKEND_REF:'*)
+			# An empty value is the unset case wearing a costume.
+			rr_ref="${stripped_line#RR_BACKEND_REF:}"
+			rr_ref="${rr_ref#"${rr_ref%%[![:space:]]*}"}"
+			[ -n "$rr_ref" ] && step_has_override=1
+			;;
+		esac
+		case "$stripped_line" in
+		*'ci/setup-rr-backend.sh'*)
+			case "$stripped_line" in
+			'#'*) ;;
+			*)
+				rr_sites=$((rr_sites + 1))
+				if [ "$step_has_override" -eq 0 ]; then
+					rr_missing+=("$wf_name:$line_no: runs ci/setup-rr-backend.sh without RR_BACKEND_REF")
+				fi
+				;;
+			esac
+			;;
+		esac
+	done <"$wf"
+done
+
+if [ "${#rr_missing[@]}" -eq 0 ]; then
+	ok "all $rr_sites ci/setup-rr-backend.sh call sites set RR_BACKEND_REF"
+else
+	fail "all ci/setup-rr-backend.sh call sites set RR_BACKEND_REF" \
+		"without it the script resolves the revision from the workspace lock via" \
+		"scripts/resolve-sibling-rev.sh, which exits 3 with 'cannot locate the" \
+		"manifest repo locks/ tree' on a runner -- there is no .repro/manifests there" \
+		"${rr_missing[@]}"
+fi
+
+# ---------------------------------------------------------------------------
 # Self-accounting: a contract that is deleted or short-circuited must not leave
 # this script reporting success on fewer checks than it claims.
 # ---------------------------------------------------------------------------
 echo
-readonly EXPECTED_ASSERTIONS=4
+readonly EXPECTED_ASSERTIONS=5
 if [ "$assertions" -ne "$EXPECTED_ASSERTIONS" ]; then
 	printf 'FAIL: ran %d assertions, expected %d\n' "$assertions" "$EXPECTED_ASSERTIONS"
 	failures=$((failures + 1))

--- a/ci/test/visual-replay-build-sibling-preflight.sh
+++ b/ci/test/visual-replay-build-sibling-preflight.sh
@@ -18,6 +18,23 @@ REQUIRED_BUILD_SIBLING_FILES=(
 	"codetracer-trace-format-nim/src/codetracer_trace_writer/new_trace_reader.nim"
 	"io-mon/src/io_mon.nim"
 	"nim-shm-queue/src/shm_queue/ring.nim"
+	# io-mon and nim-shm-gset are a MATCHED PAIR, for the same reason
+	# codetracer-trace-format and codetracer-trace-format-nim are. `io_mon.nim`
+	# imports `io_mon/writer` and `io_mon/fs_snoop`, both of which import
+	# `shm_gset` / `shm_gset/transport` -- the grow-only shared-memory set that
+	# backs io-mon's Linux dependency-capture channel. Nothing in io-mon's own
+	# manifest names nim-shm-gset (io-mon resolves it as a plain sibling via its
+	# `config.nims` `SHM_GSET_SRC` default), so provisioning io-mon alone looks
+	# complete and is not.
+	#
+	# The repo-root `config.nims` threads it on with `addPathIfDir`, which is
+	# SILENT when the directory is absent: the missing sibling does not surface
+	# at provisioning time, it surfaces much later as
+	#
+	#     cannot open file: shm_gset/transport
+	#
+	# out of the `ct` compile. Checking it here names the real cause instead.
+	"nim-shm-gset/src/shm_gset/transport.nim"
 	"nim-stackable-hooks/src/stackable_hooks/propagation.nim"
 )
 

--- a/ci/test/visual-replay-private-cargo-preflight-test.sh
+++ b/ci/test/visual-replay-private-cargo-preflight-test.sh
@@ -271,7 +271,14 @@ SECOND_GIT_SOURCE
 # into the checkout's `.git/config`. `git config --get-urlmatch` consults the
 # repository config, and `https://github.com/` is a prefix of every URL the
 # boundary check probes, so the old "no header may match at all" formulation
-# failed on every real run while the property it protects was intact.
+# failed while the property it protects was intact. (One run is on record for
+# this gate — 30726348404; see the corrected evidence note in
+# `visual-replay-private-cargo-preflight.sh`, which retracts a wider claim.)
+#
+# The gate's own checkout now sets `persist-credentials: false`, so it should no
+# longer produce this header itself. These cases are kept regardless: a
+# persistent self-hosted runner can carry ambient Git configuration from other
+# sources, and the preflight must stay correct when it does.
 #
 # Neither of these is a mock: each builds a real git repository and writes the
 # real configuration actions/checkout writes, then runs the preflight as a

--- a/ci/test/visual-replay-private-cargo-preflight.sh
+++ b/ci/test/visual-replay-private-cargo-preflight.sh
@@ -128,9 +128,19 @@ fi
 # exists to protect was intact — the lldb-sys URL still resolved to the
 # lldb-sys header, and nothing else did.
 #
-# Asserting "no header at all" was always stronger than the contract and was
-# never in the gate's power to guarantee: the ambient header belongs to the
-# checkout, not to this script.
+# RE-EXAMINE THIS. As of 2026-08-14 the gate's checkout sets
+# `persist-credentials: false`, so the ambient header this relaxation exists to
+# tolerate is no longer written by the one step known to write it. Reading (1)
+# below may now be satisfiable in the real environment again, which would make
+# the stronger "no header matches at all" form achievable. It has deliberately
+# NOT been re-tightened in the same change: a persistent self-hosted GPU runner
+# can carry ambient Git configuration from sources other than actions/checkout,
+# and with the runner pool saturated that could not be observed here. Re-tighten
+# only against a green run that proves it, not against this comment.
+#
+# Asserting "no header at all" was also always stronger than the contract and
+# was never wholly in the gate's power to guarantee — ambient config belongs to
+# the environment, not to this script.
 git_isolated_dir="$(mktemp -d)"
 if git -C "$git_isolated_dir" rev-parse --git-dir >/dev/null 2>&1; then
 	# TMPDIR inside a work tree would silently reintroduce repository config

--- a/ci/test/visual-replay-private-cargo-preflight.sh
+++ b/ci/test/visual-replay-private-cargo-preflight.sh
@@ -124,9 +124,31 @@ fi
 # into the checkout's `.git/config`. `git config --get-urlmatch` reads the
 # repository config too, and `https://github.com/` is a prefix of every URL
 # below, so all three matched and the gate failed `auth-header-url-boundary`
-# on every run (30726348404, 31180327493, 31385899773) while the property it
-# exists to protect was intact — the lldb-sys URL still resolved to the
-# lldb-sys header, and nothing else did.
+# while the property it exists to protect was intact — the lldb-sys URL still
+# resolved to the lldb-sys header, and nothing else did.
+#
+# EVIDENCE, CORRECTED (2026-08-14). 57ef307d4 cited three runs here —
+# 30726348404, 31180327493, 31385899773 — and said the gate failed this way on
+# "every run". Only the first is real:
+#
+#   30726348404  2026-08-02  failed in `Run visual replay regression gate`,
+#                            log: "Visual replay CI private Cargo
+#                            authentication invariant failed:
+#                            auth-header-url-boundary."   <- genuine
+#   31180327493  2026-08-07  failed in `Setup dev env`    <- never reached here
+#   31385899773  2026-08-10  failed in `Setup dev env`    <- never reached here
+#
+# The latter two are the workspace-lock outage (see the header of
+# `.github/workflows/codetracer.yml`); they died before this script ran and
+# cannot evidence anything about it. The same three run IDs appear in
+# codetracer.yml for the *Windows* git/bash defect, where all three genuinely
+# do show the failure — that citation is sound, and is the likely source this
+# one was copied from.
+#
+# So the relaxation rests on ONE observed failure plus a mechanism that is
+# verifiable from first principles (the persisted header prefix-matches every
+# URL). That is not nothing, but it is not what was claimed, and a security
+# check should not be loosened on a count of runs nobody re-read.
 #
 # RE-EXAMINE THIS. As of 2026-08-14 the gate's checkout sets
 # `persist-credentials: false`, so the ambient header this relaxation exists to
@@ -138,9 +160,9 @@ fi
 # and with the runner pool saturated that could not be observed here. Re-tighten
 # only against a green run that proves it, not against this comment.
 #
-# Asserting "no header at all" was also always stronger than the contract and
-# was never wholly in the gate's power to guarantee — ambient config belongs to
-# the environment, not to this script.
+# Independently of the citation count: asserting "no header at all" was also
+# always stronger than the contract and was never wholly in the gate's power to
+# guarantee — ambient config belongs to the environment, not to this script.
 git_isolated_dir="$(mktemp -d)"
 if git -C "$git_isolated_dir" rev-parse --git-dir >/dev/null 2>&1; then
 	# TMPDIR inside a work tree would silently reintroduce repository config

--- a/ci/verdict/workspace-lock-freshness.sh
+++ b/ci/verdict/workspace-lock-freshness.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Alarm: the shared manifests repo is still receiving workspace locks for this
+# repo's commits.
+#
+# # Why this file exists
+#
+# Until 2026-08-04, "is this commit locked?" was answered on every run as a side
+# effect: `setup-dev-env` resolved each cross-repo sibling's revision from the
+# per-commit workspace lock, so an unlocked commit could not get past
+# `Setup dev env`. That coupling was a terrible gate — it took six jobs down in
+# their first real step and left nine more `skipped` for eight days — and the
+# `siblings:` entries now name their refs explicitly so it cannot happen again.
+#
+# But that coupling was also the ONLY thing anyone was watching. Removing it
+# fixes the pipeline and silences the alarm in the same stroke, and the
+# underlying condition is not small:
+#
+#   Nothing has been committed to metacraft-labs/metacraft-manifests, for ANY
+#   repo, since 2026-08-02 (`b3b0ac6 Publish 1 workspace lock entry`).
+#
+# Those per-commit locks are what make a published workspace state reproducible.
+# A stall means no reproducible snapshot of the workspace exists for any commit
+# in that window — a fact about the whole workspace, not about CI.
+#
+# The failure is quieter than "the tooling broke". `repro`'s post-commit hook
+# still WRITES the lock, into a workspace-local checkout of the manifests repo,
+# and logs `ok wrote <path>` and exits 0. It is the commit-and-push that stopped:
+# the files sit untracked in that checkout. On 2026-08-13 a developer's checkout
+# held twenty untracked codetracer locks, including one for the exact commit CI
+# was reporting as unlocked. The tooling's success message was true and useless
+# — the artefact existed on one disk and nowhere else.
+#
+# So this job exists to say that out loud, on every run, in its own name.
+#
+# # Why it is a job and not a gate
+#
+# Nothing declares `needs:` on this job and it is absent from
+# `ci/verdict/required-jobs.txt`. That is deliberate, and it is the whole design:
+# a red check here must never be able to skip a test job. Coupling lock
+# publication to the test suite is precisely the defect this repo just spent a
+# PR undoing; re-introducing it as a gate would trade an eight-day outage for
+# the next one. It is loud (a named, red check on every run) and structurally
+# incapable of cascading.
+#
+# # What is asserted
+#
+# A lock exists for the commit under test, or for its first parent (the same two
+# candidates `clone-siblings` probes, and the same `--no-walk` reasoning: CI
+# checkouts are shallow, so an ancestry walk would hide the diagnosis rather
+# than answer it). Resolution is delegated to `scripts/resolve-sibling-rev.sh`,
+# the repo's existing resolver — it already knows both lock layouts (nested and
+# flat) and both spellings (repo-workspaces `.xml`, reprobuild `.toml`), and it
+# carries its own 51-assertion contract suite. Exit 3 from it is its only "this
+# commit is not locked" answer; anything else means a lock exists but cannot be
+# trusted, which is a different and worse report.
+#
+# # No mocks
+#
+# The input is a real checkout of the manifests repo, cloned by the caller.
+# `--manifest-dir` exists so the check can be exercised against a fixture
+# directory offline, not so CI can be handed a stub.
+#
+# Usage:
+#   ci/verdict/workspace-lock-freshness.sh --manifest-dir DIR --sha SHA [--sha PARENT_SHA]
+#
+# Exit: 0 a lock exists · 1 no lock (the alarm) · 2 usage error
+# Lane: the `workspace-lock-freshness` job (stock ubuntu-latest, bash + git).
+# =============================================================================
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+readonly REPO_ROOT
+readonly RESOLVER="$REPO_ROOT/scripts/resolve-sibling-rev.sh"
+
+# The sibling probed is irrelevant to the question being asked — any entry in
+# the lock proves the lock exists. `codetracer-trace-format` is used because it
+# is in every one of this repo's sibling lists, so a lock that omits it is
+# itself worth the louder exit-4 report.
+readonly PROBE_SIBLING="codetracer-trace-format"
+
+MANIFEST_DIR=""
+SHAS=()
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+	--manifest-dir)
+		MANIFEST_DIR="${2:-}"
+		shift 2
+		;;
+	--sha)
+		[ -n "${2:-}" ] && SHAS+=("$2")
+		shift 2
+		;;
+	*)
+		echo "usage: workspace-lock-freshness.sh --manifest-dir DIR --sha SHA [--sha SHA]" >&2
+		exit 2
+		;;
+	esac
+done
+
+if [ -z "$MANIFEST_DIR" ] || [ "${#SHAS[@]}" -eq 0 ]; then
+	echo "usage: workspace-lock-freshness.sh --manifest-dir DIR --sha SHA [--sha SHA]" >&2
+	exit 2
+fi
+
+# The all-zero SHA is what GitHub reports for a branch's first push; it is not a
+# commit and must not be probed.
+readonly ZERO_SHA="0000000000000000000000000000000000000000"
+
+locked_sha=""
+untrusted=""
+for sha in "${SHAS[@]}"; do
+	[ "$sha" = "$ZERO_SHA" ] && continue
+	rc=0
+	"$RESOLVER" --repo codetracer --sibling "$PROBE_SIBLING" \
+		--manifest-dir "$MANIFEST_DIR" --sha "$sha" --no-walk >/dev/null 2>&1 || rc=$?
+	if [ "$rc" -eq 0 ]; then
+		locked_sha="$sha"
+		break
+	fi
+	# 3 is "not locked" (try the next candidate). 4/5/6 mean a lock EXISTS but
+	# cannot be trusted — a different report, and not the stall this watches for.
+	if [ "$rc" -ne 3 ]; then
+		untrusted="$sha (resolver exit $rc)"
+		break
+	fi
+done
+
+# How stale is the shared repo overall? Reported either way: a lock for THIS
+# commit does not prove publication is healthy for everyone else.
+newest_lock_date="$(git -C "$MANIFEST_DIR" log -1 --format=%ad --date=short -- locks/ 2>/dev/null || true)"
+[ -z "$newest_lock_date" ] && newest_lock_date="unknown"
+
+if [ -n "$untrusted" ]; then
+	echo "::error::A workspace lock exists for $untrusted but cannot be used. This is not a publication stall; read the resolver's diagnostic."
+	exit 1
+fi
+
+if [ -n "$locked_sha" ]; then
+	echo "Workspace lock present for ${locked_sha}."
+	echo "Newest commit touching locks/ in the manifests repo: ${newest_lock_date}."
+	exit 0
+fi
+
+cat <<EOF
+
+==============================================================
+  WORKSPACE LOCK PUBLICATION HAS STALLED
+==============================================================
+
+No workspace lock exists in the shared manifests repo for any of:
+
+$(printf '  - %s\n' "${SHAS[@]}")
+
+Newest commit touching locks/ in that repo: ${newest_lock_date}.
+
+This is NOT a CI failure and it does not affect the test jobs — they
+stopped depending on the lock deliberately. It is a statement about
+the WORKSPACE: for every commit in this window there is no published,
+reproducible snapshot of which sibling revisions it was built against.
+
+The likely shape, because it is the one already observed: 'repro's
+post-commit hook still writes the lock into a workspace-local checkout
+of the manifests repo and logs 'ok wrote <path>', exit 0 — and nothing
+commits or pushes it. Check for untracked files:
+
+    git -C <workspace>/.repro/manifests status --porcelain locks/
+
+Two other silent modes have been seen in the same logs, both exit 0:
+
+    skipped-dirty  dirty sibling(s): <repo>     (no lock written at all)
+    failed         repo '<x>' has no on-disk checkout at ...
+
+    <workspace>/.repro/workspace/post-commit-lock.log
+
+EOF
+exit 1


### PR DESCRIPTION
## The failure

Every job that clones cross-repo siblings through `setup-dev-env` has been dying in that step on every push since **2026-08-04**:

```
##[error]No workspace lock for codetracer (candidates: 253a4f67… 57ef307d…).
Neither a repo-workspaces locks/<project>/codetracer/<sha>.xml nor a
reprobuild locks/<project>/codetracer/<sha>.toml exists in
metacraft-labs/metacraft-manifests@latest.
```

A bare `siblings:` entry asks `clone-siblings` to resolve that sibling's revision from a per-commit **workspace lock** published to a separate manifests repo. Publication stopped after 2026-08-02 (last entry: `locks/dev/codetracer/784c9bda….xml`), and the resolver probes only the pushed commit and its parent (`--no-walk`), so `dev` stayed resolvable for exactly one more commit and then broke:

| commit | parent | `Setup dev env` |
|---|---|---|
| `8d587343` | `784c9bda` (locked) | last green |
| `3583cd6b` | `8d587343` | **first red**, run 30951549711, 2026-08-04 |

Affected: `lint-rust`, `test-non-gui`, `test-ui-tests` (both legs), `test-ui-tests-rr`, `visual-replay-regression-gate`, `ct-test-providers` — and, in consequence, the nine jobs that `needs:` them, reported `skipped`. `ci-verdict` has been saying exactly this: `expected=26 executed=15 did-not-run=11`.

---

## ⚠️ Read this part even if you skip the rest

**Nothing has been committed to `metacraft-labs/metacraft-manifests`, for *any* repo, since 2026-08-02.**

Those per-commit locks are what make a published workspace state reproducible. The stall means **no reproducible snapshot of the workspace exists for any commit in the last eleven days** — a fact about the whole workspace, not about this pipeline. CI going red was only its most visible symptom, and this PR removes that symptom.

The failure is quieter than "the tooling broke", which is why it lasted. `repro`'s post-commit hook **still writes the lock** — into a *workspace-local* checkout of the manifests repo — and logs `ok wrote <path>`, exit 0. It is the commit-and-push that stopped. A developer checkout inspected on 2026-08-13 was a clean, up-to-date checkout of `metacraft-manifests@latest` holding **twenty untracked codetracer lock files**, including `locks/codetracer/codetracer/253a4f6745261efe733f6ce0702c3bbcfd52ff54.toml` — the exact commit CI was reporting as unlocked, written that same day at 14:08. The tooling's success message was true and useless: the artefact existed on one disk and nowhere else.

Two further silent modes appear in the same `post-commit-lock.log` files, both exit 0:

```
skipped-dirty  dirty sibling(s): <repo>                       (no lock written at all)
failed         repo '<x>' has no on-disk checkout at ...      (no lock written at all)
```

So this PR adds **`workspace-lock-freshness`** — a job, deliberately *not* a gate. Nothing declares `needs:` on it and it is absent from `ci/verdict/required-jobs.txt`, because a red check here must never be able to skip a test job; coupling lock publication to the test suite is precisely the defect being undone. It is loud (a named, red check on every run while the stall lasts) and structurally incapable of cascading. Stock runner, bash + git — a watchdog must not share the failure mode it watches for.

**What is needed outside this repo:** commit and push those locks (or restore whatever used to). Nothing here can do it.

---

## The fix

Every sibling entry now names its ref explicitly (`name=dev`), which skips the lock lookup entirely.

`dev` is the branch the last published lock itself recorded (`upstream="dev"`) for all eighteen siblings, and it is what the lock-free paths in this workflow already use — `.github/actions/setup-isonim-siblings` and the `clone-repo` steps in `viewmodel-tests` / `test-non-gui` all clone `ref: dev`. Dispatch-input refs get a `|| 'dev'` fallback, because an empty input evaluates to the bare-entry case.

**This changes where a revision comes from, not which repos are provisioned or what any job asserts.** No `continue-on-error`, no job dropped from the required set, no check weakened. Dropping the `=dev` suffixes restores per-commit pinning once locks are published again — and `workspace-lock-freshness` is what will tell you when that day comes.

`test-ui-tests-rr` meets the same missing lock one step later: `ci/setup-rr-backend.sh` resolves `codetracer-native-backend` from the lock via `scripts/resolve-sibling-rev.sh`, which locates the `locks/` tree by walking up for `.repro/manifests` or `.repo/manifests` — neither of which exists in a CI checkout, so it exits 3. It gets the documented `RR_BACKEND_REF` override; the script's lock path is untouched and still works in a real workspace.

## Second, independent failure: the macOS non-nix leg

`test-non-gui`'s macOS leg runs `./non-nix-build/build.sh`, which (via `env.sh` → `build_trace_writer_ffi.sh`) needs a `codetracer-trace-format` checkout at `../codetracer-trace-format`. That stopped being an in-repo submodule in `e901eb6c8` (2026-05-12), and this leg's `Setup dev env` — the step that clones siblings — is `if: matrix.platform == 'nixos'`, so the sibling was never provisioned there:

```
ERROR: codetracer-trace-format checkout not found at
.../non-nix-build/../../codetracer-trace-format.
```

Cloned with the same `clone-repo` + `ref: dev` pattern the leg already uses for the python / ruby / BEAM recorders, plus the build environment its sibling job `test-ui-tests` passes to the same script.

That leg's last green run anywhere is 24457842335 (`main`, 2026-04-15) and it has **never** been green on `dev`, so this clears the current error without claiming to make the leg green — and indeed it now fails later in the same step, on the older defect underneath. It is `continue-on-error` on macOS either way.

## Regression cover

`ci/test/sibling-provisioning-test.sh` (5 assertions, each mutation-verified) fails if any sibling entry stops naming a ref, if an expression ref loses its fallback, if a non-nix build leg stops provisioning `codetracer-trace-format`, or if a `ci/setup-rr-backend.sh` call site loses `RR_BACKEND_REF`. Static checks over the workflow files, run in `ci-verdict` on a stock runner.

## Also still needed outside this repo

**`eph-macos-arm64` has no runner.** `reprobuild-macos-smoke` and `origin-dap-macos` (and now `dmg-lib-check`) request it; no registered org runner carries that label — the darwin runners expose `darwin` / `nix-darwin` / `aarch64-darwin`. Those jobs sit queued for GitHub's 24-hour ceiling and are then cancelled, which is why every `Codetracer CI` run on `dev` shows a 24h duration and why `ci-verdict` cannot publish a prompt verdict. Deliberately not "fixed" here by relabelling, since `3a79a23b1` is actively migrating more jobs *onto* that class — it needs the pool, not a workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update (2026-08-14): second matched pair, and the first green `Setup dev env` since 2026-08-02

### A second matched pair: `io-mon` implies `nim-shm-gset`

`32a9de3c7` / `436f72677` fixed `codetracer-trace-format` + `codetracer-trace-format-nim`. Asking the same question of every other provisioned sibling turns up one more.

`io-mon/src/io_mon.nim` pulls in `io_mon/writer` and `io_mon/fs_snoop`; both import `shm_gset` / `shm_gset/transport`. Nothing in io-mon's manifest names nim-shm-gset — io-mon resolves it as a plain sibling via its `config.nims` `SHM_GSET_SRC` default, and codetracer's repo-root `config.nims` mirrors that with `addPathIfDir(workspaceRoot / "nim-shm-gset" / "src")`. **`addPathIfDir` is silent when the directory is absent**, so an io-mon-only `siblings:` block provisions successfully and the omission surfaces much later, out of the `ct` compile, as `cannot open file: shm_gset/transport`, with nothing pointing back at the sibling list.

The sibling clone also *wins* over the `IO_MON_SRC` flake input (Nim searches `--path` newest-first; the repo-root config adds the workspace sibling after it). So pinning `io-mon=dev` is both what makes the newer `shm_gset` import reachable and what makes the missing sibling fatal — currency without coordination, the same shape as the trace-format pair.

Both blocks that provision io-mon now provision `nim-shm-gset`, the build-sibling preflight names it, and the provisioning contract gains a seventh assertion (mutation-verified: dropping either entry fails it with the offending `file:line`). This was a **static** finding — both jobs had been dying earlier than the `ct` compile for the whole period it was reachable.

### `persist-credentials: false` on the gate's checkout

`actions/checkout` defaults to persisting `http.https://github.com/.extraHeader` into `.git/config`. That header prefix-matches every GitHub URL, which is the only reason the private-Cargo preflight's `auth-header-url-boundary` check had to be weakened from "no header matches at all". The gate's checkout now opts out. Blast radius re-confirmed before changing it, and then confirmed empirically by the run below:

* `Setup dev env` receives the same installation token explicitly as `gh-token`.
* `submodules: recursive` is unaffected — actions/checkout installs a temporary **global** auth config for submodule fetching regardless of the setting, and strips the credential in its `finally` block, *after* submodules are checked out.
* The gate does no network git against this checkout. Its single authenticated fetch (`git ls-remote` on lldb-sys, in the preflight) uses the process-scoped `GIT_CONFIG_KEY_0` extraHeader; every other git-touching step runs with its working directory inside a *sibling* repo.

The boundary check is deliberately **not** re-tightened in the same change: a persistent self-hosted runner can carry ambient Git config from sources other than actions/checkout. Re-tighten only against a run that proves it.

Separately, `57ef307d4` justified the original relaxation by citing three runs and claiming failure on "every run". Re-reading them, only `30726348404` reached this script; `31180327493` and `31385899773` died in `Setup dev env`. (The same three IDs are cited elsewhere for the *Windows* git/bash defect, where all three genuinely do show it — that citation is sound and is the likely copy source.) The relaxation stands on one observed failure plus a first-principles mechanism; the comment now says so.

### What CI actually showed — run [31777765164](https://github.com/metacraft-labs/codetracer/actions/runs/31777765164)

**`Setup dev env` passed in `visual-replay-regression-gate` — the first time since 2026-08-02.** That is this PR's purpose, and it is confirmed, not inferred. `CT_SIBLING_PATHS` lists all sixteen siblings including the newly added `nim-shm-gset`. The checkout also succeeded with `persist-credentials: false` + `submodules: recursive`, the private-Cargo preflight reported `Visual replay private Cargo preflight tests passed.`, and the authenticated lldb-sys fetch resolved a new ref — so the process-scoped header is doing the authenticating, exactly as claimed.

The gate then failed **further along, on a defect this PR made reachable rather than one it introduced** (see below).

## Defects now visible because the signal was restored

Recorded here so they are not lost when the pipeline greens. **None of these is fixed in this PR.**

1. **Stale sibling `Cargo.lock` under `--locked`** — the gate's current blocker:
   ```
   error: cannot update the lock file .../codetracer-native-backend/Cargo.lock
   because --locked was passed to prevent this
   ```
   Same coordination defect one level out: `codetracer-native-backend=dev` is cloned independently, and its committed lock no longer resolves against the pinned `codetracer-trace-format`. **The `--locked` is load-bearing and must not simply be dropped** — `visual-replay-private-cargo-preflight.sh` first asserts the lock contains exactly one `git+` source (`locked-git-source-boundary`) and then fetches *under that verified lock*; without `--locked`, cargo may resolve git sources the boundary check never saw. `codetracer.yml` already drops `--locked` for the BEAM leg for the mirror-image reason, so the two halves of the repo currently disagree about this. Needs a decision, not a patch.

2. **macOS linker name mismatch.** `non-nix-build/build_trace_writer_ffi.sh` stages `libcodetracer_trace_writer_ffi.a`, but the link asks for the un-suffixed name:
   ```
   ld: library 'codetracer_trace_writer' not found
   ```
   Observed in run 31710210728, job 94480896994, `test-non-gui (macos, macos-latest)`. The `-l` flag is emitted from the `codetracer-trace-format` sibling, so this is not reproducible from this tree alone.

3. **`push-install-script` has no Nix setup.** The job goes straight from `Checkout` to a bare `nix develop .#devShells.x86_64-linux.default --command aws …` with no `Setup dev env` step, so nothing enables the `nix-command` / `flakes` experimental features on the ephemeral runner. `push-gpg-public-key` has the same shape. Neither is in `ci/verdict/required-jobs.txt`.

4. **`eph-macos-arm64` has no runner** — see the section above. Re-verified today against the live org runner list: no registered runner carries that label (nor `eph-linux-x64` / `eph-win-x64` statically; those are served by GARM pools, which is why the linux legs *do* start). Three **required** jobs sit on it: `reprobuild-macos-smoke`, `origin-dap-macos`, `dmg-lib-check`. Until the pool exists, no `Codetracer CI` run on this repo can go fully green.

5. **Private-registry auth: two competing patterns, needs an owner decision.** `ct-test-providers` (and `test-ui-tests`) use
   ```
   git config --global url."https://x-access-token:<token>@github.com/".insteadOf …
   ```
   — global, all of github.com, token embedded in the rewritten URL. `visual-replay-regression-gate` uses the opposite: a process-scoped `GIT_CONFIG_KEY_0` extraHeader scoped to **one** URL, `GIT_CONFIG_GLOBAL=/dev/null`, `credential.helper` disabled, the token kept out of `git-remote-https` argv, and a preflight asserting the credential does not widen. These are genuinely different security postures for the same problem; picking one is not a mechanical change.

## Honest statement of evidence

Everything above marked "observed" is from a real CI run, cited by run/job id. The `io-mon` → `nim-shm-gset` pair is a **static** finding confirmed against a local checkout (`nim dump` shows the path is supplied only by the sibling), **not** a CI reproduction — both jobs that would hit it die earlier. The contract test, the private-Cargo preflight suite and the provisioning suite were run **locally**; those are local runs and are not presented as CI results. `workspace-lock-freshness` is red by design (an alarm, deliberately absent from `required-jobs.txt`) and must not be read as a regression.
