### PR TITLE
ci: stop the CLA check from booting a VM to do nothing

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -17,10 +17,43 @@ permissions:
 
 jobs:
   CLAAssistant:
-    runs-on: eph-linux-x64  # CIP-5: nix job → eph-linux-x64
+    # The gate is on the JOB, not on the step. It used to sit on the single
+    # step below, which meant every `issue_comment` on every *issue* in the
+    # repo still allocated a runner, booted it, skipped its only step, and
+    # tore it down. That is not hypothetical: run 31920424241 occupied the
+    # ephemeral runner `garm-qjynbrvg9hfi` to produce
+    # `CLA Assistant ... skipped`. With 25 such comments queued at once the
+    # workflow was holding the entire `eph-linux-x64` class (6 slots) hostage
+    # to do nothing. A job-level `if` is evaluated before scheduling, so no
+    # runner is requested at all.
+    #
+    # `github.event.issue.pull_request` is present only when the comment is on
+    # a pull request, so plain-issue chatter no longer reaches this job.
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event.issue.pull_request != null &&
+       (github.event.comment.body == 'recheck' ||
+        github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'))
+
+    # A CLA lookup is a git checkout plus an API call. It needs none of the
+    # custom NixOS image, so it has no business on the 6-slot self-hosted
+    # class. codetracer is a public repository, so `ubuntu-latest` is free.
+    runs-on: ubuntu-latest
+
+    # Grouped per pull request, NOT per `github.ref`: on `pull_request_target`
+    # and `issue_comment` the ref is the *base* branch, so a ref-keyed group
+    # would put every open PR in one group and let one PR's CLA run cancel
+    # another's.
+    #
+    # `cancel-in-progress: false` because this action commits the signature
+    # file back to the `main` branch; cancelling mid-commit can leave the
+    # signature store half-written. Queueing is the correct behaviour here.
+    concurrency:
+      group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: false
+
     steps:
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/elixir-flow-dap.yml
+++ b/.github/workflows/elixir-flow-dap.yml
@@ -22,7 +22,10 @@ permissions:
 
 jobs:
   redirect-notice:
-    runs-on: eph-linux-x64  # CIP-5: nix job → eph-linux-x64
+    # Two `echo` lines. This is not a nix job and never was — it needs nothing
+    # from the custom image, so it does not belong on the 6-slot
+    # `eph-linux-x64` class. codetracer is public, so `ubuntu-latest` is free.
+    runs-on: ubuntu-latest
     steps:
       - name: Notify and redirect
         run: |


### PR DESCRIPTION
## What

The CLA workflow gated its only step with a **step-level** `if`. A step-level condition is evaluated *after* a runner has been assigned, so every comment on every issue in the repo still provisioned an ephemeral Linux VM, started the job, skipped the step, and tore the VM down.

This is not a hypothesis. Run [31920424241](https://github.com/metacraft-labs/codetracer/actions/runs/31920424241) occupied the ephemeral runner `garm-qjynbrvg9hfi` (label `eph-linux-x64`) and its job steps read:

| step | conclusion |
| --- | --- |
| Set up job | success |
| CLA Assistant | **skipped** |
| Complete job | success |

At the time of writing **25 such runs were queued simultaneously** on a runner class with **6 concurrent slots**. They came from 25 comments on 25 *different* bug-report issues — none of them pull requests, so none of them could ever have signed a CLA.

## Changes

1. **Move the condition to the job.** Job-level `if` is evaluated before scheduling, so no runner is requested at all. Also require `github.event.issue.pull_request`, so comments on plain issues no longer reach the job.
2. **`runs-on: ubuntu-latest`.** A CLA lookup is a checkout plus an API call — it uses nothing from the custom NixOS image. This repository is public, so hosted runners are free.
3. **Per-pull-request concurrency group**, keyed on the PR number and *not* `github.ref`. On `pull_request_target` and `issue_comment` the ref is the **base** branch, so a ref-keyed group would put every open PR in one group and let one PR's CLA run cancel another's. `cancel-in-progress: false` because the action commits the signature file back to `main`, and a cancelled commit can leave it half-written.

Also moves the deprecated `elixir-flow-dap.yml` redirect notice — two `echo` lines — off `eph-linux-x64` for the same reason.

## Effect

Frees the 25 queued `eph-linux-x64` jobs immediately and prevents the class of waste recurring. No CLA behaviour changes for actual pull requests.

## Validation

`actionlint` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)