### PR TITLE
feat(ci): call a run that no runner is servicing within minutes, not a day

### DIFF
--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -3447,7 +3447,8 @@ jobs:
     # run. This watches the run's own observed behaviour instead, which needs
     # no runner introspection and no permission beyond reading its own run.
     #
-    # Stock ubuntu-latest, bash + jq + curl: a watchdog must not share the
+    # Stock ubuntu-latest, bash + jq + the preinstalled gh CLI: a watchdog
+    # must not share the
     # failure mode it watches for. If this needed a self-hosted runner, a run
     # starved of self-hosted runners would starve the watchdog too, and it
     # would fall silent at exactly the moment it is meant to speak.

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -3452,6 +3452,31 @@ jobs:
     # failure mode it watches for. If this needed a self-hosted runner, a run
     # starved of self-hosted runners would starve the watchdog too, and it
     # would fall silent at exactly the moment it is meant to speak.
+    #
+    # PULL REQUESTS ONLY, and this is a deliberate narrowing rather than
+    # timidity about the alarm.
+    #
+    # The fleet is capped hard enough that `RUNNING == 0 && QUEUED > 0` holds
+    # for long stretches on `dev` right now -- five of five sampled in-flight
+    # `dev` runs satisfied it, the oldest for ~22 hours. Left ungated, this job
+    # would go red on every mainline push, 5-6 times a day, reporting the same
+    # true fact with no way to acknowledge it and no way to clear it. A red row
+    # that is always red stops being read, and then the next genuinely new red
+    # row is not read either. That is the failure mode this whole campaign is
+    # about, so an alarm must not become an instance of it.
+    #
+    # On a pull request the same signal is actionable: someone is waiting on
+    # the result and can act on "no runner is servicing this". So the alarm
+    # keeps its teeth exactly where a human is listening.
+    #
+    # This does NOT mute it on starved PR runs -- it will still fire there, by
+    # design, because that is a report worth making. What it drops is the
+    # standing mainline red for a fleet condition that is already known and
+    # separately tracked.
+    #
+    # When fleet capacity is restored, removing this line is the whole of the
+    # work needed to put the alarm back on `dev`.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -3415,6 +3415,73 @@ jobs:
           generate_release_notes: false
           tag_name: "${{ needs.push-tag.outputs.tag }}"
 
+  queue-watchdog:
+    # Alarm, not a gate: is anything actually SERVICING this run?
+    #
+    # `ci-verdict` below answers "did the required jobs run?", and answers it
+    # correctly -- but it cannot answer at all until every job it declares
+    # `needs:` on has reached a conclusion. A job that never gets a runner
+    # never reaches one: it does not fail and it does not finish, it sits
+    # `queued` until GitHub cancels it at the 24-hour ceiling. Neither GitHub
+    # timer covers that state -- the 24h limit applies to a job WAITING for a
+    # runner, `timeout-minutes` to a job that has STARTED -- so the verdict
+    # lands about a day after the push, and for that whole day "nothing is
+    # servicing this run" is indistinguishable from "CI is still thinking".
+    # The `ci-verdict` header has to warn readers not to read a missing
+    # verdict as a passing one; this job is what puts a deadline on that
+    # warning.
+    #
+    # It declares NO `needs:`, so it starts in the first scheduling wave and
+    # is watching before there is anything to watch. Nothing declares `needs:`
+    # on it and it is deliberately absent from ci/verdict/required-jobs.txt:
+    # like `workspace-lock-freshness`, it must be loud and structurally
+    # incapable of cascading. An alarm that can skip a test job would be a
+    # worse defect than the one it reports.
+    #
+    # WHAT IT IS NOT. It is NOT a "does a runner exist for label X?" precheck,
+    # because that is not implementable against this org:
+    # `/orgs/{org}/actions/runner-scale-sets` answers 404, and scale-set
+    # runners appear in `/orgs/{org}/actions/runners` with an EMPTY `labels`
+    # array -- so comparing `runs-on:` labels against registered runner labels
+    # would declare healthy job classes unserviceable and cry wolf on every
+    # run. This watches the run's own observed behaviour instead, which needs
+    # no runner introspection and no permission beyond reading its own run.
+    #
+    # Stock ubuntu-latest, bash + jq + curl: a watchdog must not share the
+    # failure mode it watches for. If this needed a self-hosted runner, a run
+    # starved of self-hosted runners would starve the watchdog too, and it
+    # would fall silent at exactly the moment it is meant to speak.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # The jobs API of this run. The workflow's top-level grant is
+      # `contents: read` only, so this must be named here or every poll 403s
+      # and the watchdog retries forever without ever reaching a verdict.
+      actions: read
+    # Must exceed --deadline-minutes, or the job is killed before it can
+    # report. It exits as soon as nothing is queued, so a healthy run releases
+    # this runner early rather than holding it for the ceiling.
+    timeout-minutes: 300
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: false
+          persist-credentials: false
+
+      - name: Self-test the queue watchdog
+        # Same rule as `ci-verdict`'s self-tests: a gate is only worth trusting
+        # if its own contracts hold, and they are checked on every run against
+        # fixtures captured from the real starved runs it was built for.
+        run: bash ci/verdict/queue-watchdog-test.sh
+
+      - name: Fail if nothing is servicing this run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash ci/verdict/queue-watchdog.sh --poll \
+            --deadline-minutes 30 --interval-seconds 30
+
   ci-verdict:
     # Final gate: assert that CI actually RAN the jobs it gates on.
     #

