### PR TITLE
fix(build): declare runquota where the build actually looks for it

### DIFF
--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -1477,6 +1477,23 @@ jobs:
         with:
           gh-token: ${{ steps.ci_token.outputs.token }}
 
+      - name: Clone runquota sibling
+        # `just build-once` below compiles `ct`, and src/ct/codetracer.nim ->
+        # ../ct_test/ct_test -> src/ct_test/process_exec.nim opens with
+        # `import runquota_process`. On the tup driver this checkout is the only
+        # source of those modules: src/Tuprules.tup's NIM_REPO_PATH_FLAGS names
+        # `$(ROOT)/../runquota/...`, and tup's environment allowlist in that
+        # same file omits RUNQUOTA_SRC, so the dev shell export cannot stand in
+        # for it. Cloned here rather than via the two composite actions above
+        # because neither owns this dependency (issue #641).
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        with:
+          repo: metacraft-labs/runquota
+          ref: dev
+          path: ${{ github.workspace }}/../runquota
+          gh-token: ${{ steps.ci_token.outputs.token }}
+          submodules: 'false'
+
       - name: Build frontend (needed by gated Playwright stage)
         env:
           CODETRACER_DB_BACKEND_SKIP_DIRENV: "1"
@@ -1597,6 +1614,21 @@ jobs:
         # zero-test guard that fails if they all skip (so a missing recorder
         # cannot masquerade as a pass).
         run: nix develop .#devShells.x86_64-linux.default --command just test-vm-recorder-gated
+
+      - name: Clone runquota sibling
+        # The `just build-once` step below compiles `ct`, whose import chain
+        # (src/ct/codetracer.nim -> ../ct_test/ct_test ->
+        # src/ct_test/process_exec.nim) starts with `import runquota_process`.
+        # Under tup the checkout is the only way those modules resolve --
+        # NIM_REPO_PATH_FLAGS points at `$(ROOT)/../runquota/...` and tup's
+        # environment allowlist omits RUNQUOTA_SRC (issue #641).
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        with:
+          repo: metacraft-labs/runquota
+          ref: dev
+          path: ${{ github.workspace }}/../runquota
+          gh-token: ${{ steps.ci_token.outputs.token }}
+          submodules: 'false'
 
       - name: Build ct (needed by the CLI dispatch tests)
         # record_missing_recorder_test.nim and record_dispatch_e2e_test.nim
@@ -2352,6 +2384,14 @@ jobs:
         # (setup-nix). Nix is provisioned here for both the macOS sibling
         # ``nix develop`` builds and the ct build + Playwright run, which now
         # all go through codetracer's dev shell.
+        #
+        # ``runquota`` is listed because the macOS leg runs ``just build-once``
+        # and `ct` imports ``runquota_process`` through
+        # src/ct_test/process_exec.nim. On Darwin build-once selects the
+        # reprobuild driver, which could resolve runquota from its nix flake
+        # input alone -- but scripts/require-siblings.sh requires the checkout
+        # on every driver so there is a single workspace-completeness rule (the
+        # tup driver has no other way in; see the notes in that script).
         uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
         with:
           env-flavor: nix
@@ -2366,6 +2406,7 @@ jobs:
             nim-stackable-hooks=dev
             codetracer-visual-replay=dev
             codetracer-native-backend=dev
+            runquota=dev
 
       - name: Stage codetracer-trace-format into libs/
         # The nix flake build below overrides the codetracer-trace-format input
@@ -2744,6 +2785,16 @@ jobs:
         # frontend's IsoNim/agent libraries, the incremental runner's trace and
         # I/O libraries, and visual replay's own native siblings. A missing
         # lock entry fails loudly before the build starts.
+        #
+        # `runquota` is on the list because this gate runs `just build-once`,
+        # which compiles `ct`, which pulls in src/ct_test/process_exec.nim ->
+        # `import runquota_process`. Under the tup driver this CHECKOUT is the
+        # only way those modules resolve: NIM_REPO_PATH_FLAGS points at
+        # `$(ROOT)/../runquota/...`, and tup's environment allowlist in
+        # src/Tuprules.tup does not carry RUNQUOTA_SRC, so the dev shell's
+        # export of it never reaches `nim`. Its absence is what made this job
+        # die on `cannot open file: runquota_process` (issue #641), fifteen
+        # minutes into the Nim compile rather than here.
         uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
         with:
           env-flavor: nix
