### PR TITLE
fix(ci): mint one org-scoped CI token per job, from the repo secret

### DIFF
--- a/.github/workflows/beam-flow.yml
+++ b/.github/workflows/beam-flow.yml
@@ -65,10 +65,10 @@ jobs:
         # defect meant it could never have checked out if it had been.
         # `cross-repo-tests.yml` already mints its token first and passes it —
         # this is that same shape.
-        id: app-token
-        uses: actions/create-github-app-token@v1
+        id: ci_token
+        uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.CI_TOKEN_PROVIDER_APP_ID }}
+          app-id: ${{ secrets.CI_TOKEN_PROVIDER_APP_ID }}
           private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
           owner: metacraft-labs
 
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.ci_token.outputs.token }}
 
       - name: Setup dev env
         # setup-dev-env installs Nix (with the Attic substituter/keys) and
@@ -92,7 +92,7 @@ jobs:
         uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
         with:
           env-flavor: nix
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
           # codetracer-trace-format-nim is the second half of a MATCHED FFI PAIR

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -363,10 +363,10 @@ jobs:
           }
 
       - name: Generate CI token
-        id: app-token
-        uses: actions/create-github-app-token@v1
+        id: ci_token
+        uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.CI_TOKEN_PROVIDER_APP_ID }}
+          app-id: ${{ secrets.CI_TOKEN_PROVIDER_APP_ID }}
           private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
           owner: metacraft-labs
 
@@ -374,12 +374,12 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.ci_token.outputs.token }}
 
       - name: Setup db-backend siblings
         uses: ./.github/actions/setup-db-backend-siblings
         with:
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -415,7 +415,7 @@ jobs:
         shell: powershell
         env:
           RECORDER_REVISION: ${{ steps.python-recorder-lock.outputs.revision }}
-          SIBLING_TOKEN: ${{ steps.app-token.outputs.token }}
+          SIBLING_TOKEN: ${{ steps.ci_token.outputs.token }}
         run: |
           $destination = Join-Path $env:GITHUB_WORKSPACE "..\codetracer-python-recorder"
           ./ci/checkout-locked-python-recorder.ps1 `
@@ -522,10 +522,10 @@ jobs:
           }
 
       - name: Generate CI token
-        id: app-token
-        uses: actions/create-github-app-token@v1
+        id: ci_token
+        uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.CI_TOKEN_PROVIDER_APP_ID }}
+          app-id: ${{ secrets.CI_TOKEN_PROVIDER_APP_ID }}
           private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
           owner: metacraft-labs
 
@@ -533,12 +533,12 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.ci_token.outputs.token }}
 
       - name: Setup db-backend siblings
         uses: ./.github/actions/setup-db-backend-siblings
         with:
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -571,7 +571,7 @@ jobs:
         shell: pwsh
         env:
           RECORDER_REVISION: ${{ steps.python-recorder-lock.outputs.revision }}
-          SIBLING_TOKEN: ${{ steps.app-token.outputs.token }}
+          SIBLING_TOKEN: ${{ steps.ci_token.outputs.token }}
         run: |
           $destination = Join-Path $env:GITHUB_WORKSPACE "..\codetracer-python-recorder"
           ./ci/checkout-locked-python-recorder.ps1 `
@@ -752,10 +752,10 @@ jobs:
           }
 
       - name: Generate CI token
-        id: app-token
-        uses: actions/create-github-app-token@v1
+        id: ci_token
+        uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.CI_TOKEN_PROVIDER_APP_ID }}
+          app-id: ${{ secrets.CI_TOKEN_PROVIDER_APP_ID }}
           private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
           owner: metacraft-labs
 
@@ -763,7 +763,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.ci_token.outputs.token }}
 
       - name: Setup dev env
         # setup-dev-env (windows-diy) clones the cross-repo siblings adjacent
@@ -777,7 +777,7 @@ jobs:
         uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
         with:
           env-flavor: windows-diy
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           siblings: |
             codetracer-trace-format=dev
             codetracer-trace-format-nim=dev
@@ -969,10 +969,10 @@ jobs:
           }
 
       - name: Generate CI token
-        id: app-token
-        uses: actions/create-github-app-token@v1
+        id: ci_token
+        uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.CI_TOKEN_PROVIDER_APP_ID }}
+          app-id: ${{ secrets.CI_TOKEN_PROVIDER_APP_ID }}
           private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
           owner: metacraft-labs
 
@@ -980,7 +980,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.ci_token.outputs.token }}
 
       - name: Disable TTD validation for the Windows DIY bootstrap
         # setup-dev-env (windows-diy) sources env.ps1 inside the composite;
@@ -1001,7 +1001,7 @@ jobs:
         uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
         with:
           env-flavor: windows-diy
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           env-ps1-path: ./env.ps1
           siblings: |
             codetracer-native-recorder=dev
@@ -1172,14 +1172,6 @@ jobs:
           private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
           owner: metacraft-labs
 
-      - name: Generate CI token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.CI_TOKEN_PROVIDER_APP_ID }}
-          private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
-          owner: metacraft-labs
-
       - name: Checkout
         uses: actions/checkout@v5
         with:
@@ -1197,7 +1189,7 @@ jobs:
         uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
         with:
           env-flavor: nix
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
           siblings: |
@@ -1335,19 +1327,11 @@ jobs:
           private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
           owner: metacraft-labs
 
-      - name: Generate CI token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.CI_TOKEN_PROVIDER_APP_ID }}
-          private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
-          owner: metacraft-labs
-
       - name: Checkout
         uses: actions/checkout@v5
         with:
           submodules: recursive
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.ci_token.outputs.token }}
 
       - name: Install Nix
         uses: ./.github/actions/setup-nix
@@ -1359,7 +1343,7 @@ jobs:
       - name: Setup db-backend siblings
         uses: ./.github/actions/setup-db-backend-siblings
         with:
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
 
       - name: Run required materialized Python origin-DAP gate
         env:
@@ -1390,19 +1374,11 @@ jobs:
           private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
           owner: metacraft-labs
 
-      - name: Generate CI token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.CI_TOKEN_PROVIDER_APP_ID }}
-          private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
-          owner: metacraft-labs
-
       - name: Checkout
         uses: actions/checkout@v5
         with:
           submodules: recursive
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.ci_token.outputs.token }}
 
       - name: Install Nix
         uses: ./.github/actions/setup-nix
@@ -1414,7 +1390,7 @@ jobs:
       - name: Setup db-backend siblings
         uses: ./.github/actions/setup-db-backend-siblings
         with:
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
 
       - name: Run routed materialized origin-DAP matrix
         env:
@@ -1436,10 +1412,10 @@ jobs:
     name: cross-process value-origin (Linux)
     steps:
       - name: Generate CI token
-        id: app-token
-        uses: actions/create-github-app-token@v1
+        id: ci_token
+        uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.CI_TOKEN_PROVIDER_APP_ID }}
+          app-id: ${{ secrets.CI_TOKEN_PROVIDER_APP_ID }}
           private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
           owner: metacraft-labs
 