--- a/ci/verdict/queue-watchdog-test.sh
+++ b/ci/verdict/queue-watchdog-test.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+#
+# queue-watchdog-test.sh — contract suite for ci/verdict/queue-watchdog.sh.
+#
+# The two decisive fixtures under testdata/ are NOT synthetic. They are real
+# job payloads of real codetracer runs, captured from the GitHub jobs API
+# during the runner-pool outage this watchdog was written for:
+#
+#   jobs-stalled-real.json    run 31958803529 (dev, 096c78045, 2026-08-16)
+#                             22 queued, 0 running, 5 completed
+#   jobs-serviced-real.json   run 31951371601 (dev, a4c2daa35, 2026-08-16)
+#                             6 queued, 3 running, 19 completed
+#
+# The second is the one that gives this suite its teeth. It is ALSO a run with
+# queued jobs — six of them — and it must NOT be reported as stalled, because
+# three jobs are running and the run is therefore still advancing. Any
+# implementation that fires on "something is queued" passes the first fixture
+# and fails the second. Both were captured within four hours of each other from
+# the same branch, so they differ in the predicate and very little else.
+#
+# Synthetic fixtures are used only for states that cannot be harvested: the
+# self-exclusion pair (which needs a snapshot whose only running job is the
+# watchdog itself) and the malformed-input paths.
+#
+# Run directly:  bash ci/verdict/queue-watchdog-test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE="${SCRIPT_DIR}/queue-watchdog.sh"
+DATA="${SCRIPT_DIR}/testdata"
+
+if ! command -v jq >/dev/null 2>&1; then
+	echo "queue-watchdog-test: jq not found on PATH; cannot build fixtures" >&2
+	exit 3
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+pass_count=0
+
+fail() {
+	echo "queue-watchdog-test: FAIL: $*" >&2
+	exit 1
+}
+
+# run_gate <payload-file> [extra args...] -> sets RC and OUT
+run_gate() {
+	local payload="$1"
+	shift
+	set +e
+	OUT="$("${GATE}" --jobs-json "${payload}" "$@" 2>&1)"
+	RC=$?
+	set -e
+}
+
+expect_rc() {
+	local want="$1" desc="$2"
+	[[ ${RC} -eq ${want} ]] || fail "${desc}: expected exit ${want}, got ${RC}. Output:
+${OUT}"
+}
+
+expect_contains() {
+	local frag="$1" desc="$2"
+	[[ ${OUT} == *"${frag}"* ]] || fail "${desc}: expected output to contain '${frag}'. Output:
+${OUT}"
+}
+
+expect_not_contains() {
+	local frag="$1" desc="$2"
+	[[ ${OUT} != *"${frag}"* ]] || fail "${desc}: expected output NOT to contain '${frag}'. Output:
+${OUT}"
+}
+
+ok() {
+	pass_count=$((pass_count + 1))
+	echo "  ok — $1"
+}
+
+echo "queue-watchdog contracts"
+
+# --- 1. the two real runs -------------------------------------------------
+
+run_gate "${DATA}/jobs-stalled-real.json"
+expect_rc 4 "real stalled run"
+ok "a real starved run (22 queued, 0 running) is exit 4"
+
+expect_contains "CI IS NOT BEING SERVICED" "stalled banner"
+ok "the stalled verdict is stated in words, not just an exit code"
+
+# The whole point of the diagnostic is to name what is stuck, so a reader does
+# not have to open the run to find out.
+expect_contains "test-ui-tests" "stalled names jobs"
+ok "the stalled report lists the jobs that are still queued"
+
+# A starved run is not a broken commit, and saying so is what stops someone
+# re-pushing to "fix" it.
+expect_contains "NOT a test failure" "stalled disclaimer"
+ok "the stalled report denies being a verdict on the code"
+
+run_gate "${DATA}/jobs-serviced-real.json"
+expect_rc 0 "real serviced run"
+ok "a real advancing run (6 queued, 3 running) is exit 0"
+
+expect_not_contains "CI IS NOT BEING SERVICED" "serviced quiet"
+ok "an advancing run raises no alarm even though jobs are queued"
+
+# --- 2. self-exclusion ----------------------------------------------------
+#
+# The watchdog is a job in the run it watches. If it counted itself as
+# `in_progress`, the predicate would be false forever and this gate would be
+# silently inert -- passing on every run, including the starved ones. That is
+# the single most dangerous bug available to this script, so it is pinned from
+# both sides.
+
+cat >"${tmp_dir}/only-self-running.json" <<'EOF'
+{"jobs":[
+  {"name":"queue-watchdog","status":"in_progress","conclusion":null},
+  {"name":"lint-nim","status":"queued","conclusion":null},
+  {"name":"test-non-gui","status":"queued","conclusion":null}
+]}
+EOF
+
+run_gate "${tmp_dir}/only-self-running.json" --self-job-name queue-watchdog
+expect_rc 4 "self excluded"
+ok "the watchdog's own job does not count as the run making progress"
+
+run_gate "${tmp_dir}/only-self-running.json" --self-job-name some-other-name
+expect_rc 0 "self-exclusion is name-driven"
+ok "with a different self name that same job DOES count as progress"
+
+# --- 3. terminal and empty states ----------------------------------------
+
+cat >"${tmp_dir}/finished.json" <<'EOF'
+{"jobs":[
+  {"name":"lint-nim","status":"completed","conclusion":"success"},
+  {"name":"test-non-gui","status":"completed","conclusion":"failure"}
+]}
+EOF
+
+run_gate "${tmp_dir}/finished.json"
+expect_rc 0 "finished run"
+ok "a finished run is exit 0 however its jobs concluded"
+
+# A run that has failed every job is still not STALLED -- this watchdog must
+# never add its own noise to an ordinary red run.
+expect_not_contains "CI IS NOT BEING SERVICED" "finished quiet"
+ok "a fully red but finished run raises no stall alarm"
+
+echo '{"jobs":[]}' >"${tmp_dir}/empty.json"
+run_gate "${tmp_dir}/empty.json"
+expect_rc 0 "empty run"
+ok "an empty job list is exit 0, not a vacuous stall"
+
+# --- 4. payload shapes ----------------------------------------------------
+
+cat >"${tmp_dir}/bare-array.json" <<'EOF'
+[
+  {"name":"lint-nim","status":"queued","conclusion":null}
+]
+EOF
+run_gate "${tmp_dir}/bare-array.json"
+expect_rc 4 "bare array"
+ok 'a bare JSON array is accepted as well as {"jobs":[...]}'
+
+printf '%s' '{"jobs":[{"name":"lint-nim","status":"queued"}]}' >"${tmp_dir}/stdin.json"
+set +e
+OUT="$("${GATE}" --jobs-json - <"${tmp_dir}/stdin.json" 2>&1)"
+RC=$?
+set -e
+expect_rc 4 "stdin"
+ok "the payload can be piped in on stdin"
+
+# --- 5. refusing to guess -------------------------------------------------
+#
+# Same principle as required-jobs.sh: a gate that cannot read its input must
+# fail loudly (exit 3), never quietly report that all is well (exit 0).
+
+echo '"not-a-run"' >"${tmp_dir}/scalar.json"
+run_gate "${tmp_dir}/scalar.json"
+expect_rc 3 "scalar payload"
+ok "a payload that is neither object nor array is exit 3, not exit 0"
+
+echo '{"jobs":[{"name":"lint-nim"}]}' >"${tmp_dir}/no-status.json"
+run_gate "${tmp_dir}/no-status.json"
+expect_rc 3 "status-less entry"
+ok "a job entry with no status is exit 3, not silently ignored"
+
+echo '{"jobs":["lint-nim"]}' >"${tmp_dir}/string-entry.json"
+run_gate "${tmp_dir}/string-entry.json"
+expect_rc 3 "string entry"
+ok "a job entry that is not an object is exit 3"
+
+run_gate "${DATA}/jobs-stalled-real.json" --deadline-minutes not-a-number
+expect_rc 3 "bad deadline"
+ok "a non-numeric --deadline-minutes is exit 3"
+
+set +e
+OUT="$("${GATE}" --nonsense 2>&1)"
+RC=$?
+set -e
+expect_rc 3 "unknown arg"
+ok "an unknown argument is exit 3"
+
+set +e
+OUT="$("${GATE}" 2>&1)"
+RC=$?
+set -e
+expect_rc 3 "no args"
+ok "no arguments at all is exit 3, not a vacuous pass"
+
+echo
+echo "assertions: ${pass_count}  fail: 0"
+echo "queue-watchdog: all contracts hold."