@@ -2767,6 +2818,7 @@ jobs:
             codetracer-native-recorder=dev
             codetracer-native-test-programs=dev
             codetracer-visual-replay-fixtures=dev
+            runquota=dev
 
       - name: Run visual replay regression gate
         env:

--- a/scripts/require-siblings.sh
+++ b/scripts/require-siblings.sh
@@ -11,7 +11,7 @@
 # sits next to `<workspace>/isonim`, `<workspace>/io-mon`, ... and both build
 # drivers reach across by relative path:
 #
-#   * Nim   -- `src/Tuprules.tup:47-55` passes `--path:$(ROOT)/../<sibling>/src`
+#   * Nim   -- `src/Tuprules.tup:72-88` passes `--path:$(ROOT)/../<sibling>/src`
 #              unconditionally, and `config.nims` adds the same directories
 #              through `addPathIfDir`.
 #   * Cargo -- `src/db-backend/Cargo.toml` declares `path = "../../../
@@ -96,6 +96,37 @@ sibling_remote_org="${CODETRACER_SIBLING_REMOTE_ORG:-https://github.com/metacraf
 # nim-agent-harbor, nim-agents) -- intersected with what a build here has
 # actually been observed to need.
 #
+# `runquota` was added to that tier after issue #641. `src/ct/codetracer.nim`
+# imports `../ct_test/ct_test`, which reaches `src/ct_test/process_exec.nim` ->
+# `import runquota_process`, so every `ct` build needs it somehow.
+#
+# The two build drivers get it from different places, and that is the whole
+# reason this entry is worded the way it is:
+#
+#   * tup (the Linux default) takes its Nim search path from
+#     `src/Tuprules.tup`'s NIM_REPO_PATH_FLAGS, whose runquota entries are
+#     `$(ROOT)/../runquota/...`. Tup also sanitizes the environment down to that
+#     file's `export` list, which does NOT name RUNQUOTA_SRC. On this driver the
+#     sibling checkout is the ONLY way in.
+#   * reprobuild (Darwin/Windows, opt-in on Linux) resolves runquota as a nix
+#     flake input, with RUNQUOTA_SRC as its repo-path alias (`repro.nim`'s
+#     CodeTracerNixSiblingInputs / CodeTracerRepoEnvAliases). This driver does
+#     not strictly need a checkout at all.
+#
+# The override column is nonetheless left EMPTY, i.e. the checkout is required
+# on both drivers. Honouring RUNQUOTA_SRC here would make this check pass on the
+# strength of a variable tup strips, and hand the tup lane back precisely the
+# `cannot open file: runquota_process` that this entry exists to pre-empt --
+# a false green on the one driver that actually needed the warning. Requiring
+# the checkout keeps ONE workspace-completeness rule that holds on every driver,
+# which is also how every other `--path` sibling in NIM_REPO_PATH_FLAGS is
+# handled. The cost is that a reprobuild-only build now wants a checkout it
+# could have done without; CODETRACER_SKIP_SIBLING_CHECK=1 is the escape hatch.
+#
+# All four jobs that reach `just build-once` (visual-replay-regression-gate,
+# test-ui-tests, viewmodel-tests, cross-process-linux) provision it in
+# .github/workflows/codetracer.yml.
+#
 # Everything else the source references across a relative path goes in the
 # advisory tier: a warning naming the module that will fail to resolve, and a
 # zero exit. `isonim-tui` / `isonim-gpui` / `nim-termctl` / `nim-pty` are on