@@ -1447,17 +1423,17 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.ci_token.outputs.token }}
 
       - name: Setup db-backend siblings
         uses: ./.github/actions/setup-db-backend-siblings
         with:
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
 
       - name: Setup isonim siblings
         uses: ./.github/actions/setup-isonim-siblings
         with:
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
 
       - name: Build frontend (needed by gated Playwright stage)
         env:
@@ -1477,10 +1453,10 @@ jobs:
     name: ViewModel headless tests (native + JS)
     steps:
       - name: Generate CI token
-        id: app-token
-        uses: actions/create-github-app-token@v1
+        id: ci_token
+        uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.CI_TOKEN_PROVIDER_APP_ID }}
+          app-id: ${{ secrets.CI_TOKEN_PROVIDER_APP_ID }}
           private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
           owner: metacraft-labs
 
@@ -1488,12 +1464,12 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.ci_token.outputs.token }}
 
       - name: Setup isonim siblings
         uses: ./.github/actions/setup-isonim-siblings
         with:
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
 
       - name: Clone codetracer-trace-format-nim sibling
         # Nine ViewModel suites -- the eight request-panel ones plus
@@ -1520,7 +1496,7 @@ jobs:
           # `main` is not where its work lands.
           ref: dev
           path: ${{ github.workspace }}/../codetracer-trace-format-nim
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           submodules: 'false'
 
       - name: Install Nix
@@ -1528,7 +1504,7 @@ jobs:
         with:
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
 
       - name: Run ViewModel headless tests (native + JS backends)
         run: nix develop .#devShells.x86_64-linux.default --command just test-vm
@@ -1570,7 +1546,7 @@ jobs:
           # stale recorder while reporting green.
           ref: dev
           path: ${{ github.workspace }}/../codetracer-js-recorder
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           submodules: 'false'
 
       - name: Run recorder-gated ViewModel tests (JS recorder + replay-server)
@@ -1689,14 +1665,6 @@ jobs:
           private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
           owner: metacraft-labs
 
-      - name: Generate CI token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.CI_TOKEN_PROVIDER_APP_ID }}
-          private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
-          owner: metacraft-labs
-
       - name: Checkout
         uses: actions/checkout@v5
         with:
@@ -1706,12 +1674,12 @@ jobs:
       - name: Setup isonim siblings
         uses: ./.github/actions/setup-isonim-siblings
         with:
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
 
       - name: Setup db-backend siblings
         uses: ./.github/actions/setup-db-backend-siblings
         with:
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
 
       - name: Install Nix
         uses: ./.github/actions/setup-nix
@@ -2086,14 +2054,6 @@ jobs:
           private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
           owner: metacraft-labs
 
-      - name: Generate CI token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.CI_TOKEN_PROVIDER_APP_ID }}
-          private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
-          owner: metacraft-labs
-
       - name: Checkout
         uses: actions/checkout@v5
         with:
@@ -2107,7 +2067,7 @@ jobs:
         # ``path:"../isonim/src"`` directives resolve.
         uses: ./.github/actions/setup-isonim-siblings
         with:
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
 
       - name: Install Nix
         uses: ./.github/actions/setup-nix
@@ -2368,15 +2328,6 @@ jobs:
           private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
           owner: metacraft-labs
 
-      - name: Generate CI token
-        if: matrix.platform == 'nixos'
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.CI_TOKEN_PROVIDER_APP_ID }}
-          private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
-          owner: metacraft-labs
-
       - name: Checkout
         uses: actions/checkout@v5
         with:
@@ -2389,7 +2340,7 @@ jobs:
         if: matrix.platform == 'nixos'
         uses: ./.github/actions/setup-isonim-siblings
         with:
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
 
       # --- NixOS setup ---
       - name: Install Nix
@@ -2512,7 +2463,7 @@ jobs:
         uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
         with:
           env-flavor: nix
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
           # MATCHED FFI PAIR. The "Build codetracer-beam-recorder (nixos)" step
@@ -2663,19 +2614,11 @@ jobs:
           private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
           owner: metacraft-labs
 
-      - name: Generate CI token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.CI_TOKEN_PROVIDER_APP_ID }}
-          private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
-          owner: metacraft-labs
-
       - name: Checkout
         uses: actions/checkout@v5
         with:
           submodules: recursive
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.ci_token.outputs.token }}
 
       - name: Setup dev env
         # setup-dev-env (nix) installs Nix via the shared setup-nix (which
@@ -2699,7 +2642,7 @@ jobs:
         uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
         with:
           env-flavor: nix
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
           nix-develop-args: '.?submodules=1'
@@ -2789,7 +2732,7 @@ jobs:
         # the Linux jobs already use.
         uses: ./.github/actions/setup-isonim-siblings
         with:
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
 
       # NOTE: codetracer-trace-format, codetracer-trace-format-nim,
       # codetracer-native-recorder, nim-stackable-hooks, codetracer-visual-replay and
@@ -2813,7 +2756,7 @@ jobs:
           repo: metacraft-labs/codetracer-snapshot-codecs
           ref: main
           path: ${{ github.workspace }}/../codetracer-snapshot-codecs
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           submodules: 'false'
 
       - name: Clone codetracer-image-diff sibling (macOS)
@@ -2826,7 +2769,7 @@ jobs:
           repo: metacraft-labs/codetracer-image-diff
           ref: main
           path: ${{ github.workspace }}/../codetracer-image-diff
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           submodules: 'false'
 
       # NOTE: Nix is installed by the ``Setup dev env`` step above. On the
@@ -2861,8 +2804,8 @@ jobs:
           # private ``lldb-sys.rs`` dependency picks up the App-token
           # we set via ``GIT_CREDENTIALS`` below.
           export CARGO_NET_GIT_FETCH_WITH_CLI=true
-          git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
-          git config --global --add url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://x-access-token:${{ steps.ci_token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+          git config --global --add url."https://x-access-token:${{ steps.ci_token.outputs.token }}@github.com/".insteadOf "ssh://git@github.com/"
           nix develop --no-write-lock-file --command just build-ct-mcr
 
       - name: Build ct_gfx_player via codetracer-visual-replay nix develop (macOS)
@@ -2949,19 +2892,11 @@ jobs:
           private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
           owner: metacraft-labs
 
-      - name: Generate CI token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.CI_TOKEN_PROVIDER_APP_ID }}
-          private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
-          owner: metacraft-labs
-
       - name: Checkout
         uses: actions/checkout@v5
         with:
           submodules: recursive
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.ci_token.outputs.token }}
 
       - name: Setup dev env
         # setup-dev-env installs Nix (with the Attic substituter/keys) and
@@ -2974,7 +2909,7 @@ jobs:
         uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
         with:
           env-flavor: nix
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
           siblings: |
