### PR TITLE
ci(windows): let the Windows jobs run

### DIFF
--- a/.github/actions/setup-db-backend-siblings/action.yml
+++ b/.github/actions/setup-db-backend-siblings/action.yml
@@ -5,11 +5,32 @@ description: >
   codetracer-native-recorder), each at the revision pinned by the
   repo-workspaces workspace lock. This is a thin wrapper over the shared
   ``setup-dev-env`` action: it clones the three siblings adjacent to the
-  host checkout (``../<name>``) and installs the ``dev-exec`` wrapper. Nix
-  itself is installed by ``setup-dev-env`` when ``env-flavor: nix``; jobs
-  that already run their own ``setup-nix`` step can still call this action —
-  installing Nix twice is idempotent.
+  host checkout (``../<name>``) and installs the ``dev-exec`` wrapper.
+
+  Sibling cloning happens for every ``env-flavor``; the flavor decides only
+  which dev environment is materialised alongside it. Nix itself is installed
+  by ``setup-dev-env`` when ``env-flavor: nix``; jobs that already run their
+  own ``setup-nix`` step can still call this action — installing Nix twice is
+  idempotent.
 inputs:
+  env-flavor:
+    description: >
+      Which dev environment ``setup-dev-env`` should materialise alongside the
+      sibling clones: ``nix``, ``windows-diy`` or ``reprobuild``.
+
+      THERE IS NO DEFAULT, AND THAT IS THE POINT. This action hard-coded
+      ``nix`` for all of its callers, and ``nix`` cannot be installed on a
+      Windows runner at all: ``DeterminateSystems/nix-installer-action`` has no
+      Windows platform mapping, so the step aborts with "ArchOs (X64-Windows)
+      doesn't map to a supported Nix platform" before the calling job runs a
+      single step of its own. Windows callers pass ``windows-diy``, which
+      sources the repo's ``env.ps1``. A caller that says nothing gets an empty
+      value, which ``setup-dev-env``'s own ``Validate env-flavor`` step
+      rejects by name — a loud failure rather than a silently wrong platform.
+
+      ``ci/test/windows-runner-bootstrap-test.sh`` fails if a job on a Windows
+      runner reaches this action with the ``nix`` flavor.
+    required: true
   gh-token:
     description: GitHub token with access to sibling repositories.
     required: true
@@ -24,7 +45,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup dev env (clone db-backend siblings + install Nix)
+    - name: Setup dev env (clone db-backend siblings + materialise the dev env)
       # setup-dev-env clones each sibling to ../<name> at its pinned `dev`
       # ref. The refs are explicit because a bare entry resolves through a
       # per-commit workspace lock in the shared manifests repo, which has
@@ -39,7 +60,7 @@ runs:
       # needs it, and those jobs already perform it).
       uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
       with:
-        env-flavor: nix
+        env-flavor: ${{ inputs.env-flavor }}
         gh-token: ${{ inputs.gh-token }}
         substituters: ${{ inputs.substituters }}
         trusted-public-keys: ${{ inputs.trusted-public-keys }}

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -394,8 +394,25 @@ jobs:
           token: ${{ steps.ci_token.outputs.token }}
 
       - name: Setup db-backend siblings
+        # This job needs exactly one thing from this action: the three
+        # db-backend sibling checkouts. It provisions its own toolchain right
+        # below (`ensure-origin-dap-windows-toolchain.ps1` downloads pinned
+        # capnp/nim/just; Rust and Python come from their own actions) and it
+        # never calls `dev-exec`.
+        #
+        # The flavor is `windows-diy` because `nix` is not merely unnecessary
+        # here, it is impossible: it installs Nix through
+        # DeterminateSystems/nix-installer-action, which has no Windows
+        # platform mapping, and the step aborts with "ArchOs (X64-Windows)
+        # doesn't map to a supported Nix platform" before this job reaches any
+        # step of its own. `windows-diy` sources env.ps1 instead -- the same
+        # flavor windows-rust-components and windows-headless-test already use
+        # on this runner class, and the reason `npm` resolves in "Generate
+        # tree-sitter-nim parser" below, since nothing else in this job
+        # provides Node.
         uses: ./.github/actions/setup-db-backend-siblings
         with:
+          env-flavor: windows-diy
           gh-token: ${{ steps.ci_token.outputs.token }}
 
       - name: Install Rust toolchain
@@ -553,8 +570,13 @@ jobs:
           token: ${{ steps.ci_token.outputs.token }}
 
       - name: Setup db-backend siblings
+        # `windows-diy`, for the reason spelled out in the per-PR job above:
+        # the `nix` flavor cannot install Nix on a Windows runner, and this
+        # job wants the sibling checkouts, not a Nix shell. Keep the two in
+        # step.
         uses: ./.github/actions/setup-db-backend-siblings
         with:
+          env-flavor: windows-diy
           gh-token: ${{ steps.ci_token.outputs.token }}
 
       - name: Install Rust toolchain
@@ -1417,6 +1439,7 @@ jobs:
       - name: Setup db-backend siblings
         uses: ./.github/actions/setup-db-backend-siblings
         with:
+          env-flavor: nix
           gh-token: ${{ steps.ci_token.outputs.token }}
 
       - name: Run required materialized Python origin-DAP gate
@@ -1471,6 +1494,7 @@ jobs:
       - name: Setup db-backend siblings
         uses: ./.github/actions/setup-db-backend-siblings
         with:
+          env-flavor: nix
           gh-token: ${{ steps.ci_token.outputs.token }}
 
       - name: Run routed materialized origin-DAP matrix
@@ -1509,6 +1533,7 @@ jobs:
       - name: Setup db-backend siblings
         uses: ./.github/actions/setup-db-backend-siblings
         with:
+          env-flavor: nix
           gh-token: ${{ steps.ci_token.outputs.token }}
 
       - name: Setup isonim siblings
@@ -1823,6 +1848,7 @@ jobs:
       - name: Setup db-backend siblings
         uses: ./.github/actions/setup-db-backend-siblings
         with:
+          env-flavor: nix
           gh-token: ${{ steps.ci_token.outputs.token }}
 
       - name: Install Nix

--- a/ci/ensure-git-for-checkout.ps1
+++ b/ci/ensure-git-for-checkout.ps1
@@ -345,6 +345,78 @@ function Add-CodeTracerGitLongPathEnvironment {
   $env:GIT_CONFIG_VALUE_0 = "true"
 }
 
