### PR TITLE
fix(ci): check the private-Cargo credential boundary at the host, not the repo

### DIFF
--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -3033,11 +3033,17 @@ jobs:
           submodules: recursive
           token: ${{ steps.ci_token.outputs.token }}
           # Do not leave `http.https://github.com/.extraHeader` behind in
-          # `.git/config`. That persisted header prefix-matches every URL, which
-          # is what forced `visual-replay-private-cargo-preflight.sh` to weaken
-          # its `auth-header-url-boundary` check from "no header matches at all"
-          # to "the lldb-sys credential does not widen"; see the long comment
-          # there. Nothing downstream needs it:
+          # `.git/config` for the rest of a three-hour job on a persistent GPU
+          # runner. This is ordinary least-persistence hygiene — the same reason
+          # actions/checkout v6 moved the credential out of `.git/config`
+          # entirely — and NOT a boundary the private-Cargo preflight depends
+          # on: that header carries the org-wide CI App token, which by policy
+          # also authenticates the private lldb-sys dependency, so its presence
+          # is never a leak and the preflight no longer asserts anything about
+          # it. See the long note in
+          # `ci/test/visual-replay-private-cargo-preflight.sh`.
+          #
+          # Nothing downstream needs the persisted header:
           #   * `Setup dev env` gets the same token explicitly via `gh-token`.
           #   * `submodules: recursive` is unaffected — actions/checkout fetches
           #     submodules under a temporary *global* auth config it installs

--- a/ci/test/visual-replay-private-cargo-preflight-test.sh
+++ b/ci/test/visual-replay-private-cargo-preflight-test.sh
@@ -163,6 +163,19 @@ run_negative_case() {
 		# and it is the case that reddens if that reading is deleted.
 		GIT_CONFIG_KEY_0="http.https://github.com/metacraft-labs/.extraHeader"
 		;;
+	auth-key-hostless)
+		# The widening that matters most now the credential is known to be
+		# org-wide: a key with no URL section at all. Git applies
+		# `http.extraHeader` to *every* URL it fetches, github.com or not,
+		# so this would hand an organisation-scoped token to whatever host a
+		# dependency happens to name. Reading (1) catches it — via the
+		# same-host probes as well as the off-host ones, since a host-less
+		# key matches everything. That redundancy is the point: the
+		# `auth-key-wide` case above only widens within github.com, so
+		# without this case nothing would distinguish "keyed to one URL"
+		# from "keyed to one host".
+		GIT_CONFIG_KEY_0="http.extraHeader"
+		;;
 	probe-isolation)
 		# The boundary probe's reading (1) is only meaningful while its
 		# working directory is outside every work tree. `mktemp -d` honours
@@ -180,15 +193,16 @@ run_negative_case() {
 		;;
 	leak-lowercase-field | leak-uppercase-scheme | leak-trailing-space | \
 		leak-doubled-space)
-		# One leaked credential, four wire-valid spellings. RFC 9110 §5.1
-		# makes the field name case-insensitive, RFC 7617 §2 makes the
-		# `basic` scheme token case-insensitive, and RFC 9110 §5.5 allows
-		# optional whitespace around the field value — so every one of these
-		# hands the *same* lldb-sys secret to `https://github.com/`, and a
-		# `==` comparison against `AUTHORIZATION: basic <token>` waves three
-		# of the four through. Git preserves the spelling verbatim
-		# (values with edge whitespace are written quoted), so what
-		# `--get-urlmatch` returns here is what the wire would carry.
+		# One leaked credential, four wire-valid spellings, all pointed at a
+		# host that is not github.com. RFC 9110 §5.1 makes the field name
+		# case-insensitive, RFC 7617 §2 makes the `basic` scheme token
+		# case-insensitive, and RFC 9110 §5.5 allows optional whitespace
+		# around the field value — so every one of these hands the *same*
+		# organisation-scoped token to `https://example.invalid/`, and a `==`
+		# comparison against `AUTHORIZATION: basic <token>` waves three of the
+		# four through. Git preserves the spelling verbatim (values with edge
+		# whitespace are written quoted), so what `--get-urlmatch` returns
+		# here is what the wire would carry.
 		local leak_repo="$TEST_ROOT/leak-checkout-$case_name"
 		local leaked_header
 		case "$case_name" in
@@ -197,7 +211,8 @@ run_negative_case() {
 		leak-trailing-space) leaked_header="AUTHORIZATION: basic ${SENTINEL_BASIC}   " ;;
 		leak-doubled-space) leaked_header="AUTHORIZATION:  basic  ${SENTINEL_BASIC}" ;;
 		esac
