### PR TITLE
fix(ci): retire the two long-lived PATs and stop persisting tokens that go unused

### DIFF
--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -3533,13 +3533,21 @@ jobs:
           # contents:write permission below) -- the same reliable mechanism the
           # isonim/isonim-docs docs deploys use. The old origin+CODETRACER_PUSH_
           # GITHUB_TOKEN path failed auth ("Authentication failed for .../codetracer").
+          #
+          # `origin` is deliberately NOT re-pointed at a credentialed URL here.
+          # docs.sh only reads `origin` in its DEPLOY_TOKEN-absent fallback
+          # (`ci/deploy/docs.sh`, the `git push --force "$REMOTE" HEAD:gh-pages`
+          # branch), and DEPLOY_TOKEN is always set on this step -- so the
+          # rewrite could never be the credential that pushed, it could only
+          # expand a long-lived PAT into `.git/config` on a self-hosted runner
+          # that reuses its workspace. This is a category-1 push (the
+          # workflow's own public repo), and the policy credential for that is
+          # the token Actions already provides.
           DEPLOY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config init.defaultBranch main
-
-          git remote set-url origin https://x-access-token:${{ secrets.CODETRACER_PUSH_GITHUB_TOKEN }}@github.com/metacraft-labs/codetracer
 
           nix develop .#devShells.x86_64-linux.default --command ./ci/deploy/docs.sh
 
@@ -3595,6 +3603,24 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config init.defaultBranch main
 
+          # KNOWN DEVIATION from the credential policy
+          # (metacraft-dev-guidelines/policies/ci-workflow-standards.md
+          # §"Which credential for which repo"). This is a category-1 push --
+          # the workflow's OWN public repo -- so the credential should be the
+          # one Actions already provides; this job already declares
+          # `permissions: contents: write` for it. `CODETRACER_PUSH_GITHUB_TOKEN`
+          # is a long-lived PAT and therefore the one rotation-bearing GitHub
+          # credential left in this workflow, which is exactly what the policy
+          # exists to eliminate.
+          #
+          # It is left in place deliberately rather than swapped blind: this is
+          # the release tag-push path and it cannot be exercised outside a real
+          # release, and the checkout above persists an
+          # `http.https://github.com/.extraheader` for the App token, which
+          # takes precedence over any userinfo in a push URL. Correcting it
+          # means also setting `persist-credentials: false` on that checkout
+          # (or scoping the header) and verifying on a release run, not just
+          # deleting this line.
           git remote set-url origin https://x-access-token:${{ secrets.CODETRACER_PUSH_GITHUB_TOKEN }}@github.com/metacraft-labs/codetracer
 
           git tag -a "$YEAR.$MONTH.$BUILD" -m "Release $YEAR.$MONTH.$BUILD" || echo "Tag already exists"

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -3603,26 +3603,39 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config init.defaultBranch main
 
-          # KNOWN DEVIATION from the credential policy
-          # (metacraft-dev-guidelines/policies/ci-workflow-standards.md
-          # §"Which credential for which repo"). This is a category-1 push --
-          # the workflow's OWN public repo -- so the credential should be the
-          # one Actions already provides; this job already declares
-          # `permissions: contents: write` for it. `CODETRACER_PUSH_GITHUB_TOKEN`
-          # is a long-lived PAT and therefore the one rotation-bearing GitHub
-          # credential left in this workflow, which is exactly what the policy
-          # exists to eliminate.
+          # `origin` is deliberately NOT re-pointed at a credentialed URL.
           #
