### PR TITLE
fix(ci): record the non-nix build lane as retired instead of failing on it

### DIFF
--- a/ci/test/sibling-provisioning-test.sh
+++ b/ci/test/sibling-provisioning-test.sh
@@ -437,12 +437,35 @@ for wf in "${SIBLING_SOURCE_FILES[@]}"; do
 	done <"$wf"
 done
 
-if [ "$build_sites" -gt 0 ]; then
-	ok "the workflows still run the non-nix build ($build_sites call sites)"
+# How many `./non-nix-build/build.sh` call sites this workflow is EXPECTED to
+# have. The Homebrew-native macOS legs were migrated into the nix dev shell on
+# eph-macos-arm64 (6fee21a17), so the answer is now zero and the pairing
+# contract below has nothing left to pair.
+#
+# This is asserted as an exact count rather than dropped, because the check it
+# guards -- "the scanner still matches the thing it scans for" -- is still
+# worth having in both directions. Requiring `> 0` reported the retirement as a
+# failure on every run. Deleting the check outright would mean a re-introduced
+# non-nix leg silently reinstates the original defect (a build.sh with no
+# codetracer-trace-format sibling, which fails with "checkout not found"). An
+# exact count keeps that loud: bring the lane back and this fails until the
+# number is updated, which is precisely the moment someone must confirm the
+# pairing contract below still holds.
+EXPECTED_BUILD_SITES=0
+
+if [ "$build_sites" -eq "$EXPECTED_BUILD_SITES" ]; then
+	if [ "$build_sites" -eq 0 ]; then
+		ok "the non-nix build lane is retired, as recorded (0 call sites)"
+	else
+		ok "the workflows still run the non-nix build ($build_sites call sites)"
+	fi
 else
-	fail "the workflows still run the non-nix build" \
-		"no './non-nix-build/build.sh' step was found -- either the macOS lane was" \
-		"removed or the scanner no longer matches it, and this check is vacuous"
+	fail "the non-nix build call sites match what this contract expects" \
+		"expected $EXPECTED_BUILD_SITES './non-nix-build/build.sh' step(s), found $build_sites." \
+		"If a non-nix leg was (re)introduced, confirm it provisions" \
+		"codetracer-trace-format first -- see the pairing contract below -- and then" \
+		"update EXPECTED_BUILD_SITES. If a leg was removed, update the count." \
+		"If neither is true, this scanner has stopped matching the steps it scans."
 fi
 
 if [ "${#missing_sites[@]}" -eq 0 ]; then


### PR DESCRIPTION
`sibling-provisioning-test.sh` asserted that the workflows still contain
at least one `./non-nix-build/build.sh` step. That assertion existed to
stop its own scanner going quietly blind: the contract underneath it
pairs every non-nix build with a `codetracer-trace-format` checkout, and
a scanner that matches nothing would report that pairing as holding
vacuously.

The lane is now genuinely gone. 6fee21a17 moved the macOS non-gui and UI
legs into the nix dev shell on eph-macos-arm64, and the five remaining
mentions of `./non-nix-build/build.sh` in the workflows are all prose in
comments recording that migration -- there is no call site left to pair.
So the guard fired on every run, and since `ci-verdict` runs this suite,
it made that job red for a reason unrelated to anything it gates.

Replacing `> 0` with an exact expected count keeps the guard honest in
both directions rather than deleting it. Bringing a non-nix leg back now
fails this contract until the count is updated -- which is exactly the
moment someone has to confirm the pairing contract still holds, and that
contract is the one that originally caught a macOS leg building with no
sibling checkout and dying on "codetracer-trace-format checkout not
found". Verified by injecting a synthetic non-nix step: both the count
contract and the pairing contract fail, as intended.