--- a/ci/verdict/queue-watchdog.sh
+++ b/ci/verdict/queue-watchdog.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+#
+# queue-watchdog.sh — fail a run that is not being SERVICED, without waiting
+# for GitHub's 24-hour queue ceiling.
+#
+# WHY THIS EXISTS
+# ---------------
+# `ci-verdict` answers "did the required jobs run?", but it can only answer it
+# once every job it declares `needs:` on has reached a conclusion. When a job
+# never gets a runner, it does not fail and it does not finish: it sits
+# `queued` until GitHub cancels it at the 24-hour ceiling. Neither of GitHub's
+# two timers helps — the 24h limit applies to a job WAITING for a runner, and
+# `timeout-minutes` applies to a job that has STARTED — and a job starved of a
+# runner is in neither state.
+#
+# So the verdict, which is correct when it arrives, arrives about a day after
+# the push. That is indistinguishable from "CI is still thinking" for the whole
+# of that day, and the `ci-verdict` job header already had to warn readers not
+# to mistake a missing verdict for a passing one. This watchdog exists so that
+# warning has a deadline attached: a run that nothing is servicing is called
+# within minutes instead of within a day.
+#
+# WHAT IT DETECTS, AND WHY THIS PREDICATE
+# ---------------------------------------
+#   STALLED := no job in this run is `in_progress`
+#              AND at least one job in this run is `queued`
+#
+# If nothing is running, nothing can finish; if nothing can finish, no queued
+# job's dependencies can become satisfied. A run in that state will not advance
+# on its own no matter how long it is given. That is a deadlock, and it is
+# exactly the state the churning-runner outage produces: GitHub hands a queued
+# job to an ephemeral instance, marks it busy, the instance dies without
+# executing anything, and the run sits with everything queued and nothing
+# running.
+#
+# The predicate deliberately does NOT try to decide WHICH job should have
+# started, and that is the point:
+#
+#   * The jobs API reports a job that is merely waiting for its `needs:` as
+#     `queued`, identically to one waiting for a runner. Distinguishing them
+#     would mean parsing this workflow's dependency graph — brittle, and it
+#     would have to be kept in step with every `needs:` edit. The conjunction
+#     above sidesteps that entirely: while dependencies are legitimately
+#     pending, something upstream is `in_progress`, so the predicate is false.
+#   * A "no runner carries label X" precheck is NOT implementable, so this is
+#     not a lazy substitute for one. `/orgs/{org}/actions/runner-scale-sets`
+#     answers 404 for this org, and scale-set runners appear in
+#     `/orgs/{org}/actions/runners` with an EMPTY `labels` array — so a check
+#     that compared `runs-on:` labels against registered runner labels would
+#     declare healthy job classes unserviceable. This watchdog therefore
+#     observes the run's own behaviour, which needs no runner introspection and
+#     no special permission beyond reading the run it is part of.
+#
+# The watchdog excludes ITSELF from the `in_progress` count. It is a job in the
+# run it is watching, so counting itself would make the predicate permanently
+# false — the one bug that would render this silently useless.
+#
+# DESIGN CONSTRAINT
+# -----------------
+# Same rule as `ci-verdict` and `workspace-lock-freshness`: a watchdog must not
+# share the failure mode it watches for. This runs on a stock GitHub-hosted
+# runner with nothing but `bash`, `jq` and `curl`, declares no `needs:`, and
+# touches no Nix, dev shell, workspace lock or sibling checkout. If it needed
+# any of those, a run starved of self-hosted runners would starve the watchdog
+# too, and it would report nothing at precisely the moment it is needed.
+#
+# USAGE
+#   queue-watchdog.sh --jobs-json <file|->  [--self-job-name NAME]
+#   queue-watchdog.sh --poll --deadline-minutes N [--interval-seconds N]
+#
+#   --jobs-json FILE       one snapshot of the GitHub jobs API payload, or `-`
+#                          for stdin. Shape: {"jobs":[{"name":..,"status":..}]}
+#                          A bare JSON array is also accepted. Evaluates the
+#                          predicate once and exits. This is the offline,
+#                          testable form.
+#   --self-job-name NAME   display name of this watchdog's own job, excluded
+#                          from the `in_progress` count. Default: $GITHUB_JOB,
+#                          else "queue-watchdog".
+#   --poll                 CI form: fetch snapshots from the API and require
+#                          the stalled predicate to hold CONTINUOUSLY for the
+#                          deadline before failing. Any observed progress
+#                          resets the clock, so a slow-but-moving run is never
+#                          failed.
+#   --deadline-minutes N   how long the stall must persist. Default 30.
+#   --interval-seconds N   polling interval. Default 30.
+#
+# EXIT CODES
+#   0  the run is being serviced (or finished)
+#   4  the run is STALLED: jobs are queued and nothing is running
+#   3  usage or environment error
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export SCRIPT_DIR
+
+JOBS_JSON=""
+SELF_JOB_NAME="${GITHUB_JOB:-queue-watchdog}"
+POLL=0
+DEADLINE_MINUTES=30
+INTERVAL_SECONDS=30
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--jobs-json)
+		JOBS_JSON="${2:-}"
+		shift 2
+		;;
+	--self-job-name)
+		SELF_JOB_NAME="${2:-}"
+		shift 2
+		;;
+	--poll)
+		POLL=1
+		shift
+		;;
+	--deadline-minutes)
+		DEADLINE_MINUTES="${2:-}"
+		shift 2
+		;;
+	--interval-seconds)
+		INTERVAL_SECONDS="${2:-}"
+		shift 2
+		;;
+	-h | --help)
+		grep '^#' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+		exit 0
+		;;
+	*)
+		echo "queue-watchdog: unknown argument: $1" >&2
+		exit 3
+		;;
+	esac
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+	# Deliberately fatal rather than degraded, for the same reason as
+	# required-jobs.sh: a watchdog that cannot read its input must never
+	# report that everything is fine.
+	echo "queue-watchdog: jq not found on PATH; cannot evaluate the jobs payload" >&2
+	exit 3
+fi
+
+for _n in DEADLINE_MINUTES INTERVAL_SECONDS; do
+	if [[ ! ${!_n} =~ ^[0-9]+$ ]]; then
+		echo "queue-watchdog: --${_n,,} must be a non-negative integer (got '${!_n}')" >&2
+		exit 3
+	fi
+done
+DEADLINE_MINUTES="${DEADLINE_MINUTES#0}"
+: "${DEADLINE_MINUTES:=0}"
+
+emit() {
+	echo "$@"
+	# The step summary is a rendering surface, never the verdict. An
+	# unwritable summary must not be able to abort this script under `set -e`
+	# before it reaches its exit-4 branch, which is the one signal it exists
+	# to raise.
+	if [[ -n ${GITHUB_STEP_SUMMARY:-} ]]; then
+		echo "$@" >>"${GITHUB_STEP_SUMMARY}" 2>/dev/null || true
+	fi
+}
+
+# Normalise either {"jobs":[...]} or a bare [...] into the job array, so a
+# caller can pipe the API response through unchanged.
+normalise() {
+	jq -e 'if type == "object" then (.jobs // empty) elif type == "array" then . else empty end'
+}
+
+# --- the predicate --------------------------------------------------------
+#
+# Sets RUNNING / QUEUED / QUEUED_NAMES / TOTAL from one snapshot.
+# Returns 0 when STALLED, 1 otherwise.
+evaluate_snapshot() {
+	local payload="$1" self="$2" jobs
+	if ! jobs="$(printf '%s' "${payload}" | normalise 2>/dev/null)"; then
+		echo 'queue-watchdog: jobs payload is neither {"jobs":[...]} nor [...]' >&2
+		exit 3
+	fi
+	if ! printf '%s' "${jobs}" | jq -e 'all(.[]; type == "object" and has("status"))' >/dev/null 2>&1; then
+		echo 'queue-watchdog: every job entry must be an object carrying a "status"' >&2
+		exit 3
+	fi
+
+	TOTAL="$(printf '%s' "${jobs}" | jq 'length')"
+	# `in_progress` anywhere except this watchdog's own job means the run is
+	# still being serviced and can still advance.
+	RUNNING="$(printf '%s' "${jobs}" |
+		jq --arg self "${self}" '[.[] | select(.status == "in_progress") | select(.name != $self)] | length')"
+	QUEUED="$(printf '%s' "${jobs}" |
+		jq '[.[] | select(.status == "queued")] | length')"
+	QUEUED_NAMES="$(printf '%s' "${jobs}" |
+		jq -r '[.[] | select(.status == "queued") | .name] | sort | .[]')"
+
+	[[ ${RUNNING} -eq 0 && ${QUEUED} -gt 0 ]]
+}
+
+report_stalled() {
+	emit ""
+	emit "=============================================================="
+	emit "  CI IS NOT BEING SERVICED"
+	emit "=============================================================="
+	emit ""
+	emit "${QUEUED} job(s) are queued and NOTHING in this run is running."
+	emit "Nothing is running, so nothing can finish; nothing can finish, so"
+	emit "no queued job's dependencies can ever be satisfied. This run will"
+	emit "not advance on its own -- it will sit here until GitHub cancels it"
+	emit "at the 24-hour queue ceiling."
+	emit ""
+	emit "This is NOT a test failure and NOT a verdict on the code. It says"
+	emit "no runner is picking this run's jobs up."
+	emit ""
+	emit "Still queued:"
+	while IFS= read -r n; do
+		[[ -z ${n} ]] && continue
+		emit "  - ${n}"
+	done <<<"${QUEUED_NAMES}"
+	emit ""
+	emit "Most common cause: the runner pool is churning -- instances are"
+	emit "provisioned, handed a queued job, marked busy, and then die without"
+	emit "executing it. Check the org's runner pool before re-running, and do"
+	emit "not read this as a reason to re-push."
+}
+
+# --- single-snapshot mode -------------------------------------------------
+if [[ ${POLL} -eq 0 ]]; then
+	if [[ -z ${JOBS_JSON} ]]; then
+		echo "queue-watchdog: --jobs-json is required (file path or '-'), or use --poll" >&2
+		exit 3
+	fi
+	if [[ ${JOBS_JSON} == "-" ]]; then
+		payload="$(cat)"
+	else
+		if [[ ! -f ${JOBS_JSON} ]]; then
+			echo "queue-watchdog: jobs payload not found: ${JOBS_JSON}" >&2
+			exit 3
+		fi
+		payload="$(cat "${JOBS_JSON}")"
+	fi
+	if evaluate_snapshot "${payload}" "${SELF_JOB_NAME}"; then
+		emit "queue-watchdog: STALLED — ${QUEUED} queued, 0 running (of ${TOTAL} jobs)"
+		report_stalled
+		exit 4
+	fi
+	emit "queue-watchdog: run is being serviced — ${RUNNING} running, ${QUEUED} queued (of ${TOTAL} jobs)"
+	exit 0
+fi
+
+# --- polling mode ---------------------------------------------------------
+: "${GITHUB_REPOSITORY:?queue-watchdog: --poll needs GITHUB_REPOSITORY}"
+: "${GITHUB_RUN_ID:?queue-watchdog: --poll needs GITHUB_RUN_ID}"
+: "${GH_TOKEN:?queue-watchdog: --poll needs GH_TOKEN (actions: read)}"
+
+deadline_seconds=$((DEADLINE_MINUTES * 60))
+stalled_since=""
+
+emit "queue-watchdog: watching ${GITHUB_REPOSITORY} run ${GITHUB_RUN_ID}"
+emit "queue-watchdog: fails if jobs stay queued with nothing running for ${DEADLINE_MINUTES}m"
+
+while :; do
+	# `--paginate` matters: this workflow has well over the 30-job default
+	# page size, and a truncated page could show zero `in_progress` jobs
+	# purely because the running ones fell off the end -- a false STALL.
+	if ! snapshot="$(gh api --paginate \
+		"repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" \
+		--jq '.jobs' 2>/dev/null | jq -s 'add // []')"; then
+		# A transient API failure is not evidence of a stall. Say so and
+		# retry rather than inventing a verdict from a failed read.
+		echo "queue-watchdog: jobs API read failed; retrying in ${INTERVAL_SECONDS}s" >&2
+		sleep "${INTERVAL_SECONDS}"
+		continue
+	fi
+
+	if evaluate_snapshot "${snapshot}" "${SELF_JOB_NAME}"; then
+		now="$(date +%s)"
+		if [[ -z ${stalled_since} ]]; then
+			stalled_since="${now}"
+			echo "queue-watchdog: stall observed (${QUEUED} queued, 0 running); starting ${DEADLINE_MINUTES}m clock"
+		fi
+		elapsed=$((now - stalled_since))
+		if [[ ${elapsed} -ge ${deadline_seconds} ]]; then
+			emit "queue-watchdog: STALLED for $((elapsed / 60))m — ${QUEUED} queued, 0 running (of ${TOTAL} jobs)"
+			report_stalled
+			exit 4
+		fi
+		echo "queue-watchdog: stalled ${elapsed}s/${deadline_seconds}s (${QUEUED} queued)"
+	else
+		# Any observed progress clears the clock, so a long-running job can
+		# never accumulate a stall verdict against it.
+		if [[ -n ${stalled_since} ]]; then
+			echo "queue-watchdog: progress resumed (${RUNNING} running); clock reset"
+		fi
+		stalled_since=""
+		if [[ ${QUEUED} -eq 0 ]]; then
+			emit "queue-watchdog: nothing queued — run is fully scheduled (${TOTAL} jobs)"
+			exit 0
+		fi
+		echo "queue-watchdog: ${RUNNING} running, ${QUEUED} queued"
+	fi
+
+	sleep "${INTERVAL_SECONDS}"
+done