@@ -110,12 +141,16 @@ sibling_remote_org="${CODETRACER_SIBLING_REMOTE_ORG:-https://github.com/metacraf
 required_siblings=(
 	'isonim|src/isonim.nim|ISONIM_SRC|the reactive UI framework the whole renderer is written against (223 `import isonim/...` sites); also the source `build-tailwind.sh` extracts utility classes from'
 	'nim-agents|src/nim_agents.nim||`import nim_agents` in src/frontend/viewmodel/agent_service.nim and the agentic-session UI'
-	"nim-agent-harbor|src/nim_agent_harbor.nim||the session/worktree backend nim_agents is written against; passed unconditionally by src/Tuprules.tup:54"
-	"nim-acp|src||the Agent Client Protocol bindings src/Tuprules.tup:53 puts on the Nim search path"
-	"nim-everywhere|src||the patched Nim 2.x distribution src/Tuprules.tup:52 puts on the Nim search path"
+	"nim-agent-harbor|src/nim_agent_harbor.nim||the session/worktree backend nim_agents is written against; passed unconditionally by src/Tuprules.tup:79"
+	"nim-acp|src||the Agent Client Protocol bindings src/Tuprules.tup:78 puts on the Nim search path"
+	"nim-everywhere|src||the patched Nim 2.x distribution src/Tuprules.tup:77 puts on the Nim search path"
 	'codetracer-trace-format-nim|src/codetracer_ct_print_lib.nim|CODETRACER_TRACE_FORMAT_NIM_SRC|`ct print` (src/ct/cli/print_trace.nim) imports codetracer_trace_writer/* and codetracer_ct_print_lib'
 	'codetracer-trace-format|codetracer_trace_types/Cargo.toml||five `path = "../../../codetracer-trace-format/..."` dependencies in src/db-backend/Cargo.toml; cargo cannot even parse the manifest without them'
 	'codetracer-native-recorder|ct_emulator/src/ct_emulator/emulator_wasm_api.nim|CT_CODETRACER_NATIVE_RECORDER_SIBLING|src/db-backend/build.rs compiles the Nim MCR emulator from ct_emulator/ and links it as lib${CT_MCR_EMULATOR_LINK_NAME}.so; without it the db-backend link fails with 81 undefined `mcr*` symbols'
+	# Override column deliberately empty -- see the RUNQUOTA_SRC discussion in
+	# the tier notes above. Accepting the env var here would green this check on
+	# the tup driver, which strips it.
+	'runquota|libs/runquota_process/src/runquota_process.nim||`import runquota_process` in src/ct_test/process_exec.nim, reached from EVERY `ct` build via src/ct/codetracer.nim -> ../ct_test/ct_test; src/Tuprules.tup puts libs/runquota_*/src on the Nim search path'
 )
 
 advisory_siblings=(
@@ -123,10 +158,10 @@ advisory_siblings=(
 	'nim-stackable-hooks|src/stackable_hooks.nim|NIM_STACKABLE_HOOKS_SRC|`import stackable_hooks/propagation` in src/ct_test/incremental/io_mon_capture.nim'
 	"nim-shm-queue|src/shm_queue.nim|SHM_QUEUE_SRC|io-mon's dependency queue imports \`shm_queue\`"
 	"nim-shm-gset|src/shm_gset.nim|SHM_GSET_SRC|io-mon's writer imports \`shm_gset/transport\` (the symptom config.nims:74-77 documents)"
-	"isonim-tui|src||src/Tuprules.tup:48 puts it on the Nim search path"
-	"isonim-gpui|src||src/Tuprules.tup:49 puts it on the Nim search path"
-	"nim-termctl|src||src/Tuprules.tup:50 puts it on the Nim search path"
-	"nim-pty|src||src/Tuprules.tup:51 puts it on the Nim search path"
+	"isonim-tui|src||src/Tuprules.tup:73 puts it on the Nim search path"
+	"isonim-gpui|src||src/Tuprules.tup:74 puts it on the Nim search path"
+	"nim-termctl|src||src/Tuprules.tup:75 puts it on the Nim search path"
+	"nim-pty|src||src/Tuprules.tup:76 puts it on the Nim search path"
 )
 
 if [ -n "${CODETRACER_STRICT_SIBLING_CHECK:-}" ]; then

--- a/src/Tuprules.tup
+++ b/src/Tuprules.tup
@@ -23,6 +23,31 @@ NIM_COMMON_FLAGS=\
 
 ROOT = $(TUP_CWD)/../../
 
+# The Nim search path for every binary this build produces.
+#
+# On the runquota entries at the end of the list: `src/ct/codetracer.nim`
+# imports `../ct_test/ct_test`, which reaches `src/ct_test/process_exec.nim` ->
+# `import runquota_process`, so every `ct` build needs runquota's libraries
+# here. They are declared in this file, rather than left to a config file,
+# because neither config that mentions runquota is consulted for this compile:
+#
+#   * `src/ct_test/nim.cfg` and `src/ct_test/config.nims` are read only when the
+#     PROJECT DIRECTORY is `src/ct_test` -- which is how
+#     `ci/test/m16-release-gate.sh` compiles the ct_test suites, so there they
+#     are load-bearing and must stay. Tup's project directory is `src/ct`, a
+#     SIBLING of `src/ct_test`, and Nim reads config files from the project
+#     directory and its ANCESTORS only, so they contribute nothing to `ct`.
+#   * the repo-root `config.nims` IS read here (it is an ancestor) and does
+#     carry a runquota block -- but its two sources are `getEnv("RUNQUOTA_SRC")`
+#     and the `../runquota` sibling checkout. Tup sanitizes the environment down
+#     to the `export` list further down this file, which does not name
+#     `RUNQUOTA_SRC`, so under tup only the sibling checkout can ever resolve.
+#
+# Listing them here makes the tup build state its own dependency instead of
+# inheriting it from a config whose env half is stripped. It does NOT remove the
+# need for the checkout: `$(ROOT)/../runquota` still has to exist, which is what
+# `scripts/require-siblings.sh` checks for by name and what the `siblings:`
+# lists in .github/workflows/codetracer.yml provision.
 NIM_REPO_PATH_FLAGS=\
 --path:$(ROOT)/libs/NimYAML\
 --path:$(ROOT)/libs/asynctools\
@@ -52,7 +77,15 @@ NIM_REPO_PATH_FLAGS=\
 --path:$(ROOT)/../nim-everywhere/src\
 --path:$(ROOT)/../nim-acp/src\
 --path:$(ROOT)/../nim-agent-harbor/src\
---path:$(ROOT)/../nim-agents/src
+--path:$(ROOT)/../nim-agents/src\
+--path:$(ROOT)/../runquota/libs/runquota_process/src\
+--path:$(ROOT)/../runquota/libs/runquota_core/src\
+--path:$(ROOT)/../runquota/libs/runquota_host/src\
+--path:$(ROOT)/../runquota/libs/runquota_host_linux/src\
+--path:$(ROOT)/../runquota/libs/runquota_host_macos/src\
+--path:$(ROOT)/../runquota/libs/runquota_host_windows/src\
+--path:$(ROOT)/../runquota/libs/runquota_codec/src\
+--path:$(ROOT)/../runquota/libs/runquota_protocol/src
 
 NIM_DEBUG_FLAGS=\
 $(NIM_COMMON_FLAGS)\

--- a/src/ct_test/config.nims
+++ b/src/ct_test/config.nims
@@ -1,3 +1,9 @@
+# SCOPE: this file is read only when the project directory is `src/ct_test`
+# (the ct_test suites compiled by ci/test/m16-release-gate.sh). It is NOT read
+# for the `ct` binary, whose project directory is the sibling `src/ct`. See the
+# SCOPE note at the top of nim.cfg beside this file for the full explanation and
+# for where `ct` gets these same dependencies (issue #641).
+#
 # RUNQUOTA_SRC fallback for the runquota_process import paths.
 #
 # nim.cfg (next to this file) lists the runquota library paths relative to a

--- a/src/ct_test/nim.cfg
+++ b/src/ct_test/nim.cfg
@@ -1,3 +1,23 @@
+# SCOPE — read this before adding anything here (issue #641).
+#
+# Nim reads config files from the PROJECT DIRECTORY and its ANCESTORS. This file
+# therefore applies only when the project directory IS `src/ct_test` — that is,
+# when something compiles a module that lives in this directory, which is what
+# `ci/test/m16-release-gate.sh` does for the ct_test suites
+# (`nim c src/ct_test/<name>_test.nim`, `nim c src/ct_test/ct_test.nim`). For
+# those compiles this file and config.nims beside it are load-bearing.
+#
+# It does NOT apply to the `ct` binary, even though `ct` compiles these very
+# sources: `src/ct/codetracer.nim` imports `../ct_test/ct_test`, so the project
+# directory is `src/ct` — a SIBLING of this one, not a descendant. Nothing in
+# this file is consulted for that build. `ct` gets the same dependencies from
+# `src/Tuprules.tup`'s NIM_REPO_PATH_FLAGS (tup driver) or `repro.nim`
+# (reprobuild driver), and the repo-root `config.nims`, which IS an ancestor of
+# `src/ct`. A path added ONLY here will compile the ct_test suites and then fail
+# the `ct` build with a bare `cannot open file:` — which is exactly how the
+# missing runquota entry in NIM_REPO_PATH_FLAGS stayed hidden. Add to all the
+# places the dependency is actually consumed, not just this one.
+#
 # ct_test routes process launch through the shared runner (runquota_process)
 # in the runquota repo (see process_exec.nim). That source is not vendored
 # under codetracer's libs/; in a workspace checkout it is the sibling repo,


### PR DESCRIPTION
Fixes #641. Sits on top of #640 in the `visual-replay-regression-gate` failure
queue: #640 clears the private-Cargo preflight, this clears the `build-once`
step immediately after it. The two touch disjoint files and can land in either
order.

## What actually causes it (the issue's mechanism is partly wrong)

#641 says the runquota paths are unreachable because "Nim reads `config.nims`
from the project directory only", so the repo-root `config.nims` is not
consulted. That is not right, and it matters: Nim reads `config.nims` from the
project directory **and its ancestors**, so the repo-root file *is* read for a
`src/ct` project. Verified directly:

```
$ nim dump --dump.format:json src/ct/codetracer.nim   # runquota checked out
/home/zahary/m/repro-fixes/runquota/libs/runquota_process/src
... 8 runquota paths present
```

The half of the mechanism that holds is the **sibling** half: `src/ct_test/nim.cfg`
and `src/ct_test/config.nims` are not ancestors of `src/ct`, so they contribute
nothing to `ct`.

So the real cause is narrower, and it is not "no declaration exists" but "every
declaration that exists needs something CI does not provide":

| source | status for the tup `ct` compile |
|---|---|
| `src/ct_test/nim.cfg` / `config.nims` | not read — sibling directory, not an ancestor |
| repo-root `config.nims`, `RUNQUOTA_SRC` branch | read, but tup sanitizes the environment to the `export` list in `src/Tuprules.tup`, which does **not** name `RUNQUOTA_SRC` |
| repo-root `config.nims`, `../runquota` sibling branch | read, and works — **but nothing checks the sibling out** |
| `src/Tuprules.tup` NIM_REPO_PATH_FLAGS | no runquota entry at all |

The load-bearing omission is therefore the missing **checkout**: the gate's
`siblings:` list never asked for `runquota`. Adding the `--path` flags alone
would not have fixed CI, because they point at `$(ROOT)/../runquota` too.

## Changes

1. `src/Tuprules.tup` — the eight runquota library paths on NIM_REPO_PATH_FLAGS,
   so the tup build states its own dependency rather than inheriting it from a
   config whose environment half is stripped.
2. `scripts/require-siblings.sh` — `runquota` in the **required** tier. Override
   column deliberately empty: accepting `RUNQUOTA_SRC` would green the check on
   the strength of a variable tup discards, and hand the job back the same
   `cannot open file`.
3. All four jobs that reach `just build-once` provision it —
   `visual-replay-regression-gate` and `test-ui-tests` via `siblings:`,
   `viewmodel-tests` and `cross-process-linux` via an explicit clone step
   (neither of their composite actions owns this dependency).
4. `src/ct_test/nim.cfg` and `config.nims` keep a scope note. They are **not**
   dead — `ci/test/m16-release-gate.sh` compiles `src/ct_test/*.nim`, making
   `src/ct_test` the project directory, and there they are load-bearing. They
   are only silent for `ct`. The note records that boundary, since a file that
   looks authoritative and is conditionally ignored is how this stayed hidden.

## Validation (local, in the dev shell)

Reproduced and fixed on the real import chain, project dir `src/ct`, configs
disabled so only NIM_REPO_PATH_FLAGS is in play:

```
BEFORE (flags as on dev): src/ct_test/process_exec.nim(25, 8) Error: cannot open file: runquota_process
AFTER  (flags as in this PR): binary built, runquota_process resolved
```

The `BEFORE` line is byte-identical to what the gate reported.

`just build-once` was run end to end. The `ct` compile it now emits carries the
runquota paths and produces **zero** `cannot open file` errors. It does not go
fully green on this host for two pre-existing, unrelated reasons: 8 Nim targets
fail on `could not load: libpcre.so` (the dev shell exposes pcre only through
`LD_LIBRARY_PATH`, which tup strips — it is not on the `export` list), and
`codetracer_trace_writer_nim`'s build script exits 101. Neither is touched by
this change and neither occurs on the CI runner, which got past every Nim
compile to reach the runquota error.

Mutation check on the new prerequisite:

```
runquota present -> exit 0
runquota removed -> exit 1
  * runquota
      expected:  <workspace>/runquota/libs/runquota_process/src/runquota_process.nim
      state:     not checked out
```

`ci/lint/bash.sh` and `scripts/test-build-alignment.sh` (63 checks) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)