### PR TITLE
ci: build macOS via reprobuild, retire non-nix-build/build.sh

### DIFF
--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -2100,16 +2100,16 @@ jobs:
           nix develop .#devShells.x86_64-linux.default --command aws --endpoint-url=${{ secrets.R2_CODETRACER_BUCKET_S3_ENDPOINT }} s3 cp CodeTracer.AppImage.asc s3://${{ vars.R2_CODETRACER_BUCKET_NAME }}/CodeTracer-${{ github.ref_name }}-amd64.AppImage.asc
 
   dmg-build:
-    # DEFERRED (CIP-5 Wave 4): stays on the GitHub-hosted macOS image. The
-    # `brew install awscli` step alone would be a trivial `nixpkgs#awscli2`
-    # swap, but the actual dmg build (`./ci/build/dmg.sh` ->
-    # `./non-nix-build/build.sh`) is Homebrew-native end to end:
-    # non-nix-build/env.sh, build_with_nim.sh, build_dmg.sh, install_tup.sh and
-    # install_node.sh all `brew install` their deps (sqlite3, ruby, capnp,
-    # libzip, create-dmg, pcre2, macFUSE, node, …). The nix-darwin runners have
-    # no Homebrew, so migrating this leg means porting the whole non-nix-build
-    # toolchain to nix (a build-system redesign), not a tool-provisioning swap.
-    runs-on: macos-latest  # DEFERRED (CIP-5 Wave 4): Homebrew-native non-nix build — see note above
+    # CIP-5 Wave 4: migrated to the self-hosted nix-darwin runner. The DIY
+    # `dtolnay/rust-toolchain` + `./ci/build/dmg.sh` (-> Homebrew-native
+    # `./non-nix-build/build.sh`) and `brew install awscli` steps are gone. The
+    # dmg is now produced toolchain-free by reprobuild
+    # (`repro build .#dmg --tool-provisioning=nix`, driven by
+    # `ci/reprobuild/macos-daemon-build.sh`), which lands the artifact at the
+    # same `non-nix-build/CodeTracer.dmg` path the sign + upload steps consume.
+    # `aws` comes from `nixpkgs#awscli2`, provisioned per-command via `nix
+    # shell`.
+    runs-on: eph-macos-arm64  # CIP-5: nix macOS job -> eph-macos-arm64
     needs:
       - lint-bash
       - lint-nim
@@ -2136,6 +2136,13 @@ jobs:
           submodules: recursive
           token: ${{ steps.ci_token.outputs.token }}
 
+      - name: Install Nix
+        uses: ./.github/actions/setup-nix
+        with:
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
+
       - name: "Import GPG key for signing commits"
         id: import-gpg
         uses: crazy-max/ghaction-import-gpg@v6
@@ -2146,14 +2153,12 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Build
-        run: ./ci/build/dmg.sh
-
-      - name: Install AWS CLI
-        run: brew install awscli
+      - name: Build DMG via reprobuild
+        # Toolchain-free reprobuild macOS build: starts runquotad, runs
+        # `repro build .#dmg --tool-provisioning=nix`, and asserts the artifact
+        # at `non-nix-build/CodeTracer.dmg` — the exact path the sign + upload
+        # steps below consume.
+        run: nix develop . --command bash ci/reprobuild/macos-daemon-build.sh
 
       - name: Upload artifact
         env:
@@ -2163,8 +2168,8 @@ jobs:
           gpg --armor --detach-sign non-nix-build/CodeTracer.dmg
           # for now apply workaround from https://community.cloudflare.com/t/an-error-occurred-internalerror-when-calling-the-putobject-operation/764905/11:
           #   adding `--checksum-algorithm CRC32`
