### PR TITLE
fix(ci): read a routed lock record as an unlocked commit, not a broken one

### DIFF
--- a/scripts/resolve-sibling-rev-test.sh
+++ b/scripts/resolve-sibling-rev-test.sh
@@ -32,7 +32,7 @@ if [[ ! -x $RESOLVER && ! -f $RESOLVER ]]; then
 	exit 3
 fi
 
-EXPECTED_ASSERTIONS=76
+EXPECTED_ASSERTIONS=86
 
 PASS=0
 FAIL=0
@@ -919,6 +919,189 @@ expect_rev "an explicit --manifest-dir ignores CT_PRIVATE_MANIFEST_DIR" "$REV_NB
 	--manifest-dir "$LPUB" --sha "$SHA_SELF" --no-walk
 unset CT_MANIFEST_DIR
 unset CT_PRIVATE_MANIFEST_DIR
+
+# =========================================================================
+# 12. Routed per-repo participation records are NOT locks
+# =========================================================================
+#
+# `repro locking adopt-manifest` puts a workspace in ROUTED locking mode. In
+# that mode reprobuild's HL-2 tier isolation deliberately skips the monolithic
+# workspace-lock document and `recordRoutedParticipation` writes one minimal
+# per-repo record — via the git-checkout backend, into the SAME
+# `locks/<project>/<repo>/<sha>.toml` namespace the lock documents use.
+#
+# Such a record pins only the repo whose directory it sits in, so it cannot
+# answer this resolver's question at all. Read as a lock it produced
+# "malformed lock ... no top-level 'schema' key" and EXIT 5 — the code that
+# means "a lock exists but cannot be trusted", which callers escalate to a job
+# abort. 98 of these records (96 repos) are published in
+# metacraft-labs/metacraft-manifests@latest and 71 of them reproduced that
+# exit 5, so a commit that merely lacked a lock became a commit that killed the
+# job.
+#
+# The contract below is that they degrade EXACTLY like a missing lock: exit 3,
+# candidate fall-through intact, ancestry walk intact — while every genuinely
+# untrustworthy document stays loud at exit 5.
+
+# A routed participation record, byte-for-byte the shape reprobuild's
+# `routedParticipationBody` emits.
+mk_participation_record() {
+	local file="$1" name="$2" path="$3" sha="$4"
+	mkparent "$file"
+	{
+		printf '%s\n' '[[repo]]'
+		printf '%s\n' "name = \"$name\""
+		printf '%s\n' "path = \"$path\""
+		printf '%s\n' "revision = \"$sha\""
+	} >"$file"
+}
+
+P="$TMPROOT/participation"
+
+# (a) A routed record ALONE is a missing lock, not a broken one. This is the
+# whole point: exit 5 aborts the job, exit 3 is the graceful "not locked".
+mk_participation_record "$P/a/locks/codetracer/codetracer/$SHA_SELF.toml" \
+	"codetracer" "codetracer" "$SHA_SELF"
+expect_fail "participation: a routed record alone is exit 3, not exit 5" 3 \
+	"no workspace lock found" -- \
+	--repo codetracer --sibling codetracer-native-backend \
+	--manifest-dir "$P/a" --sha "$SHA_SELF" --no-walk
+
+# (b) ...and the diagnostic must say WHY, naming the file. A silent exit 3 for
+# a commit that visibly has a file on disk is its own debugging trap.
+expect_fail "participation: the exit-3 diagnostic names the ignored record" 3 \
+	"locks/codetracer/codetracer/$SHA_SELF.toml" -- \
+	--repo codetracer --sibling codetracer-native-backend \
+	--manifest-dir "$P/a" --sha "$SHA_SELF" --no-walk
+
+# (c) A routed record must not poison a REAL lock written for the same commit.
+# Before this was recognised, the record was collected alongside the lock and
+# failed the whole resolve at exit 5 even though the answer was right there.
+mk_xml_lock "$P/c/locks/codetracer/codetracer/$SHA_SELF.xml" "$REV_NB_XML" "$REV_NIM_XML"
+mk_participation_record "$P/c/locks/codetracer/codetracer/$SHA_SELF.toml" \
+	"codetracer" "codetracer" "$SHA_SELF"
+expect_rev "participation: a routed record does not poison a real xml lock" "$REV_NB_XML" -- \
+	--repo codetracer --sibling codetracer-native-backend \
+	--manifest-dir "$P/c" --sha "$SHA_SELF" --no-walk
+
+# (d) The same in the flat legacy spelling, so the recognition is not attached
+# to one layout.
+mk_xml_lock "$P/d/locks/codetracer/codetracer-$SHA_SELF.xml" "$REV_NB_XML" "$REV_NIM_XML"
+mk_participation_record "$P/d/locks/codetracer/codetracer-$SHA_SELF.toml" \
+	"codetracer" "codetracer" "$SHA_SELF"
+expect_rev "participation: recognised in the flat layout too" "$REV_NB_XML" -- \
+	--repo codetracer --sibling codetracer-native-backend \
+	--manifest-dir "$P/d" --sha "$SHA_SELF" --no-walk
+
+# (e) Candidate FALL-THROUGH. This is what parsing the record into an exit 4
+# would NOT have bought: a caller probing HEAD then its parent must move past
+# the routed record to the parent's real lock, exactly as it moves past a
+# commit with no file at all.
+mk_participation_record "$P/e/locks/codetracer/codetracer/$SHA_OTHER.toml" \
+	"codetracer" "codetracer" "$SHA_OTHER"
+mk_toml_lock "$P/e/locks/codetracer/codetracer/$SHA_SELF.toml" "$REV_NB_TOML" "$REV_NIM_TOML"
+expect_rev "participation: a routed leading candidate falls through to a locked one" "$REV_NB_TOML" -- \
+	--repo codetracer --sibling codetracer-native-backend \
+	--manifest-dir "$P/e" --sha "$SHA_OTHER" --sha "$SHA_SELF" --no-walk
+
+# (f) The ancestry walk must survive it too: a routed record at the tip must
+# not stop the walk reaching the locked parent.
+GP="$TMPROOT/walkp"
+mkdir -p "$GP/codetracer"
+(
+	cd "$GP/codetracer" || exit 1
+	git init -q .
+	git config user.email t@t.invalid
+	git config user.name t
+	git config commit.gpgsign false
+	: >a
+	git add a
+	git commit -qm one
+	: >b
+	git add b
+	git commit -qm two
+) >/dev/null 2>&1
+PBASE="$(git -C "$GP/codetracer" rev-parse HEAD~1)"
+PTIP="$(git -C "$GP/codetracer" rev-parse HEAD)"
+mk_toml_lock "$GP/.repro/manifests/locks/codetracer/codetracer/$PBASE.toml" \
+	"$REV_NB_TOML" "$REV_NIM_TOML"
+mk_participation_record "$GP/.repro/manifests/locks/codetracer/codetracer/$PTIP.toml" \
+	"codetracer" "codetracer" "$PTIP"
+expect_rev "participation: a routed record at the tip does not stop the walk" "$REV_NB_TOML" -- \
+	--repo codetracer --sibling codetracer-native-backend \
+	--repo-dir "$GP/codetracer" --sha "$PTIP"
+
+# (g) Extra keys must not un-recognise it. Recognition is semantic — "declares
+# no schema, only [[repo]] tables, names nobody but itself" — precisely so that
+# reprobuild adding `remote` / `branch` to the record does not silently restore
+# the exit-5 abort.
+mkdir -p "$P/g/locks/codetracer/codetracer"
+{
+	printf '%s\n' '# written by repro'
+	printf '%s\n' '[[repo]]'
+	printf '%s\n' 'name = "codetracer"'
+	printf '%s\n' 'path = "codetracer"'
+	printf '%s\n' 'remote = "metacraft-labs"'
+	printf '%s\n' 'branch = "dev"'
+	printf '%s\n' "revision = \"$SHA_SELF\""
+} >"$P/g/locks/codetracer/codetracer/$SHA_SELF.toml"
+expect_fail "participation: extra keys still degrade to exit 3" 3 \
+	"no workspace lock found" -- \
+	--repo codetracer --sibling codetracer-native-backend \
+	--manifest-dir "$P/g" --sha "$SHA_SELF" --no-walk
+
+# (h) OVER-BREADTH GUARD. A schema-less document that names some OTHER repo is
+# not a participation record — it is a lock document that failed to declare
+# itself, and it claims to know a sibling's revision. Trusting it silently, or
+# skipping it silently, would both be wrong: it stays exit 5.
+mkdir -p "$P/h/locks/codetracer/codetracer"
+{
+	printf '%s\n' '[[repo]]'
+	printf '%s\n' 'name = "codetracer"'
+	printf '%s\n' 'path = "codetracer"'
+	printf '%s\n' "revision = \"$SHA_SELF\""
+	printf '%s\n' '[[repo]]'
+	printf '%s\n' 'name = "codetracer-native-backend"'
+	printf '%s\n' 'path = "codetracer-native-backend"'
+	printf '%s\n' "revision = \"$REV_NB_TOML\""
+} >"$P/h/locks/codetracer/codetracer/$SHA_SELF.toml"
+expect_fail "participation: a schema-less doc naming a sibling is still exit 5" 5 \
+	"schema" -- \
+	--repo codetracer --sibling codetracer-native-backend \
+	--manifest-dir "$P/h" --sha "$SHA_SELF" --no-walk
+
+# (i) OVER-BREADTH GUARD. A schema-less document carrying a non-[[repo]] table
+# is a truncated or corrupt LOCK, not a participation record: reprobuild's
+# record has no `[lock]` header. Still exit 5.
+mkdir -p "$P/i/locks/codetracer/codetracer"
+{
+	printf '%s\n' '[lock]'
+	printf '%s\n' 'project = "codetracer"'
+	printf '%s\n' '[[repo]]'
+	printf '%s\n' 'name = "codetracer"'
+	printf '%s\n' 'path = "codetracer"'
+	printf '%s\n' "revision = \"$SHA_SELF\""
+} >"$P/i/locks/codetracer/codetracer/$SHA_SELF.toml"
+expect_fail "participation: a schema-less doc with a [lock] table is still exit 5" 5 \
+	"schema" -- \
+	--repo codetracer --sibling codetracer-native-backend \
+	--manifest-dir "$P/i" --sha "$SHA_SELF" --no-walk
+
+# (j) A document that DOES declare the schema is a lock even when it pins only
+# one repo — a one-repo workspace is legitimate, and its "sibling absent"
+# answer is the honest exit 4, not exit 3.
+mkdir -p "$P/j/locks/codetracer/codetracer"
+{
+	printf '%s\n' 'schema = "reprobuild.workspace.lock.v1"'
+	printf '%s\n' '[[repo]]'
+	printf '%s\n' 'name = "codetracer"'
+	printf '%s\n' 'path = "codetracer"'
+	printf '%s\n' "revision = \"$SHA_SELF\""
+} >"$P/j/locks/codetracer/codetracer/$SHA_SELF.toml"
+expect_fail "participation: a schema'd self-only lock is exit 4, not exit 3" 4 \
+	"not present in lock" -- \
+	--repo codetracer --sibling codetracer-native-backend \
+	--manifest-dir "$P/j" --sha "$SHA_SELF" --no-walk
 
 # =========================================================================
 