@@ -3863,15 +3798,24 @@ jobs:
         # for the months this went unnoticed.
         run: bash ci/test/windows-runner-bootstrap-test.sh
 
-      - name: Assert no job's siblings depend on a published workspace lock
-        # A bare `siblings:` entry resolves its revision from a workspace lock
-        # in metacraft-labs/metacraft-manifests, which has published nothing
-        # for this repo since 2026-08-02. Six jobs died in their first real
-        # step for eight days because of it, and nine more were reported
-        # `skipped` in consequence -- the state the verdict step below exists
-        # to name. Like the Windows contract above this is a static check over
-        # this workflow file, so it runs here, from a stock runner, where it
-        # cannot be taken down by the outage it watches for.
+      - name: Assert every job's sibling checkout is self-sufficient
+        # Two halves of one contract, both static checks over this workflow
+        # file, so they run here from a stock runner where they cannot be
+        # taken down by the outages they watch for.
+        #
+        # WHICH REF: a bare `siblings:` entry resolves its revision from a
+        # workspace lock in metacraft-labs/metacraft-manifests, which has
+        # published nothing for this repo since 2026-08-02. Six jobs died in
+        # their first real step for eight days because of it, and nine more
+        # were reported `skipped` in consequence -- the state the verdict step
+        # below exists to name.
+        #
+        # WHICH CREDENTIAL: one org-scoped installation token per job, minted
+        # from the per-repo secret. The org-variable form of the app id
+        # resolves only because this repo is public and evaluates to the empty
+        # string anywhere else; a job that minted two tokens made it ambiguous
+        # which one a step used; and an unresolved `steps.*.outputs.token`
+        # silently becomes an empty token rather than an error.
         run: bash ci/test/sibling-provisioning-test.sh
 
       - name: Self-test the private-registry credential preflight

--- a/.github/workflows/mcr-dap-flow.yml
+++ b/.github/workflows/mcr-dap-flow.yml
@@ -53,18 +53,32 @@ jobs:
     runs-on: [self-hosted, nixos]
 
     steps:
-      - name: Checkout codetracer
-        uses: actions/checkout@v5
-        with:
-          submodules: recursive
-
       - name: Generate CI token
+        # Must precede the checkout below, not follow it. `libs/tree-sitter-nim`
+        # is a PRIVATE submodule, so a checkout with no `token:` clones it with
+        # whatever credential the runner happens to have and fails with
+        #
+        #   fatal: repository 'https://github.com/metacraft-labs/tree-sitter-nim.git/'
+        #     not found
+        #   fatal: clone of '...' into submodule path '.../libs/tree-sitter-nim' failed
+        #
+        # taking every step after it down as `skipped`. beam-flow.yml carries
+        # the same note for the same defect; this job kept the original
+        # ordering and so kept failing intermittently -- intermittently because
+        # a runner with the submodule already in its work tree gets away with
+        # it, which is why it survived this long.
         id: ci_token
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.CI_TOKEN_PROVIDER_APP_ID }}
           private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
           owner: metacraft-labs
+
+      - name: Checkout codetracer
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          token: ${{ steps.ci_token.outputs.token }}
 
       - name: Install Nix
         uses: ./.github/actions/setup-nix

--- a/.github/workflows/mcr-dap-flow.yml
+++ b/.github/workflows/mcr-dap-flow.yml
@@ -59,10 +59,10 @@ jobs:
           submodules: recursive
 
       - name: Generate CI token
-        id: app-token
-        uses: actions/create-github-app-token@v1
+        id: ci_token
+        uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.CI_TOKEN_PROVIDER_APP_ID }}
+          app-id: ${{ secrets.CI_TOKEN_PROVIDER_APP_ID }}
           private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
           owner: metacraft-labs
 
@@ -71,7 +71,7 @@ jobs:
         with:
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
 
       - name: Resolve sibling refs
         id: refs
@@ -106,7 +106,7 @@ jobs:
           repo: metacraft-labs/codetracer-native-recorder
           ref: ${{ steps.refs.outputs.recorder-ref }}
           path: ${{ github.workspace }}/../codetracer-native-recorder
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           submodules: 'false'
 
       - name: Clone codetracer-native-backend
@@ -117,7 +117,7 @@ jobs:
           repo: metacraft-labs/codetracer-native-backend
           ref: ${{ steps.refs.outputs.backend-ref }}
           path: ${{ github.workspace }}/../codetracer-native-backend
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           submodules: 'false'
 
       - name: Clone codetracer-trace-format sibling
@@ -128,7 +128,7 @@ jobs:
           repo: metacraft-labs/codetracer-trace-format
           ref: ${{ steps.refs.outputs.trace-format-ref }}
           path: ${{ github.workspace }}/../codetracer-trace-format
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           submodules: 'false'
 
       - name: Clone codetracer-trace-format-nim sibling
@@ -139,7 +139,7 @@ jobs:
           repo: metacraft-labs/codetracer-trace-format-nim
           ref: ${{ steps.refs.outputs.trace-format-nim-ref }}
           path: ${{ github.workspace }}/../codetracer-trace-format-nim
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           submodules: 'false'
 
       - name: Run MCR DAP flow tests

--- a/.github/workflows/request-panel-sidecar-retirement.yml
+++ b/.github/workflows/request-panel-sidecar-retirement.yml
@@ -56,10 +56,10 @@ jobs:
     name: No recorder writes sidecar manifests (6 recorders, 6 live servers)
     steps:
       - name: Generate CI token
-        id: app-token
-        uses: actions/create-github-app-token@v1
+        id: ci_token
+        uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.CI_TOKEN_PROVIDER_APP_ID }}
+          app-id: ${{ secrets.CI_TOKEN_PROVIDER_APP_ID }}
           private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
           owner: metacraft-labs
 
@@ -67,21 +67,21 @@ jobs:
         uses: actions/checkout@v5
         with:
           submodules: recursive
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.ci_token.outputs.token }}
 
       - name: Setup isonim siblings
         # `test-no-sidecar-manifests` depends on `vm-test-prereqs`, which runs
         # scripts/build-tailwind.sh against isonim's style extractor.
         uses: ./.github/actions/setup-isonim-siblings
         with:
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
 
       - name: Install Nix
         uses: ./.github/actions/setup-nix
         with:
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
 
       # The six recorder siblings, cloned into the workspace-sibling layout
       # `workspaceRoot() / lang.recorderRepo` resolves (see
@@ -96,7 +96,7 @@ jobs:
           repo: metacraft-labs/codetracer-python-recorder
           ref: stable
           path: ${{ github.workspace }}/../codetracer-python-recorder
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           submodules: 'false'
 
       - name: Clone codetracer-ruby-recorder sibling
@@ -105,7 +105,7 @@ jobs:
           repo: metacraft-labs/codetracer-ruby-recorder
           ref: dev
           path: ${{ github.workspace }}/../codetracer-ruby-recorder
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           submodules: 'false'
 
       - name: Clone codetracer-php-recorder sibling