-          # It is left in place deliberately rather than swapped blind: this is
-          # the release tag-push path and it cannot be exercised outside a real
-          # release, and the checkout above persists an
-          # `http.https://github.com/.extraheader` for the App token, which
-          # takes precedence over any userinfo in a push URL. Correcting it
-          # means also setting `persist-credentials: false` on that checkout
-          # (or scoping the header) and verifying on a release run, not just
-          # deleting this line.
-          git remote set-url origin https://x-access-token:${{ secrets.CODETRACER_PUSH_GITHUB_TOKEN }}@github.com/metacraft-labs/codetracer
-
+          # It used to be, at `CODETRACER_PUSH_GITHUB_TOKEN` -- a long-lived
+          # PAT, and the last rotation-bearing GitHub credential in this
+          # workflow. That userinfo could never be the credential that pushed.
+          # The `Checkout` step above runs with `persist-credentials` at its
+          # default of true, so actions/checkout leaves
+          # `http.https://github.com/.extraheader` in `.git/config` carrying
+          # the App installation token, and Git prefers a configured
+          # Authorization header over userinfo in the remote URL.
+          #
+          # That preference is total, not merely a first choice, which is what
+          # makes deleting the line safe rather than a gamble. Against a server
+          # that answers 401, `git push` retries with the SAME header and then
+          # gives up; the userinfo is never put on the wire at all, so it is not
+          # a fallback either. (Reproducible without any real credential: point
+          # a checkout at a local HTTP server with both an `extraHeader` and
+          # userinfo configured, and read the `Authorization` it receives.)
+          #
+          # So the App token was already performing this push, and removing the
+          # rewrite changes which credential authenticates not at all -- it only
+          # stops expanding a PAT into `.git/config` on a self-hosted runner
+          # that reuses its workspace. `persist-credentials` must therefore STAY
+          # enabled on the checkout above: here the persisted header is
+          # load-bearing, which is the opposite of the situation in most jobs.
+          #
+          # STILL UNVERIFIED, for whoever runs the next release. Whether the App
+          # installation has `contents: write` on this repo has never been
+          # exercised: the last tag (25.11.1) predates the switch to App tokens,
+          # and no `main` run has reached this job since. If the tag push fails
+          # with 403, that is the App's permission set, NOT this change -- the
+          # PAT was already inert and restoring it would not help. Grant the
+          # installation contents:write rather than reintroducing a PAT.
           git tag -a "$YEAR.$MONTH.$BUILD" -m "Release $YEAR.$MONTH.$BUILD" || echo "Tag already exists"
           (git push origin "$YEAR.$MONTH.$BUILD" && echo "tag=$YEAR.$MONTH.$BUILD" >> $GITHUB_OUTPUT) || echo "Tag already exists"
 

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -1084,6 +1084,13 @@ jobs:
         with:
           submodules: recursive
           token: ${{ steps.ci_token.outputs.token }}
+          # Do not leave the installation token in `.git/config` for the rest
+          # of the job: these runners reuse their work tree. Nothing here needs
+          # the persisted header -- `submodules:` is fetched by actions/checkout
+          # before it strips the credential, and every later step that talks to
+          # a remote is handed the token explicitly (`gh-token:`). Same reasoning
+          # as the visual-replay gate; the long form is in that job.
+          persist-credentials: false
 
       - name: Install Nix
         uses: ./.github/actions/setup-nix
@@ -1115,6 +1122,13 @@ jobs:
         with:
           submodules: recursive
           token: ${{ steps.ci_token.outputs.token }}
+          # Do not leave the installation token in `.git/config` for the rest
+          # of the job: these runners reuse their work tree. Nothing here needs
+          # the persisted header -- `submodules:` is fetched by actions/checkout
+          # before it strips the credential, and every later step that talks to
+          # a remote is handed the token explicitly (`gh-token:`). Same reasoning
+          # as the visual-replay gate; the long form is in that job.
+          persist-credentials: false
 
       - name: Install Nix
         uses: ./.github/actions/setup-nix
@@ -1146,6 +1160,13 @@ jobs:
         with:
           submodules: recursive
           token: ${{ steps.ci_token.outputs.token }}
+          # Do not leave the installation token in `.git/config` for the rest
+          # of the job: these runners reuse their work tree. Nothing here needs
+          # the persisted header -- `submodules:` is fetched by actions/checkout
+          # before it strips the credential, and every later step that talks to
+          # a remote is handed the token explicitly (`gh-token:`). Same reasoning
+          # as the visual-replay gate; the long form is in that job.
+          persist-credentials: false
 
       - name: Install Nix
         uses: ./.github/actions/setup-nix
@@ -1177,6 +1198,13 @@ jobs:
         with:
           submodules: recursive
           token: ${{ steps.ci_token.outputs.token }}
+          # Do not leave the installation token in `.git/config` for the rest
+          # of the job: these runners reuse their work tree. Nothing here needs
+          # the persisted header -- `submodules:` is fetched by actions/checkout
+          # before it strips the credential, and every later step that talks to
+          # a remote is handed the token explicitly (`gh-token:`). Same reasoning
+          # as the visual-replay gate; the long form is in that job.
+          persist-credentials: false
 
       - name: Setup dev env
         # setup-dev-env installs Nix (with the Attic substituter/keys) and
@@ -1260,6 +1288,13 @@ jobs:
         uses: actions/checkout@v5
         with:
           token: ${{ steps.ci_token.outputs.token }}
