### PR TITLE
fix(ci): judge native-backend's lock by what it pins, not by --locked

### DIFF
--- a/ci/test/cargo-lock-pin-guard.py
+++ b/ci/test/cargo-lock-pin-guard.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Classify what changed when a sibling-coupled Cargo.lock is re-resolved.
+
+Why this exists
+---------------
+``codetracer-native-backend/Cargo.lock`` is *not* a pure function of that
+repository's own content.  Its manifest routes one dependency through a
+sibling working tree::
+
+    [patch.crates-io]
+    ct-dap-client = { path = "../codetracer/libs/ct-dap-client" }
+
+A path dependency records no source, no checksum and no revision, so Cargo
+writes the sibling's *dependency edges* into the lock verbatim.  The hunk is
+therefore a function of whatever happens to sit at ``../codetracer`` when the
+lock is written -- and in this gate that is the CodeTracer pull request under
+test, which is by design newer than any revision native-backend was locked
+against.
+
+That coupling is deliberate and correct: native-backend's flow tests drive the
+sibling's ``db-backend`` binary through the sibling's own ``test_support``
+client, so the client must come from the tree being tested, not from a pinned
+revision.  What is *not* correct is asserting the whole lock with ``--locked``:
+that turns an expected cross-repo lag into "cannot update the lock file because
+--locked was passed", a message that names a flag instead of a cause.
+
+So the gate re-resolves the lock and asks this script a sharper question than
+``--locked`` can: did anything that is actually pinned move?
+
+Verdicts
+--------
+FAIL  a package that carries a ``source`` changed version, source or checksum.
+      That is version drift, and it is exactly what ``--locked`` protected.
+FAIL  a package that carries a ``source`` is present only after re-resolution.
+      A sibling pulled in a crate the committed lock does not pin, so Cargo
+      just picked whatever the registry offers today.
+FAIL  a source-less package that is NOT reached through a sibling directory --
+      a workspace member, or an in-repo path dependency -- changed its edges.
+      Nothing outside the repository can explain that, so it is an unrefreshed
+      lock and the repository that owns it has to say so.
+PASS  differences confined to the dependency edges of packages reached through
+      a sibling directory (a path that leaves the repository), and to pinned
+      packages the re-resolved graph stopped using. This is cross-repo lag:
+      reported in full, with the sibling revision that caused it, so the next
+      reader sees the cause rather than the flag.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tomllib
+from pathlib import Path
+
+
+def load_packages(path: Path) -> list[dict]:
+    with path.open("rb") as handle:
+        return tomllib.load(handle).get("package", [])
+
+
+def pinned_identities(packages: list[dict]) -> dict[str, set[tuple]]:
+    """name -> {(version, source, checksum)} for packages that carry a source."""
+    out: dict[str, set[tuple]] = {}
+    for pkg in packages:
+        if "source" not in pkg:
+            continue
+        out.setdefault(pkg["name"], set()).add(
+            (pkg.get("version", ""), pkg["source"], pkg.get("checksum", ""))
+        )
+    return out
+
+
+def path_edges(packages: list[dict]) -> dict[str, list[str]]:
+    """name -> sorted dependency edges, for packages with no source (path deps)."""
+    return {
+        pkg["name"]: sorted(pkg.get("dependencies", []))
+        for pkg in packages
+        if "source" not in pkg
+    }
+
+
+def sibling_paths(manifest: Path) -> dict[str, str]:
+    """Map crate name -> declared relative path, for every path-routed entry."""
+    if not manifest.is_file():
+        return {}
+    with manifest.open("rb") as handle:
+        data = tomllib.load(handle)
+    found: dict[str, str] = {}
+    tables: list[dict] = []
+    for key in ("dependencies", "dev-dependencies", "build-dependencies"):
+        tables.append(data.get(key, {}))
+    tables.extend(data.get("patch", {}).values())
+    for target in data.get("target", {}).values():
+        for key in ("dependencies", "dev-dependencies", "build-dependencies"):
+            tables.append(target.get(key, {}))
+    for table in tables:
+        for name, spec in table.items():
+            if isinstance(spec, dict) and "path" in spec:
+                found.setdefault(name, spec["path"])
+    return found
+
+
+def describe_origin(repo: Path, relative: str | None) -> str:
+    """Human-readable '<path> @ <revision>' for a sibling crate directory."""
+    if relative is None:
+        return "unknown origin"
+    crate_dir = (repo / relative).resolve()
+    revision = "revision unavailable"
+    git_dir = crate_dir
+    for candidate in [git_dir, *git_dir.parents]:
+        if (candidate / ".git").exists():
+            head = candidate / ".git" / "HEAD"
+            try:
+                raw = head.read_text(encoding="utf-8").strip()
+            except OSError:
+                break
+            if raw.startswith("ref: "):
+                ref = (candidate / ".git" / raw[5:]).resolve()
+                try:
+                    revision = ref.read_text(encoding="utf-8").strip()[:12]
+                except OSError:
+                    revision = raw[5:]
+            else:
+                revision = raw[:12]
+            break
+    return f"{relative} @ {revision}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--committed", required=True, type=Path)
+    parser.add_argument("--resolved", required=True, type=Path)
+    parser.add_argument("--manifest", required=True, type=Path)
+    parser.add_argument(
+        "--label",
+        default="codetracer-native-backend",
+        help="repository name used in the report",
+    )
+    args = parser.parse_args()
+
+    repo = args.manifest.parent
+    before = load_packages(args.committed)
+    after = load_packages(args.resolved)
+
+    before_pins = pinned_identities(before)
+    after_pins = pinned_identities(after)
+    paths = sibling_paths(args.manifest)
+
+    moved: list[str] = []
+    for name in sorted(set(before_pins) & set(after_pins)):
+        if before_pins[name] == after_pins[name]:
+            continue
+        for version, source, _ in sorted(before_pins[name] - after_pins[name]):
+            moved.append(f"    - {name} {version}  ({source})")
+        for version, source, _ in sorted(after_pins[name] - before_pins[name]):
+            moved.append(f"    + {name} {version}  ({source})")
+
+    entered = sorted(set(after_pins) - set(before_pins))
+    dropped = sorted(set(before_pins) - set(after_pins))
+
+    before_edges = path_edges(before)
+    after_edges = path_edges(after)
+    repo_root = repo.resolve()
+    lagging: list[str] = []
+    local: list[str] = []
+    for name in sorted(set(before_edges) | set(after_edges)):
+        old = before_edges.get(name)
+        new = after_edges.get(name)
+        if old == new:
+            continue
+        relative = paths.get(name)
+        origin = describe_origin(repo, relative)
+        added = sorted(set(new or []) - set(old or []))
+        removed = sorted(set(old or []) - set(new or []))
+        detail = ", ".join(
+            [f"+{edge}" for edge in added] + [f"-{edge}" for edge in removed]
+        )
+        line = f"    {name} ({origin}): {detail or 'entry added/removed'}"
+        # A workspace member, or a path dependency that stays inside the
+        # repository, is content the repository controls: nothing outside it can
+        # explain the drift, so it is simply an unrefreshed lock.
+        outside = relative is not None and repo_root not in (
+            repo / relative
+        ).resolve().parents
+        if outside:
+            lagging.append(line)
+        else:
+            local.append(line)
+
+    if moved:
+        print(
+            f"{args.label}'s Cargo.lock does not pin the graph it resolves to.\n"
+            "  A package that carries a source changed version, source or checksum:\n"
+            + "\n".join(moved)
+            + "\n"
+            "  This is dependency version drift, not sibling lag. The visual replay\n"
+            "  gate builds ct-native-replay against pinned versions and refuses to\n"
+            f"  continue against a graph {args.label}'s Cargo.lock does not describe.\n"
+            f"  Fix in {args.label}: refresh Cargo.lock and commit the result.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if entered:
+        detail = "\n".join(
+            f"    {name} {sorted(after_pins[name])[0][0]}"
+            f"  ({sorted(after_pins[name])[0][1]})"
+            for name in entered
+        )
+        causes = "\n".join(lagging) or "    (no path-package edge changed)"
+        print(
+            f"{args.label}'s Cargo.lock does not match the sibling revision under\n"
+            "  test. Re-resolving it pulls in packages the committed lock does not\n"
+            "  pin, so Cargo picked whatever the registry offers right now:\n"
+            + detail
+            + "\n  Caused by these sibling dependency changes:\n"
+            + causes
+            + "\n"
+            f"  Fix in {args.label}: check the siblings above out next to it, run\n"
+            "  `cargo fetch`, and commit the refreshed Cargo.lock.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if local:
+        print(
+            f"{args.label}'s Cargo.lock is out of date with {args.label}'s own\n"
+            "  manifests. These packages are workspace members or in-repo path\n"
+            "  dependencies -- no sibling checkout can explain their edges moving:\n"
+            + "\n".join(local)
+            + "\n"
+            f"  Fix in {args.label}: run `cargo fetch` and commit Cargo.lock.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if lagging or dropped:
+        print(
+            f"{args.label}'s Cargo.lock lags the sibling revisions under test.\n"
+            "  Every pinned version, source and checksum is unchanged; only the\n"
+            "  dependency edges of path packages differ, which is what a path\n"
+            "  dependency on a sibling working tree means:"
+        )
+        for line in lagging:
+            print(line)
+        for name in dropped:
+            print(f"    {name}: no longer reachable from the resolved graph")
+        print(
+            f"  Refresh {args.label}'s Cargo.lock against these siblings to clear\n"
+            "  this notice. The gate continues: nothing pinned moved."
+        )
+        return 0
+
+    print(f"{args.label}'s Cargo.lock matches the sibling revisions under test.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/test/cargo-lock-pin-guard.py
+++ b/ci/test/cargo-lock-pin-guard.py
@@ -178,10 +178,12 @@ def main() -> int:
         line = f"    {name} ({origin}): {detail or 'entry added/removed'}"
         # A workspace member, or a path dependency that stays inside the
         # repository, is content the repository controls: nothing outside it can
-        # explain the drift, so it is simply an unrefreshed lock.
-        outside = relative is not None and repo_root not in (
-            repo / relative
-        ).resolve().parents
+        # explain the drift, so it is simply an unrefreshed lock. `path = "."`
+        # is the repository itself and must land on that side of the line.
+        outside = False
+        if relative is not None:
+            crate_dir = (repo / relative).resolve()
+            outside = crate_dir != repo_root and repo_root not in crate_dir.parents
         if outside:
             lagging.append(line)
         else:

--- a/ci/test/visual-replay-private-cargo-preflight-test.sh
+++ b/ci/test/visual-replay-private-cargo-preflight-test.sh
@@ -19,6 +19,19 @@ cat >"$TEST_ROOT/bin/cargo" <<'FAKE_CARGO'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >"${CARGO_CALL_LOG:?}"
+# The preflight no longer asserts the whole lock with `--locked`; it re-resolves
+# it and classifies the diff. Modelling that needs a cargo that can actually
+# rewrite the lock, so the drift cases hand this stub the lock a real
+# re-resolution would have produced.
+if [[ -n ${FAKE_CARGO_RESOLVED_LOCK:-} ]]; then
+	manifest=""
+	prev=""
+	for arg in "$@"; do
+		[[ $prev == "--manifest-path" ]] && manifest="$arg"
+		prev="$arg"
+	done
+	[[ -n $manifest ]] && cp "$FAKE_CARGO_RESOLVED_LOCK" "$(dirname "$manifest")/Cargo.lock"
+fi
 FAKE_CARGO
 chmod +x "$TEST_ROOT/bin/cargo"
 
@@ -33,14 +46,41 @@ edition = "2021"
 
 [patch.crates-io]
 lldb-sys = { git = "https://github.com/metacraft-labs/lldb-sys.rs.git" }
+ct-dap-client = { path = "../codetracer/libs/ct-dap-client" }
 CARGO_TOML
 	cat >"$workspace/Cargo.lock" <<'CARGO_LOCK'
 version = 4
 
 [[package]]
+name = "ct-dap-client"
+version = "0.1.0"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "private-cargo-preflight-fixture"
+version = "0.1.0"
+dependencies = [
+ "lldb-sys",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.180"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1111111111111111111111111111111111111111111111111111111111111111"
+
+[[package]]
 name = "lldb-sys"
 version = "0.0.31"
 source = "git+https://github.com/metacraft-labs/lldb-sys.rs.git#0123456789abcdef0123456789abcdef01234567"
+
+[[package]]
+name = "log"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2222222222222222222222222222222222222222222222222222222222222222"
 CARGO_LOCK
 }
 
@@ -113,8 +153,79 @@ run_positive_case() {
 	PATH="$TEST_ROOT/bin:$PATH" \
 		bash "$REPO_ROOT/ci/test/visual-replay-private-cargo-preflight.sh" \
 		"$workspace"
-	grep -Fxq "fetch --locked --manifest-path $workspace/Cargo.toml" \
+	grep -Fxq "fetch --manifest-path $workspace/Cargo.toml" \
 		"$CARGO_CALL_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# The native-backend lock is a function of a sibling working tree.
+#
+# `codetracer-native-backend/Cargo.toml` routes `ct-dap-client` through
+# `[patch.crates-io] path = "../codetracer/libs/ct-dap-client"`, and in the
+# visual replay job that sibling is THIS pull request's checkout. A path
+# dependency records no source, checksum or revision, so Cargo copies the
+# sibling's dependency edges into the lock and the hunk moves with the tree
+# under test. `cargo fetch --locked` therefore asserted "native-backend was
+# relocked after the CodeTracer commit you are testing", which no CodeTracer
+# author can satisfy from this repository, and reported it as "cannot update
+# the lock file because --locked was passed" — the flag, not the cause.
+#
+# The three cases below pin the replacement contract. They are not mocks of the
+# classifier: each writes a real pair of lock files and runs the real preflight
+# against them, with a stub `cargo` standing in only for the network fetch.
+#
+#   sibling lag   — only path-package edges moved. MUST PASS, and must name the
+#                   package, the sibling path and the edge that moved.
+#   version drift — a package carrying a source changed version. MUST FAIL:
+#                   this is what `--locked` was protecting and the reason
+#                   dropping it outright would have been a regression.
+#   new pin       — a package carrying a source appears only after
+#                   re-resolution. MUST FAIL: a sibling pulled in a crate the
+#                   committed lock does not pin, so Cargo took whatever the
+#                   registry serves today.
+# ---------------------------------------------------------------------------
+run_lock_drift_case() {
+	# $1 = case name, $2 = expected exit status, $3 = required output fragment,
+	# $4 = sed program producing the re-resolved lock from the committed one.
+	local case_name="$1" expected_status="$2" expected_text="$3" mutation="$4"
+	local workspace="$TEST_ROOT/workspace/lock-$case_name"
+	local resolved="$TEST_ROOT/resolved-$case_name.lock"
+	local output status
+	write_valid_workspace "$workspace"
+	prepare_two_slot_environment "$TEST_ROOT/cargo-lock-$case_name"
+	# shellcheck disable=SC1091
+	source "$REPO_ROOT/ci/test/visual-replay-private-cargo-env.sh" >/dev/null
+	sed "$mutation" "$workspace/Cargo.lock" >"$resolved"
+
+	set +e
+	output="$(
+		CARGO_CALL_LOG="$TEST_ROOT/cargo-lock-$case_name.args" \
+			FAKE_CARGO_RESOLVED_LOCK="$resolved" \
+			PATH="$TEST_ROOT/bin:$PATH" \
+			bash "$REPO_ROOT/ci/test/visual-replay-private-cargo-preflight.sh" \
+			"$workspace" 2>&1
+	)"
+	status=$?
+	set -e
+	if ((status != expected_status)) || [[ $output != *"$expected_text"* ]]; then
+		echo "Native-backend lock drift case failed: $case_name" >&2
+		echo "expected status $expected_status and text: $expected_text" >&2
+		printf '%s\n' "$output" >&2
+		exit 1
+	fi
+	# The preflight must hand the sibling checkout back exactly as it found it;
+	# a gate that leaves another repository's lock rewritten is a gate that
+	# changes what the build it is guarding compiles.
+	if ! diff -q "$workspace/Cargo.lock" <(write_committed_lock_to_stdout) >/dev/null; then
+		echo "Preflight left the sibling Cargo.lock rewritten: $case_name" >&2
+		exit 1
+	fi
+}
+
+write_committed_lock_to_stdout() {
+	local reference="$TEST_ROOT/workspace/lock-reference"
+	write_valid_workspace "$reference"
+	cat "$reference/Cargo.lock"
 }
 
 run_negative_case() {
@@ -484,6 +595,33 @@ run_negative_case extra-padded "unexpected-inline-config-slot"
 run_negative_case extra-huge "unexpected-inline-config-slot"
 run_negative_case raw-token "Raw visual replay CI token"
 run_negative_case lock-boundary "locked-git-source-boundary"
+
+# The exact shape of the failure this replaced: native-backend's committed lock
+# lacked `ct-dap-client -> libc`, which `libs/ct-dap-client` has declared since
+# codetracer 26f0bdba2. Nothing pinned moves — `libc` is already in the lock —
+# so the gate continues and says why.
+run_lock_drift_case sibling-lag 0 \
+	"lags the sibling revisions under test" \
+	's|^ "log",$| "libc",\n "log",|'
+run_lock_drift_case sibling-lag-names-cause 0 \
+	"ct-dap-client (../codetracer/libs/ct-dap-client" \
+	's|^ "log",$| "libc",\n "log",|'
+# Version drift: the protection `--locked` was actually buying. Dropping the
+# flag without this check is the regression a previous attempt correctly refused.
+run_lock_drift_case version-drift 1 \
+	"does not pin the graph it resolves to" \
+	's|^version = "0.2.180"$|version = "0.2.181"|'
+# A crate that is not in the committed lock at all: resolved from the registry
+# at whatever version it serves today, so the gate must refuse it.
+# The hole a "path packages may lag" rule would otherwise open: the drifting
+# package is the workspace member itself, so no sibling checkout can explain it
+# and the lock is simply unrefreshed.
+run_lock_drift_case local-member-drift 1 \
+	"is out of date with codetracer-native-backend's own" \
+	's|^ "lldb-sys",$| "libc",\n "lldb-sys",|'
+run_lock_drift_case new-pin 1 \
+	"does not match the sibling revision under" \
+	's|^checksum = "2222222222222222222222222222222222222222222222222222222222222222"$|checksum = "2222222222222222222222222222222222222222222222222222222222222222"\n\n[[package]]\nname = "unpinned-newcomer"\nversion = "9.9.9"\nsource = "registry+https://github.com/rust-lang/crates.io-index"\nchecksum = "3333333333333333333333333333333333333333333333333333333333333333"|'
 
 if grep -R -aFq -- "$SENTINEL" "$TEST_ROOT" ||
 	grep -R -aFq -- "$SENTINEL_BASIC" "$TEST_ROOT"; then

--- a/ci/test/visual-replay-private-cargo-preflight-test.sh
+++ b/ci/test/visual-replay-private-cargo-preflight-test.sh
@@ -47,6 +47,9 @@ edition = "2021"
 [patch.crates-io]
 lldb-sys = { git = "https://github.com/metacraft-labs/lldb-sys.rs.git" }
 ct-dap-client = { path = "../codetracer/libs/ct-dap-client" }
+
+[dev-dependencies]
+private-cargo-preflight-fixture = { path = "." }
 CARGO_TOML
 	cat >"$workspace/Cargo.lock" <<'CARGO_LOCK'
 version = 4
@@ -170,7 +173,7 @@ run_positive_case() {
 # author can satisfy from this repository, and reported it as "cannot update
 # the lock file because --locked was passed" — the flag, not the cause.
 #
-# The three cases below pin the replacement contract. They are not mocks of the
+# The four cases below pin the replacement contract. They are not mocks of the
 # classifier: each writes a real pair of lock files and runs the real preflight
 # against them, with a stub `cargo` standing in only for the network fetch.
 #
@@ -183,6 +186,10 @@ run_positive_case() {
 #                   re-resolution. MUST FAIL: a sibling pulled in a crate the
 #                   committed lock does not pin, so Cargo took whatever the
 #                   registry serves today.
+#   local drift   — the drifting package is the workspace member itself, or an
+#                   in-repo path dependency. MUST FAIL: no sibling checkout can
+#                   explain it, so the lock is simply unrefreshed. `path = "."`
+#                   is the repository, not a sibling, and lands on this side.
 # ---------------------------------------------------------------------------
 run_lock_drift_case() {
 	# $1 = case name, $2 = expected exit status, $3 = required output fragment,

--- a/ci/test/visual-replay-private-cargo-preflight.sh
+++ b/ci/test/visual-replay-private-cargo-preflight.sh
@@ -13,6 +13,11 @@ fi
 
 LLDB_SYS_URL="https://github.com/metacraft-labs/lldb-sys.rs.git"
 
+# Resolved once, before anything changes directory, so the lock guard below is
+# found whether this script is invoked by path or from a sibling checkout.
+PREFLIGHT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly PREFLIGHT_DIR
+
 redact_cargo_fetch_output() {
 	sed -E \
 		-e 's#(https://x-access-token:)[^@[:space:]]+(@github\.com)#\1[REDACTED]\2#g' \
@@ -374,15 +379,70 @@ fi
 # Cargo cache used by the later native-replay build and turns bad credentials,
 # a missing private revision, or an accidental return to libgit2 into an early
 # gate failure before the long CodeTracer build and GUI-test phases.
+#
+# This fetch is deliberately NOT `--locked`, and the guard below is why.
+#
+# native-backend's Cargo.lock is not a function of native-backend alone. Its
+# manifest routes `ct-dap-client` through a sibling working tree:
+#
+#     [patch.crates-io]
+#     ct-dap-client = { path = "../codetracer/libs/ct-dap-client" }
+#
+# A path dependency records no source, no checksum and no revision, so Cargo
+# writes that sibling's dependency edges into the lock verbatim. In this job the
+# sibling IS this pull request's checkout, so the hunk is a function of the tree
+# under test. `--locked` therefore asserted "native-backend was relocked after
+# the CodeTracer commit you are testing" -- an assertion no CodeTracer author
+# can satisfy from this repository, reported as "cannot update the lock file
+# because --locked was passed", which names the flag and not the cause.
+#
+# Dropping `--locked` on its own would trade that for a worse failure: Cargo
+# would silently re-resolve pinned versions and the gate would build
+# ct-native-replay against whatever crates.io serves today. So the lock is
+# re-resolved and then compared, and the comparison is stricter than `--locked`
+# in the dimension that matters: no package carrying a source may change
+# version, source or checksum, and no unpinned package may enter the graph.
+# Only path-package edges are allowed to lag, and every one of them is named.
+cargo_lock_committed="$(mktemp "${TMPDIR:-/tmp}/native-backend-lock.XXXXXX")"
+cp "$native_backend_repo/Cargo.lock" "$cargo_lock_committed"
+
 cargo_fetch_output=""
 if ! cargo_fetch_output="$(
-	cargo fetch --locked --manifest-path "$native_backend_repo/Cargo.toml" 2>&1
+	cargo fetch --manifest-path "$native_backend_repo/Cargo.toml" 2>&1
 )"; then
 	printf '%s\n' "$cargo_fetch_output" |
 		redact_cargo_fetch_output >&2
+	rm -f "$cargo_lock_committed"
 	echo "Visual replay CI could not prefetch the native-backend Cargo graph." >&2
 	exit 1
 fi
+
+cargo_lock_pin_guard_python="$(type -P python3 2>/dev/null || true)"
+if [[ -z $cargo_lock_pin_guard_python ]]; then
+	rm -f "$cargo_lock_committed"
+	echo "Visual replay CI needs python3 to classify native-backend lock drift." >&2
+	exit 1
+fi
+
+cargo_lock_guard_status=0
+"$cargo_lock_pin_guard_python" -I \
+	"$PREFLIGHT_DIR/cargo-lock-pin-guard.py" \
+	--committed "$cargo_lock_committed" \
+	--resolved "$native_backend_repo/Cargo.lock" \
+	--manifest "$native_backend_repo/Cargo.toml" \
+	--label codetracer-native-backend || cargo_lock_guard_status=$?
+
+# Leave the sibling checkout exactly as it was found. The later
+# `cargo build --bin ct-native-replay` re-resolves it the same way, against the
+# cache this fetch just warmed.
+cp "$cargo_lock_committed" "$native_backend_repo/Cargo.lock"
+rm -f "$cargo_lock_committed"
+
+if [[ $cargo_lock_guard_status -ne 0 ]]; then
+	exit "$cargo_lock_guard_status"
+fi
+
+unset cargo_lock_committed cargo_lock_guard_status cargo_lock_pin_guard_python
 unset cargo_fetch_output cargo_auth_header cargo_auth_credential cargo_auth_key
 unset cargo_auth_prefix native_backend_repo
 unset LLDB_SYS_URL


### PR DESCRIPTION
## The defect

`visual-replay-regression-gate` is red on `dev` and on every open PR. Everything
upstream of the failure passes (Playwright 19/19 fake + 1/1 real, Nim lifecycle
3/3, adversarial contracts, the private-Cargo preflight's own auth contract);
the whole failure is one command in
`ci/test/visual-replay-private-cargo-preflight.sh`:

```
cargo fetch --locked --manifest-path <native-backend>/Cargo.toml
error: cannot update the lock file ... because --locked was passed to prevent this
```

`codetracer-native-backend/Cargo.toml` routes one dependency through a sibling
working tree:

```toml
[patch.crates-io]
ct-dap-client = { path = "../codetracer/libs/ct-dap-client" }
```

A path dependency records no source, no checksum and no revision, so Cargo
copies the sibling's dependency edges verbatim into `Cargo.lock`. In this job
the sibling is **this repository's checkout**, so that lock hunk is a function
of the working directory, not of any pinned revision. `--locked` therefore
asserted "native-backend was relocked after the CodeTracer commit you are
testing" — something no CodeTracer author can satisfy from this repo — and
reported it by naming a flag.

The concrete instance: `libs/ct-dap-client` has declared `libc = "0.2"` since
`26f0bdba2` (the `cfg(unix)` `killpg` teardown in `DapStdioClient`);
native-backend's committed lock does not record that edge.

## What was verified before choosing a fix

With `codetracer@dev` (`52162408`) and `codetracer-trace-format@dev` checked out
as siblings of `codetracer-native-backend@dev` (`ed9088a1`), in an isolated
`CARGO_HOME`:

| command | result |
|---|---|
| `cargo fetch --locked` | exit 101, "needs to be updated but --locked was passed" |
| `cargo fetch` then `diff` | exit 0, **one line**: `+ "libc",` under `ct-dap-client` |

Nothing else in the lock moves. No package version, source or checksum changes.
The re-resolved lock is byte-identical to the head of
`codetracer-native-backend#83`.

## Why not the alternatives

**Make `ct-dap-client` a git dependency with a `rev`.** This would make the lock
self-contained, and it is the option the lock's shape superficially argues for.
Rejected: native-backend's flow tests drive *this repository's* `db-backend`
binary through *this repository's* `test_support` client. Pinning the client to
a revision while the binary is built from the sibling working tree makes the
harness disagree with the thing it drives. It also puts two actively developed
repositories on a mutual bump treadmill (native-backend pins codetracer;
codetracer's workspace pins native-backend), and it would have this repository's
own CI download a pinned copy of itself in order to test its HEAD. It would also
break the preflight's `locked-git-source-boundary` assertion, which exists to
keep exactly one git source — the private `lldb-sys` fork — in that lock.

**Keep the path dep for local development and resolve through `[patch]` for CI.**
Cargo has no conditional `[patch]`: whatever the path points at is what gets
locked. This is the status quo restated, not a fix.

**Stop checking in native-backend's `Cargo.lock`.** Rejected on evidence:
`codetracer-native-backend/nix/packages/default.nix` consumes it via
`cargoLock.lockFile`, so `build-nix`, `build-appimage` and `create-release` all
depend on it existing and being accurate.

**Add or remove `--locked` and stop there.** Removing it lets CI paper over
genuine version drift; adding it elsewhere blocks a developer legitimately
adding a dependency to `libs/ct-dap-client` until native-backend's lock moves.
A previous attempt declined this for the right reason.

## The change

Re-resolve the lock, then classify the difference. The comparison is *stricter*
than `--locked` in the dimension that matters and silent only where the answer
is genuinely not this repository's to give:

| difference | verdict |
|---|---|
| a package carrying a `source` changed version, source or checksum | **fail** — version drift, exactly what `--locked` was buying |
| a package carrying a `source` appears only after re-resolution | **fail** — a sibling pulled in a crate the lock does not pin, so Cargo took today's registry answer |
| a workspace member or in-repo path package changed its edges | **fail** — no sibling can explain it; the lock is unrefreshed |
| a *sibling* path package changed its edges | **report and continue**, naming package, sibling directory and revision |

The sibling checkout is restored byte-for-byte afterwards, so the gate still
never leaves another repository's lock rewritten.

### The failure is now legible

Today's `dev`, with the real siblings and the real Cargo:

```
codetracer-native-backend's Cargo.lock lags the sibling revisions under test.
  Every pinned version, source and checksum is unchanged; only the
  dependency edges of path packages differ, which is what a path
  dependency on a sibling working tree means:
    ct-dap-client (../codetracer/libs/ct-dap-client @ 521624086a00): +libc
  Refresh codetracer-native-backend's Cargo.lock against these siblings to clear
  this notice. The gate continues: nothing pinned moved.
```

And when something genuinely disagrees — committed lock pinned `zstd 0.12.4`
against a manifest requiring `0.13.3`, real `cargo fetch`, real repos:

```
codetracer-native-backend's Cargo.lock does not pin the graph it resolves to.
  A package that carries a source changed version, source or checksum:
    - zstd 0.12.4  (registry+https://github.com/rust-lang/crates.io-index)
    + zstd 0.13.3  (registry+https://github.com/rust-lang/crates.io-index)
  This is dependency version drift, not sibling lag. ...
```

## Mutation evidence

`ci/test/visual-replay-private-cargo-preflight-test.sh` gains four cases, one
per verdict. Each writes a real pair of lock files and runs the real preflight
against them; only the network fetch is stubbed. Every rule was verified to be
load-bearing by removing it and observing the suite go red:

| mutation | result |
|---|---|
| restore `--locked` on the fetch | suite fails (`run_positive_case` argv assertion) |
| guard invocation neutered | `sibling-lag` fails |
| version-drift rule removed | `version-drift` fails |
| new-pin rule removed | `new-pin` fails |
| local-member rule removed | `local-member-drift` fails |
| nothing removed | `Visual replay private Cargo preflight tests passed.` |

End to end against the real repositories: committed `dev` lock → passes with the
lag notice above; lock refreshed (`codetracer-native-backend#83`) → "matches the
sibling revisions under test"; `zstd` pin mutated → fails as shown.

`shellcheck` is clean on both scripts. `shfmt` diffs both files under the repo's
`.editorconfig`, and diffs the unmodified upstream copies identically — not a
regression from this change.

## Relationship to `codetracer-native-backend#83`

That PR restores the missing `libc` edge, and I verified independently that its
lock is byte-identical to a clean re-resolution against `codetracer@dev`. It is
correct and worth merging: it clears the notice this gate now prints. It is no
longer a *blocker*, and this PR deliberately does not depend on it landing —
after this change the gate is green on `dev` whether or not native-backend's
lock has been refreshed, because a stale sibling edge is not a CodeTracer
regression.

## Adjacent, not fixed here

`ci/test/beam-flow-cross-repo.sh` runs `cargo build --locked` against
`codetracer-beam-recorder`, which path-depends on `codetracer-trace-format` the
same way. The two `.github/workflows/codetracer.yml` BEAM build steps already
work around it by dropping `--locked` outright (see the comments at lines
~2230 and ~2276). Same class of defect, same available remedy; left for a
separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)