@@ -114,7 +114,7 @@ jobs:
           repo: metacraft-labs/codetracer-php-recorder
           ref: dev
           path: ${{ github.workspace }}/../codetracer-php-recorder
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           submodules: 'false'
 
       - name: Clone codetracer-beam-recorder sibling
@@ -123,7 +123,7 @@ jobs:
           repo: metacraft-labs/codetracer-beam-recorder
           ref: main
           path: ${{ github.workspace }}/../codetracer-beam-recorder
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           submodules: 'false'
 
       - name: Clone codetracer-js-recorder sibling
@@ -132,7 +132,7 @@ jobs:
           repo: metacraft-labs/codetracer-js-recorder
           ref: dev
           path: ${{ github.workspace }}/../codetracer-js-recorder
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           submodules: 'false'
 
       - name: Clone codetracer-native-recorder sibling
@@ -141,7 +141,7 @@ jobs:
           repo: metacraft-labs/codetracer-native-recorder
           ref: dev
           path: ${{ github.workspace }}/../codetracer-native-recorder
-          gh-token: ${{ steps.app-token.outputs.token }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
           submodules: 'false'
 
       - name: Allow direnv in the cloned recorder siblings

--- a/ci/test/origin-dap-gate.sh
+++ b/ci/test/origin-dap-gate.sh
@@ -176,10 +176,14 @@ printf '%s\n' "$git_bootstrap" | grep -Fq '& $bootstrapScript' ||
 	fail "Windows Git bootstrap must invoke the downloaded tested helper"
 printf '%s\n' "$git_bootstrap" | grep -Fq 'Invoke-WebRequest' ||
 	fail "Windows Git bootstrap must retrieve the helper before checkout"
-# The app token is reserved for authenticated checkout and later private
-# recorder fetches. The public immutable helper fetch must not receive it.
+# The installation token is reserved for authenticated checkout and later
+# private recorder fetches. The public immutable helper fetch must not receive
+# it. Matched by SHAPE (`steps.<any-id>.outputs.token`) rather than by the id
+# of the day: this check previously named `app-token` literally and would have
+# gone quietly blind the moment that step was renamed, which is exactly what
+# the consolidation onto a single `ci_token` mint step did.
 if printf '%s\n' "$git_bootstrap" |
-	grep -Eq 'app-token\.outputs\.token|SIBLING_TOKEN|[Aa]uthorization|[Hh]eader'; then
+	grep -Eq 'steps\.[A-Za-z0-9_-]+\.outputs\.token|SIBLING_TOKEN|[Aa]uthorization|[Hh]eader'; then
 	fail "Windows Git bootstrap must not receive or transmit repository credentials"
 fi
 # shellcheck disable=SC2016 # Match literal inline PowerShell.

--- a/ci/test/origin-dap-gate.sh
+++ b/ci/test/origin-dap-gate.sh
@@ -250,7 +250,15 @@ done
 
 [ "$(printf '%s\n' "$checkout_step" | grep -c 'submodules: recursive$')" -eq 1 ] ||
 	fail "Windows checkout must retain recursive submodules"
-[ "$(printf '%s\n' "$checkout_step" | grep -c "token: \${{ steps.app-token.outputs.token }}$")" -eq 1 ] ||
+# Matched by SHAPE, not by the mint step's id of the day. The id moved from
+# `app-token` to `ci_token` when the workflows were consolidated onto a single
+# mint step per job, and an id-literal assertion would have started failing on
+# a workflow that had in fact got MORE correct. What must hold is that this
+# checkout authenticates with a token minted in this job at all -- the
+# credential contract in ci/test/sibling-provisioning-test.sh is what pins the
+# id to a mint step that actually exists.
+[ "$(printf '%s\n' "$checkout_step" |
+	grep -cE 'token: \$\{\{ steps\.[A-Za-z0-9_-]+\.outputs\.token \}\}$')" -eq 1 ] ||
 	fail "Windows checkout must retain the generated CI token"
 printf '%s\n' "$required_gate_step" | grep -Fq 'run: just test-origin-dap' ||
 	fail "Windows required gate must still run the strict origin-DAP router"

--- a/ci/test/sibling-provisioning-test.sh
+++ b/ci/test/sibling-provisioning-test.sh
@@ -94,6 +94,11 @@
 #      installation token per job, minted from the per-repo SECRET, org-scoped
 #      by `owner:` and never narrowed by `repositories:`, and every consuming
 #      step naming a mint step that exists in its own job.
+#   6b. A checkout that pulls `submodules:` passes a `token:`. A submodule
+#      checkout is a clone of OTHER repositories and `libs/tree-sitter-nim` is
+#      private, so an untokened one is a private clone with no credential --
+#      which is why `mcr-dap-flow` failed at `Checkout codetracer` on a fresh
+#      runner and passed on a warm one.
 #
 # # No mocks
 #
@@ -606,6 +611,8 @@ mint_duplicate=()
 legacy_pat_refs=()
 unresolved_consumers=()
 consumer_count=0
+submodule_checkouts=0
+untokened_submodule_checkouts=()
 
 # Per-scope record of the mint step ids declared in it. A "scope" is a job in a
 # workflow, or the whole file for a composite action (which has no jobs but can
@@ -645,6 +652,29 @@ flush_mint_step() {
 	SCOPE_MINT_IDS[$key]="${already} ${mint_step_id}"
 }
 
+# flush_checkout_step: record the actions/checkout step whose body has just
+# ended. A checkout that pulls submodules is a CLONE OF OTHER REPOSITORIES,
+# not just of this one, and this repo's `libs/tree-sitter-nim` submodule is
+# private -- so an untokened `submodules: recursive` is a private clone with no
+# credential. It does not fail deterministically, which is what makes it worth
+# a contract: a runner whose work tree already holds the submodule succeeds,
+# and a fresh one dies with
+#
+#   fatal: repository 'https://github.com/metacraft-labs/tree-sitter-nim.git/'
+#     not found
+#
+# after which every remaining step in the job is reported `skipped`.
+flush_checkout_step() {
+	[ "$in_checkout" -eq 1 ] || return 0
+	in_checkout=0
+	case "$checkout_submodules" in
+	'' | 'false' | "'false'" | '"false"' | '0') return 0 ;;
+	esac
+	submodule_checkouts=$((submodule_checkouts + 1))
+	[ "$checkout_token" -eq 1 ] && return 0
+	untokened_submodule_checkouts+=("$wf_name:$checkout_line: job '$scope' checks out 'submodules: $checkout_submodules' with no token:")
+}
+
 for wf in "${SIBLING_SOURCE_FILES[@]}"; do
 	wf_name="${wf##*/}"
 	scope="(file scope)"
@@ -658,6 +688,10 @@ for wf in "${SIBLING_SOURCE_FILES[@]}"; do
 	mint_owner=0
 	mint_repositories=0
 	cur_step_id=""