+          # Do not leave the installation token in `.git/config` for the rest
+          # of the job: these runners reuse their work tree. Nothing here needs
+          # the persisted header -- `submodules:` is fetched by actions/checkout
+          # before it strips the credential, and every later step that talks to
+          # a remote is handed the token explicitly (`gh-token:`). Same reasoning
+          # as the visual-replay gate; the long form is in that job.
+          persist-credentials: false
 
       - name: Install Nix
         uses: ./.github/actions/setup-nix
@@ -1291,6 +1326,13 @@ jobs:
         uses: actions/checkout@v5
         with:
           token: ${{ steps.ci_token.outputs.token }}
+          # Do not leave the installation token in `.git/config` for the rest
+          # of the job: these runners reuse their work tree. Nothing here needs
+          # the persisted header -- `submodules:` is fetched by actions/checkout
+          # before it strips the credential, and every later step that talks to
+          # a remote is handed the token explicitly (`gh-token:`). Same reasoning
+          # as the visual-replay gate; the long form is in that job.
+          persist-credentials: false
 
       - name: Install Nix
         uses: ./.github/actions/setup-nix
@@ -3250,6 +3292,13 @@ jobs:
         with:
           submodules: recursive
           token: ${{ steps.ci_token.outputs.token }}
+          # Do not leave the installation token in `.git/config` for the rest
+          # of the job: these runners reuse their work tree. Nothing here needs
+          # the persisted header -- `submodules:` is fetched by actions/checkout
+          # before it strips the credential, and every later step that talks to
+          # a remote is handed the token explicitly (`gh-token:`). Same reasoning
+          # as the visual-replay gate; the long form is in that job.
+          persist-credentials: false
 
       - name: Setup isonim siblings
         # The gate's last two suites are ViewModel tests under


### PR DESCRIPTION
Three changes to how this repo's CI handles GitHub credentials, in increasing order of blast radius.

### 1. The docs deploy PAT (unchanged from the original scope of this PR)

`build-and-deploy-docs` re-pointed `origin` at a URL carrying `CODETRACER_PUSH_GITHUB_TOKEN`. `ci/deploy/docs.sh` only reads `origin` in its `DEPLOY_TOKEN`-absent fallback, and `DEPLOY_TOKEN` is always set on that step, so the rewrite could never be the credential that pushed — it could only expand a long-lived PAT into `.git/config` on a workspace-reusing runner.

### 2. The release-tag PAT

`push-tag` used the same PAT, and it was likewise never the credential in use — but for a different and less obvious reason, so it is worth stating how it was established rather than argued.

The checkout above it runs with `persist-credentials` at its default of true, so `actions/checkout` leaves `http.https://github.com/.extraheader` in `.git/config` carrying the App installation token. Git prefers a configured `Authorization` header over userinfo in the remote URL. That preference is **total, not a first choice**: pointed at a local HTTP server that answers `401`, `git push` retries with the *same* header and then gives up. The userinfo never reaches the wire, on either request.

This is reproducible with no real credential at all — configure a checkout with both an `extraHeader` and userinfo, point it at a local server, and read the `Authorization` it receives. So deleting the rewrite changes *which credential authenticates* not at all; it only stops writing a PAT into `.git/config`.

Note the consequence for `persist-credentials` in this one job: it must **stay enabled**, because here the persisted header is what actually performs the push. Setting it to `false` while leaving the PAT rewrite in place would have *activated* the PAT rather than retiring it.

**Still unverified, and annotated in the job for whoever runs the next release:** whether the App installation carries `contents: write` on this repository has never been exercised — the last tag predates the move to App tokens and no `main` run has reached this job since. A `403` there is the App's permission set, not this change; the fix is to grant the installation write access, not to reintroduce a PAT.

### 3. `persist-credentials` where it is determinable *and* falsifiable

Of the tokened checkouts in the tree, exactly one had opted out of persisting the installation token. Seven more do here: `lint-bash`, `lint-nim`, `lint-nix`, `lint-rust`, `reprobuild-linux-smoke`, `ct-test-release-gate`, and `reprobuild-macos-smoke`.

These are the jobs that do nothing with a remote after checkout — `submodules:` is fetched before `actions/checkout` strips the credential, so the private `libs/tree-sitter-nim` submodule is unaffected, and every later network step is handed the token explicitly via `gh-token:`. They are also, apart from the macOS half, **the jobs currently passing on `dev`**, so a hidden dependency on the persisted header turns them red here instead of staying invisible.

The remaining tokened checkouts keep the default deliberately: `push-tag` needs it, and the rest die early on `dev` for unrelated reasons, so flipping them would be a change this repo's CI cannot presently demonstrate either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)