### PR TITLE
fix(ci): scope the macOS ct-mcr credential instead of rewriting all of github.com

### DIFF
--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -2497,12 +2497,44 @@ jobs:
         run: |
           set -euo pipefail
           cd "${{ github.workspace }}/../codetracer-native-recorder"
-          # Allow cargo to use git's credential helper so cloning the
-          # private ``lldb-sys.rs`` dependency picks up the App-token
-          # we set via ``GIT_CREDENTIALS`` below.
+          # Cargo's default libgit2 transport does not read gitconfig, so the
+          # git CLI has to be forced for the private ``lldb-sys.rs``
+          # dependency. The CREDENTIAL it then uses is already installed
+          # job-wide by ``Setup dev env`` above, so nothing is configured here.
+          #
+          # That step runs the shared ``setup-nix``, which exports
+          #
+          #   GIT_CONFIG_KEY_0=http.https://github.com/metacraft-labs/.extraHeader
+          #
+          # through $GITHUB_ENV. Four things make it sufficient here, and each
+          # was checked rather than assumed:
+          #
+          #   * ``Setup dev env`` is unconditional on this job -- it is not
+          #     gated on ``matrix.platform`` -- so the macOS leg gets it too.
+          #   * ``lldb-sys.rs`` lives at github.com/metacraft-labs/lldb-sys.rs,
+          #     and git matches ``http.<url>.*`` by scheme + host + port +
+          #     slash-delimited path prefix, so the metacraft-labs scope covers
+          #     it (and nothing outside the org).
+          #   * GIT_CONFIG_COUNT/KEY_n/VALUE_n are ordinary environment
+          #     variables, so they survive ``nix develop --command`` into
+          #     cargo's child git processes. Verified directly: inside a
+          #     ``nix develop`` shell, ``git config --get-all`` resolves the
+          #     header from the environment alone.
+          #   * The same scoped-header + git-CLI combination already fetches
+          #     this exact dependency in ``visual-replay-regression-gate``,
+          #     which builds its own per-repo header and neutralises
+          #     ~/.gitconfig entirely.
+          #
+          # What used to be here was a GLOBAL catch-all rewriting every
+          # github.com URL to carry the token as userinfo. Unlike a
+          # per-checkout local header, ``--global`` config IS inherited by
+          # ``git clone``, and it put the token into argv, into the
+          # ``.git/config`` of every clone it touched, and into git's own error
+          # messages -- for nixpkgs and every third-party fetch as well, none of
+          # which the token is for. ``setup-nix`` evicts exactly that pattern
+          # from a reused ~/.gitconfig at the start of the job; re-adding it
+          # here put it straight back.
           export CARGO_NET_GIT_FETCH_WITH_CLI=true
-          git config --global url."https://x-access-token:${{ steps.ci_token.outputs.token }}@github.com/".insteadOf "https://github.com/"
-          git config --global --add url."https://x-access-token:${{ steps.ci_token.outputs.token }}@github.com/".insteadOf "ssh://git@github.com/"
           nix develop --no-write-lock-file --command just build-ct-mcr
 
       - name: Build ct_gfx_player via codetracer-visual-replay nix develop (macOS)


### PR DESCRIPTION
The macOS ct-mcr build installed a GLOBAL catch-all before invoking the
recorder's nix shell:

    git config --global url."https://x-access-token:$TOKEN@github.com/" \
      .insteadOf "https://github.com/"

That is the pattern the shared `setup-nix` stopped using, and it undid
that fix from inside the job. Unlike a per-checkout LOCAL header, global
config is inherited by `git clone`, and a rewritten URL carries the token
in argv, in the `.git/config` of every clone the rewrite touches, and in
git's own "unable to access 'https://x-access-token:...'" failure text.
It applied to every github.com fetch in the job -- nixpkgs, third-party
crates, any transitive git dependency -- none of which the token is for.
`setup-nix` evicts exactly this pattern from a reused `~/.gitconfig` at
the start of every job; these two lines put it straight back, after the
eviction had run.

They are also unnecessary, which is the part that had to be established
rather than assumed. `Setup dev env` already installs an owner-scoped
credential job-wide, and four links were checked end to end:

  * `Setup dev env` carries no `if:` on this job, so the macOS leg gets
    it as well as the nixos leg.
  * It runs the shared `setup-nix`, which exports
    `GIT_CONFIG_KEY_0=http.https://github.com/metacraft-labs/.extraHeader`
    through `$GITHUB_ENV`, making it job-wide rather than step-local.
  * The dependency being fetched is
    `github.com/metacraft-labs/lldb-sys.rs`. Git matches `http.<url>.*`
    by scheme, host, port and slash-delimited path prefix, so the
    `metacraft-labs/` scope covers it -- and covers nothing outside the
    org, which is the whole point of the narrower form.
  * `GIT_CONFIG_COUNT`/`KEY_n`/`VALUE_n` are ordinary environment
    variables, so they survive `nix develop --command` into cargo's child
    git processes. This was measured, not inferred: inside a
    `nix develop` shell with only those variables set, `git config
    --get-all` resolves the header from the environment alone.

`CARGO_NET_GIT_FETCH_WITH_CLI=true` is untouched -- it is what routes the
fetch through the git CLI at all, and cargo's default libgit2 transport
would ignore any gitconfig. The same scoped-header plus git-CLI
combination already fetches this exact dependency in
`visual-replay-regression-gate`, which additionally neutralises
`~/.gitconfig`, so the mechanism is in production use here today.

The two remaining catch-alls, in `push-tag` and `create-release`, are
deliberately left alone. They sit on the release path, which no PR or
`dev` run exercises, so the same reasoning cannot be demonstrated for
them the way it can here -- and an untested credential change on the
release path is the wrong trade. They are recorded for a maintainer to
check during a real release rather than changed blind.