-		make_checkout_like_repo "$leak_repo" "$leaked_header"
+		make_checkout_like_repo "$leak_repo" "$leaked_header" \
+			"https://example.invalid/"
 		NEGATIVE_CASE_CWD="$leak_repo"
 		NEGATIVE_CASE_CLEANUP="$leak_repo"
 		;;
@@ -266,21 +281,31 @@ SECOND_GIT_SOURCE
 # `actions/checkout` defaults to `persist-credentials: true` and writes
 #
 #     [http "https://github.com/"]
-#         extraheader = AUTHORIZATION: basic <the run's own GITHUB_TOKEN>
+#         extraheader = AUTHORIZATION: basic <the token the job supplied>
 #
-# into the checkout's `.git/config`. `git config --get-urlmatch` consults the
-# repository config, and `https://github.com/` is a prefix of every URL the
-# boundary check probes, so the old "no header may match at all" formulation
-# failed while the property it protects was intact. (One run is on record for
-# this gate — 30726348404; see the corrected evidence note in
-# `visual-replay-private-cargo-preflight.sh`, which retracts a wider claim.)
+# into the checkout's `.git/config`, and `git config --get-urlmatch` consults
+# the repository config. A persistent self-hosted runner can carry equivalent
+# configuration from other sources too, so the preflight has to stay correct
+# in the presence of a github.com-wide header regardless of what any one
+# `actions/checkout` step is configured to do.
 #
-# The gate's own checkout now sets `persist-credentials: false`, so it should no
-# longer produce this header itself. These cases are kept regardless: a
-# persistent self-hosted runner can carry ambient Git configuration from other
-# sources, and the preflight must stay correct when it does.
+# Two of the cases below are the crux of the boundary contract, and they differ
+# only in the *host* the ambient header applies to:
 #
-# Neither of these is a mock: each builds a real git repository and writes the
+#   * github.com-wide, carrying the very same token the gate installs for
+#     lldb-sys — MUST PASS. `metacraft-labs/lldb-sys.rs` is a private repo in
+#     this organisation, reached with the org-wide CI Token Provider App
+#     installation token; the same token authenticates this checkout and every
+#     private sibling the gate clones. One credential covering all of them is
+#     the policy, not a leak. See the long note in
+#     `visual-replay-private-cargo-preflight.sh` and
+#     `metacraft-dev-guidelines/policies/ci-workflow-standards.md`.
+#   * off-github.com, carrying that same token — MUST FAIL. An
+#     organisation-scoped credential handed to a third-party host is a leak
+#     under any policy, and is the only sense in which "this credential
+#     widened" is still a meaningful accusation.
+#
+# None of these is a mock: each builds a real git repository and writes the
 # real configuration actions/checkout writes, then runs the preflight as a
 # subprocess with that repository as its working directory — exactly how CI
 # invokes it.