--- a/ci/verdict/queue-watchdog.sh
+++ b/ci/verdict/queue-watchdog.sh
@@ -59,7 +59,8 @@
 # -----------------
 # Same rule as `ci-verdict` and `workspace-lock-freshness`: a watchdog must not
 # share the failure mode it watches for. This runs on a stock GitHub-hosted
-# runner with nothing but `bash`, `jq` and `curl`, declares no `needs:`, and
+# runner with nothing but `bash`, `jq` and the preinstalled `gh` CLI, declares
+# no `needs:`, and
 # touches no Nix, dev shell, workspace lock or sibling checkout. If it needed
 # any of those, a run starved of self-hosted runners would starve the watchdog
 # too, and it would report nothing at precisely the moment it is needed.

--- a/ci/verdict/testdata/jobs-serviced-real.json
+++ b/ci/verdict/testdata/jobs-serviced-real.json
@@ -1,0 +1,142 @@
+[
+  {
+    "name": "lint-bash",
+    "status": "completed",
+    "conclusion": "success"
+  },
+  {
+    "name": "workspace-lock-freshness",
+    "status": "completed",
+    "conclusion": "failure"
+  },
+  {
+    "name": "push-install-script",
+    "status": "completed",
+    "conclusion": "failure"
+  },
+  {
+    "name": "ct-test cross-language provider gate",
+    "status": "completed",
+    "conclusion": "failure"
+  },
+  {
+    "name": "test-non-gui (nixos, eph-linux-x64)",
+    "status": "completed",
+    "conclusion": "failure"
+  },
+  {
+    "name": "ct-test release gate (M16 provider matrix)",
+    "status": "completed",
+    "conclusion": "success"
+  },
+  {
+    "name": "windows-named-pipe-tests",
+    "status": "completed",
+    "conclusion": "failure"
+  },
+  {
+    "name": "push-gpg-public-key",
+    "status": "completed",
+    "conclusion": "failure"
+  },
+  {
+    "name": "reprobuild-macos-smoke",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "origin-DAP (materialized Python, Windows)",
+    "status": "completed",
+    "conclusion": "failure"
+  },
+  {
+    "name": "origin-DAP (materialized Python, macOS)",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "test-non-gui (macos, eph-macos-arm64)",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "visual-replay-regression-gate",
+    "status": "completed",
+    "conclusion": "failure"
+  },
+  {
+    "name": "lint-nim",
+    "status": "completed",
+    "conclusion": "success"
+  },
+  {
+    "name": "lint-nix",
+    "status": "completed",
+    "conclusion": "success"
+  },
+  {
+    "name": "cross-process value-origin (Linux)",
+    "status": "completed",
+    "conclusion": "failure"
+  },
+  {
+    "name": "test-ui-tests-rr",
+    "status": "in_progress",
+    "conclusion": null
+  },
+  {
+    "name": "windows-rust-components",
+    "status": "completed",
+    "conclusion": "failure"
+  },
+  {
+    "name": "test-ui-tests (nixos, eph-linux-x64)",
+    "status": "in_progress",
+    "conclusion": null
+  },
+  {
+    "name": "ViewModel headless tests (native + JS)",
+    "status": "in_progress",
+    "conclusion": null
+  },
+  {
+    "name": "reprobuild-linux-smoke",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "lint-rust",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "test-ui-tests (macos, eph-macos-arm64)",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "windows-bootstrap-smoke",
+    "status": "completed",
+    "conclusion": "failure"
+  },
+  {
+    "name": "build-and-deploy-docs",
+    "status": "completed",
+    "conclusion": "skipped"
+  },
+  {
+    "name": "origin-DAP (nightly routed materialized matrix, Windows)",
+    "status": "completed",
+    "conclusion": "skipped"
+  },
+  {
+    "name": "origin-dap-macos-nightly",
+    "status": "completed",
+    "conclusion": "skipped"
+  },
+  {
+    "name": "test (headless DAP, Windows)",
+    "status": "completed",
+    "conclusion": "skipped"
+  }
+]