+	in_checkout=0
+	checkout_line=0
+	checkout_submodules=""
+	checkout_token=0
 
 	while IFS= read -r line || [ -n "$line" ]; do
 		line_no=$((line_no + 1))
@@ -685,6 +719,7 @@ for wf in "${SIBLING_SOURCE_FILES[@]}"; do
 			'   '*) ;;
 			'  '[a-zA-Z0-9_-]*':')
 				flush_mint_step
+				flush_checkout_step
 				scope="${header#  }"
 				scope="${scope%:}"
 				cur_step_id=""
@@ -698,6 +733,7 @@ for wf in "${SIBLING_SOURCE_FILES[@]}"; do
 		case "$stripped" in
 		'- name: '* | '- uses: '* | '- run: '* | '- id: '* | '- if: '* | '- with:'*)
 			flush_mint_step
+			flush_checkout_step
 			cur_step_id=""
 			;;
 		esac
@@ -707,6 +743,25 @@ for wf in "${SIBLING_SOURCE_FILES[@]}"; do
 			cur_step_id="${cur_step_id#id: }"
 			;;
 		esac
+
+		case "$stripped" in
+		'uses: actions/checkout@'* | '- uses: actions/checkout@'*)
+			in_checkout=1
+			checkout_line="$line_no"
+			checkout_submodules=""
+			checkout_token=0
+			;;
+		esac
+
+		if [ "$in_checkout" -eq 1 ]; then
+			case "$stripped" in
+			'submodules:'*)
+				checkout_submodules="${stripped#submodules:}"
+				checkout_submodules="${checkout_submodules#"${checkout_submodules%%[![:space:]]*}"}"
+				;;
+			'token:'*) checkout_token=1 ;;
+			esac
+		fi
 
 		case "$stripped" in
 		*"$MINT_ACTION"*)
@@ -770,6 +825,7 @@ for wf in "${SIBLING_SOURCE_FILES[@]}"; do
 		esac
 	done <"$wf"
 	flush_mint_step
+	flush_checkout_step
 done
 
 for record in ${CONSUMER_RECORDS+"${CONSUMER_RECORDS[@]}"}; do
@@ -860,6 +916,18 @@ else
 		"${mint_bad_scope[@]}"
 fi
 
+if [ "${#untokened_submodule_checkouts[@]}" -eq 0 ]; then
+	ok "all $submodule_checkouts submodule checkouts authenticate with a minted token"
+else
+	fail "all submodule checkouts authenticate with a minted token" \
+		"a checkout that pulls submodules clones OTHER repositories, and" \
+		"libs/tree-sitter-nim is private; with no token: it clones with whatever" \
+		"credential the runner happens to carry, so it succeeds on a runner that" \
+		"already has the submodule and dies with 'repository ... not found' on a fresh" \
+		"one, taking every later step down as 'skipped'" \
+		"${untokened_submodule_checkouts[@]}"
+fi
+
 if [ "${#unresolved_consumers[@]}" -eq 0 ]; then
 	ok "every token reference names a mint step in its own job"
 else
@@ -876,7 +944,7 @@ fi
 # this script reporting success on fewer checks than it claims.
 # ---------------------------------------------------------------------------
 echo
-readonly EXPECTED_ASSERTIONS=15
+readonly EXPECTED_ASSERTIONS=16
 if [ "$assertions" -ne "$EXPECTED_ASSERTIONS" ]; then
 	printf 'FAIL: ran %d assertions, expected %d\n' "$assertions" "$EXPECTED_ASSERTIONS"
 	failures=$((failures + 1))

--- a/ci/test/sibling-provisioning-test.sh
+++ b/ci/test/sibling-provisioning-test.sh
@@ -88,6 +88,12 @@
 #      `.repo/manifests` -- neither of which exists in a CI checkout. Without
 #      the override the step exits 3 with "cannot locate the manifest repo
 #      locks/ tree", one step after `Setup dev env` was made to survive.
+#   6. The CREDENTIAL half of the same contract: which token those sibling
+#      clones authenticate with, and how many of them a job mints. See the
+#      section header further down for the full rationale -- in brief, one
+#      installation token per job, minted from the per-repo SECRET, org-scoped
+#      by `owner:` and never narrowed by `repositories:`, and every consuming
+#      step naming a mint step that exists in its own job.
 #
 # # No mocks
 #
