### PR TITLE
ci: collapse superseded pull-request runs

### DIFF
--- a/.github/workflows/beam-flow.yml
+++ b/.github/workflows/beam-flow.yml
@@ -41,6 +41,17 @@ on:
         required: false
         default: ''
 
+# Collapse superseded pull-request runs only.
+#
+# `github.head_ref` is set on `pull_request` and empty everywhere else, so PR
+# runs group per source branch and a new push cancels the run it superseded.
+# Pushes to `main` and manual dispatches fall through to `github.run_id`,
+# which is unique per run: each gets its own group and is never cancelled, so
+# the per-commit history on the mainline stays complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -7,6 +7,23 @@ on:
       - stable
   pull_request:
 
+# Collapse superseded pull-request runs only.
+#
+# This is the widest workflow in the repository -- Windows, Linux and macOS
+# legs across three runner classes -- so a superseded pull-request run is the
+# single most expensive thing the fleet can be doing.
+#
+# `github.head_ref` is set on `pull_request` and empty everywhere else, so PR
+# runs group per source branch and a new push cancels the run it superseded.
+# Pushes to `main`/`dev`/`stable` fall through to `github.run_id`, which is
+# unique per run: every mainline commit keeps a group of its own and is never
+# cancelled. That is deliberate -- `dev` is the integration branch and each
+# commit's build result is independently meaningful for bisecting, so
+# collapsing mainline pushes would destroy history rather than save capacity.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/cross-repo-tests.yml
+++ b/.github/workflows/cross-repo-tests.yml
@@ -25,6 +25,17 @@ on:
         required: false
         default: ''
 
+# Collapse superseded pull-request runs only.
+#
+# `github.head_ref` is set on `pull_request` and empty everywhere else, so PR
+# runs group per source branch and a new push cancels the run it superseded.
+# Pushes to `main`/`dev`/`stable` and manual dispatches fall through to
+# `github.run_id`, which is unique per run: each gets its own group and is
+# never cancelled, so the per-commit history on the mainlines stays complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/request-panel-sidecar-retirement.yml
+++ b/.github/workflows/request-panel-sidecar-retirement.yml
@@ -46,6 +46,19 @@ on:
     - cron: '0 3 * * *'
   workflow_dispatch:
 
+# Collapse superseded pull-request runs only.
+#
+# `github.head_ref` is set on `pull_request` and empty everywhere else, so PR
+# runs group per source branch and a new push cancels the run it superseded.
+# Pushes to `main`/`dev`/`stable`, the nightly cron and manual dispatches fall
+# through to `github.run_id`, which is unique per run: each gets its own group
+# and is never cancelled. That matters here -- this workflow is the standing
+# proof that no recorder writes a sidecar manifest, so a nightly result is a
+# data point that must not be discarded because a PR happened to be busy.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   id-token: write


### PR DESCRIPTION
## What

Only the newest push to a pull request is worth validating, but every intermediate push was holding its own set of runners until it finished. On a fleet capped at six concurrent `eph-linux-x64` slots that is capacity spent producing answers nobody will read.

Adds a concurrency group to the pull-request validation workflows:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
  cancel-in-progress: true
```

## The group key is deliberate

`github.head_ref` is populated **only** on `pull_request` and is empty everywhere else. So:

- **pull requests** collapse per source branch — a new push cancels the run it superseded;
- **pushes to `main`/`dev`/`stable`**, the **nightly cron**, and **manual dispatches** fall through to `github.run_id`, which is unique per run. Each keeps a group of its own and is **never** cancelled.

That exemption is the point. `dev` is the integration branch and each commit's build result is independently meaningful when bisecting, so collapsing mainline pushes would destroy history rather than save capacity. The same reasoning protects the nightly `request-panel-sidecar-retirement` run, which is a standing proof whose data points must not be dropped because a PR happened to be busy.

Using `github.ref` instead — as is the common cargo-culted form — would have been wrong here: on `push` the ref *is* the mainline branch, so all mainline pushes would share one group and cancel each other.

## Per-workflow judgement

| workflow | triggers | category | applied |
| --- | --- | --- | --- |
| `codetracer.yml` | PR + push main/dev/stable | PR validation (widest fan-out: Windows + Linux + macOS) | yes, PR-only |
| `cross-repo-tests.yml` | PR + push + dispatch | PR validation | yes, PR-only |
| `beam-flow.yml` | PR + push main + dispatch | PR validation | yes, PR-only |
| `request-panel-sidecar-retirement.yml` | PR + push + nightly cron + dispatch | PR validation, but nightly is a data series | yes, PR-only; cron exempt via `run_id` |
| `elixir-flow-dap.yml` | dispatch only | deprecated redirect; each dispatch meaningful | no |
| `cla.yml` | `pull_request_target` + `issue_comment` | commits a signature file | separate PR, per-PR group, `cancel-in-progress: false` |
| `mcr-dap-flow.yml` | — | owned by another change in flight | not touched |

No publishing, release, tagging, deploy or cache-push workflow received a cancelling group.

## Validation

`actionlint` output is **byte-identical** before and after on every changed file (the repo has pre-existing warnings about the unknown custom `eph-*` labels; this change adds none).

`codetracer.yml` is in its own commit so it can be dropped independently if it conflicts with the credential-step work in flight on that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)