--- a/scripts/resolve-sibling-rev.sh
+++ b/scripts/resolve-sibling-rev.sh
@@ -38,6 +38,13 @@
 # The historical flat spelling ``locks/<project>/<repo>-<sha>.<ext>`` is also
 # accepted, for both extensions.
 #
+# A THIRD kind of file shares that ``.toml`` namespace and is NOT a lock: the
+# per-repo participation record reprobuild's ROUTED locking mode writes (see
+# ``is_participation_record`` below). It pins only the repo whose directory it
+# sits in, so it can never answer a question about a sibling. It is recognised
+# and IGNORED, which makes such a commit read as UNLOCKED (exit 3) rather than
+# as carrying a broken lock (exit 5).
+#
 # Legacy ``.github/sibling-pins`` / ``.github/sibling-pins.json`` /
 # ``.github/rr-backend-pin.txt`` files and the ``locks/<project>/index.json``
 # layout are NOT used: the lock keyed by the commit-under-test is the only
@@ -434,11 +441,108 @@ fi
 #      tools are cross-checked against each other rather than silently resolved
 #      by glob order. THIS is the migration hazard worth refusing: neither
 #      spelling is the elder, so there is no basis for preferring one.
+# ROUTED PER-REPO PARTICIPATION RECORDS (not locks)
+# -------------------------------------------------
+#
+# `repro locking adopt-manifest` puts a workspace into ROUTED mode (an explicit
+# `[locking] route` in the repo's VCS-private reprobuild config). In that mode
+# reprobuild's HL-2 tier isolation deliberately stops writing the monolithic
+# all-repos lock document — that document is the cross-tier leak it exists to
+# prevent — and `recordRoutedParticipation` instead writes ONE MINIMAL RECORD
+# PER REPO, through that repo's routed backend. The git-checkout backend's
+# records land in the SAME `locks/<project>/<repo>/<sha>.toml` namespace as the
+# lock documents, and their whole body is (reprobuild's
+# `routedParticipationBody`):
+#
+#     [[repo]]
+#     name = "<repo>"
+#     path = "<workspace path>"
+#     revision = "<sha>"
+#
+# That is not a workspace lock and cannot be read as one: it announces no
+# schema, and it pins ONLY the repo whose directory it sits in. It cannot
+# answer "what revision is sibling S at for commit C" because nothing in it,
+# or keyed to C, mentions S at all. Reprobuild itself treats it as a separate
+# thing — its strict `readLock` rejects the body and only the lenient
+# `shasFromBody` accepts it.
+#
+# Fed to `rev_from_toml` these records fail as "no top-level 'schema' key" and
+# the resolver exits 5. That is the wrong answer and an actively dangerous one:
+# exit 5 means "a lock exists but cannot be trusted", which callers escalate to
+# a job abort, whereas the truth is the strictly milder "this commit has no
+# workspace lock" (exit 3), which every caller already degrades from gracefully.
+# 98 such records, covering 96 repos, are already published under
+# `locks/codetracer/` in metacraft-labs/metacraft-manifests@latest, so this is
+# not hypothetical and cannot be fixed by changing what reprobuild writes NEXT.
+#
+# So they are recognised HERE, at discovery, and excluded from the lock set —
+# which is strictly better than parsing them into an exit 4, because a commit
+# whose only record is routed then falls through to the NEXT candidate SHA (the
+# parent) exactly as an unlocked commit does, instead of stopping the probe.
+#
+# The recognition is SEMANTIC, not a syntax fingerprint, so it does not break
+# the first time reprobuild adds a key to the record:
+#
+#   * the document announces no top-level `schema`, AND
+#   * every table in it is `[[repo]]`, AND
+#   * the only repo NAME it pins is $SELF_REPO itself.
+#
+# A schema-less document that names some OTHER repo is not a participation
+# record — it is a lock document that failed to declare itself — and must still
+# be refused loudly (exit 5). Likewise a document that DOES declare a schema is
+# a lock, and a one-repo workspace's lock is answered normally.
+is_participation_record() { # $1 = .toml file
+	local file="$1" l key val
+	local tables=0 repo_tables=0 names=0 foreign=0
+
+	while IFS= read -r l || [[ -n $l ]]; do
+		l="${l%$'\r'}"
+		while [[ $l == [[:space:]]* ]]; do l="${l#?}"; done
+		while [[ $l == *[[:space:]] ]]; do l="${l%?}"; done
+		[[ -z $l ]] && continue
+		[[ ${l:0:1} == "#" ]] && continue
+
+		if [[ ${l:0:1} == "[" ]]; then
+			tables=$((tables + 1))
+			[[ $l == "[[repo]]" ]] && repo_tables=$((repo_tables + 1))
+			continue
+		fi
+
+		key="${l%%=*}"
+		[[ $key == "$l" ]] && continue
+		val="${l#*=}"
+		while [[ $key == *[[:space:]] ]]; do key="${key%?}"; done
+		while [[ $val == [[:space:]]* ]]; do val="${val#?}"; done
+		case "$val" in
+		\"*\") val="${val#\"}" && val="${val%\"}" ;;
+		\'*\') val="${val#\'}" && val="${val%\'}" ;;
+		esac
+
+		# A top-level `schema` (i.e. before any table header) makes this a lock
+		# document, whatever else it contains.
+		if [[ $tables -eq 0 && $key == "schema" ]]; then
+			return 1
+		fi
+		if [[ $key == "name" ]]; then
+			names=$((names + 1))
+			[[ $val != "$SELF_REPO" ]] && foreign=1
+		fi
+	done <"$file"
+
+	# At least one [[repo]], nothing but [[repo]] tables, at least one name, and
+	# no name other than our own.
+	[[ $repo_tables -gt 0 && $tables -eq $repo_tables && $names -gt 0 && $foreign -eq 0 ]]
+}
+
 # `find_locks <locks-root> <sha>` — the search is per LAYER, because each layer
 # is its own manifest repo with its own `locks/` tree; the three tie-breaks
 # below narrow ONE layer's locks for one commit. Ordering BETWEEN layers is the
 # caller's explicit `--manifest-dir` order and is applied further down.
 declare -a LOCK_FILES=()
+# Routed participation records passed over while searching, so the exit-3
+# diagnostic can name them instead of reporting a bare "nothing found" for a
+# commit that visibly has files on disk.
+declare -a SKIPPED_PARTICIPATION=()
 find_locks() {
 	local locks_root="$1" sha="$2" f proj
 	local -a pref_nested=() pref_flat=() other_nested=() other_flat=()
@@ -447,6 +551,10 @@ find_locks() {
 		"$locks_root"/*/"$SELF_REPO"/"$sha.xml" \
 		"$locks_root"/*/"$SELF_REPO"/"$sha.toml"; do
 		[[ -f $f ]] || continue
+		if [[ $f == *.toml ]] && is_participation_record "$f"; then
+			SKIPPED_PARTICIPATION+=("$f")
+			continue
+		fi
 		if [[ $f == "$locks_root/$PREFER_PROJECT/"* ]]; then
 			pref_nested+=("$f")
 			continue
@@ -460,6 +568,10 @@ find_locks() {
 		"$locks_root"/*/"$SELF_REPO-$sha.xml" \
 		"$locks_root"/*/"$SELF_REPO-$sha.toml"; do
 		[[ -f $f ]] || continue
+		if [[ $f == *.toml ]] && is_participation_record "$f"; then
+			SKIPPED_PARTICIPATION+=("$f")
+			continue
+		fi
 		if [[ $f == "$locks_root/$PREFER_PROJECT/"* ]]; then
 			pref_flat+=("$f")
 			continue
@@ -732,6 +844,19 @@ if [[ -z $CHOSEN_SHA ]]; then
 			echo "    $lr/*/$SELF_REPO-<sha>.toml   (legacy flat)"
 		done
 		[[ $NO_WALK -eq 0 ]] && echo "  (also walked first-parent ancestry of ${SHAS[0]})"
+		if [[ ${#SKIPPED_PARTICIPATION[@]} -gt 0 ]]; then
+			echo "  Ignored ${#SKIPPED_PARTICIPATION[@]} routed per-repo participation record(s):"
+			for f in "${SKIPPED_PARTICIPATION[@]}"; do
+				echo "    $f"
+			done
+			echo "  Those are written by reprobuild's ROUTED locking mode ('repro locking"
+			echo "  adopt-manifest'), which by design does not write the monolithic workspace"
+			echo "  lock document. Each record pins only '$SELF_REPO' itself, so none of them"
+			echo "  can name a sibling. Treated exactly as a missing lock, never as a broken"
+			echo "  one. To make these commits resolvable, the workspace must publish a"
+			echo '  workspace-lock document (schema = "reprobuild.workspace.lock.v1") for the'
+			echo "  public tier alongside the routed records."
+		fi
 		echo "  Every commit under cross-repo CI must be locked by the workspace tooling"
 		echo "  ('repro workspace lock' / the reprobuild post-commit + pre-push hooks, or"
 		echo "  legacy 'workspace lock'). A missing lock means the commit was not published"


### PR DESCRIPTION
A routed per-repo lock record made the sibling-revision resolver abort the job
instead of degrading like a missing lock.

## What is wrong

`repro locking adopt-manifest` puts a workspace into **routed** locking mode.
In that mode the workspace tooling stops writing the monolithic workspace-lock
document and instead writes one minimal per-repo record — into the **same**
`locks/<project>/<repo>/<sha>.toml` namespace the lock documents use:

```toml
[[repo]]
name = "codetracer"
path = "codetracer"
revision = "<sha>"
```

That is not a workspace lock. It declares no schema and pins only the repo
whose directory it sits in, so it can never say what revision a *sibling* is
at. Read as a lock it fails with `no top-level 'schema' key` and **exit 5** —
the code meaning "a lock exists but cannot be trusted", which callers escalate
to a job abort. The honest answer is the far milder "this commit has no
workspace lock" (**exit 3**), which every caller already degrades from
gracefully.

So a commit that merely *lacked* a lock was killing the job. Reproduce on the
published data:

```
scripts/resolve-sibling-rev.sh --repo codetracer --sibling codetracer-nim \
  --sha 81f8e91f0aa882bff85c99bf8a4edb2ac0caff40 --no-walk   # was exit 5, now exit 3
```

## Scale, measured

Against a fresh clone of `metacraft-labs/metacraft-manifests@latest`:

| | count |
|---|---|
| `.toml` files under `locks/` | 127 |
| genuine `reprobuild.workspace.lock.v1` documents | 29 |
| **routed per-repo records (no `schema` key)** | **98**, covering **96 repos** |
| of those, reproducing **exit 5** today | **71** |

The other 27 already resolved because a valid `.xml` lock for the same commit
won the project-preference tie-break. After this change those 71 become 68
graceful exit 3, 2 **successful resolves** (the record had been poisoning a
real lock written for the same commit), and 1 honest exit 4.

These records are already published, so this cannot be fixed by changing what
the tooling writes next.

## The fix

Recognise the records at **discovery** and exclude them from the lock set.
That beats parsing them into an exit 4: a commit whose only record is routed
now falls through to the **next candidate SHA**, and the ancestry walk still
reaches the locked parent — exactly as an unlocked commit does.

Recognition is **semantic**, not a syntax fingerprint, so adding a field to the
record cannot silently restore the abort:

* the document declares no top-level `schema`, **and**
* every table in it is `[[repo]]`, **and**
* the only repo name it pins is the one being resolved.

A schema-less document naming some *other* repo is still refused loudly — it
claims to know a sibling's revision without declaring what it is — and so is
one carrying a non-`[[repo]]` table. The exit-3 diagnostic names every record
it ignored and why, so the degradation is never silent.

## Tests

Ten contracts added to the shared suite (76 → 86 assertions). Each was
mutation-verified:

* all 7 behavioural contracts fail against the unfixed resolver;
* dropping the "names nobody but itself" condition kills the over-breadth guard
  **and** two pre-existing contracts;
* dropping the "only `[[repo]]` tables" condition, the top-level-schema escape,
  and the diagnostic each kill exactly their own guard.

No pre-existing contract changed.

## Companion

`metacraft-labs/metacraft-github-actions#<pr>` carries the identical change to
`clone-siblings/resolve-sibling-rev.sh` — the copy CI actually executes. This
file is the vendored copy and the two are kept byte-identical below the header.