@@ -502,11 +508,369 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 4. CREDENTIAL CONTRACT: one installation token per job, minted from the
+#    per-repo secret, org-scoped, and named explicitly by every consumer.
+#
+# The three sections above check WHICH siblings a job provisions and at WHAT
+# ref. This one checks WITH WHAT CREDENTIAL, because the same clone fails just
+# as hard on a token that was never minted as on a ref that does not resolve --
+# and it fails less legibly.
+#
+# `metacraft-dev-guidelines/policies/ci-workflow-standards.md` lists the two
+# shapes below under "Forbidden patterns". Both were live in this repo and
+# neither was catchable by any test:
+#
+#   * `${{ vars.CI_TOKEN_PROVIDER_APP_ID }}` in 17 mint steps (14 in
+#     codetracer.yml, plus beam-flow.yml, mcr-dap-flow.yml and
+#     request-panel-sidecar-retirement.yml).
+#   * two mint steps in one job -- a `ci_token` and an `app-token` -- in 8
+#     jobs, whose outputs were then used interchangeably from step to step.
+#
+# # Why the `vars.` form worked here, and why that is the problem
+#
+# `CI_TOKEN_PROVIDER_APP_ID` exists BOTH as a metacraft-labs ORGANIZATION
+# VARIABLE with visibility `all` and as a per-repo SECRET on this repo. On the
+# organization's Free plan, an org-level variable is readable from PUBLIC
+# member repos only; private repos need Team/Enterprise for it to resolve. So
+# `vars.CI_TOKEN_PROVIDER_APP_ID` evaluates to the App ID in codetracer purely
+# because codetracer is public, and the moment this repo -- or any private repo
+# the job body is copied into -- reads it, the expression evaluates to the
+# EMPTY STRING. GitHub Actions does not error on an undefined `vars.` lookup
+# and does not enforce an action's `required: true` inputs, so nothing upstream
+# of the action notices.
+#
+# What happens next differs by action major, and it is worth writing down
+# because the policy text describes it as minting "nothing" silently, which is
+# not what either version does:
+#
+#   @v1  dist/main.cjs guards the input itself --
+#        `if (!appId) throw new Error("Input required and not supplied: app-id")`
+#        at module top level, outside the promise chain. The step fails with
+#        that message.
+#   @v2  that guard was REMOVED in favour of `required: true` in action.yml
+#        (which the runner does not enforce). The empty value reaches
+#        @octokit/auth-app, which throws
+#        `[@octokit/auth-app] appId option is required`; the action's
+#        `.catch()` turns it into `core.setFailed(...)`.
+#
+# Either way the job fails loudly at the mint step -- but it fails pointing at
+# a library internal rather than at "this repo cannot read org variables", and
+# every step downstream that was going to clone a sibling never runs. The
+# per-repo secret form has no such dependency on repo visibility at all, which
+# is the whole reason the policy names it.
+#
+# # Why `@v1` is not merely cosmetic
+#
+# Checked against the published action rather than assumed: v1 and v2 are
+# IDENTICAL on the three axes that would actually matter to us -- `owner`
+# semantics, the `repositories:` default ("defaults to current repository if
+# owner is unset", the same sentence in both action.yml files), and token
+# lifetime (fixed at one hour by GitHub's installation-token API; both majors
+# revoke in their post step by default). Both even run on `node20`. The real
+# v2 breaking change was the removal of the deprecated `app_id` / `private_key`
+# / `skip_token_revoke` aliases. So `@v1` is not a security difference; it is a
+# stale pin -- v1's last release is v1.12.0 (2025-03-27) and v2 and v3 have
+# shipped since -- and, more to the point here, a SECOND shape for one thing.
+# This contract therefore does not hard-code "v2": it requires that every mint
+# step in the repo agrees on one ref, and that the ref is not the abandoned v1.
+#
+# # The assertion that makes a half-finished consolidation impossible
+#
+# `${{ steps.does-not-exist.outputs.token }}` is not an error in GitHub
+# Actions. It evaluates to the empty string, and `actions/checkout` with an
+# empty `token:` silently falls back to the workflow's own credentials -- which
+# work for this public repo and fail for every private sibling. Renaming or
+# deleting a mint step while leaving one consumer behind is therefore invisible
+# in review, invisible in the YAML linter, and invisible in CI until a private
+# clone 404s. The reachability check below is what closes that.
+# ---------------------------------------------------------------------------
+echo
+echo "cross-repo credential: one org-scoped installation token per job"
+
+readonly MINT_ACTION='actions/create-github-app-token@'
+# The literal expression text a mint step must NOT use for its app id, and the
+# legacy long-lived PAT that the App token replaced. Both are named verbatim in
+# the policy's "Forbidden patterns" list.
+# shellcheck disable=SC2016
+readonly FORBIDDEN_APP_ID_EXPR='${{ vars.CI_TOKEN_PROVIDER_APP_ID }}'
+readonly LEGACY_PAT='GH_READ_METACRAFT_PRIVATE_REPOS'
+# v1 is the abandoned major. Kept as a named constant so the failure message
+# and the check cannot drift apart.
+readonly ABANDONED_MINT_REF='v1'
+
+mint_steps=0
+mint_refs=""
+mint_bad_app_id=()
+mint_bad_scope=()
+mint_duplicate=()
+legacy_pat_refs=()
+unresolved_consumers=()
+consumer_count=0
+
+# Per-scope record of the mint step ids declared in it. A "scope" is a job in a
+# workflow, or the whole file for a composite action (which has no jobs but can
+# still declare steps and consume their outputs).
+declare -A SCOPE_MINT_IDS=()
+# Parallel list of "scope<TAB>id<TAB>where" consumer records, validated after
+# each file is fully read -- a consumer may legally precede its mint in the
+# file even though it cannot precede it at runtime.
+declare -a CONSUMER_RECORDS=()
+
+# flush_mint_step: record the mint step whose body has just ended.
+flush_mint_step() {
+	[ "$in_mint" -eq 1 ] || return 0
+	in_mint=0
+	mint_steps=$((mint_steps + 1))
+
+	case " $mint_refs " in
+	*" $mint_ref "*) ;;
+	*) mint_refs="$mint_refs $mint_ref" ;;
+	esac
+
+	if [ "$mint_app_id_forbidden" -eq 1 ]; then
+		mint_bad_app_id+=("$wf_name:$mint_line: job '$scope' mints with $FORBIDDEN_APP_ID_EXPR")
+	fi
+	if [ "$mint_owner" -eq 0 ]; then
+		mint_bad_scope+=("$wf_name:$mint_line: job '$scope' mints without 'owner: metacraft-labs'")
+	fi
+	if [ "$mint_repositories" -eq 1 ]; then
+		mint_bad_scope+=("$wf_name:$mint_line: job '$scope' narrows the installation with 'repositories:'")
+	fi
+
+	local key="$wf_name|$scope"
+	local already="${SCOPE_MINT_IDS[$key]-}"
+	if [ -n "$already" ]; then
+		mint_duplicate+=("$wf_name:$mint_line: job '$scope' mints a second token (already mints:${already})")
+	fi
+	SCOPE_MINT_IDS[$key]="${already} ${mint_step_id}"
+}
+
+for wf in "${SIBLING_SOURCE_FILES[@]}"; do
+	wf_name="${wf##*/}"
+	scope="(file scope)"
+	seen_jobs_key=0
+	line_no=0
+	in_mint=0
+	mint_ref=""
+	mint_step_id=""
+	mint_line=0
+	mint_app_id_forbidden=0
+	mint_owner=0
+	mint_repositories=0
+	cur_step_id=""
+
+	while IFS= read -r line || [ -n "$line" ]; do
+		line_no=$((line_no + 1))
+		stripped="${line#"${line%%[![:space:]]*}"}"
+
+		# A commented-out expression is documentation, not wiring; matching it
+		# would invent consumers and mint steps that GitHub never sees.
+		case "$stripped" in
+		'#'*) continue ;;
+		esac
+
+		case "$line" in
+		'jobs:'*) seen_jobs_key=1 ;;
+		esac
+
+		# Job header: `  <id>:` at exactly two spaces, after the `jobs:` key.
+		if [ "$seen_jobs_key" -eq 1 ]; then
+			case "$line" in
+			'   '*) ;;
+			'  '[a-zA-Z0-9_-]*':')
+				flush_mint_step
+				scope="${line#  }"
+				scope="${scope%:}"
+				cur_step_id=""
+				;;
+			esac
+		fi
+
+		# Step boundary. `id:` may appear either before or after the `uses:`
+		# line inside the same step -- in this repo it precedes it -- so the
+		# step id is tracked separately and attached when the step is flushed.
+		case "$stripped" in
+		'- name: '* | '- uses: '* | '- run: '* | '- id: '* | '- if: '* | '- with:'*)
+			flush_mint_step
+			cur_step_id=""
+			;;
+		esac
+		case "$stripped" in
+		'id: '* | '- id: '*)
+			cur_step_id="${stripped#- }"
+			cur_step_id="${cur_step_id#id: }"
+			;;
+		esac
+
+		case "$stripped" in
+		*"$MINT_ACTION"*)
+			in_mint=1
+			mint_line="$line_no"
+			mint_ref="${stripped##*"$MINT_ACTION"}"
+			mint_step_id="$cur_step_id"
+			mint_app_id_forbidden=0
+			mint_owner=0
+			mint_repositories=0
+			;;
+		esac
+
+		if [ "$in_mint" -eq 1 ]; then
+			case "$stripped" in
+			'app-id:'*)
+				case "$stripped" in
+				*"$FORBIDDEN_APP_ID_EXPR"*) mint_app_id_forbidden=1 ;;
+				esac
+				;;
+			'owner: metacraft-labs') mint_owner=1 ;;
+			'repositories:'*) mint_repositories=1 ;;
+			esac
+			# The mint step id may still be arriving (`uses:` first, `id:`
+			# second); keep it current until the step is flushed.
+			[ -n "$cur_step_id" ] && mint_step_id="$cur_step_id"
+		fi
+
+		# Consumers. Every `steps.<id>.outputs.token` reference names the step
+		# it expects to have minted; record it with its scope for the
+		# reachability check below.
+		case "$stripped" in
+		*'steps.'*'.outputs.token'*)
+			rest="$stripped"
+			while :; do
+				case "$rest" in
+				*'steps.'*'.outputs.token'*) ;;
+				*) break ;;
+				esac
+				rest="${rest#*steps.}"
+				ref_id="${rest%%.outputs.token*}"
+				# Only a bare step id can precede `.outputs.token`; anything
+				# with a space or brace in it is a different expression that
+				# merely contains the substring.
+				case "$ref_id" in
+				*[!a-zA-Z0-9_-]*) ;;
+				'') ;;
+				*)
+					consumer_count=$((consumer_count + 1))
+					CONSUMER_RECORDS+=("$wf_name|$scope	$ref_id	$wf_name:$line_no")
+					;;
+				esac
+			done
+			;;
+		esac
+
+		case "$stripped" in
+		*"$LEGACY_PAT"*)
+			legacy_pat_refs+=("$wf_name:$line_no: $stripped")
+			;;
+		esac
+	done <"$wf"
+	flush_mint_step
+done
+
+for record in ${CONSUMER_RECORDS+"${CONSUMER_RECORDS[@]}"}; do
+	key="${record%%	*}"
+	tail_="${record#*	}"
+	ref_id="${tail_%%	*}"
+	where="${tail_#*	}"
+	declared="${SCOPE_MINT_IDS[$key]-}"
+	case " $declared " in
+	*" $ref_id "*) ;;
+	*)
+		unresolved_consumers+=("$where: '\${{ steps.$ref_id.outputs.token }}' names no mint step in job '${key#*|}' (declared:${declared:- none})")
+		;;
+	esac
+done
+
+if [ "$mint_steps" -gt 0 ]; then
+	ok "the workflows still mint installation tokens ($mint_steps mint steps, $consumer_count consuming references)"
+else
+	fail "the workflows still mint installation tokens" \
+		"no '$MINT_ACTION' step was found -- either cross-repo auth was reworked or" \
+		"this scanner no longer matches it, and every check below is vacuous"
+fi
+
+if [ "${#mint_bad_app_id[@]}" -eq 0 ]; then
+	ok "every mint step reads the app id from the per-repo secret"
+else
+	fail "every mint step reads the app id from the per-repo secret" \
+		"an org variable is readable from PUBLIC member repos only on this plan, so this" \
+		"form resolves here and evaluates to the empty string in any private repo the job" \
+		"body is copied into; the mint step then dies inside @octokit/auth-app" \
+		"${mint_bad_app_id[@]}"
+fi
+
+if [ "${#legacy_pat_refs[@]}" -eq 0 ]; then
+	ok "no workflow reads the retired $LEGACY_PAT PAT"
+else
+	fail "no workflow reads the retired $LEGACY_PAT PAT" \
+		"it is a long-lived org-wide token superseded by the per-job App installation" \
+		"token; the policy lists it as a forbidden pattern to migrate out of" \
+		"${legacy_pat_refs[@]}"
+fi
+
+mint_ref_list="${mint_refs# }"
+mint_ref_count=0
+for _ref in $mint_ref_list; do
+	mint_ref_count=$((mint_ref_count + 1))
+done
+unset _ref
+if [ "$mint_ref_count" -le 1 ]; then
+	ok "all mint steps agree on one action ref (${mint_ref_list:-none})"
+else
+	fail "all mint steps agree on one action ref" \
+		"two majors of the same action in one repo is how a job ends up with two mint" \
+		"steps that look deliberate; pick one and use it everywhere" \
+		"refs in use: $mint_ref_list"
+fi
+
+case " $mint_ref_list " in
+*" $ABANDONED_MINT_REF "*)
+	fail "no mint step pins the abandoned $ABANDONED_MINT_REF major" \
+		"v1's last release is v1.12.0 (2025-03-27); v2 and v3 have shipped since." \
+		"It is behaviourally equivalent for our usage -- same owner semantics, same" \
+		"repositories: default, same one-hour token -- so this is a staleness check," \
+		"not a security one, and it exists to keep exactly one shape in the tree"
+	;;
+*)
+	ok "no mint step pins the abandoned $ABANDONED_MINT_REF major"
+	;;
+esac
+
+if [ "${#mint_duplicate[@]}" -eq 0 ]; then
+	ok "no job mints more than one installation token"
+else
+	fail "no job mints more than one installation token" \
+		"two tokens for one purpose double the credential surface of the job and make it" \
+		"ambiguous which one a given step is actually using; mint once and reference it" \
+		"${mint_duplicate[@]}"
+fi
+
+if [ "${#mint_bad_scope[@]}" -eq 0 ]; then
+	ok "every mint step is org-scoped by construction (owner set, no repositories:)"
+else
+	fail "every mint step is org-scoped by construction (owner set, no repositories:)" \
+		"the App installation is org-scoped, so 'owner: metacraft-labs' with no" \
+		"'repositories:' is what makes the credential need no rotation as siblings are" \
+		"added; narrowing it turns every new sibling into a workflow edit" \
+		"${mint_bad_scope[@]}"
+fi
+
+if [ "${#unresolved_consumers[@]}" -eq 0 ]; then
+	ok "every token reference names a mint step in its own job"
+else
+	fail "every token reference names a mint step in its own job" \
+		"GitHub Actions does not error on an unknown step output: the expression" \
+		"evaluates to the empty string, and actions/checkout with an empty token: falls" \
+		"back to the workflow's own credentials, which work for this public repo and" \
+		"fail for every private sibling" \
+		"${unresolved_consumers[@]}"
+fi
+
+# ---------------------------------------------------------------------------
 # Self-accounting: a contract that is deleted or short-circuited must not leave
 # this script reporting success on fewer checks than it claims.
 # ---------------------------------------------------------------------------
 echo