+function Invoke-CodeTracerGitCommand {
+  param(
+    [Parameter(Mandatory)][string]$GitPath,
+    [Parameter(Mandatory)][string[]]$Arguments
+  )
+
+  $output = (& $GitPath @Arguments 2>&1 | Out-String)
+  $status = $LASTEXITCODE
+  if ($null -eq $status) {
+    $status = if ($?) { 0 } else { 1 }
+  }
+  return [PSCustomObject]@{
+    ExitCode = $status
+    Output = $output.Trim()
+  }
+}
+
+function Enable-CodeTracerGitSystemLongPaths {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][string]$GitPath,
+    [scriptblock]$GitRunner = {
+      param($gitPath, $arguments)
+      Invoke-CodeTracerGitCommand -GitPath $gitPath -Arguments $arguments
+    }
+  )
+
+  # Windows refuses paths longer than MAX_PATH (260 characters), and Git for
+  # Windows gates its `\\?\` long-path expansion on `core.longpaths`. The gate
+  # is git's own: without this key git fails with "Filename too long" even on a
+  # host where the machine-wide LongPathsEnabled policy is already set, so the
+  # registry policy (which every OTHER tool needs) is not a substitute for it.
+  # codetracer's recursively nested submodules cross 260 characters under the
+  # runner's `C:\actions-runner\_work\...` workspace, which is where the
+  # eph-win-x64 jobs were dying.
+  #
+  # This is the SYSTEM scope, and it is not a duplicate of the job-scoped
+  # numbered environment installed below. That environment reaches the git
+  # processes this job's own steps launch; `actions/checkout` is a separate
+  # action that runs its own git -- and, for `submodules: recursive`, a tree of
+  # further git processes below that -- so the setting has to live somewhere
+  # that does not depend on the environment being handed down intact. A
+  # configuration FILE is read by every git process on the machine whatever
+  # environment it was given. `--local` and `--global` would not do: the deep
+  # paths are inside the submodules, and each submodule is its own repository,
+  # cloned by a process that never reads the superproject's config.
+  # https://git-scm.com/docs/git-config#Documentation/git-config.txt-corelongpaths
+  $set = & $GitRunner $GitPath `
+    @("config", "--system", "--replace-all", "core.longpaths", "true")
+  if ($null -eq $set -or $set.ExitCode -ne 0) {
+    $detail = if ($null -eq $set) { "no result" } else { "git exit $($set.ExitCode): $($set.Output)" }
+    throw "Enabling core.longpaths in the system Git configuration failed ($detail)."
+  }
+
+  # Read it back rather than trusting the exit status. `git config --system`
+  # writes into the Git installation's own configuration file, which the runner
+  # account may not own; a write that is reported as successful but lands
+  # nowhere would otherwise surface minutes later, in the middle of
+  # actions/checkout, as the original "Filename too long" -- with nothing
+  # pointing at the cause. Failing here fails the job's FIRST step instead.
+  $read = & $GitRunner $GitPath @("config", "--system", "--get", "core.longpaths")
+  if ($null -eq $read) {
+    throw "Reading back the system core.longpaths setting produced no result."
+  }
+  $value = ([string]$read.Output).Trim()
+  if ($read.ExitCode -ne 0 -or $value -cne "true") {
+    throw ("Windows long-path support is not enabled: system core.longpaths " +
+      "reads back as '$value' (git exit $($read.ExitCode)).")
+  }
+  return $value
+}
+
 function Ensure-CodeTracerGitForCheckout {
   [CmdletBinding()]
   param(
@@ -359,6 +431,10 @@ function Ensure-CodeTracerGitForCheckout {
       Install-CodeTracerPortableGit `
         -Destination $destination `
         -VersionReader $versionReader
+    },
+    [scriptblock]$EnableSystemLongPaths = {
+      param($gitPath)
+      Enable-CodeTracerGitSystemLongPaths -GitPath $gitPath
     }
   )
 
@@ -381,6 +457,12 @@ function Ensure-CodeTracerGitForCheckout {
   $entries = @(Add-CodeTracerGitToPath `
     -GitPath $git.Path `
     -GitHubPathFile $GitHubPathFile)
+  # Both long-path channels are installed here, before this function returns,
+  # because the step that returns from it is immediately followed by
+  # actions/checkout. The selected git is named by absolute path so the system
+  # write goes to the installation that checkout will actually use, not to
+  # whichever git happens to be first on PATH.
+  & $EnableSystemLongPaths $git.Path | Out-Null
   Add-CodeTracerGitLongPathEnvironment -GitHubEnvFile $GitHubEnvFile
   Write-Host "Using git version $verifiedVersion from $($git.Path) for checkout."
   return [PSCustomObject]@{

--- a/ci/test/ensure-git-for-checkout.ps1
+++ b/ci/test/ensure-git-for-checkout.ps1
@@ -96,6 +96,7 @@ $savedGitConfigParameters = $env:GIT_CONFIG_PARAMETERS
 $savedGitConfigCount = $env:GIT_CONFIG_COUNT
 $savedGitConfigKey0 = $env:GIT_CONFIG_KEY_0
 $savedGitConfigValue0 = $env:GIT_CONFIG_VALUE_0
+$savedGitConfigSystem = $env:GIT_CONFIG_SYSTEM
 $hostGit = (Get-Command git -ErrorAction Stop).Source
 
 try {
@@ -128,19 +129,33 @@ try {
     [IO.File]::WriteAllText($githubPath, "")
     [IO.File]::WriteAllText($githubEnv, "")
     $env:PATH = "original-path"
-    $state = [PSCustomObject]@{ Provisioned = $false }
+    # The candidate git.exe here is a text fixture, so the system-scope write is
+    # recorded rather than executed. What the recorder asserts is the WIRING --
+    # that the entry point performs the opt-in exactly once, against the git it
+    # selected. `Enable-CodeTracerGitSystemLongPaths` itself is exercised
+    # against the real binary further below.
+    $state = [PSCustomObject]@{ Provisioned = $false; LongPathCalls = 0; LongPathGit = "" }
     $result = Ensure-CodeTracerGitForCheckout `
       -Destination (Join-Path $caseRoot "must-not-install") `
       -GitHubPathFile $githubPath `
       -GitHubEnvFile $githubEnv `
       -CandidateProvider { @($git) } `
       -VersionReader { param($path) [Version]"2.51.2" } `
+      -EnableSystemLongPaths {
+        param($gitPath)
+        $state.LongPathCalls += 1
+        $state.LongPathGit = $gitPath
+      } `
       -ProvisionGit {
         param($destination, $versionReader)
         $state.Provisioned = $true
         throw "provisioning must not run"
       }
     Assert-True (-not $state.Provisioned) "A supported existing Git triggered provisioning."
+    Assert-True ($state.LongPathCalls -eq 1) `
+      "The bootstrap did not enable system long-path support exactly once."
+    Assert-True ($state.LongPathGit -ceq (Resolve-Path $git).Path) `
+      "System long-path support was not enabled through the selected Git."
     Assert-True ($result.Path -ceq (Resolve-Path $git).Path) `
       "The supported Git candidate was not selected."
     Assert-True ($result.Version -eq [Version]"2.51.2") `