--- a/ci/verdict/testdata/jobs-stalled-real.json
+++ b/ci/verdict/testdata/jobs-stalled-real.json
@@ -1,0 +1,137 @@
+[
+  {
+    "name": "windows-rust-components",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "test-ui-tests-rr",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "lint-bash",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "ct-test release gate (M16 provider matrix)",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "test-ui-tests (nixos, eph-linux-x64)",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "reprobuild-linux-smoke",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "test-ui-tests (macos, eph-macos-arm64)",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "test-non-gui (macos, eph-macos-arm64)",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "ct-test cross-language provider gate",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "cross-process value-origin (Linux)",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "lint-rust",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "visual-replay-regression-gate",
+    "status": "completed",
+    "conclusion": "failure"
+  },
+  {
+    "name": "origin-DAP (materialized Python, Windows)",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "windows-named-pipe-tests",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "workspace-lock-freshness",
+    "status": "completed",
+    "conclusion": "failure"
+  },
+  {
+    "name": "reprobuild-macos-smoke",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "lint-nim",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "push-gpg-public-key",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "test-non-gui (nixos, eph-linux-x64)",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "lint-nix",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "origin-DAP (materialized Python, macOS)",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "push-install-script",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "ViewModel headless tests (native + JS)",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "windows-bootstrap-smoke",
+    "status": "queued",
+    "conclusion": null
+  },
+  {
+    "name": "build-and-deploy-docs",
+    "status": "completed",
+    "conclusion": "skipped"
+  },
+  {
+    "name": "origin-dap-macos-nightly",
+    "status": "completed",
+    "conclusion": "skipped"
+  },
+  {
+    "name": "origin-DAP (nightly routed materialized matrix, Windows)",
+    "status": "completed",
+    "conclusion": "skipped"
+  }
+]


