### PR TITLE
fix(test): let the JS ViewModel lane observe the failures it reports

### DIFF
--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -3536,6 +3536,23 @@ jobs:
         # runner, regardless of the state of the heavy lanes.
         run: bash ci/test/visual-replay-private-cargo-preflight-test.sh
 
+      - name: Assert the JS ViewModel lane can observe its own failures
+        # `test-vm-js` believed it was checking node's exit code. It was not:
+        # without `-d:nodejs` std/unittest cannot set a failing exit code on
+        # the js backend, so a failing suite exited 0 -- and the compile
+        # redirected the compiler warning that says exactly that to
+        # /dev/null. The lane went red only when a test printed `[FAILED]`,
+        # so a suite that ran zero tests, or died before printing anything,
+        # scored `OK`.
+        #
+        # The shape half of this suite is a static check over the justfile, so
+        # it belongs here on a stock runner: the lane it guards runs inside the
+        # dev shell on a self-hosted runner, and is therefore exactly the kind
+        # of lane that can stop reporting without anyone noticing. The suite's
+        # toolchain-dependent half skips cleanly where nim and node are absent
+        # and is exercised in full by `viewmodel-tests`.
+        run: bash ci/test/vm-js-lane-test.sh
+
       - name: Assert the required jobs actually ran
         env:
           NEEDS_JSON: ${{ toJSON(needs) }}