-          aws --endpoint-url=${{ secrets.R2_CODETRACER_BUCKET_S3_ENDPOINT }} s3 cp ./non-nix-build/CodeTracer.dmg s3://${{ vars.R2_CODETRACER_BUCKET_NAME }}/CodeTracer-${{ github.ref_name }}-arm64.dmg --checksum-algorithm CRC32
-          aws --endpoint-url=${{ secrets.R2_CODETRACER_BUCKET_S3_ENDPOINT }} s3 cp ./non-nix-build/CodeTracer.dmg.asc s3://${{ vars.R2_CODETRACER_BUCKET_NAME }}/CodeTracer-${{ github.ref_name }}-arm64.dmg.asc --checksum-algorithm CRC32
+          nix shell nixpkgs#awscli2 --command aws --endpoint-url=${{ secrets.R2_CODETRACER_BUCKET_S3_ENDPOINT }} s3 cp ./non-nix-build/CodeTracer.dmg s3://${{ vars.R2_CODETRACER_BUCKET_NAME }}/CodeTracer-${{ github.ref_name }}-arm64.dmg --checksum-algorithm CRC32
+          nix shell nixpkgs#awscli2 --command aws --endpoint-url=${{ secrets.R2_CODETRACER_BUCKET_S3_ENDPOINT }} s3 cp ./non-nix-build/CodeTracer.dmg.asc s3://${{ vars.R2_CODETRACER_BUCKET_NAME }}/CodeTracer-${{ github.ref_name }}-arm64.dmg.asc --checksum-algorithm CRC32
 
   dmg-lib-check:
     # CIP-5 Wave 4: migrated to the self-hosted nix-darwin runner. The DIY

--- a/ci/build/dmg.sh
+++ b/ci/build/dmg.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-./non-nix-build/build.sh


### PR DESCRIPTION
## What

Migrate the macOS **DMG release build** (`dmg-build`) off the GitHub-hosted
`macos-latest` image + Homebrew toolchain and onto the self-hosted
`eph-macos-arm64` runner, building via the existing reprobuild path.

## Changes

- **`dmg-build`**: `runs-on: macos-latest` -> `eph-macos-arm64`. Dropped the
  DIY `dtolnay/rust-toolchain` + `./ci/build/dmg.sh` (-> Homebrew-native
  `./non-nix-build/build.sh`) and `brew install awscli` steps. The dmg is now
  produced toolchain-free by reprobuild
  (`repro build .#dmg --tool-provisioning=nix`, driven by
  `ci/reprobuild/macos-daemon-build.sh`, invoked under `nix develop .`). It
  lands at the same `non-nix-build/CodeTracer.dmg` path, so the **GPG-sign and
  R2-upload steps, secrets, and env are unchanged** — only `aws` now comes
  from `nix shell nixpkgs#awscli2` instead of `brew install awscli`. Stale
  `DEFERRED (CIP-5 Wave 4)` note removed.
- Deleted the now-unused `ci/build/dmg.sh` wrapper (only the migrated leg
  referenced it).

## Deliberately NOT changed (see PR discussion)

- **`non-nix-build/build.sh` + helpers KEPT.** They remain the documented
  no-Nix local macOS build path (README, both `installation.md`), and
  `non-nix-build/env.sh` is sourced by `.envrc` for the `NO_NIX=1` dev flow.
  Deleting them is a product decision for reviewers, not a CI-migration
  side effect. Only CI usage was retired.
- **`test-non-gui` / `test-ui-tests` macOS legs (continue-on-error) NOT
  migrated.** Their runners stay on `macos-latest` because `ci/test/non-gui.sh`
  and `ci/test/ui-tests-db.sh` hardcode the `non-nix-build/` toolchain +
  app-bundle layout (`non-nix-build/deps/nim/bin`,
  `non-nix-build/CodeTracer.app/...`). Re-homing them onto reprobuild output
  is a test-harness redesign, not a command swap — tracked as follow-up.
- **`build-python-packages` macos-arm64 (static-link wheel) NOT migrated.** It
  does not use `non-nix-build/build.sh` (its `sh build.sh` is Nim's own
  bootstrap inside the downloaded Nim tarball), and reprobuild has no
  python-wheel target that reproduces the `build-python/...` artifact.

## Validation

actionlint is clean apart from the pre-existing `eph-*` unknown-label
warnings (self-hosted labels), shellcheck noise, and the pre-existing
`packages_dir` / always-true-`if` findings elsewhere in the file. **The DMG
release build can only be fully validated by cutting a tagged release** (the
`dmg-build` leg runs on tag/release refs) — this PR should not be merged
without a release to exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)