@@ -186,7 +201,12 @@ try {
     [IO.File]::WriteAllText($githubEnv, "")
     $assetBytes = [Text.Encoding]::UTF8.GetBytes("reviewed portable git fixture")
     $assetSha = Get-BytesSha256 $assetBytes
-    $state = [PSCustomObject]@{ Downloads = 0; Extractions = 0 }
+    $state = [PSCustomObject]@{
+      Downloads = 0
+      Extractions = 0
+      LongPathCalls = 0
+      LongPathGit = ""
+    }
     $env:PATH = "runner-path-without-git-or-choco"
 
     $result = Ensure-CodeTracerGitForCheckout `
@@ -195,6 +215,11 @@ try {
       -GitHubEnvFile $githubEnv `
       -CandidateProvider { @() } `
       -VersionReader { param($path) [Version]"2.55.0" } `
+      -EnableSystemLongPaths {
+        param($gitPath)
+        $state.LongPathCalls += 1
+        $state.LongPathGit = $gitPath
+      } `
       -ProvisionGit {
         param($installDestination, $versionReader)
         Install-CodeTracerPortableGit `
@@ -225,6 +250,10 @@ try {
       "PortableGit did not propagate both cmd and bin."
     Assert-True (@(Get-ChildItem -LiteralPath $caseRoot -Filter '*.exe').Count -eq 0) `
       "The verified self-extracting archive was not cleaned up."
+    Assert-True ($state.LongPathCalls -eq 1) `
+      "The bootstrap did not enable system long-path support exactly once."
+    Assert-True ($state.LongPathGit -ceq $result.Path) `
+      "System long-path support was not enabled through the provisioned Git."
   }
 
   Invoke-Test "rejects an artifact whose SHA256 does not match" {
@@ -507,6 +536,77 @@ try {
       Remove-Item -LiteralPath Env:GIT_CONFIG_VALUE_1 -ErrorAction SilentlyContinue
     }
   }
+
+  # The system-scoped opt-in, exercised against the real git binary rather than
+  # a stub. `git config --system` honours $GIT_CONFIG_SYSTEM, so the scope can
+  # be redirected at a temporary file and the write, the read-back and the
+  # resulting file are all genuine.
+  # https://git-scm.com/docs/git-config#Documentation/git-config.txt-GITCONFIGSYSTEM
+  Invoke-Test "enables Windows long paths in the system Git configuration" {
+    $caseRoot = New-TestDirectory "system-longpaths"
+    $systemConfig = Join-Path $caseRoot "gitconfig-system"
+    $env:GIT_CONFIG_SYSTEM = $systemConfig
+    try {
+      Assert-True (-not (Test-Path -LiteralPath $systemConfig)) `
+        "The system configuration fixture existed before the opt-in ran."
+      $value = Enable-CodeTracerGitSystemLongPaths -GitPath $hostGit
+      Assert-True ($value -ceq "true") `
+        "The opt-in did not report the value it read back."
+      Assert-True (Test-Path -LiteralPath $systemConfig -PathType Leaf) `
+        "The opt-in did not write git's system configuration file."
+      $observed = (& $hostGit config --system --get core.longpaths)
+      Assert-True ($LASTEXITCODE -eq 0 -and $observed -ceq "true") `
+        "git does not resolve core.longpaths to true in the system scope."
+    }
+    finally {
+      $env:GIT_CONFIG_SYSTEM = $savedGitConfigSystem
+    }
+  }
+
+  # The failure the read-back exists for: `git config` reporting success while
+  # persisting nothing, which is what an unreachable or unwritable system scope
+  # looks like from the caller's side.
+  #
+  # MOCK JUSTIFIED. This is the one branch a real binary cannot be driven into:
+  # git either writes the value and reports success, or reports failure. An
+  # injected runner is the only way to observe that the read-back -- rather than
+  # the exit status -- is what gates the step. It also records the exact
+  # argument vectors, so a fix that quietly changed scope (`--global`, which
+  # does not reach submodule clones) is caught here too. Every other assertion
+  # about this function above and below runs the real git.
+  Invoke-Test "fails closed when the system configuration does not take" {
+    $recorded = New-Object Collections.ArrayList
+    Assert-Throws -ExpectedMessage "reads back as" -Action {
+      Enable-CodeTracerGitSystemLongPaths `
+        -GitPath "git" `
+        -GitRunner {
+          param($gitPath, $arguments)
+          [void]$recorded.Add(($arguments -join " "))
+          [PSCustomObject]@{ ExitCode = 0; Output = "" }
+        } | Out-Null
+    }
+    Assert-True ($recorded.Count -eq 2) `
+      "The opt-in did not both write and read the setting back."
+    Assert-True ($recorded[0] -ceq "config --system --replace-all core.longpaths true") `
+      "The opt-in did not enable core.longpaths in git's system scope."
+    Assert-True ($recorded[1] -ceq "config --system --get core.longpaths") `
+      "The opt-in did not read the system value back."
+  }
+
+  Invoke-Test "propagates a failed system configuration write" {
+    $caseRoot = New-TestDirectory "system-longpaths-unwritable"
+    $directoryInsteadOfFile = Join-Path $caseRoot "gitconfig-system-directory"
+    New-Item -ItemType Directory -Path $directoryInsteadOfFile | Out-Null
+    $env:GIT_CONFIG_SYSTEM = $directoryInsteadOfFile
+    try {
+      Assert-Throws -ExpectedMessage "system Git configuration failed" -Action {
+        Enable-CodeTracerGitSystemLongPaths -GitPath $hostGit | Out-Null
+      }
+    }
+    finally {
+      $env:GIT_CONFIG_SYSTEM = $savedGitConfigSystem
+    }
+  }
 }
 finally {
   $env:PATH = $savedPath
@@ -514,10 +614,11 @@ finally {
   $env:GIT_CONFIG_COUNT = $savedGitConfigCount
   $env:GIT_CONFIG_KEY_0 = $savedGitConfigKey0
   $env:GIT_CONFIG_VALUE_0 = $savedGitConfigValue0
+  $env:GIT_CONFIG_SYSTEM = $savedGitConfigSystem
   Remove-Item -LiteralPath $script:TestRoot -Recurse -Force -ErrorAction SilentlyContinue
 }
 
-if ($script:Passed -ne 16) {
-  throw "Expected 16 Git bootstrap tests, but $($script:Passed) passed."
+if ($script:Passed -ne 19) {
+  throw "Expected 19 Git bootstrap tests, but $($script:Passed) passed."
 }
-Write-Host "Git bootstrap contract tests passed: 16/16"
+Write-Host "Git bootstrap contract tests passed: 19/19"

--- a/ci/test/windows-runner-bootstrap-test.sh
+++ b/ci/test/windows-runner-bootstrap-test.sh
@@ -60,6 +60,14 @@
 #      execution on the runner.
 #   6. The set of eph-win-x64 jobs is non-empty (a rename of the runner class
 #      must not turn this suite into a vacuous pass).
+#   7. Every Windows job that reaches `setup-dev-env` -- directly or through a
+#      local composite action -- asks it for a flavor that can exist on
+#      Windows. The `nix` flavor cannot: it installs Nix through
+#      `DeterminateSystems/nix-installer-action`, which has no Windows platform
+#      mapping. `origin-dap-windows` died that way 56 times, in the wrapper
+#      action `setup-db-backend-siblings`, which hard-coded `env-flavor: nix`
+#      for all six of its callers -- four of them Linux/macOS. Section 4 has
+#      its own header with the details.
 #
 # # No mocks
 #
@@ -77,12 +85,40 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 readonly REPO_ROOT
 WORKFLOW="${1:-$REPO_ROOT/.github/workflows/codetracer.yml}"
 readonly WORKFLOW
+# Local composite actions a job can reach `setup-dev-env` through. Section 4
+# follows that indirection: the flavor a Windows job ends up with is not
+# necessarily written in the workflow.
+ACTIONS_DIR="${2:-$REPO_ROOT/.github/actions}"
+readonly ACTIONS_DIR
 BOOTSTRAP_SCRIPT="$REPO_ROOT/ci/ensure-git-for-checkout.ps1"
 readonly BOOTSTRAP_SCRIPT
 
 # The exact display name every eph-win-x64 job must open with.
 readonly BOOTSTRAP_STEP_NAME="Ensure Git and Git Bash are on PATH"
 readonly WINDOWS_RUNNER_LABEL="eph-win-x64"
+# Every runner label that lands a job on Windows. `eph-win-x64` is the only one
+# in use today; the rest are the labels a Windows job could plausibly be moved
+# to (the hosted images the lane came from, and the arm64 class the header note
+# says to revisit). Section 4's contract is about the OS, not about one class,
+# and must not be escapable by relabelling.
+readonly WINDOWS_RUNNER_LABELS="eph-win-x64 eph-win-arm64 windows-latest windows-2025 windows-2022 windows-2019 windows-11-arm"
+# The action that materialises a job's dev environment, and the flavor of it
+# that cannot exist on Windows.
+readonly SETUP_DEV_ENV_USES="metacraft-labs/metacraft-github-actions/setup-dev-env@"
+readonly NIX_FLAVOR="nix"
+# The flavors `setup-dev-env` accepts, minus `nix`. Anything outside this set
+# fails the action's own `Validate env-flavor` step on the runner; asserting it
+# here means a typo is a red test rather than a red job.
+readonly NON_NIX_FLAVORS="windows-diy reprobuild"
+# How many places a Windows job reaches `setup-dev-env` from. Today: four --
+# `windows-rust-components` and `windows-headless-test` use it directly, and
+# `origin-dap-windows` plus `origin-dap-windows-nightly` reach it through
+# `.github/actions/setup-db-backend-siblings`. A floor rather than an equality
+# so adding a Windows job is not a test edit, but dropping below it means the
+# scanner (or the workflow) changed shape and this contract must be RETARGETED,
+# not deleted: with zero sites found, every per-site assertion below vanishes
+# and the suite passes while asserting nothing.
+readonly MIN_WINDOWS_DEV_ENV_SITES=4
 # The only origin the bootstrap may be fetched from. Everything under this
 # prefix is this repository at a pinned commit; anything else is somebody
 # else's code running on the runner before the checkout has even happened.
@@ -174,6 +210,16 @@ declare -A job_bootstrap_body=()
 # so renaming the step cannot drop it out of the contract.
 declare -a wsl_stub_jobs=()
 declare -A job_wsl_stub_body=()
+# Every job whose `runs-on:` names a Windows runner, by ANY of the labels in
+# WINDOWS_RUNNER_LABELS -- not just the one class the lane happens to use
+# today. Section 4 below walks this set; a job moved to `eph-win-arm64` or
+# back onto a hosted `windows-*` image must not fall out of the dev-env
+# contract just because the label changed.
+declare -a windows_runner_jobs=()
+# job -> its steps, each step's list-item text and body concatenated and
+# separated by a record separator (\x1e). Section 4 needs the `uses:` of every
+# step, which the two contracts above never had to look at.
+declare -A job_step_blobs=()
 
 current_job=""
 current_runs_on=""
@@ -182,6 +228,7 @@ seen_any_step=""
 seen_first_step=""
 step_index=0
 current_step_name=""
+current_step_item=""
 current_step_body=""
 
 trim_trailing() {
@@ -199,6 +246,10 @@ flush_step() {
 	if [[ $current_step_body == *'System32\bash.exe'* ]]; then
 		job_wsl_stub_body["$current_job"]+="$current_step_body"
 	fi
+	# Section 4 reads `uses:`, which for an unnamed step lives in the list-item
+	# text rather than in the body, so both halves go into the blob.
+	job_step_blobs["$current_job"]+="$current_step_item"$'\n'"$current_step_body"$'\x1e'
+	current_step_item=""
 	current_step_body=""
 }
 
@@ -206,13 +257,33 @@ flush_step() {
 # called.
 begin_step() {
 	local name="$1"
+	local item="${2:-}"
 	flush_step
 	step_index=$((step_index + 1))
 	current_step_name="$name"
+	current_step_item="$item"
 	if [ -z "$seen_any_step" ]; then
 		seen_any_step="yes"
 		seen_first_step="$name"
 	fi
+}
+
+# Is this `runs-on:` value a Windows runner? Matched against the label list
+# rather than against one hard-coded class, so retiring or adding a Windows
+# runner class cannot silently empty section 4's job set.
+is_windows_runs_on() {
+	local value="$1"
+	local label token
+	# `runs-on:` is either a scalar label or a flow sequence of labels
+	# (`[self-hosted, gpu]`); both forms must be classified, or a Windows job
+	# escapes this contract by being written the other way round.
+	value="${value//[\[\],]/ }"
+	for label in $WINDOWS_RUNNER_LABELS; do
+		for token in $value; do
+			[ "$token" = "$label" ] && return 0
+		done
+	done
+	return 1
 }
 
 flush_job() {
@@ -224,8 +295,12 @@ flush_job() {
 			wsl_stub_jobs+=("$current_job")
 		fi
 	fi
+	if [ -n "$current_job" ] && is_windows_runs_on "$current_runs_on"; then
+		windows_runner_jobs+=("$current_job")
+	fi
 	step_index=0
 	current_step_name=""
+	current_step_item=""
 	current_step_body=""
 }
 
@@ -268,11 +343,11 @@ while IFS= read -r line; do
 	if [[ $line =~ ^\ \ \ \ \ \ -\ (.*)$ ]]; then
 		step_item="$(trim_trailing "${BASH_REMATCH[1]}")"
 		if [[ $step_item =~ ^name:[[:space:]]+(.*)$ ]]; then
-			begin_step "$(trim_trailing "${BASH_REMATCH[1]}")"
+			begin_step "$(trim_trailing "${BASH_REMATCH[1]}")" "$step_item"
 		else
 			# An unnamed step. Keep the item text so the failure message can
 			# point at the thing that was inserted.
-			begin_step "<unnamed step #$((step_index + 1)): - $step_item>"
+			begin_step "<unnamed step #$((step_index + 1)): - $step_item>" "$step_item"
 		fi
 		continue
 	fi
@@ -450,13 +525,262 @@ for job in "${wsl_stub_jobs[@]+"${wsl_stub_jobs[@]}"}"; do
 done
 
 # ---------------------------------------------------------------------------
+# 4. The dev-env flavor every Windows job asks `setup-dev-env` for.
+#
+# `setup-dev-env` takes an `env-flavor`, and the `nix` one installs Nix through
+# `DeterminateSystems/nix-installer-action`. That installer has no Windows
+# platform mapping, so on any Windows runner the step dies with
+#
+#     ArchOs (X64-Windows) doesn't map to a supported Nix platform
+#
+# ...before the job reaches a single one of its own steps. `origin-dap-windows`
+# failed that way 56 times: its "Setup db-backend siblings" step is a thin
+# wrapper over `setup-dev-env`, and the wrapper hard-coded `env-flavor: nix`
+# for all six of its callers, four of which are Linux/macOS.
+#
+# The flavor is not a style choice on Windows -- `nix` cannot work there. The
+# two flavors that can are `windows-diy` (source the repo's `env.ps1`) and
+# `reprobuild`. What a Windows job needs OUT of the action is the cross-repo
+# sibling clones, which every flavor performs before it branches on flavor at
+# all.
+#
+# What is asserted:
+#
+#   a. Every step of a Windows job that reaches `setup-dev-env` -- directly, or
+#      through a local composite under `.github/actions/` -- resolves to a
+#      concrete flavor. An empty one is not benign: the composite's input has
+#      no default, so a caller that forgets it passes the empty string and the
+#      action's `Validate env-flavor` step fails the job.
+#   b. That flavor is not `nix`, and is one the action accepts.
+#   c. The set of such steps is at least MIN_WINDOWS_DEV_ENV_SITES, reached
+#      both directly and through a composite. A parser that stopped matching --
+#      the local-composite indirection is the fragile half -- would otherwise
+#      report "no violations" in exactly the same words as a clean tree.
+#
+# A local composite that a Windows job references but that does not exist is a
+# failure here too: it is the same "the indirection was renamed and nothing
+# noticed" defect, seen from the other side.
+# ---------------------------------------------------------------------------
+echo
+echo "Windows jobs' dev-env flavor"
+
+# Strip full-line comments before looking for keys: a `uses:` or `env-flavor:`
+# inside a step's explanatory comment is prose, not configuration.
+uncommented() {
+	printf '%s' "$1" | grep -vE '^[[:space:]]*#' || true
+}
+
+# The `uses:` of a step blob, whether it arrived as `- uses: x` or as a
+# `uses: x` key under `- name: ...`.
+blob_uses() {
+	uncommented "$1" |
+		grep -oE '(^|[[:space:]-])uses:[[:space:]]*[^[:space:]]+' |
+		head -1 |
+		sed -E 's/.*uses:[[:space:]]*//'
+}
+
+# The `env-flavor:` a blob passes in its `with:` block, verbatim (it may be a
+# `${{ inputs.* }}` expression when read out of a composite).
+blob_env_flavor() {
+	uncommented "$1" |
+		grep -oE '^[[:space:]]*env-flavor:[[:space:]]*.*$' |
+		head -1 |
+		sed -E 's/^[[:space:]]*env-flavor:[[:space:]]*//; s/[[:space:]]+$//'
+}
+
+# The `env-flavor:` a composite action passes to `setup-dev-env`, verbatim.
+# Scoped to the lines AFTER the `uses:` that names the action: the composite
+# also DECLARES an `env-flavor:` input, and reading that declaration instead
+# would report every caller as passing the empty string.
+composite_env_flavor() {
+	awk -v needle="$SETUP_DEV_ENV_USES" '
+		/^[[:space:]]*#/ { next }
+		index($0, needle) { seen = 1; next }
+		seen && /^[[:space:]]*env-flavor:[[:space:]]*/ {
+			sub(/^[[:space:]]*env-flavor:[[:space:]]*/, "")
+			sub(/[[:space:]]+$/, "")
+			print
+			exit
+		}
+	' "$1"
+}
+
+# The `default:` of one input of a composite action file, empty when the input
+# declares none.
+composite_input_default() {
+	awk -v want="$2" '
+		$0 ~ "^  " want ":[[:space:]]*$" { inblock = 1; next }
+		inblock && /^  [A-Za-z0-9_-]+:/ { inblock = 0 }
+		inblock && /^[[:space:]]*default:[[:space:]]*/ {
+			sub(/^[[:space:]]*default:[[:space:]]*/, "")
+			gsub(/^"|"$|^'"'"'|'"'"'$/, "")
+			print
+			exit
+		}
+	' "$1"
+}
+
+declare -a dev_env_sites=()
+declare -a dev_env_sites_direct=()
+declare -a dev_env_sites_via_composite=()
+declare -A site_flavor=()
+declare -A site_detail=()
+
+for job in "${windows_runner_jobs[@]+"${windows_runner_jobs[@]}"}"; do
+	while IFS= read -r -d $'\x1e' blob; do
+		uses="$(blob_uses "$blob")"
+		[ -n "$uses" ] || continue
+
+		site=""
+		flavor=""
+		detail=""
+		case "$uses" in
+		*"$SETUP_DEV_ENV_USES"*)
+			site="$job (direct)"
+			flavor="$(blob_env_flavor "$blob")"
+			detail="step passes env-flavor: ${flavor:-<none>}"
+			dev_env_sites_direct+=("$site")
+			;;
+		./.github/actions/*)
+			composite_name="${uses#./.github/actions/}"
+			composite_file="$ACTIONS_DIR/$composite_name/action.yml"
+			if [ ! -f "$composite_file" ]; then
+				site="$job (via $composite_name)"
+				detail="no action.yml at ${composite_file#"$REPO_ROOT/"}"
+				dev_env_sites+=("$site")
+				dev_env_sites_via_composite+=("$site")
+				site_flavor["$site"]=""
+				site_detail["$site"]="$detail"
+				continue
+			fi
+			grep -q "$SETUP_DEV_ENV_USES" "$composite_file" || continue
+			site="$job (via $composite_name)"
+			composite_flavor="$(composite_env_flavor "$composite_file")"
+			if [[ $composite_flavor =~ \$\{\{[[:space:]]*inputs\.([A-Za-z0-9_-]+)[[:space:]]*\}\} ]]; then
+				# The composite forwards one of its own inputs: the flavor is
+				# whatever the CALLING job passed, or the input's default.
+				input_name="${BASH_REMATCH[1]}"
+				flavor="$(blob_env_flavor "$blob")"
+				if [ -n "$flavor" ]; then
+					detail="job passes $input_name: $flavor to $composite_name"
+				else
+					flavor="$(composite_input_default "$composite_file" "$input_name")"
+					detail="job passes no $input_name; composite default is ${flavor:-<none>}"
+				fi
+			else
+				flavor="$composite_flavor"
+				detail="$composite_name hard-codes env-flavor: ${flavor:-<none>}"
+			fi
+			dev_env_sites_via_composite+=("$site")
+			;;
+		*)
+			continue
+			;;
+		esac
+
+		dev_env_sites+=("$site")
+		site_flavor["$site"]="$flavor"
+		site_detail["$site"]="$detail"
+	done <<<"${job_step_blobs[$job]:-}"
+done
+
+if [ "${#dev_env_sites[@]}" -ge "$MIN_WINDOWS_DEV_ENV_SITES" ]; then
+	ok "Windows jobs reach setup-dev-env from ${#dev_env_sites[@]} places (>= $MIN_WINDOWS_DEV_ENV_SITES)"
+else
+	fail "Windows jobs reach setup-dev-env from at least $MIN_WINDOWS_DEV_ENV_SITES places" \
+		"found ${#dev_env_sites[@]}. Either a Windows job stopped provisioning its" \
+		"siblings through setup-dev-env -- in which case this contract must be" \
+		"retargeted, not deleted -- or the scanner no longer matches the file." \
+		"Every per-site assertion below is generated from this set, so a short" \
+		"one reports 'no violations' while checking nothing."
+fi
+
+# The scanner reads `runs-on:` literally, so a job whose runner comes from a
+# build matrix (`runs-on: ${{ matrix.runner }}`) is classified by neither
+# branch of `is_windows_runs_on`. Today every matrix leg is Linux or macOS. If
+# a Windows leg is ever added, this contract must learn to follow the matrix
+# rather than quietly stop covering it -- which is what this assertion says out
+# loud.
+matrix_windows_legs=""
+for label in $WINDOWS_RUNNER_LABELS; do
+	# Matrix legs are written both as a bare `runner:` key under an `include:`
+	# entry and as the first key of one (`- runner: ...`); match either.
+	if grep -qE "^[[:space:]]*(-[[:space:]]+)?runner:[[:space:]]*$label([[:space:]]|#|$)" "$WORKFLOW"; then
+		matrix_windows_legs="$matrix_windows_legs $label"
+	fi
+done
+if [ -z "$matrix_windows_legs" ]; then
+	ok "no build-matrix leg selects a Windows runner behind an expression"
+else
+	fail "no build-matrix leg selects a Windows runner behind an expression" \
+		"found matrix runner value(s):$matrix_windows_legs." \
+		"A job with 'runs-on: \${{ matrix.runner }}' is classified by neither" \
+		"branch of is_windows_runs_on, so its flavor goes unchecked. Teach the" \
+		"scanner to expand the matrix before adding a Windows leg."
+fi
+
+if [ "${#dev_env_sites_direct[@]}" -gt 0 ]; then
+	ok "at least one Windows job names setup-dev-env directly (${#dev_env_sites_direct[@]})"
+else
+	fail "at least one Windows job names setup-dev-env directly" \
+		"none found, though windows-rust-components and windows-headless-test do." \
+		"The direct-use branch of the scanner above has stopped matching."
+fi
+
+if [ "${#dev_env_sites_via_composite[@]}" -gt 0 ]; then
+	ok "at least one Windows job reaches setup-dev-env through a local composite (${#dev_env_sites_via_composite[@]})"
+else
+	fail "at least one Windows job reaches setup-dev-env through a local composite" \
+		"none found, though origin-dap-windows and origin-dap-windows-nightly reach" \
+		"it through .github/actions/setup-db-backend-siblings. THIS is the half that" \
+		"hid the outage: the flavor those jobs get is not written in the workflow," \
+		"so a scanner that only reads workflow steps sees a clean file."
+fi
+
+for site in "${dev_env_sites[@]+"${dev_env_sites[@]}"}"; do
+	flavor="${site_flavor[$site]:-}"
+	detail="${site_detail[$site]:-}"
+
+	if [ -n "$flavor" ]; then
+		ok "$site resolves an env-flavor ($detail)"
+	else
+		fail "$site resolves an env-flavor" \
+			"$detail." \
+			"setup-dev-env's own 'Validate env-flavor' step rejects an empty value," \
+			"so this fails the job on the runner -- after minutes of checkout."
+	fi
+
+	flavor_ok=""
+	for candidate in $NON_NIX_FLAVORS; do
+		[ "$flavor" = "$candidate" ] && flavor_ok="yes"
+	done
+	if [ -n "$flavor_ok" ]; then
+		ok "$site asks for a Windows-capable flavor ($flavor)"
+	elif [ "$flavor" = "$NIX_FLAVOR" ]; then
+		fail "$site asks for a Windows-capable flavor" \
+			"it asks for '$NIX_FLAVOR' ($detail)." \
+			"The nix flavor installs Nix via DeterminateSystems/nix-installer-action," \
+			"which has no Windows mapping: the step dies with 'ArchOs (X64-Windows)" \
+			"doesn't map to a supported Nix platform' before the job runs anything of" \
+			"its own. Use one of: $NON_NIX_FLAVORS."
+	else
+		fail "$site asks for a Windows-capable flavor" \
+			"it asks for '${flavor:-<none>}' ($detail), which setup-dev-env does not" \
+			"accept. Use one of: $NON_NIX_FLAVORS."
+	fi
+done
+
+# ---------------------------------------------------------------------------
 # Self-accounting: a contract that is deleted or short-circuited must not leave
 # this script reporting success on fewer checks than it claims. Four fixed
 # assertions (script exists, script provisions bash, job set non-empty, WSL
-# stub-step set non-empty), six per Windows job, and two per WSL stub step.
+# stub-step set non-empty), six per Windows job, two per WSL stub step, four
+# fixed dev-env-flavor assertions (site count, no matrix-hidden Windows leg,
+# one direct, one via composite) and two per dev-env site.
 # ---------------------------------------------------------------------------
 echo
-expected_assertions=$((4 + 6 * ${#windows_jobs[@]} + 2 * ${#wsl_stub_jobs[@]}))
+expected_assertions=$((4 + 6 * ${#windows_jobs[@]} + 2 * ${#wsl_stub_jobs[@]} + \
+	4 + 2 * ${#dev_env_sites[@]}))
 if [ "$assertions" -ne "$expected_assertions" ]; then
 	printf 'FAIL: ran %d assertions, expected %d\n' "$assertions" "$expected_assertions"
 	failures=$((failures + 1))

--- a/ci/test/windows-runner-bootstrap-test.sh
+++ b/ci/test/windows-runner-bootstrap-test.sh
@@ -68,6 +68,9 @@
 #      action `setup-db-backend-siblings`, which hard-coded `env-flavor: nix`
 #      for all six of its callers -- four of them Linux/macOS. Section 4 has
 #      its own header with the details.
+#   8. The bootstrap turns Windows long-path support on in git's SYSTEM
+#      configuration, and verifies it by reading the value back. Section 5 has
+#      its own header with the details.
 #
 # # No mocks
 #
@@ -129,6 +132,41 @@ readonly BOOTSTRAP_URL_PREFIX="https://raw.githubusercontent.com/metacraft-labs/
 # this is the exact text the workflow must contain.
 # shellcheck disable=SC2016
 readonly BOOTSTRAP_REVISION_BINDING='CODETRACER_GIT_BOOTSTRAP_REVISION: ${{ github.sha }}'
+
+# --- Section 5's needles ----------------------------------------------------
+# The function that owns the system-scoped opt-in, and the two `git config`
+# argument vectors it must run, quoted as PowerShell source. Asserting the
+# DECLARATION FORM rather than the bare word `longpaths` is deliberate: the
+# word already appears in this script's own comments and in the job-scoped
+# environment channel, so a bare grep is green before the fix exists.
+readonly LONGPATHS_FUNCTION="Enable-CodeTracerGitSystemLongPaths"
+readonly LONGPATHS_SET_FORM='@("config", "--system", "--replace-all", "core.longpaths", "true")'
+readonly LONGPATHS_GET_FORM='@("config", "--system", "--get", "core.longpaths")'
+# The comparison that turns the read-back into a gate. `-cne` is PowerShell's
+# case-sensitive inequality; git writes the canonical lowercase `true`.
+readonly LONGPATHS_READBACK_GUARD='-cne "true"'
+# The entry point the opt-in must run from, the CALL it must make there, and
+# the statement that call must precede: whatever else changes, the
+# configuration has to be in force before the step returns, because the next
+# step is the checkout it exists to unblock.
+#
+# The call is matched, not the function's NAME. The name also appears in the
+# entry point's parameter block, as the default of the injection seam, and it
+# appears there ABOVE the return -- so a name match is satisfied by an entry
+# point that declares the seam and never uses it, and by one that invokes it
+# after returning. Both of those mutations survived exactly that reading.
+readonly BOOTSTRAP_ENTRY_FUNCTION="Ensure-CodeTracerGitForCheckout"
+# `$EnableSystemLongPaths` and `$git` are PowerShell variables quoted verbatim.
+# shellcheck disable=SC2016
+readonly BOOTSTRAP_ENTRY_INVOCATION='& $EnableSystemLongPaths $git.Path'
+readonly BOOTSTRAP_ENTRY_SEAM_DEFAULT="Enable-CodeTracerGitSystemLongPaths -GitPath"
+readonly BOOTSTRAP_ENTRY_RETURN='return [PSCustomObject]@{'
+# Floors for the two scans section 5 performs. Both exist so that a stripper or
+# an extractor that stopped matching FAILS here instead of reporting "no
+# violations" over an empty input. The script is ~400 lines; 200 is a floor,
+# not a measurement, so ordinary edits never touch it.
+readonly MIN_BOOTSTRAP_CODE_LINES=200
+readonly MIN_LONGPATHS_FUNCTION_LINES=8
 
 assertions=0
 failures=0
@@ -771,16 +809,238 @@ for site in "${dev_env_sites[@]+"${dev_env_sites[@]}"}"; do
 done
 
 # ---------------------------------------------------------------------------
+# 5. The SYSTEM-scoped Windows long-path opt-in inside the bootstrap.
+#
+# Git for Windows refuses any path longer than MAX_PATH (260 characters) with
+#
+#     error: unable to create file <path>: Filename too long
+#
+# unless `core.longpaths` is true. That opt-in is GIT'S OWN and is not the
+# machine-wide `LongPathsEnabled` registry policy: Git for Windows gates its
+# `\\?\` path expansion on this configuration key and fails in exactly the way
+# above even on a host where the OS policy is already on. The registry policy
+# is for every OTHER tool; this key is for git.
+#
+# codetracer's `.gitmodules` nests submodules that themselves recurse, under a
+# workspace that already starts at `C:\actions-runner\_work\codetracer\
+# codetracer\`, so the depth is not marginal -- `submodules: recursive` lands
+# past 260 characters, and the eph-win-x64 jobs failed with
+#
+#     submodule update failed ... Filename too long
+#
+# The bootstrap already exports the same setting through the numbered
+# `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_n`/`GIT_CONFIG_VALUE_n` environment
+# channel (`Add-CodeTracerGitLongPathEnvironment`), and that is NOT what this
+# section is about. The two channels cover different processes and neither is
+# redundant:
+#
+#   * the environment channel is process state. It reaches git processes that
+#     are launched with it intact, which is every git a `run:` step of this job
+#     spawns.
+#   * the system configuration is a FILE. Every git process on the machine
+#     reads it, whatever environment it was handed and whoever its parent is.
+#
+# `actions/checkout` is a node action with its own git invocation, not a child
+# of the bootstrap, and the submodule processes underneath it are two more
+# levels removed again. The system scope is the channel that does not depend on
+# any of that plumbing surviving.
+#
+# What is asserted, against the committed script rather than against a mock:
+#
+#   a. The two `git config` argument vectors are present in CODE (comments
+#      stripped), in the `--system` scope, with the value `true`.
+#   b. The value is READ BACK and the script fails when it is not `true`. A
+#      `git config` that exits 0 without persisting -- an unwritable system
+#      config, a scope the runner's account cannot reach -- would otherwise
+#      leave the job to fail minutes later, in the checkout, with the original
+#      "Filename too long".
+#   c. Neither the write nor the read-back is swallowed: no `SilentlyContinue`
+#      anywhere in that function.
+#   d. The opt-in runs from the bootstrap's entry point, before it returns --
+#      i.e. inside the step that precedes `actions/checkout` (section 2 pins
+#      that the bootstrap step is the job's first). Ordering is the whole
+#      point: configuration installed after the checkout configures nothing
+#      that the checkout needed.
+#   e. Every eph-win-x64 job actually runs this script, counted rather than
+#      assumed.
+#
+# NOT PROVEN HERE: that git accepts the write on a real eph-win-x64 runner.
+# `--system` writes into the git installation's own config, and whether the
+# runner account may do so is a property of that host. The read-back is the
+# part of that question this repository can answer, and it answers it at the
+# earliest step of the job rather than in the middle of a checkout.
+# ---------------------------------------------------------------------------
+echo
+echo "system-scoped long-path opt-in"
+
+# Full-line comments are prose, not configuration -- the same rule section 4
+# already applies to `uses:`. The floor asserted immediately below is what
+# makes a stripper that matched everything (or nothing) a FAILURE rather than a
+# vacuous pass.
+bootstrap_code="$(grep -vE '^[[:space:]]*(#.*)?$' "$BOOTSTRAP_SCRIPT" 2>/dev/null || true)"
+bootstrap_code_lines="$(printf '%s\n' "$bootstrap_code" | grep -c . || true)"
+if [ "$bootstrap_code_lines" -ge "$MIN_BOOTSTRAP_CODE_LINES" ]; then
+	ok "the bootstrap exposes $bootstrap_code_lines lines of code to scan (>= $MIN_BOOTSTRAP_CODE_LINES)"
+else
+	fail "the bootstrap exposes at least $MIN_BOOTSTRAP_CODE_LINES lines of code to scan" \
+		"found $bootstrap_code_lines. Either the script was gutted, or the" \
+		"comment stripper above stopped matching -- and every assertion in this" \
+		"section reads from that same stripped text, so a short scan reports" \
+		"'not found' for reasons that have nothing to do with the contract."
+fi
+
+# How many lines of CODE mention the system scope at all. Two are required (the
+# write and the read-back); asserting the count before asserting the forms
+# means a fix that collapsed to a single unverified write is visible as such.
+system_scope_lines="$(printf '%s\n' "$bootstrap_code" | grep -cF -- '"--system"' || true)"
+if [ "$system_scope_lines" -ge 2 ]; then
+	ok "the bootstrap configures git's --system scope on $system_scope_lines lines of code"
+else
+	fail "the bootstrap configures git's --system scope on at least 2 lines of code" \
+		"found $system_scope_lines. The opt-in has to be written AND read back," \
+		"and both halves name the scope. Anything less is either missing or" \
+		"unverified. Note that a --local or --global opt-in does not help: the" \
+		"deep paths are inside submodules, and a submodule is its own repository" \
+		"with its own config, cloned by a process that never reads the" \
+		"superproject's."
+fi
+
+if printf '%s\n' "$bootstrap_code" | grep -qF -- "$LONGPATHS_SET_FORM"; then
+	ok "the bootstrap enables core.longpaths in the system scope"
+else
+	fail "the bootstrap enables core.longpaths in the system scope" \
+		"expected the literal argument vector" \
+		"  $LONGPATHS_SET_FORM" \
+		"in code (not in a comment). Without core.longpaths, git refuses paths" \
+		"over 260 characters with 'Filename too long' regardless of the" \
+		"LongPathsEnabled OS policy, and actions/checkout's recursive submodule" \
+		"update is where codetracer crosses that line."
+fi
+
+if printf '%s\n' "$bootstrap_code" | grep -qF -- "$LONGPATHS_GET_FORM"; then
+	ok "the bootstrap reads the system core.longpaths value back"
+else
+	fail "the bootstrap reads the system core.longpaths value back" \
+		"expected the literal argument vector" \
+		"  $LONGPATHS_GET_FORM" \
+		"in code (not in a comment). A write that is not read back can report" \
+		"success and persist nothing; the job then dies minutes later inside the" \
+		"checkout, with the original error and no hint of the cause."
+fi
+
+# The function that owns both halves, extracted so the remaining assertions are
+# scoped to it rather than to the file. `^}` closes it: this script indents
+# every nested block.
+ps_function_body() { # <file> <function-name>
+	awk -v name="$2" '
+		$0 ~ "^function " name " \\{" { inside = 1; next }
+		inside && /^\}/ { inside = 0; next }
+		inside { print }
+	' "$1"
+}
+
+longpaths_body="$(ps_function_body "$BOOTSTRAP_SCRIPT" "$LONGPATHS_FUNCTION")"
+longpaths_body_lines="$(printf '%s\n' "$longpaths_body" | grep -c . || true)"
+if [ "$longpaths_body_lines" -ge "$MIN_LONGPATHS_FUNCTION_LINES" ]; then
+	ok "$LONGPATHS_FUNCTION has a $longpaths_body_lines-line body to inspect (>= $MIN_LONGPATHS_FUNCTION_LINES)"
+else
+	fail "$LONGPATHS_FUNCTION has at least $MIN_LONGPATHS_FUNCTION_LINES lines of body to inspect" \
+		"found $longpaths_body_lines. Either the function is gone or renamed --" \
+		"in which case this contract must be retargeted, not deleted -- or the" \
+		"extractor above no longer matches. The two assertions below read from" \
+		"this body, so an empty one would report a missing guard that is in fact" \
+		"present, or (worse, after a needle edit) find nothing to complain about."
+fi
+
+if printf '%s\n' "$longpaths_body" | grep -qF -- "$LONGPATHS_READBACK_GUARD" &&
+	printf '%s\n' "$longpaths_body" | grep -q 'throw'; then
+	ok "$LONGPATHS_FUNCTION fails the step when the read-back is not 'true'"
+else
+	fail "$LONGPATHS_FUNCTION fails the step when the read-back is not 'true'" \
+		"expected the read-back to be compared with '$LONGPATHS_READBACK_GUARD' and" \
+		"a 'throw' to follow. Reading the value and then ignoring it is the same" \
+		"as not reading it: the step goes green and the checkout still fails."
+fi
+
+if printf '%s\n' "$longpaths_body" | grep -q 'SilentlyContinue'; then
+	fail "$LONGPATHS_FUNCTION does not swallow a failed configuration write" \
+		"it contains 'SilentlyContinue'. This step exists to fail loudly at the" \
+		"top of the job instead of quietly at the checkout; suppressing the error" \
+		"restores exactly the failure mode it was added to remove."
+else
+	ok "$LONGPATHS_FUNCTION does not swallow a failed configuration write"
+fi
+
+# Ordering. The opt-in has to be installed by the entry point, before it hands
+# control back -- the very next step is the checkout.
+entry_body="$(ps_function_body "$BOOTSTRAP_SCRIPT" "$BOOTSTRAP_ENTRY_FUNCTION")"
+line_of() { # <text> <fixed-needle> -> 1-based line, or 0
+	local found
+	found="$(printf '%s\n' "$1" | grep -nF -- "$2" | head -1 | cut -d: -f1)"
+	printf '%s' "${found:-0}"
+}
+entry_enable_line="$(line_of "$entry_body" "$BOOTSTRAP_ENTRY_INVOCATION")"
+entry_return_line="$(line_of "$entry_body" "$BOOTSTRAP_ENTRY_RETURN")"
+if [ "$entry_enable_line" -gt 0 ] &&
+	[ "$entry_return_line" -gt 0 ] &&
+	[ "$entry_enable_line" -lt "$entry_return_line" ]; then
+	ok "$BOOTSTRAP_ENTRY_FUNCTION runs the opt-in before it returns"
+else
+	fail "$BOOTSTRAP_ENTRY_FUNCTION runs the opt-in before it returns" \
+		"'$BOOTSTRAP_ENTRY_INVOCATION' is at line ${entry_enable_line} of the entry" \
+		"point's body and its 'return' is at line ${entry_return_line} (0 means not" \
+		"found). A seam that is declared but never invoked configures nothing, and" \
+		"one invoked after the return runs never. Either way actions/checkout -- the" \
+		"very next step -- gets the git it would have got without this script."
+fi
+
+# ...and that seam has to lead to the real function. Its default is what runs
+# when nothing is injected, which is every case except the tests.
+if printf '%s\n' "$entry_body" | grep -qF -- "$BOOTSTRAP_ENTRY_SEAM_DEFAULT"; then
+	ok "$BOOTSTRAP_ENTRY_FUNCTION's opt-in seam defaults to $LONGPATHS_FUNCTION"
+else
+	fail "$BOOTSTRAP_ENTRY_FUNCTION's opt-in seam defaults to $LONGPATHS_FUNCTION" \
+		"expected '$BOOTSTRAP_ENTRY_SEAM_DEFAULT' in the entry point's parameter" \
+		"block. The injection seam exists so the tests can observe the call; if its" \
+		"default no longer reaches the function, the tests keep passing on an" \
+		"injected stub while the real runner configures nothing."
+fi
+
+# ...and the jobs that need it must actually be running this script. Counted,
+# not assumed: section 2's per-job assertions are generated from the same set,
+# so if that set were ever empty they would all vanish silently.
+bootstrap_running_jobs=0
+for job in "${windows_jobs[@]+"${windows_jobs[@]}"}"; do
+	case "${job_bootstrap_body[$job]:-}" in
+	*"ci/ensure-git-for-checkout.ps1"*) bootstrap_running_jobs=$((bootstrap_running_jobs + 1)) ;;
+	esac
+done
+if [ "$bootstrap_running_jobs" -gt 0 ] &&
+	[ "$bootstrap_running_jobs" -eq "${#windows_jobs[@]}" ]; then
+	ok "all ${#windows_jobs[@]} ${WINDOWS_RUNNER_LABEL} jobs run the bootstrap that installs the opt-in"
+else
+	fail "all ${WINDOWS_RUNNER_LABEL} jobs run the bootstrap that installs the opt-in" \
+		"$bootstrap_running_jobs of ${#windows_jobs[@]} do." \
+		"A job that skips the bootstrap gets neither git, nor bash, nor the" \
+		"long-path opt-in -- and a zero here would mean this whole section is" \
+		"asserting things about a script nothing runs."
+fi
+
+# ---------------------------------------------------------------------------
 # Self-accounting: a contract that is deleted or short-circuited must not leave
 # this script reporting success on fewer checks than it claims. Four fixed
 # assertions (script exists, script provisions bash, job set non-empty, WSL
 # stub-step set non-empty), six per Windows job, two per WSL stub step, four
 # fixed dev-env-flavor assertions (site count, no matrix-hidden Windows leg,
-# one direct, one via composite) and two per dev-env site.
+# one direct, one via composite), two per dev-env site, and ten fixed
+# long-path assertions (code-line floor, system-scope line count, the write
+# form, the read-back form, the function-body floor, the read-back guard, no
+# suppression, ordering inside the entry point, the seam's default, and the
+# jobs that run the bootstrap).
 # ---------------------------------------------------------------------------
 echo
 expected_assertions=$((4 + 6 * ${#windows_jobs[@]} + 2 * ${#wsl_stub_jobs[@]} + \
-	4 + 2 * ${#dev_env_sites[@]}))
+	4 + 2 * ${#dev_env_sites[@]} + 10))
 if [ "$assertions" -ne "$expected_assertions" ]; then
 	printf 'FAIL: ran %d assertions, expected %d\n' "$assertions" "$expected_assertions"
 	failures=$((failures + 1))


### PR DESCRIPTION
The Windows CI lane has not produced a green run in weeks. Three separate
things stopped jobs before they could run anything of their own; this branch
fixes the two that live in this repository.

**Windows jobs asked for a Nix dev environment.** The `setup-db-backend-siblings`
composite hard-coded `env-flavor: nix`, which installs Nix via
`DeterminateSystems/nix-installer-action`. On a Windows runner that fails with
`ArchOs (X64-Windows) doesn't map to a supported Nix platform` before the job
reaches a single step of its own. The composite now takes `env-flavor` as a
required input with no default, and the two Windows callers ask for
`windows-diy` — the flavor the other Windows jobs on this runner class already
use, and the one that provides the Node these jobs need. The four non-Windows
callers now state `nix` explicitly; their behaviour is unchanged.

**Recursive submodule checkout hit the Windows path limit.** `actions/checkout`
spawns its own git, so the long-path opt-in has to be in place before the
checkout step runs. The Git bootstrap that already runs first on every Windows
job now enables `core.longpaths` in git's system scope and reads the value back,
so a write that silently fails is a loud, early failure rather than a confusing
one later.

Both changes are covered by assertions in the existing CI test suites, which run
on Linux as part of the verdict job. The suites check the declaration form and
enforce positive counts on everything they enumerate, so a scan that stops
matching fails instead of quietly reporting a clean tree.

Opening this to get a real Windows run: no Windows job has been observed getting
past the sibling clone, and none has been observed reaching a `pwsh` step.