--- a/ci/test/vm-js-lane-test.sh
+++ b/ci/test/vm-js-lane-test.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+#
+# vm-js-lane-test.sh — contract suite for the `test-vm-js` recipe in justfile.
+#
+# WHY THIS EXISTS
+# ---------------
+# The JS ViewModel lane reported test results it could not actually observe.
+# Three defects stacked, and each one hid the next:
+#
+#   1. `nim` auto-defines `nodejs` only for `nim js -r`. This lane compiles and
+#      runs as separate steps, so the define was absent, so
+#      `std/exitprocs.setProgramResult` was undeclared, so `std/unittest`
+#      substituted a no-op and a FAILING suite exited 0.
+#   2. The compile redirected everything to /dev/null, so the compiler's own
+#      "unittest will not give failing exit code on test failure" warning --
+#      which names defect 1 outright -- was discarded on every run.
+#   3. `output=$(node ...)` followed by `exitcode=$?` cannot observe a failure
+#      under the recipe's `set -e`: a non-zero `node` kills the loop before
+#      the assignment is read. So the `$exitcode` arm was dead even where
+#      defect 1 did not apply.
+#
+# The lane still went red when a test printed `[FAILED]`, which is why this
+# survived: the human console report was doing all the work, and the structured
+# signal the recipe believed it was also checking did not exist. A suite that
+# crashed before printing anything, or that ran zero tests, scored `OK`.
+#
+# The static contracts below pin the recipe's shape; the dynamic ones prove the
+# claim about `-d:nodejs` against the real toolchain rather than asserting it.
+#
+# DESIGN CONSTRAINT
+# -----------------
+# The static half is pure bash over the justfile, so it runs on a stock runner
+# with no Nim, no node and no dev shell -- the same rule the other CI gates
+# follow, and what lets `ci-verdict` run it. The dynamic half needs `nim` and
+# `node`; when they are absent it says so and is counted as skipped rather than
+# quietly passing.
+#
+# Run directly:  bash ci/test/vm-js-lane-test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+JUSTFILE="${REPO_ROOT}/justfile"
+
+pass_count=0
+skip_count=0
+
+fail() {
+	echo "vm-js-lane-test: FAIL: $1" >&2
+	shift
+	for line in "$@"; do echo "    ${line}" >&2; done
+	exit 1
+}
+
+ok() {
+	pass_count=$((pass_count + 1))
+	echo "  ok — $1"
+}
+
+skip() {
+	skip_count=$((skip_count + 1))
+	echo "  -- skipped: $1"
+}
+
+[ -f "${JUSTFILE}" ] || fail "justfile not found at ${JUSTFILE}"
+
+# Extract the `test-vm-js` recipe body: from its target line to the next
+# top-level target or comment block at column 0.
+recipe="$(awk '
+	/^test-vm-js:/ { inrec = 1; next }
+	inrec && /^[^[:space:]#]/ { exit }
+	inrec { print }
+' "${JUSTFILE}")"
+
+[ -n "${recipe}" ] || fail "could not extract the test-vm-js recipe from ${JUSTFILE}" \
+	"either the recipe was renamed or this extractor no longer matches it," \
+	"and every contract below would be vacuous"
+
+# The shape contracts below must read the recipe's CODE, never its prose.
+# This recipe carries a long comment explaining the very defects being pinned,
+# and those comments necessarily quote the tokens under test (`-d:nodejs`,
+# `>/dev/null`). Grepping the raw recipe therefore matched the explanation
+# instead of the command -- verified: with `-d:nodejs` deleted from the actual
+# `nim js` invocation, a raw grep still passed. Strip comment lines first.
+# shellcheck disable=SC2001 # parameter expansion cannot express this trim
+recipe_code="$(sed 's/[[:space:]]*#.*$//' <<<"${recipe}")"
+
+# The `nim js` invocation is spread over five lines with backslash
+# continuations, so a line-oriented grep can only ever see its first fragment.
+# That is not hypothetical: contract 4 below looks for a `>/dev/null` on the
+# compile, and the redirect sits on the LAST continuation line -- with the
+# redirect reinstated, a per-line grep matched nothing and the contract passed
+# against the very defect it exists to catch. Fold continuations first so each
+# shell command is one line.
+recipe_joined="$(sed -e ':a' -e '/\\$/{N;s/\\\n//;ba' -e '}' <<<"${recipe_code}")"
+
+# Guard against either transform going wrong and silently emptying the
+# haystack, which would make every contract below pass vacuously.
+grep -q 'nim js' <<<"${recipe_joined}" ||
+	fail "the comment stripper preserved the recipe's nim js invocation" \
+		"After stripping comments and folding continuations there is no" \
+		"'nim js' left, so the shape contracts would be checking an empty string."
+
+echo "test-vm-js lane contracts"
+
+# --- static: the recipe's shape -------------------------------------------
+
+# 1. The define that makes an exit code exist at all. Anchored to the actual
+#    `nim js` invocation, not merely present somewhere in the recipe.
+if grep -qE 'nim js[[:space:]]+-d:nodejs' <<<"${recipe_joined}"; then
+	ok "the recipe's nim js invocation carries -d:nodejs"
+else
+	fail "the recipe's nim js invocation carries -d:nodejs" \
+		"Without it std/unittest cannot set a failing exit code on the js" \
+		"backend, so node exits 0 for a failing suite and the exit-code arm" \
+		"below becomes dead code."
+fi
+
+# 2. node's status must be captured in a form `set -e` cannot swallow.
+# shellcheck disable=SC2016 # this is a regex over the recipe text, not an expansion
+if grep -qE 'node "\$cache/\$name\.js" 2>&1\) \|\| exitcode=' <<<"${recipe_joined}"; then
+	ok "node's exit status is captured with an || guard"
+else
+	fail "node's exit status is captured with an || guard" \
+		"A bare 'output=\$(node ...)' followed by 'exitcode=\$?' cannot observe" \
+		"a failure: under this recipe's set -e the non-zero node kills the loop" \
+		"before the assignment is read."
+fi
+
+# 3. The vacuous-pass guard the native lane has always had.
+if grep -q 'DID NOT RUN' <<<"${recipe_joined}"; then
+	ok "a build that produces no test results is reported, not scored OK"
+else
+	fail "a build that produces no test results is reported, not scored OK" \
+		"Without this guard a suite that ran zero tests, or died before printing" \
+		"anything, is reported as 'OK (0 tests)'."
+fi
+
+# 4. Compiler diagnostics must survive. The warning naming defect 1 was thrown
+#    away for as long as the compile was redirected to /dev/null.
+if grep -qE 'nim js .*>/dev/null' <<<"${recipe_joined}"; then
+	fail "the compile does not discard its diagnostics" \
+		"'nim js ... >/dev/null 2>&1' throws away the compiler warning that" \
+		"names this lane's own defect."
+else
+	ok "the compile does not discard its diagnostics"
+fi
+
+# 5. The exit code must still be consulted once it is meaningful.
+if grep -q 'exitcode" -ne 0' <<<"${recipe_joined}"; then
+	ok "the recipe still fails a suite on a non-zero exit code"
+else
+	fail "the recipe still fails a suite on a non-zero exit code" \
+		"-d:nodejs makes the exit code meaningful; something must read it."
+fi
+
+# --- dynamic: prove the -d:nodejs claim against the real toolchain --------
+#
+# Contract 1 is a grep, and a grep cannot tell you the flag WORKS. These two
+# compile the same deliberately-failing suite both ways and compare, so the
+# suite carries its own mutation: if -d:nodejs ever stops being load-bearing,
+# the second contract fails and contract 1 is revealed as cargo cult.
+
+if ! command -v nim >/dev/null 2>&1 || ! command -v node >/dev/null 2>&1; then
+	skip "nim and/or node not on PATH; cannot verify the -d:nodejs claim here"
+	skip "nim and/or node not on PATH; cannot verify the no-define counterpart"
+else
+	tmp_dir="$(mktemp -d)"
+	trap 'rm -rf "${tmp_dir}"' EXIT
+
+	cat >"${tmp_dir}/failing.nim" <<'EOF'
+import std/unittest
+suite "deliberately failing":
+  test "this check must fail":
+    check 1 == 2
+EOF
+
+	set +e
+	with_define_out="$(nim js -d:nodejs --hints:off \
+		--nimcache:"${tmp_dir}/cache-with" \
+		-o:"${tmp_dir}/with.js" "${tmp_dir}/failing.nim" 2>&1)"
+	node "${tmp_dir}/with.js" >/dev/null 2>&1
+	with_define_rc=$?
+
+	nim js --hints:off \
+		--nimcache:"${tmp_dir}/cache-without" \
+		-o:"${tmp_dir}/without.js" "${tmp_dir}/failing.nim" >/dev/null 2>&1
+	node "${tmp_dir}/without.js" >/dev/null 2>&1
+	without_define_rc=$?
+	set -e
+
+	if [ "${with_define_rc}" -ne 0 ]; then
+		ok "with -d:nodejs a failing suite exits non-zero (got ${with_define_rc})"
+	else
+		fail "with -d:nodejs a failing suite exits non-zero" \
+			"node exited 0 for a suite whose only test fails, so the lane's" \
+			"exit-code arm cannot detect failures even with the define."
+	fi
+
+	if [ "${without_define_rc}" -eq 0 ]; then
+		ok "without the define that same suite exits 0 — the flag is load-bearing"
+	else
+		fail "without the define that same suite exits 0" \
+			"node exited ${without_define_rc} without -d:nodejs. If the toolchain" \
+			"now sets a failing exit code either way, contract 1 no longer" \
+			"protects anything and this suite should be revisited rather than" \
+			"left asserting a flag that does nothing."
+	fi
+
+	if grep -q 'setProgramResult not available' <<<"${with_define_out}"; then
+		fail "compiling with -d:nodejs raises no setProgramResult warning" \
+			"The define is present but the compiler still reports that unittest" \
+			"cannot set a failing exit code."
+	else
+		ok "compiling with -d:nodejs raises no setProgramResult warning"
+	fi
+fi
+
+echo
+echo "assertions: ${pass_count}  skipped: ${skip_count}  fail: 0"
+echo "test-vm-js lane: all contracts hold."

--- a/justfile
+++ b/justfile
@@ -2361,26 +2361,52 @@ test-vm-js: vm-test-prereqs
     name=$(basename "$f" .nim)
     cache="/tmp/ct-nim-cache/vm-js-$name"
     echo -n "  $f ... "
-    if ! nim js --hints:off \
+    # `-d:nodejs` is load-bearing, not decoration.
+    #
+    # Nim auto-defines `nodejs` only for `nim js -r`. This lane compiles and
+    # runs as separate steps (same split, and for the same reasons, as the
+    # native lane above), so the define is absent unless spelled out -- and
+    # without it `std/exitprocs.setProgramResult` is undeclared, so
+    # `std/unittest` substitutes a no-op and the process exits 0 even when a
+    # test fails. The compiler says exactly that:
+    #
+    #     unittest.nim: Warning: setProgramResult not available on platform,
+    #       unittest will not give failing exit code on test failure
+    #
+    # and the old `>/dev/null 2>&1` on the compile threw the warning away.
+    # Measured on this repo's Nim with a suite whose only test fails:
+    # `nim js` -> node exits 0; `nim js -d:nodejs` -> node exits 1.
+    #
+    # So the `$exitcode` arm below was dead twice over. The define is what
+    # makes the exit code mean anything at all, and capturing it with
+    # `|| exitcode=$?` is what lets this recipe SEE it -- the old
+    # `output=$(...)` followed by `exitcode=$?` could never observe a failure,
+    # because under this recipe's `set -e` a non-zero `node` killed the whole
+    # loop before the assignment was read.
+    if ! compile_output=$(nim js -d:nodejs --hints:off \
       --path:src/frontend/viewmodel \
       --nimcache:"$cache" \
       -o:"$cache/$name.js" \
-      "$f" >/dev/null 2>&1; then
+      "$f" 2>&1); then
       echo "COMPILE ERROR"
-      nim js --hints:off \
-        --path:src/frontend/viewmodel \
-        --nimcache:"$cache" \
-        -o:"$cache/$name.js" \
-        "$f" 2>&1 | grep 'Error:' | head -2 | sed 's/^/    /'
+      echo "$compile_output" | grep 'Error:' | head -2 | sed 's/^/    /'
       failed=$((failed + 1))
       continue
     fi
-    output=$(node "$cache/$name.js" 2>&1)
-    exitcode=$?
+    exitcode=0
+    output=$(node "$cache/$name.js" 2>&1) || exitcode=$?
     oks=$(echo "$output" | grep -c '\[OK\]' || true)
     fails=$(echo "$output" | grep -c '\[FAILED\]' || true)
-    if [ "$fails" -gt 0 ] || [ "$exitcode" -ne 0 ]; then
-      echo "PARTIAL ($oks OK, $fails FAILED)"
+    if [ "$oks" -eq 0 ] && [ "$fails" -eq 0 ]; then
+      # Built, so not a compile error: it could not run, or ran and reported
+      # nothing. The native lane has had this guard for a while; without it
+      # this lane scored a silent no-op as `OK (0 tests)`, which is the one
+      # result a test lane must never invent.
+      echo "DID NOT RUN (compiled, but produced no test results)"
+      echo "$output" | head -20 | sed 's/^/    /'
+      failed=$((failed + 1))
+    elif [ "$fails" -gt 0 ] || [ "$exitcode" -ne 0 ]; then
+      echo "PARTIAL ($oks OK, $fails FAILED, exit $exitcode)"
       echo "$output" | grep '\[FAILED\]' | head -5 | sed 's/^/    /'
       failed=$((failed + 1))
     else


### PR DESCRIPTION
`test-vm-js` reported results it could not actually see. Three defects
stacked, each hiding the next:

1. Nim auto-defines `nodejs` only for `nim js -r`. This lane compiles and
   runs as separate steps, so the define was absent, so
   `std/exitprocs.setProgramResult` was undeclared, so `std/unittest`
   substituted a no-op and a FAILING suite exited 0. Measured on this
   repo's Nim with a suite whose only test fails: `nim js` gives node
   exit 0, `nim js -d:nodejs` gives exit 1.

2. The compile redirected everything to `/dev/null`, so the compiler
   warning that names defect 1 outright -- "unittest will not give
   failing exit code on test failure" -- was discarded on every run, and
   was unrecoverable from `test-logs/test-vm-js.log`. On failure the
   recipe then recompiled and printed only lines matching `Error:`. This
   is the same reporting defect the native lane's own comment records
   having fixed, where filtering threw away the one line naming a missing
   library.

3. `output=$(node ...)` followed by `exitcode=$?` cannot observe a
   failure under this recipe's `set -e`: a non-zero `node` kills the loop
   before the assignment is read. So the `$exitcode` arm was dead even
   where defect 1 did not apply.

The lane still went red when a test printed `[FAILED]`, which is why this
survived: the human console report was doing all the work, while the
structured signal the recipe believed it was also checking did not exist.
A suite that crashed before printing anything, or that ran zero tests,
was scored `OK (0 tests)` -- the one result a test lane must never
invent. The native lane has had a `DID NOT RUN` guard for that case for a
while; this lane had none.

All four are fixed by bringing the lane to parity with the native one and
adding the define: compile with `-d:nodejs`, keep the compile output
instead of recompiling, capture node's status with `|| exitcode=$?`, and
report a run that produced no test results as a failure.

`ci/test/vm-js-lane-test.sh` pins it. Its shape contracts are static
checks over the justfile, so `ci-verdict` runs them from a stock runner
where they cannot be taken down by the outages that stop the lane itself
from executing. Its dynamic contracts compile the same deliberately
failing suite both ways and assert the exit codes differ, so the suite
carries its own mutation: if `-d:nodejs` ever stops being load-bearing,
the contract asserting it fails rather than quietly becoming cargo cult.
Where nim and node are absent those two are counted as skipped, never as
passed.

Each of the five contracts was verified to fail against the unfixed
recipe. Two needed the checks tightened first: the recipe's comments
necessarily quote the tokens under test, so a raw grep matched the
explanation rather than the command, and the `nim js` invocation spans
backslash continuations, so a line-oriented grep could not see the
redirect it was looking for. The suite now strips comments and folds
continuations, and guards against either transform emptying its own
haystack.