@@ -288,16 +313,31 @@ SECOND_GIT_SOURCE
 AMBIENT_BASIC="$(printf 'x-access-token:%s' "ambient-checkout-token-$$" | base64 | tr -d '\r\n')"
 
 make_checkout_like_repo() {
-	# $1 = directory, $2 = the extraHeader value actions/checkout persisted.
-	local dir="$1" header="$2"
+	# $1 = directory, $2 = the extraHeader value actions/checkout persisted,
+	# $3 = the URL the header is scoped to (default: all of github.com, which
+	# is what actions/checkout writes).
+	local dir="$1" header="$2" url="${3:-https://github.com/}"
 	mkdir -p "$dir"
 	git -C "$dir" init -q .
-	git -C "$dir" config "http.https://github.com/.extraheader" "$header"
+	git -C "$dir" config "http.${url}.extraheader" "$header"
+}
+
+run_preflight_in_repo() {
+	# $1 = repo to run from, $2 = cargo workspace, $3 = call-log tag.
+	# Prints combined output; returns the preflight's exit status.
+	local repo="$1" workspace="$2" tag="$3"
+	(
+		cd "$repo" &&
+			CARGO_CALL_LOG="$TEST_ROOT/cargo-$tag.args" \
+				PATH="$TEST_ROOT/bin:$PATH" \
+				bash "$REPO_ROOT/ci/test/visual-replay-private-cargo-preflight.sh" \
+				"$workspace" 2>&1
+	)
 }
 
 run_ambient_credential_positive_case() {
-	# The reproduction: an unrelated, legitimate credential scoped to
-	# https://github.com/ must not fail the gate.
+	# An unrelated, legitimate credential scoped to https://github.com/ must
+	# not fail the gate.
 	local workspace="$TEST_ROOT/workspace/ambient-ok"
 	local repo="$TEST_ROOT/ambient-ok-checkout"
 	write_valid_workspace "$workspace"
@@ -306,45 +346,62 @@ run_ambient_credential_positive_case() {
 	source "$REPO_ROOT/ci/test/visual-replay-private-cargo-env.sh" >/dev/null
 	make_checkout_like_repo "$repo" "AUTHORIZATION: basic ${AMBIENT_BASIC}"
 
-	(
-		cd "$repo" &&
-			CARGO_CALL_LOG="$TEST_ROOT/cargo-ambient-ok.args" \
-				PATH="$TEST_ROOT/bin:$PATH" \
-				bash "$REPO_ROOT/ci/test/visual-replay-private-cargo-preflight.sh" \
-				"$workspace"
-	) || {
+	run_preflight_in_repo "$repo" "$workspace" "ambient-ok" || {
 		echo "Private Cargo preflight rejected a checkout carrying its own" >&2
-		echo "actions/checkout credential; that is not a leak of the lldb-sys" >&2
-		echo "header and must not fail the gate." >&2
+		echo "actions/checkout credential; that is not a leak and must not" >&2
+		echo "fail the gate." >&2
 		exit 1
 	}
 }
 
-run_ambient_credential_leak_case() {
-	# The leak that matters: the lldb-sys header itself, applied to a broader
-	# URL by the repository config, must be caught.
-	local workspace="$TEST_ROOT/workspace/ambient-leak"
-	local repo="$TEST_ROOT/ambient-leak-checkout"
-	local output status
+run_same_credential_org_wide_positive_case() {
+	# The regression this whole rework exists for. The gate installs an
+	# lldb-sys-scoped header carrying the org-wide App installation token; the
+	# checkout carries the SAME token github.com-wide because that is how
+	# every private sibling gets cloned. Failing here would mean the gate
+	# passes only when someone provisions a second, narrower token — the
+	# arrangement the policy exists to avoid, because per-repo tokens are the
+	# ones that need rotating.
+	local workspace="$TEST_ROOT/workspace/same-token"
+	local repo="$TEST_ROOT/same-token-checkout"
 	write_valid_workspace "$workspace"
-	prepare_two_slot_environment "$TEST_ROOT/cargo-ambient-leak"
+	prepare_two_slot_environment "$TEST_ROOT/cargo-same-token"
 	# shellcheck disable=SC1091
 	source "$REPO_ROOT/ci/test/visual-replay-private-cargo-env.sh" >/dev/null
 	make_checkout_like_repo "$repo" "$GIT_CONFIG_VALUE_0"
 
+	run_preflight_in_repo "$repo" "$workspace" "same-token" || {
+		echo "Private Cargo preflight failed a correctly provisioned job: the" >&2
+		echo "org-wide CI App token legitimately authenticates both this" >&2
+		echo "checkout and the private lldb-sys sibling. Do not 'fix' this by" >&2
+		echo "minting a second token; fix the assertion." >&2
+		exit 1
+	}
+	# The fixture wrote the sentinel header into a git config, so remove it
+	# before the end-of-run sweep below.
+	rm -rf "$repo"
+}
+
+run_offsite_credential_leak_case() {
+	# The leak that is still real: the run's credential, applied by ambient
+	# repository config to a host that is not github.com.
+	local workspace="$TEST_ROOT/workspace/offsite-leak"
+	local repo="$TEST_ROOT/offsite-leak-checkout"
+	local output status
+	write_valid_workspace "$workspace"
+	prepare_two_slot_environment "$TEST_ROOT/cargo-offsite-leak"
+	# shellcheck disable=SC1091
+	source "$REPO_ROOT/ci/test/visual-replay-private-cargo-env.sh" >/dev/null
+	make_checkout_like_repo "$repo" "$GIT_CONFIG_VALUE_0" \
+		"https://example.invalid/"
+
 	set +e
-	output="$(
-		cd "$repo" &&
-			CARGO_CALL_LOG="$TEST_ROOT/cargo-ambient-leak.args" \
-				PATH="$TEST_ROOT/bin:$PATH" \
-				bash "$REPO_ROOT/ci/test/visual-replay-private-cargo-preflight.sh" \
-				"$workspace" 2>&1
-	)"
+	output="$(run_preflight_in_repo "$repo" "$workspace" "offsite-leak")"
 	status=$?
 	set -e
-	if ((status == 0)) || [[ $output != *"auth-header-credential-leak"* ]]; then
-		echo "Private Cargo preflight did not catch the lldb-sys credential" >&2
-		echo "being applied to https://github.com/ by the repository config." >&2
+	if ((status == 0)) || [[ $output != *"auth-header-offsite-leak"* ]]; then
+		echo "Private Cargo preflight did not catch the run's credential being" >&2
+		echo "applied to a non-github.com host by the repository config." >&2
 		printf '%s\n' "$output" >&2
 		exit 1
 	fi
@@ -362,20 +419,22 @@ run_ambient_credential_leak_case() {
 
 run_positive_case
 run_ambient_credential_positive_case
-run_ambient_credential_leak_case
+run_same_credential_org_wide_positive_case
+run_offsite_credential_leak_case
 run_negative_case prompt "interactive-credential-blocking"
 run_negative_case global-config "config-file-isolation"
 run_negative_case count "inline-config-count"
 run_negative_case auth-key "auth-header-url-scope"
 run_negative_case auth-key-wide "auth-header-url-boundary"
+run_negative_case auth-key-hostless "auth-header-url-boundary"
 run_negative_case probe-isolation "auth-boundary-probe-isolation"
-# The same leaked lldb-sys credential, spelled four wire-valid ways. Each of
-# these passed the gate while the boundary check compared whole header strings
-# with `==`.
-run_negative_case leak-lowercase-field "auth-header-credential-leak"
-run_negative_case leak-uppercase-scheme "auth-header-credential-leak"
-run_negative_case leak-trailing-space "auth-header-credential-leak"
-run_negative_case leak-doubled-space "auth-header-credential-leak"
+# The same leaked credential, spelled four wire-valid ways, applied to a host
+# that is not github.com. Each of these passed the gate while the boundary check
+# compared whole header strings with `==`.
+run_negative_case leak-lowercase-field "auth-header-offsite-leak"
+run_negative_case leak-uppercase-scheme "auth-header-offsite-leak"
+run_negative_case leak-trailing-space "auth-header-offsite-leak"
+run_negative_case leak-doubled-space "auth-header-offsite-leak"
 run_negative_case header-shape "auth-header-shape"
 run_negative_case helper "credential-helper-blocking"
 run_negative_case redirect "redirect-blocking"

--- a/ci/test/visual-replay-private-cargo-preflight-test.sh
+++ b/ci/test/visual-replay-private-cargo-preflight-test.sh
@@ -174,7 +174,44 @@ run_negative_case() {
 		# `auth-key-wide` case above only widens within github.com, so
 		# without this case nothing would distinguish "keyed to one URL"
 		# from "keyed to one host".
+		#
+		# RUN IT FROM A CHECKOUT THAT CARRIES THE AMBIENT HEADER, not from
+		# whatever directory the suite happens to start in. A host-less key
+		# is the least specific key there is, so against the github.com-wide
+		# `extraHeader` that `actions/checkout` persists it LOSES Git's
+		# specificity contest: the lldb-sys URL resolves to the ambient
+		# header, and `effective-auth-header` fires before reading (1) is
+		# reached. That is environment-dependent — green on a laptop with no
+		# ambient header, red on the runner — and it is what made this case
+		# pass locally and fail in CI. The fixture pins the runner's
+		# environment so the ordering in the preflight cannot regress
+		# unnoticed; the expected invariant stays `auth-header-url-boundary`
+		# because reading (1) is isolated and must answer first.
 		GIT_CONFIG_KEY_0="http.extraHeader"
+		local hostless_repo="$TEST_ROOT/auth-key-hostless-checkout"
+		make_checkout_like_repo "$hostless_repo" \
+			"AUTHORIZATION: basic ${AMBIENT_BASIC}"
+		NEGATIVE_CASE_CWD="$hostless_repo"
+		NEGATIVE_CASE_CLEANUP="$hostless_repo"
+		;;
+	auth-key-narrow)
+		# The other side of `auth-key-wide`, and the case that pins
+		# `effective-auth-header` now that it runs after reading (1).
+		#
+		# This key is a strict extension of the lldb-sys URL, so it is too
+		# narrow rather than too wide: Git hands the header to
+		# `<lldb-sys>/subpath` and NOT to the lldb-sys URL the lockfile
+		# actually names. Nothing leaks — reading (1) sees a key that matches
+		# none of its probes and passes, and reading (2) has nothing to find
+		# — but the fetch this gate exists to authenticate would go out
+		# unauthenticated. Only asking Git's matcher "does the URL we fetch
+		# actually receive this gate's header" catches that.
+		#
+		# The literal key check (`auth-header-url-scope`) would catch this
+		# too, but it runs later, so this case pins the semantic check rather
+		# than the syntactic one: delete the `effective-auth-header` block and
+		# this case reports `auth-header-url-scope` instead and fails.
+		GIT_CONFIG_KEY_0="http.${LLDB_SYS_URL}/subpath.extraHeader"
 		;;
 	probe-isolation)
 		# The boundary probe's reading (1) is only meaningful while its
@@ -427,6 +464,7 @@ run_negative_case count "inline-config-count"
 run_negative_case auth-key "auth-header-url-scope"
 run_negative_case auth-key-wide "auth-header-url-boundary"
 run_negative_case auth-key-hostless "auth-header-url-boundary"
+run_negative_case auth-key-narrow "effective-auth-header"
 run_negative_case probe-isolation "auth-boundary-probe-isolation"
 # The same leaked credential, spelled four wire-valid ways, applied to a host
 # that is not github.com. Each of these passed the gate while the boundary check

--- a/ci/test/visual-replay-private-cargo-preflight.sh
+++ b/ci/test/visual-replay-private-cargo-preflight.sh
@@ -110,111 +110,119 @@ fi
 if [[ $(git config --get-urlmatch http.extraHeader "$LLDB_SYS_URL") != "$cargo_auth_header" ]]; then
 	fail_auth_contract "effective-auth-header"
 fi
-# The invariant is that *the lldb-sys credential* does not widen to any other
-# URL. It is checked twice, because the two readings answer different
-# questions and only both together say what is needed.
+# Two readings of one boundary. Both ask where the *header* this gate installs
+# may travel. Neither asks what the credential inside it is allowed to reach —
+# that is not a property this script can define, and the attempt to define it
+# was wrong.
 #
-# Why this is no longer "no header matches at all". That is what it used to
-# assert, and it was falsified by something entirely legitimate:
-# `actions/checkout` defaults to `persist-credentials: true` and writes
+# WHY THIS NO LONGER ASKS "DOES ANY OTHER github.com URL SEE THIS CREDENTIAL".
+# Until 2026-08-14 reading (2) did exactly that, under the invariant name
+# `auth-header-credential-leak`. The question was malformed.
+# `metacraft-labs/lldb-sys.rs` is a private repository in the *same
+# organisation* as this one, so it is reached with the org-wide CI Token
+# Provider App installation token — the same token this job passes to
+# `actions/checkout` and to `setup-dev-env`, which uses it to clone every
+# private sibling the gate builds against. There is no separate, narrower
+# "lldb-sys credential" for a wider header to leak, and there is deliberately
+# not going to be one: single-purpose minted tokens are the credentials that
+# accrue rotation debt, and the point of the org-wide App is that CI
+# credentials never need rotating. The policy is written down in
+# `metacraft-dev-guidelines/policies/ci-workflow-standards.md` under
+# "Cross-repo cloning".
 #
-#     [http "https://github.com/"]
-#         extraheader = AUTHORIZATION: basic <the run's own GITHUB_TOKEN>
+# The Actions-provided `GITHUB_TOKEN` cannot stand in for the App token, which
+# is why one credential legitimately covers this repository *and* the private
+# sibling: "The token's permissions are limited to the repository that contains
+# your workflow"
+# (https://docs.github.com/en/actions/concepts/security/github_token), and
+# actions/checkout says it outright — "`${{ github.token }}` is scoped to the
+# current repository, so if you want to checkout a different repository that is
+# private you will need to provide your own PAT"
+# (https://github.com/actions/checkout#checkout-multiple-repos-private).
 #
-# into the checkout's `.git/config`. `git config --get-urlmatch` reads the
-# repository config too, and `https://github.com/` is a prefix of every URL
-# below, so all three matched and the gate failed `auth-header-url-boundary`
-# while the property it exists to protect was intact — the lldb-sys URL still
-# resolved to the lldb-sys header, and nothing else did.
+# So an ambient `http.https://github.com/.extraHeader` carrying this same token
+# is the provisioning mechanism working, not a leak. The old assertion failed
+# the gate precisely when the job was provisioned the way policy requires, and
+# would have passed only if someone had introduced the second, narrower token
+# that policy says not to introduce. Do not reinstate it in any form: an
+# assertion that rewards the wrong architecture is worse than no assertion.
 #
-# EVIDENCE, CORRECTED (2026-08-14). 57ef307d4 cited three runs here —
-# 30726348404, 31180327493, 31385899773 — and said the gate failed this way on
-# "every run". Only the first is real:
-#
-#   30726348404  2026-08-02  failed in `Run visual replay regression gate`,
-#                            log: "Visual replay CI private Cargo
-#                            authentication invariant failed:
-#                            auth-header-url-boundary."   <- genuine
-#   31180327493  2026-08-07  failed in `Setup dev env`    <- never reached here
-#   31385899773  2026-08-10  failed in `Setup dev env`    <- never reached here
-#
-# The latter two are the workspace-lock outage (see the header of
-# `.github/workflows/codetracer.yml`); they died before this script ran and
-# cannot evidence anything about it. The same three run IDs appear in
-# codetracer.yml for the *Windows* git/bash defect, where all three genuinely
-# do show the failure — that citation is sound, and is the likely source this
-# one was copied from.
-#
-# So the relaxation rests on ONE observed failure plus a mechanism that is
-# verifiable from first principles (the persisted header prefix-matches every
-# URL). That is not nothing, but it is not what was claimed, and a security
-# check should not be loosened on a count of runs nobody re-read.
-#
-# RE-EXAMINE THIS. As of 2026-08-14 the gate's checkout sets
-# `persist-credentials: false`, so the ambient header this relaxation exists to
-# tolerate is no longer written by the one step known to write it. Reading (1)
-# below may now be satisfiable in the real environment again, which would make
-# the stronger "no header matches at all" form achievable. It has deliberately
-# NOT been re-tightened in the same change: a persistent self-hosted GPU runner
-# can carry ambient Git configuration from sources other than actions/checkout,
-# and with the runner pool saturated that could not be observed here. Re-tighten
-# only against a green run that proves it, not against this comment.
-#
-# Independently of the citation count: asserting "no header at all" was also
-# always stronger than the contract and was never wholly in the gate's power to
-# guarantee — ambient config belongs to the environment, not to this script.
+# WHAT REMAINS TRUE AND IS CHECKED BELOW. The credential's *authority* is
+# org-wide, but the *header* is still narrowly keyed, and an org-wide token
+# handed to a host that is not github.com is a leak under any policy. Both are
+# properties this gate installs and can therefore be held to.
+same_host_probe_urls=(
+	# github.com URLs this gate does not authenticate. A match under reading
+	# (1) means `GIT_CONFIG_KEY_0` has been widened within the host.
+	"https://github.com/metacraft-labs/"
+	"https://github.com/metacraft-labs/codetracer.git"
+	"https://github.com/metacraft-labs/lldb-sys.rs.git-lookalike"
+)
+off_host_probe_urls=(
+	# Hosts that must never see this run's credential: an unrelated host, a
+	# suffix lookalike of the real one (Git matches the host component
+	# exactly, and this pins that), and the same repository path on another
+	# forge. These carry reading (2) — under reading (1) they are
+	# belt-and-braces, because only one URL-keyed slot is permitted there and
+	# any key loose enough to reach them also reaches the same-host probes.
+	"https://example.invalid/metacraft-labs/lldb-sys.rs.git"
+	"https://github.com.lookalike.invalid/metacraft-labs/lldb-sys.rs.git"
+	"https://gitlab.com/metacraft-labs/lldb-sys.rs.git"
+)
+
+# (1) Against only the configuration this gate installs — globals are
+#     /dev/null and the probe runs outside any work tree, so the inline
+#     GIT_CONFIG_* slots are the whole config stack — nothing may match. It
+#     asks Git's own URL matcher rather than comparing key strings, so it
+#     catches a widened `GIT_CONFIG_KEY_0` (say
+#     `https://github.com/metacraft-labs/`, or a host-less `http.extraHeader`
+#     that Git applies to every URL) even when the literal key check below has
+#     not run yet — which is why that check sits *after* this loop rather than
+#     before it. Ordered the other way the literal check subsumed this one
+#     entirely and nothing could ever reach here. Covered by the
+#     `auth-key-wide` and `auth-key-hostless` cases in the test.
 git_isolated_dir="$(mktemp -d)"
 if git -C "$git_isolated_dir" rev-parse --git-dir >/dev/null 2>&1; then
 	# TMPDIR inside a work tree would silently reintroduce repository config
-	# and make reading (1) below vacuous in the other direction. Covered by
+	# and make this reading vacuous in the other direction. Covered by
 	# the `probe-isolation` case in this script's test.
 	rm -rf "$git_isolated_dir"
 	fail_auth_contract "auth-boundary-probe-isolation"
 fi
-for unauthenticated_url in \
-	"https://github.com/metacraft-labs/" \
-	"https://github.com/metacraft-labs/codetracer.git" \
-	"https://github.com/metacraft-labs/lldb-sys.rs.git-lookalike"; do
-	# (1) Against only the configuration this gate installs — globals are
-	#     /dev/null and the probe runs outside any work tree, so the inline
-	#     GIT_CONFIG_* slots are the whole config stack — nothing may match.
-	#     This is the original invariant, now measured against the config the
-	#     gate actually controls. It asks Git's own URL matcher rather than
-	#     comparing key strings, so it catches a widened `GIT_CONFIG_KEY_0`
-	#     (say `https://github.com/metacraft-labs/`) even when the literal
-	#     key check below has not run yet — which is why that check now sits
-	#     *after* this loop rather than before it. Ordered the other way the
-	#     literal check subsumed this one entirely and nothing could ever
-	#     reach here. Covered by the `auth-key-wide` case in the test.
+for unauthenticated_url in "${same_host_probe_urls[@]}" "${off_host_probe_urls[@]}"; do
 	if git -C "$git_isolated_dir" config --get-urlmatch http.extraHeader \
 		"$unauthenticated_url" >/dev/null 2>&1; then
 		rm -rf "$git_isolated_dir"
 		fail_auth_contract "auth-header-url-boundary"
 	fi
-	# (2) In the real environment, where the checkout's own credential is
-	#     present: whatever header applies to these URLs, it must not carry
-	#     the lldb-sys credential. This is the leak that matters, and it
-	#     stays detectable no matter what else is configured.
-	#
-	#     The test is on the credential, not on the header string. An earlier
-	#     formulation compared the whole matched header with `==` against
-	#     `AUTHORIZATION: basic <token>`, which let the very same token
-	#     through as `authorization: basic <token>`, `AUTHORIZATION: Basic
-	#     <token>`, `AUTHORIZATION: basic <token>  ` or `AUTHORIZATION:
-	#     basic  <token>` — four wire-valid spellings of one leak. Any header
-	#     that contains the secret is a leak regardless of how it is spelled,
-	#     so containment of the credential is both the correct test and a
-	#     strictly stronger one than equality of the header.
+done
+rm -rf "$git_isolated_dir"
+unset git_isolated_dir
+
+# (2) In the real environment, including whatever ambient Git configuration a
+#     persistent self-hosted runner carries: no header reaching a host outside
+#     github.com may carry this run's credential. Unlike reading (1) this sees
+#     the repository config of the working directory, so it is the only reading
+#     that can catch ambient configuration pointing our token at a third party.
+#
+#     The test is on the credential, not on the header string. An earlier
+#     formulation compared the whole matched header with `==` against
+#     `AUTHORIZATION: basic <token>`, which let the very same token through as
+#     `authorization: basic <token>`, `AUTHORIZATION: Basic <token>`,
+#     `AUTHORIZATION: basic <token>  ` or `AUTHORIZATION:  basic  <token>` —
+#     four wire-valid spellings of one leak. Any header that contains the
+#     secret leaks it regardless of spelling, so containment of the credential
+#     is both the correct test and a strictly stronger one than equality of the
+#     header.
+for unauthenticated_url in "${off_host_probe_urls[@]}"; do
 	effective_header="$(git config --get-urlmatch http.extraHeader \
 		"$unauthenticated_url" 2>/dev/null || true)"
 	if [[ $effective_header == *"$cargo_auth_credential"* ]]; then
-		rm -rf "$git_isolated_dir"
-		fail_auth_contract "auth-header-credential-leak"
+		fail_auth_contract "auth-header-offsite-leak"
 	fi
 done
 unset unauthenticated_url effective_header
-rm -rf "$git_isolated_dir"
-unset git_isolated_dir
+unset same_host_probe_urls off_host_probe_urls
 
 # The literal key. Git's matcher above answers "does this credential reach a
 # URL it must not"; this answers the narrower syntactic question "is the key

--- a/ci/test/visual-replay-private-cargo-preflight.sh
+++ b/ci/test/visual-replay-private-cargo-preflight.sh
@@ -104,12 +104,6 @@ if [[ -n ${CODETRACER_VISUAL_REPLAY_GITHUB_TOKEN:-} ]]; then
 	exit 1
 fi
 
-# Ask Git itself which URL receives the header. This catches subtle widening of
-# the config key without printing the credential. The sibling and lookalike
-# URLs must not inherit lldb-sys authentication.
-if [[ $(git config --get-urlmatch http.extraHeader "$LLDB_SYS_URL") != "$cargo_auth_header" ]]; then
-	fail_auth_contract "effective-auth-header"
-fi
 # Two readings of one boundary. Both ask where the *header* this gate installs
 # may travel. Neither asks what the credential inside it is allowed to reach —
 # that is not a property this script can define, and the attempt to define it
@@ -181,6 +175,19 @@ off_host_probe_urls=(
 #     before it. Ordered the other way the literal check subsumed this one
 #     entirely and nothing could ever reach here. Covered by the
 #     `auth-key-wide` and `auth-key-hostless` cases in the test.
+#
+#     `effective-auth-header` sits after this loop for the same reason, and it
+#     is a sharper instance of it. That check reads the AMBIENT config stack,
+#     so on the runner it also sees the github.com-wide `extraHeader` that
+#     `actions/checkout` persists. Against that backdrop a host-less
+#     `http.extraHeader` is the *less* specific key, so Git's matcher answers
+#     the lldb-sys URL with the ambient header instead of this gate's, and
+#     `effective-auth-header` fired first — on CI only. Reading (1) is
+#     isolated and therefore gives the same answer on a runner and on a
+#     laptop, so it must speak first; otherwise its host-less coverage is
+#     live in development and dead in the one environment the gate runs in.
+#     Both orderings fail the gate, so this is a question of which invariant
+#     is reported and of keeping this loop reachable, not of strictness.
 git_isolated_dir="$(mktemp -d)"
 if git -C "$git_isolated_dir" rev-parse --git-dir >/dev/null 2>&1; then
 	# TMPDIR inside a work tree would silently reintroduce repository config
@@ -198,6 +205,15 @@ for unauthenticated_url in "${same_host_probe_urls[@]}" "${off_host_probe_urls[@
 done
 rm -rf "$git_isolated_dir"
 unset git_isolated_dir
+
+# Ask Git itself which URL receives the header, in the real environment. This
+# catches subtle widening of the config key without printing the credential:
+# the sibling and lookalike URLs must not inherit lldb-sys authentication, and
+# the lldb-sys URL must receive this gate's header rather than an ambient one.
+# It runs after reading (1) — see the note there.
+if [[ $(git config --get-urlmatch http.extraHeader "$LLDB_SYS_URL") != "$cargo_auth_header" ]]; then
+	fail_auth_contract "effective-auth-header"
+fi
 
 # (2) In the real environment, including whatever ambient Git configuration a
 #     persistent self-hosted runner carries: no header reaching a host outside


### PR DESCRIPTION
## What

The visual-replay gate reaches a private Cargo git dependency using the organisation's CI App installation token — the same token that authenticates the job's own checkout and every private sibling the gate clones. The preflight nevertheless asserted, as `auth-header-credential-leak`, that this credential must not appear in any header applying to another `github.com` URL.

There is no narrower credential for a wider header to leak, so that assertion failed exactly when the job was provisioned correctly, and would have passed only if a second, single-purpose token had been introduced.

## Why the Actions-provided token is not an option

- *"The token's permissions are limited to the repository that contains your workflow"* — [GITHUB_TOKEN](https://docs.github.com/en/actions/concepts/security/github_token)
- *"`${{ github.token }}` is scoped to the current repository, so if you want to checkout a different repository that is private you will need to provide your own PAT"* — [actions/checkout](https://github.com/actions/checkout#checkout-multiple-repos-private)

One credential covering this repository and the private dependency is therefore the mechanism working, not a leak.

## What replaces it

The header stays narrowly keyed even though the credential is org-wide, and an org-scoped token handed to a host that is not `github.com` is a leak under any arrangement.

- The URL-scope reading now also probes off-host URLs — an unrelated host, a suffix lookalike of `github.com`, and the same path on another forge — so a host-less `http.extraHeader`, which Git applies to every URL it fetches, is caught rather than only a widening within `github.com`.
- The environment reading becomes `auth-header-offsite-leak`, checking those off-host URLs only, and keeps the credential-containment test that catches all four wire-valid spellings of one leaked header.

Everything else the preflight guards is untouched: no credential in `git-remote-https` argv, none persisted to disk, none printed on failure, no URL rewrite, no redirects, TLS verified, one pinned git source in the lockfile.

## Tests

`ci/test/visual-replay-private-cargo-preflight-test.sh` gains the case that would have caught this — the gate's own token applied `github.com`-wide by ambient config must **pass** — plus an off-host leak case and a host-less-key case. Each new assertion was mutation-checked: reverting the corresponding production change reddens exactly the intended case.

The suite runs on a stock runner in the verdict job as well as inside the GPU gate.

## Policy

Written up in `metacraft-dev-guidelines/policies/ci-workflow-standards.md` § *Which credential for which repo*, and the source carries a note saying why the retired assertion must not be reinstated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)