-readonly EXPECTED_ASSERTIONS=7
+readonly EXPECTED_ASSERTIONS=15
 if [ "$assertions" -ne "$EXPECTED_ASSERTIONS" ]; then
 	printf 'FAIL: ran %d assertions, expected %d\n' "$assertions" "$EXPECTED_ASSERTIONS"
 	failures=$((failures + 1))

--- a/ci/test/sibling-provisioning-test.sh
+++ b/ci/test/sibling-provisioning-test.sh
@@ -674,12 +674,18 @@ for wf in "${SIBLING_SOURCE_FILES[@]}"; do
 		esac
 
 		# Job header: `  <id>:` at exactly two spaces, after the `jobs:` key.
+		# A trailing comment is stripped first. Without that, `  foo:  # note`
+		# would not match, the scope would stay on the PREVIOUS job, and a
+		# consumer in `foo` could resolve against a mint step in its
+		# predecessor -- the reachability check silently weakened by a comment.
+		header="${line%%#*}"
+		header="${header%"${header##*[![:space:]]}"}"
 		if [ "$seen_jobs_key" -eq 1 ]; then
-			case "$line" in
+			case "$header" in
 			'   '*) ;;
 			'  '[a-zA-Z0-9_-]*':')
 				flush_mint_step
-				scope="${line#  }"
+				scope="${header#  }"
 				scope="${scope%:}"
 				cur_step_id=""
 				;;