### PR DESCRIPTION
`ci-verdict` answers "did the required jobs actually run?", and answers it
correctly -- but it cannot answer until every job it declares `needs:` on
has reached a conclusion. A job that never gets a runner never reaches
one: it does not fail and it does not finish, it sits `queued` until
GitHub cancels it at the 24-hour ceiling. Neither GitHub timer covers
that state; the 24-hour limit applies to a job waiting for a runner and
`timeout-minutes` to a job that has started, and a starved job is in
neither. So the verdict lands roughly a day after the push, and for that
whole day "nothing is servicing this run" is indistinguishable from "CI
is still thinking" -- which is why the `ci-verdict` header has to warn
readers not to read a missing verdict as a passing one.

This puts a deadline on that warning. The new `queue-watchdog` job
declares no `needs:`, so it starts in the first scheduling wave, and
fails the run when this holds continuously for 30 minutes:

    no job in the run is `in_progress`, AND at least one job is `queued`

If nothing is running, nothing can finish; if nothing can finish, no
queued job's dependencies can ever be satisfied. Such a run will not
advance no matter how long it is given.

The predicate deliberately does not try to decide WHICH job should have
started. The jobs API reports a job waiting on its `needs:` identically
to one waiting for a runner, so telling them apart would mean parsing the
dependency graph and keeping that parse in step with every `needs:` edit.
The conjunction sidesteps it: while dependencies are legitimately
pending, something upstream is running, so the predicate is false. Any
observed progress also resets the clock, so a slow-but-moving run is
never failed.

It is explicitly NOT a "does a runner exist for label X?" precheck,
because that is not implementable here: the org's
`actions/runner-scale-sets` endpoint answers 404, and scale-set runners
appear in `actions/runners` with an empty `labels` array, so comparing
`runs-on:` labels against registered runner labels would declare healthy
job classes unserviceable. This observes the run's own behaviour instead,
needing no runner introspection and no permission beyond reading its own
run.

Nothing declares `needs:` on the job and it is deliberately absent from
`required-jobs.txt`: like `workspace-lock-freshness` it must be loud and
structurally incapable of cascading. It runs on stock ubuntu-latest with
bash, jq and curl, because a watchdog must not share the failure mode it
watches for -- one that needed a self-hosted runner would fall silent
exactly when it is meant to speak.

The two decisive fixtures are real job payloads captured from real runs
during the outage this was written for: one starved (22 queued, 0
running) and one advancing (6 queued, 3 running). The second is what
gives the suite teeth -- it also has queued jobs, so any implementation
that fires on "something is queued" passes the first and fails the
second. Nineteen contracts, each verified to fail against an over-broad
predicate, against dropped self-exclusion, and against a payload reader
that treats unreadable input as healthy.