### PR TITLE
fix(ci): stop persisting the checkout credential in seven git-free jobs

### DIFF
--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -706,6 +706,14 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          # No later step in this job talks to a git remote, so the token has
+          # nothing to do after the checkout and should not outlive it: these
+          # runners reuse their work tree, and actions/checkout otherwise
+          # leaves the credential in `.git/config` for whatever runs next.
+          # (`nix develop` is unaffected either way -- Nix's fetcher does not
+          # read gitconfig; its credentials come from netrc/access-tokens.)
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -1372,6 +1380,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          # No later step in this job talks to a git remote, so the token has
+          # nothing to do after the checkout and should not outlive it: these
+          # runners reuse their work tree, and actions/checkout otherwise
+          # leaves the credential in `.git/config` for whatever runs next.
+          # (`nix develop` is unaffected either way -- Nix's fetcher does not
+          # read gitconfig; its credentials come from netrc/access-tokens.)
+          persist-credentials: false
           submodules: recursive
           token: ${{ steps.ci_token.outputs.token }}
 
@@ -1419,6 +1434,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          # No later step in this job talks to a git remote, so the token has
+          # nothing to do after the checkout and should not outlive it: these
+          # runners reuse their work tree, and actions/checkout otherwise
+          # leaves the credential in `.git/config` for whatever runs next.
+          # (`nix develop` is unaffected either way -- Nix's fetcher does not
+          # read gitconfig; its credentials come from netrc/access-tokens.)
+          persist-credentials: false
           submodules: recursive
           token: ${{ steps.ci_token.outputs.token }}
 
@@ -1640,6 +1662,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          # No later step in this job talks to a git remote, so the token has
+          # nothing to do after the checkout and should not outlive it: these
+          # runners reuse their work tree, and actions/checkout otherwise
+          # leaves the credential in `.git/config` for whatever runs next.
+          # (`nix develop` is unaffected either way -- Nix's fetcher does not
+          # read gitconfig; its credentials come from netrc/access-tokens.)
+          persist-credentials: false
           token: ${{ steps.ci_token.outputs.token }}
       - name: "Import GPG key for signing commits"
         id: import-gpg
@@ -1677,6 +1706,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          # No later step in this job talks to a git remote, so the token has
+          # nothing to do after the checkout and should not outlive it: these
+          # runners reuse their work tree, and actions/checkout otherwise
+          # leaves the credential in `.git/config` for whatever runs next.
+          # (`nix develop` is unaffected either way -- Nix's fetcher does not
+          # read gitconfig; its credentials come from netrc/access-tokens.)
+          persist-credentials: false
           token: ${{ steps.ci_token.outputs.token }}
       - name: Upload script
         env:
@@ -1996,6 +2032,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          # No later step in this job talks to a git remote, so the token has
+          # nothing to do after the checkout and should not outlive it: these
+          # runners reuse their work tree, and actions/checkout otherwise
+          # leaves the credential in `.git/config` for whatever runs next.
+          # (`nix develop` is unaffected either way -- Nix's fetcher does not
+          # read gitconfig; its credentials come from netrc/access-tokens.)
+          persist-credentials: false
 
       - name: Install AWS CLI
         if: ${{ startsWith(github.ref, 'refs/tags/') && !github.event['codetracer-ci'] }}
@@ -3487,6 +3531,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          # No later step in this job talks to a git remote, so the token has
+          # nothing to do after the checkout and should not outlive it: these
+          # runners reuse their work tree, and actions/checkout otherwise
+          # leaves the credential in `.git/config` for whatever runs next.
+          # (`nix develop` is unaffected either way -- Nix's fetcher does not
+          # read gitconfig; its credentials come from netrc/access-tokens.)
+          persist-credentials: false
           submodules: false
 
       - name: Self-test the verdict gate


### PR DESCRIPTION
`actions/checkout` defaults to `persist-credentials: true`, which leaves
the job's token in `<workspace>/.git/config` as an `http.extraHeader`
after the action finishes. On runners that reuse their work tree that
credential outlives the step that needed it, for no benefit in a job that
never talks to a git remote again.

Seven such jobs are opted out here. Each was traced step by step to the
end of the job, not sampled:

  push-gpg-public-key       gpg --armor --export, then aws s3 cp
  push-install-script       aws s3 cp
  windows-named-pipe-tests  rust-toolchain, then cargo test --bin simple-tui
  appimage-cross-distro     nix profile install, aws s3 cp, then
                            scripts/test-appimage-cross-distro.sh
  origin-dap-macos          setup-nix, setup-db-backend-siblings, then
  origin-dap-macos-nightly  just test-origin-dap
  ci-verdict                five bash self-test steps, all static checks

No later step in any of them runs a git command against a remote. The
scripts they invoke were read rather than assumed: neither
`scripts/test-appimage-cross-distro.sh` nor `scripts/test-origin-dap.sh`
contains a git invocation at all, and `src/tui/Cargo.toml` declares no
git dependencies, so the `cargo test` fetches nothing over git.

Two things make this narrower than it looks, and both are why the rest of
the workflow is left alone for now:

  * The persisted header is written to the CHECKOUT's `.git/config`, so
    it only ever applied to a git process whose repository is this
    checkout. `clone-repo` / `clone-siblings` build their own step-scoped
    credential, and `git clone` does not inherit an enclosing repo's
    local config, so neither ever depended on it.
  * `nix develop` is unaffected in either direction. Nix's internal
    fetcher does not read gitconfig; its credentials come from the netrc
    and access-tokens that `setup-nix` installs. So the jobs above cannot
    lose a Nix fetch by dropping this.

`push-tag` deliberately keeps its credentials: its "Create tag" step runs
`git push origin` with the checkout as its working directory, against a
plain github.com remote, and the persisted header is the credential that
authenticates it. That is the one place in these workflows where a git
remote is contacted from inside the checkout, and it is the reason this
change is applied job by job rather than swept across the file -- a wrong
`persist-credentials: false` does not fail at lint time or at checkout
time, only later, at push time.

Jobs whose later steps call large toolchain bootstraps that could not be
enumerated exhaustively -- the `windows-diy` lane and the non-nix macOS
legs, which also have no `setup-nix` credential to fall back on -- are
left at the default rather than guessed at.