### PR DESCRIPTION
Every job that clones a sibling repo now mints exactly one installation token, in one shape, and every consuming step names that step explicitly.

## What was wrong

**Seventeen mint steps read the app id from the organization variable** (`vars.CI_TOKEN_PROVIDER_APP_ID`) instead of the per-repo secret — 14 in `codetracer.yml`, plus `beam-flow.yml`, `mcr-dap-flow.yml` and `request-panel-sidecar-retirement.yml`.

That form resolves here *only because this repo is public*. `CI_TOKEN_PROVIDER_APP_ID` exists as a `metacraft-labs` org variable with visibility `all`, and on this plan an org variable is readable from public member repos only. The moment the same job body lands in a private repo, the expression evaluates to the empty string — GitHub does not error on an undefined `vars.` lookup, and does not enforce an action's `required: true` inputs — and the mint step dies inside `@octokit/auth-app` with a message that points at a library internal rather than at "this repo cannot read org variables". Every sibling clone downstream of it never runs.

**Eight jobs minted a second token as well as the first** (`ci_token` *and* `app-token`) and used the two interchangeably from step to step: two installation tokens per job for one purpose, and no way to tell from a given step which credential it was actually on.

**`mcr-dap-flow` checked out before it minted**, and passed no `token:` to a `submodules: recursive` checkout whose `libs/tree-sitter-nim` submodule is private. It failed at `Checkout codetracer` with `repository ... not found`, taking all nine later steps down as `skipped` — but only on a runner that did not already have the submodule, which is how it outlived the identical fix already made in `beam-flow.yml`.

Net: 45 mint steps across 37 jobs become 37, one per job; 115 consuming references all resolve to a mint step in their own job.

## On the v1 → v2 normalisation

Checked against the published action rather than assumed. v1 and v2 are **identical** on the three axes that would matter to us:

| | v1 | v2 |
|---|---|---|
| `owner` semantics | same | same |
| `repositories:` default | "defaults to current repository if owner is unset" | identical sentence |
| token lifetime | 1h, fixed by GitHub's installation-token API; revoked in the post step | same |
| node runtime | `node20` | `node20` |

The actual v2 breaking change was the removal of the deprecated `app_id` / `private_key` / `skip_token_revoke` aliases. So this is a **staleness** fix, not a security one — v1's last release is v1.12.0 (2025-03-27) — and mostly it is about having one shape in the tree rather than two. The contract test reflects that: it requires all mint steps to agree on one ref and rejects the abandoned v1, rather than hard-coding "v2".

One wrinkle worth recording: v1's `dist/main.cjs` guarded the input itself (`if (!appId) throw new Error("Input required and not supplied: app-id")`); v2 removed that guard in favour of `required: true` in `action.yml`, which the runner does not enforce. Both majors still fail loudly on an empty app id — the diagnostic just gets worse. Neither "silently mints nothing".

## Contract

`ci/test/sibling-provisioning-test.sh` grows a credential section (9 new assertions, 16 total). It already runs in `ci-verdict` on every run, from a stock runner, so this rides along with no new job. Run against the pre-fix tree it names all 26 violations individually — 17 `vars.` sites, the mixed v1/v2 refs, the v1 pin, all 8 double-minting jobs, and the untokened submodule checkout.

Further assertions cover reintroduction from other directions: the retired `GH_READ_METACRAFT_PRIVATE_REPOS` PAT, a mint step that drops `owner:` or narrows with `repositories:`, and any `steps.<id>.outputs.token` that names no mint step in its own job.

That last one is the load-bearing one. An unresolved step output is not an error in GitHub Actions — it evaluates to the empty string, and `actions/checkout` with an empty `token:` falls back to the workflow's own credentials, which work for this public repo and fail for every private sibling. A half-finished rename is otherwise invisible in review, in the YAML linter, and in CI until a private clone 404s.

`ci/test/origin-dap-gate.sh`'s Windows credential-leak check matched the old step id literally and would have gone quietly blind on this rename; it now matches the *shape* of any step-output token, which is strictly broader.

## Verification

- `bash ci/test/sibling-provisioning-test.sh` — 16/16 pass; against the pre-fix tree, 5 assertions fail listing all 26 violations by file, line and job.
- Ten mutations injected into a pristine copy — `vars.` app id restored, legacy PAT restored, `owner:` dropped, `repositories:` added, a second mint step added, v1 restored, a consumer left on a renamed mint id, a mint step deleted with consumers kept, the token dropped from a submodule checkout, and the mint action renamed away — all killed, none survived. The harness fails loudly if a mutation turns out to be a no-op.
- `actionlint` reports the same three pre-existing findings before and after, with no new ones; `shellcheck`, `shfmt` and the pre-commit `check-yaml` are clean; `required-jobs-test.sh`, `cross-process-gate.sh` and `windows-runner-bootstrap-test.sh` still pass.
- **Live CI:** the reordered `mcr-dap-flow` now shows `Generate CI token => success` followed by `Checkout codetracer => success`, where the immediately preceding run on this branch had `Checkout codetracer => failure` / `Generate CI token => skipped`. `Token revoked` appears in post-cleanup, confirming the single mint step's revoke still runs.

## Known-red, all pre-existing on `dev`

`workspace-lock-freshness` (no published lock since 2026-08-02), `visual-replay-regression-gate` (`Cargo.lock` drift in the `codetracer-native-backend` sibling under `--locked`), and `mcr-dap-flow`, which now gets two steps further and dies at `Resolve sibling refs` reading `.github/sibling-pins` — a repo-local sibling-pin file the policy forbids and that no longer exists in the tree. That is a revision-resolution defect, not a credential one, and is left for its own change.

`ci-verdict` — which is where the extended contract executes — cannot report for ~24h by its own documented design, because it `needs:` jobs pinned to the unprovisioned `eph-macos-arm64` class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)