### PR TITLE
fix(windows): resolve the dev-deps root by writability, not by existence

### DIFF
--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -168,7 +168,8 @@ jobs:
             "non-nix-build/windows/ensure-nargo.ps1",
             "non-nix-build/windows/ensure-ttd.ps1",
             "non-nix-build/windows/validate-toolchain-versions.ps1",
-            "non-nix-build/windows/validate-env-path-entries.ps1"
+            "non-nix-build/windows/validate-env-path-entries.ps1",
+            "non-nix-build/windows/validate-install-root.ps1"
           )
 
           foreach ($scriptPath in $scriptPaths) {
@@ -198,6 +199,17 @@ jobs:
         shell: pwsh
         run: |
           pwsh -File non-nix-build/windows/validate-env-path-entries.ps1
+
+      - name: Validate env.ps1 install-root resolution
+        # Extracts Get-DefaultInstallRoot and Test-DirectoryWritable from
+        # env.ps1 by AST and exercises them in isolation, including the case
+        # the fleet actually hit: a directory that EXISTS and still refuses
+        # every create. That is D: on an eph-win-x64 guest -- the read-only
+        # cloudbase-init config drive -- and it took out every Windows job at
+        # the first Ensure-* step.
+        shell: pwsh
+        run: |
+          pwsh -File non-nix-build/windows/validate-install-root.ps1
 
       - name: Validate arm64 mode routing smoke checks
         shell: pwsh
@@ -3969,6 +3981,16 @@ jobs:
         # -- which matters, because the Windows lane had no signal at all
         # for the months this went unnoticed.
         run: bash ci/test/windows-runner-bootstrap-test.sh
+
+      - name: Assert the Windows dev-deps root degrades to somewhere writable
+        # Every eph-win-x64 job died in Ensure-Ttd with "Access to the path
+        # 'D:\metacraft-dev-deps\ttd' is denied", because env.ps1 read
+        # "D:\ exists" as "there is a writable dev drive here". On these
+        # guests D: is the cloudbase-init config drive: a read-only CDFS
+        # volume. A runner must not fail for want of an optional performance
+        # feature. Static, so a Linux runner can hold the line -- the same
+        # reason the git/bash contract above lives here.
+        run: bash ci/test/windows-install-root-test.sh
 
       - name: Assert every job's sibling checkout is self-sufficient
         # Two halves of one contract, both static checks over this workflow

--- a/ci/test/windows-install-root-test.sh
+++ b/ci/test/windows-install-root-test.sh
@@ -1,0 +1,458 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Contract: the Windows DIY install root degrades to somewhere writable, and
+# the three scripts that resolve it agree on how.
+#
+# # Why this file exists
+#
+# Every ephemeral `eph-win-x64` job died at the first bootstrap step:
+#
+#     ensure-ttd.ps1:189  New-Item -ItemType Directory -Force -Path $ttdCacheDir
+#                         Access to the path 'D:\metacraft-dev-deps\ttd' is denied.
+#
+# `Ensure-Ttd` was not at fault. `env.ps1`'s `Get-DefaultInstallRoot` chose the
+# root, using `Test-Path -LiteralPath "D:\" -PathType Container` as its test
+# for "there is a dev drive here". On an eph-win-x64 guest there is not:
+# `D:` is the cloudbase-init config drive, a READ-ONLY CDFS volume. Confirmed
+# on a CoW clone of `golden-win11-cloudbase.qcow2`, 2026-08-23:
+#
+#     DeviceID  DriveType  FileSystem  VolumeName  SizeGB
+#     C:                3  NTFS        Windows      79.58
+#     D:                5  CDFS        config-2         0
+#
+#     Test-Path D:\ -PathType Container  =>  True
+#     New-Item  D:\metacraft-dev-deps\ttd  =>  Access to the path ... is denied.
+#
+# The guest's libvirt domain has exactly two block devices: the qcow2 system
+# disk and a read-only SATA CD-ROM carrying the config drive. There is no
+# third volume for `D:` to be, and there never was one to find.
+#
+# TTD is simply the FIRST `Ensure-*` step in `env.ps1`. Every one of them
+# would have failed on the same root; TTD only took the bullet.
+#
+# # What is asserted
+#
+#   1. Neither resolver still uses bare existence as its dev-drive test.
+#      `Test-Path -PathType Container` in PowerShell and `[[ -d ]]` in bash
+#      both answer "yes" for a read-only mount, which is the whole defect.
+#      `[[ -w ]]` is no better: Git-Bash synthesises POSIX permission bits
+#      that do not carry Windows ACLs, so it reports a CDFS mount writable.
+#   2. Both resolvers probe by CREATING a directory, which is the only test
+#      that answers the question the caller is actually asking.
+#   3. All THREE scripts that resolve this root agree. The third,
+#      `setup-codetracer-runtime-env.sh`, used to default to a bare
+#      `D:/metacraft-dev-deps` with no probe at all, so on a box without a
+#      writable D: it disagreed with `env.sh` about where the toolchain lives
+#      and silently built a PATH of directories that do not exist.
+#   4. An explicitly-set `WINDOWS_DIY_INSTALL_ROOT` is still honoured
+#      verbatim. Degrading gracefully must not mean overriding an operator.
+#   5. There is a fallback below the dev drive, and it is a PERSISTENT one.
+#      `RUNNER_TEMP` is the obvious CI scratch dir and is wiped between jobs;
+#      making it the primary fallback would quietly turn a toolchain cache
+#      into a re-download on every job on the two long-lived Windows runners.
+#      `LOCALAPPDATA` persists, so it leads and `RUNNER_TEMP` is last resort.
+#   6. `Ensure-Ttd` still takes its root as a parameter rather than
+#      recomputing one, so fixing the resolver actually fixes the caller.
+#
+# # No mocks
+#
+# The four shipped scripts are the input, read as committed. Point the suite
+# at another tree with `$1` to check a pristine copy (that is how the red run
+# for this change was produced).
+#
+# Run: bash ci/test/windows-install-root-test.sh [<repo-root>]
+# Lane: a step of the `ci-verdict` job (stock ubuntu-latest, bash only).
+# =============================================================================
+set -uo pipefail
+
+REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)}"
+readonly REPO_ROOT
+
+readonly ENV_PS1="$REPO_ROOT/env.ps1"
+readonly ENV_SH="$REPO_ROOT/env.sh"
+readonly RUNTIME_SH="$REPO_ROOT/non-nix-build/windows/setup-codetracer-runtime-env.sh"
+readonly ENSURE_TTD="$REPO_ROOT/non-nix-build/windows/ensure-ttd.ps1"
+
+readonly ROOT_ENV_VAR="WINDOWS_DIY_INSTALL_ROOT"
+# The writability probe each resolver must go through.
+readonly PS_PROBE_FN="Test-DirectoryWritable"
+readonly SH_PROBE_FN="_ct_dir_writable"
+readonly RUNTIME_PROBE_FN="_ct_runtime_dir_writable"
+# The persistent fallback that must lead, and the volatile one that must not.
+readonly PERSISTENT_FALLBACK="LOCALAPPDATA"
+readonly VOLATILE_FALLBACK="RUNNER_TEMP"
+# Floors, so an extractor that stops matching FAILS here rather than reporting
+# "no violations" over empty input. Deliberately well below the real sizes.
+# PowerShell's `$Root`, not the shell's: these `\$` are literal dollars in a
+# PowerShell parameter declaration, and live here so the assertion sites read
+# as plain strings.
+# These two `$` are PowerShell's, not the shell's -- `$true` and `$Root` are
+# literal text in a PowerShell parameter declaration. Single quotes are exactly
+# right here (shfmt normalises to them), so SC2016's "did you mean to expand
+# this?" is answered once, in writing, rather than worked around.
+# shellcheck disable=SC2016
+readonly ENSURE_TTD_ROOT_PARAM_RE='\[Parameter\(Mandatory = \$true\)\]\[string\]\$Root'
+# shellcheck disable=SC2016
+readonly ENSURE_TTD_ROOT_PARAM_LABEL='ensure-ttd.ps1 takes $Root as a mandatory parameter'
+readonly MIN_ENV_PS1_LINES=800
+readonly MIN_ENV_SH_LINES=400
+
+assertions=0
+failures=0
+
+ok() {
+	assertions=$((assertions + 1))
+	printf '  ok   %s\n' "$1"
+}
+
+fail() {
+	assertions=$((assertions + 1))
+	failures=$((failures + 1))
+	printf '  FAIL %s\n' "$1"
+	if [ "$#" -gt 1 ]; then
+		shift
+		printf '         %s\n' "$@"
+	fi
+}
+
+# Strip comments so an assertion cannot be satisfied -- or defeated -- by
+# prose. Every scan below runs over code only.
+#
+# The results are captured into variables and matched with HERE-STRINGS, never
+# by piping a producer into `grep -q`. Under `set -o pipefail` that pairing is
+# a trap: `grep -q` exits the instant it matches, the upstream `sed` takes
+# SIGPIPE, and the pipeline's status becomes 141 -- so a SUCCESSFUL match can
+# read as a failed test, nondeterministically, depending on how early in the
+# file the match happens to sit. This suite lost an afternoon to exactly that:
+# an assertion that passed on the real file and "failed" on a mutant whose only
+# change was 30 lines further down.
+ps_code() { sed 's/[[:space:]]*#.*$//' "$1"; }
+sh_code() { sed 's/^[[:space:]]*#.*$//' "$1"; }
+
+# ---------------------------------------------------------------------------
+# 0. The inputs exist and are the size they should be.
+# ---------------------------------------------------------------------------
+echo "inputs"
+
+for f in "$ENV_PS1" "$ENV_SH" "$RUNTIME_SH" "$ENSURE_TTD"; do
+	if [ -f "$f" ]; then
+		ok "exists: ${f#"$REPO_ROOT"/}"
+	else
+		fail "exists: ${f#"$REPO_ROOT"/}" \
+			"every assertion about this file below would otherwise pass vacuously"
+	fi
+done
+
+env_ps1_lines=$(wc -l <"$ENV_PS1" 2>/dev/null || echo 0)
+if [ "$env_ps1_lines" -ge "$MIN_ENV_PS1_LINES" ]; then
+	ok "env.ps1 is at least $MIN_ENV_PS1_LINES lines ($env_ps1_lines)"
+else
+	fail "env.ps1 is at least $MIN_ENV_PS1_LINES lines" \
+		"got $env_ps1_lines; the file was truncated or this suite is reading the wrong tree"
+fi
+env_sh_lines=$(wc -l <"$ENV_SH" 2>/dev/null || echo 0)
+if [ "$env_sh_lines" -ge "$MIN_ENV_SH_LINES" ]; then
+	ok "env.sh is at least $MIN_ENV_SH_LINES lines ($env_sh_lines)"
+else
+	fail "env.sh is at least $MIN_ENV_SH_LINES lines" \
+		"got $env_sh_lines; the file was truncated or this suite is reading the wrong tree"
+fi
+
+# ---------------------------------------------------------------------------
+# 1. The dev-drive branch must not use existence as its test.
+#
+# Anchored on the D: lines specifically. `Test-Path` and `[[ -d ]]` are both
+# perfectly legitimate elsewhere in these files; it is only as the DEV-DRIVE
+# test that they are the bug.
+# ---------------------------------------------------------------------------
+echo
+echo "the dev-drive probe"
+
+ps_d_lines=$(ps_code "$ENV_PS1" | grep -n 'D:[\]' || true)
+if [ -n "$ps_d_lines" ]; then
+	ok 'env.ps1 still has a D:\ dev-drive branch to check'
+else
+	fail 'env.ps1 still has a D:\ dev-drive branch to check' \
+		'no D:\ line found in code; if the dev-drive preference was removed on' \
+		"purpose this suite must be RETARGETED, not left to pass on nothing"
+fi
+
+if grep -q 'Test-Path' <<<"$ps_d_lines"; then
+	fail "env.ps1's D:\\ branch does not use Test-Path" \
+		'Test-Path cannot see a read-only mount: D:\ on eph-win-x64 is a CDFS' \
+		"config drive that exists and refuses every write. Offending line(s):" \
+		"$(printf '%s' "$ps_d_lines" | tr '\n' '|')"
+else
+	ok "env.ps1's D:\\ branch does not use Test-Path"
+fi
+
+if grep -q "$PS_PROBE_FN" <<<"$ps_d_lines"; then
+	ok "env.ps1's D:\\ branch goes through $PS_PROBE_FN"
+else
+	fail "env.ps1's D:\\ branch goes through $PS_PROBE_FN" \
+		"the dev drive must be probed by trying to create in it"
+fi
+
+sh_d_lines=$(sh_code "$ENV_SH" | grep -n '/d/' || true)
+if [ -n "$sh_d_lines" ]; then
+	ok "env.sh still has a /d/ dev-drive branch to check"
+else
+	fail "env.sh still has a /d/ dev-drive branch to check" \
+		"no /d/ line found in code; retarget this suite rather than let it pass on nothing"
+fi
+
+if grep -qE '\[\[ *-[dw] +/d/' <<<"$sh_d_lines"; then
+	fail "env.sh's /d/ branch does not use [[ -d ]] or [[ -w ]]" \
+		"both answer yes for the read-only CDFS mount that D: actually is:" \
+		"-d because it exists, -w because Git-Bash's synthesised POSIX bits" \
+		"do not carry Windows ACLs. Offending line(s):" \
+		"$(printf '%s' "$sh_d_lines" | tr '\n' '|')"
+else
+	ok "env.sh's /d/ branch does not use [[ -d ]] or [[ -w ]]"
+fi
+
+if grep -q "$SH_PROBE_FN" <<<"$sh_d_lines"; then
+	ok "env.sh's /d/ branch goes through $SH_PROBE_FN"
+else
+	fail "env.sh's /d/ branch goes through $SH_PROBE_FN" \
+		"the dev drive must be probed by trying to create in it"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. The probes must actually create something.
+#
+# A probe named `Test-DirectoryWritable` that only calls `Test-Path` would
+# satisfy section 1 and reintroduce the exact defect, so the body is checked.
+# ---------------------------------------------------------------------------
+echo
+echo "the probes create, they do not merely look"
+
+ps_probe_body=$(ps_code "$ENV_PS1" | awk "/^function $PS_PROBE_FN/,/^}/")
+if [ -n "$ps_probe_body" ]; then
+	ok "env.ps1 defines $PS_PROBE_FN"
+else
+	fail "env.ps1 defines $PS_PROBE_FN" "the two body assertions below would pass on empty input"
+fi
+if grep -q 'New-Item -ItemType Directory' <<<"$ps_probe_body"; then
+	ok "$PS_PROBE_FN creates a directory to decide"
+else
+	fail "$PS_PROBE_FN creates a directory to decide" \
+		"a probe that only calls Test-Path is the shipped bug wearing a better name"
+fi
+if grep -q 'Remove-Item' <<<"$ps_probe_body"; then
+	ok "$PS_PROBE_FN removes its probe directory"
+else
+	fail "$PS_PROBE_FN removes its probe directory" \
+		"a probe that litters the dev-deps root is a probe that gets deleted later"
+fi
+
+sh_probe_body=$(sh_code "$ENV_SH" | awk "/^$SH_PROBE_FN\(\)/,/^}/")
+if [ -n "$sh_probe_body" ]; then
+	ok "env.sh defines $SH_PROBE_FN"
+else
+	fail "env.sh defines $SH_PROBE_FN" "the two body assertions below would pass on empty input"
+fi
+if grep -q 'mkdir' <<<"$sh_probe_body"; then
+	ok "$SH_PROBE_FN creates a directory to decide"
+else
+	fail "$SH_PROBE_FN creates a directory to decide" \
+		"only an actual create answers the question; -d and -w both lie here"
+fi
+if grep -q 'rmdir' <<<"$sh_probe_body"; then
+	ok "$SH_PROBE_FN removes its probe directory"
+else
+	fail "$SH_PROBE_FN removes its probe directory"
+fi
+
+# ---------------------------------------------------------------------------
+# 2b. The bash probe, actually executed.
+#
+# Everything above is structural. This section EXTRACTS `_ct_dir_writable`
+# from env.sh and runs it, against a directory that exists and refuses
+# creation -- the same shape as the read-only CDFS mount that D: turned out to
+# be, reproduced portably with a chmod. A probe that returns "writable" here
+# would ship the outage again, and no amount of grepping would say so.
+#
+# `_ct_dir_writable` is pure bash with no Windows dependency, so this runs on
+# the Linux verdict runner where the rest of this suite already runs.
+# ---------------------------------------------------------------------------
+echo
+echo "the bash probe, executed"
+
+probe_tmp=$(mktemp -d)
+# shellcheck disable=SC1090
+if eval "$(sh_code "$ENV_SH" | awk "/^$SH_PROBE_FN\(\)/,/^}/")" 2>/dev/null; then
+	ok "$SH_PROBE_FN can be extracted from env.sh and defined"
+else
+	fail "$SH_PROBE_FN can be extracted from env.sh and defined" \
+		"the three behavioural assertions below cannot run"
+fi
+
+if declare -F "$SH_PROBE_FN" >/dev/null; then
+	mkdir -p "$probe_tmp/writable"
+	if "$SH_PROBE_FN" "$probe_tmp/writable"; then
+		ok "$SH_PROBE_FN says yes for a writable directory"
+	else
+		fail "$SH_PROBE_FN says yes for a writable directory" \
+			"a probe that refuses everything would push every host to the last-resort fallback"
+	fi
+
+	if "$SH_PROBE_FN" "$probe_tmp/does-not-exist"; then
+		fail "$SH_PROBE_FN says no for a missing directory"
+	else
+		ok "$SH_PROBE_FN says no for a missing directory"
+	fi
+
+	# The load-bearing case: EXISTS, and still refuses to be written to.
+	mkdir -p "$probe_tmp/readonly"
+	chmod a-w "$probe_tmp/readonly"
+	if [ -d "$probe_tmp/readonly" ] && ! "$SH_PROBE_FN" "$probe_tmp/readonly"; then
+		ok "$SH_PROBE_FN says no for a directory that exists but refuses creation"
+	else
+		fail "$SH_PROBE_FN says no for a directory that exists but refuses creation" \
+			"this is the eph-win-x64 D: case: Test-Path/[[ -d ]] say yes and every" \
+			"mkdir underneath fails. If this assertion passes vacuously because the" \
+			"suite runs as root, run it unprivileged."
+	fi
+	chmod u+w "$probe_tmp/readonly"
+else
+	for _ in 1 2 3; do
+		fail "$SH_PROBE_FN behavioural check" "the function could not be defined"
+	done
+fi
+rm -rf "$probe_tmp"
+
+# ---------------------------------------------------------------------------
+# 3. All three resolvers agree.
+# ---------------------------------------------------------------------------
+echo
+echo "the three resolvers agree"
+
+runtime_sh_code=$(sh_code "$RUNTIME_SH")
+
+if grep -qE 'INSTALL_ROOT="\$\{'"$ROOT_ENV_VAR"':-D:/metacraft-dev-deps\}"' <<<"$runtime_sh_code"; then
+	fail "setup-codetracer-runtime-env.sh has no unprobed D: default" \
+		"it defaulted to D:/metacraft-dev-deps with no probe at all, so on any" \
+		"box without a writable D: it disagreed with env.sh about where the" \
+		"toolchain lives and built a PATH of directories that do not exist"
+else
+	ok "setup-codetracer-runtime-env.sh has no unprobed D: default"
+fi
+
+if grep -q "$RUNTIME_PROBE_FN" <<<"$runtime_sh_code"; then
+	ok "setup-codetracer-runtime-env.sh probes writability like env.sh does"
+else
+	fail "setup-codetracer-runtime-env.sh probes writability like env.sh does" \
+		"its fallback must reach the same answer env.sh reached"
+fi
+
+if grep -q "$PERSISTENT_FALLBACK" <<<"$runtime_sh_code"; then
+	ok "setup-codetracer-runtime-env.sh falls back to $PERSISTENT_FALLBACK like env.sh"
+else
+	fail "setup-codetracer-runtime-env.sh falls back to $PERSISTENT_FALLBACK like env.sh"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. An explicit root still wins.
+# ---------------------------------------------------------------------------
+echo
+echo "an explicit root is still honoured"
+
+for f in "$ENV_PS1" "$ENV_SH" "$RUNTIME_SH"; do
+	rel="${f#"$REPO_ROOT"/}"
+	if grep -q "$ROOT_ENV_VAR" "$f"; then
+		ok "$rel honours \$$ROOT_ENV_VAR"
+	else
+		fail "$rel honours \$$ROOT_ENV_VAR" \
+			"degrading gracefully must not mean overriding an operator's pinned root"
+	fi
+done
+
+# ---------------------------------------------------------------------------
+# 5. The fallback order: persistent first, volatile last.
+# ---------------------------------------------------------------------------
+echo
+echo "fallback order"
+
+# Anchored on the line that actually ITERATES the fallback, not on any line
+# that merely names it. Both resolvers mention RUNNER_TEMP a second time in
+# their "could not resolve any writable root" diagnostic, and an earlier draft
+# of this suite accepted that -- so deleting the whole fallback loop left the
+# gate green. Requiring the loop construct is what closes it.
+ps_persist_at=$(ps_code "$ENV_PS1" | grep -n 'LocalApplicationData' | head -1 | cut -d: -f1)
+ps_volatile_at=$(ps_code "$ENV_PS1" | grep -nE "foreach .*$VOLATILE_FALLBACK" | head -1 | cut -d: -f1)
+if [ -n "$ps_persist_at" ] && [ -n "$ps_volatile_at" ]; then
+	ok "env.ps1 offers both a persistent and a last-resort fallback"
+	if [ "$ps_persist_at" -lt "$ps_volatile_at" ]; then
+		ok "env.ps1 tries the persistent fallback before $VOLATILE_FALLBACK"
+	else
+		fail "env.ps1 tries the persistent fallback before $VOLATILE_FALLBACK" \
+			"$VOLATILE_FALLBACK is wiped between jobs; leading with it turns the" \
+			"toolchain cache into a re-download on every job on the persistent runners"
+	fi
+else
+	fail "env.ps1 offers both a persistent and a last-resort fallback" \
+		"LocalApplicationData at '${ps_persist_at:-none}', $VOLATILE_FALLBACK at '${ps_volatile_at:-none}'"
+	fail "env.ps1 tries the persistent fallback before $VOLATILE_FALLBACK" \
+		"not checkable: one of the two fallbacks is missing"
+fi
+
+sh_persist_at=$(sh_code "$ENV_SH" | grep -n "$PERSISTENT_FALLBACK" | head -1 | cut -d: -f1)
+sh_volatile_at=$(sh_code "$ENV_SH" | grep -nE "for .*$VOLATILE_FALLBACK.*; do" | head -1 | cut -d: -f1)
+if [ -n "$sh_persist_at" ] && [ -n "$sh_volatile_at" ]; then
+	ok "env.sh offers both a persistent and a last-resort fallback"
+	if [ "$sh_persist_at" -lt "$sh_volatile_at" ]; then
+		ok "env.sh tries the persistent fallback before $VOLATILE_FALLBACK"
+	else
+		fail "env.sh tries the persistent fallback before $VOLATILE_FALLBACK" \
+			"$VOLATILE_FALLBACK is wiped between jobs"
+	fi
+else
+	fail "env.sh offers both a persistent and a last-resort fallback" \
+		"$PERSISTENT_FALLBACK at '${sh_persist_at:-none}', $VOLATILE_FALLBACK at '${sh_volatile_at:-none}'"
+	fail "env.sh tries the persistent fallback before $VOLATILE_FALLBACK" \
+		"not checkable: one of the two fallbacks is missing"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Ensure-Ttd takes the root it is given.
+#
+# If it ever recomputed a root of its own, fixing the resolver would leave the
+# reported failure exactly where it was.
+# ---------------------------------------------------------------------------
+echo
+echo "Ensure-Ttd uses the root it is handed"
+
+ensure_ttd_code=$(ps_code "$ENSURE_TTD")
+
+if grep -qE "$ENSURE_TTD_ROOT_PARAM_RE" <<<"$ensure_ttd_code"; then
+	ok "$ENSURE_TTD_ROOT_PARAM_LABEL"
+else
+	fail "$ENSURE_TTD_ROOT_PARAM_LABEL" \
+		"if it resolved its own root, fixing env.ps1 would not fix the reported failure"
+fi
+
+if grep -q 'D:' <<<"$ensure_ttd_code"; then
+	fail "ensure-ttd.ps1 hard-codes no D: path" \
+		"it must use the root env.ps1 resolved, not one of its own"
+else
+	ok "ensure-ttd.ps1 hard-codes no D: path"
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion budget: 4 file-existence + 2 size floors + 6 dev-drive probe
+# + 6 probe-body + 4 executed-bash-probe + 3 three-resolver + 3 explicit-root
+# + 4 fallback-order + 2 Ensure-Ttd.
+# ---------------------------------------------------------------------------
+echo
+expected_assertions=$((4 + 2 + 6 + 6 + 4 + 3 + 3 + 4 + 2))
+if [ "$assertions" -ne "$expected_assertions" ]; then
+	printf 'FAIL: ran %d assertions, expected %d\n' "$assertions" "$expected_assertions"
+	failures=$((failures + 1))
+fi
+
+if [ "$failures" -ne 0 ]; then
+	printf '%d of %d assertions failed\n' "$failures" "$assertions"
+	exit 1
+fi
+printf 'all %d assertions passed\n' "$assertions"

--- a/env.ps1
+++ b/env.ps1
@@ -54,23 +54,78 @@ function Get-RepoRoot {
   return (Split-Path -Parent $PSCommandPath)
 }
 
+# Answers "can this bootstrap actually create directories here?" by trying it,
+# not by asking whether the directory exists.
+#
+# The distinction is the whole point. On an ephemeral `eph-win-x64` runner
+# `D:\` exists and is the cloudbase-init config drive: a read-only CDFS
+# volume (`Get-CimInstance Win32_LogicalDisk` -> DriveType 5, VolumeName
+# `config-2`). An existence probe says yes, and every subsequent `New-Item`
+# under it dies with
+#
+#     New-Item : Access to the path 'D:\metacraft-dev-deps\ttd' is denied.
+#
+# which is how this surfaced: `Ensure-Ttd` is simply the FIRST bootstrap step,
+# so it took the bullet for a root that all of them would have failed on.
+#
+# There is no cheaper honest test. `Test-Path` cannot see a read-only mount,
+# ACLs do not survive the POSIX permission bits Git-Bash reports, and a
+# writable-looking directory can still refuse a create. Making the directory
+# is the only probe that answers the question the caller is actually asking.
+function Test-DirectoryWritable {
+  param([string]$Path)
+
+  if ([string]::IsNullOrWhiteSpace($Path)) { return $false }
+  if (-not (Test-Path -LiteralPath $Path -PathType Container)) { return $false }
+
+  $probe = Join-Path $Path (".codetracer-writable-probe-" + [guid]::NewGuid().ToString("N"))
+  try {
+    New-Item -ItemType Directory -Path $probe -ErrorAction Stop | Out-Null
+    return $true
+  } catch {
+    return $false
+  } finally {
+    Remove-Item -LiteralPath $probe -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}
+
 function Get-DefaultInstallRoot {
+  # An explicit operator choice is honoured verbatim, writable or not: if
+  # someone pinned this root, a silent relocation would hide their mistake and
+  # scatter half-populated toolchain trees across two locations.
   $envInstallRoot = [Environment]::GetEnvironmentVariable("WINDOWS_DIY_INSTALL_ROOT")
   if (-not [string]::IsNullOrWhiteSpace($envInstallRoot)) {
     return $envInstallRoot.Trim()
   }
 
-  # Prefer D: drive root when available (more space, avoids C: bloat).
-  if (Test-Path -LiteralPath "D:\" -PathType Container) {
+  # A dev drive is an OPTIONAL performance feature. Prefer it when it is
+  # genuinely there and genuinely writable (more space, avoids C: bloat);
+  # never fail for want of one.
+  if (Test-DirectoryWritable -Path "D:\") {
     return "D:\metacraft-dev-deps"
   }
 
+  # The documented default, and the right fallback for CI: it PERSISTS across
+  # jobs on the two long-lived Windows runners, so a cache put here survives
+  # to be reused. `RUNNER_TEMP` deliberately does not -- Actions wipes it
+  # between jobs -- so making it the primary fallback would silently convert
+  # this toolchain cache into a re-download on every single job.
   $localAppData = [Environment]::GetFolderPath([Environment+SpecialFolder]::LocalApplicationData)
-  if ([string]::IsNullOrWhiteSpace($localAppData)) {
-    throw "Could not resolve LocalApplicationData for default WINDOWS_DIY_INSTALL_ROOT."
+  if (Test-DirectoryWritable -Path $localAppData) {
+    return (Join-Path (Join-Path $localAppData "codetracer") "windows-diy")
   }
 
-  return (Join-Path (Join-Path $localAppData "codetracer") "windows-diy")
+  # Last resort. A cold cache is a slow job; no writable root at all is a dead
+  # runner, so trade the persistence away rather than throw.
+  foreach ($name in @("RUNNER_TEMP", "TEMP", "TMP")) {
+    $candidate = [Environment]::GetEnvironmentVariable($name)
+    if (Test-DirectoryWritable -Path $candidate) {
+      Write-Host "::warning::No writable dev-deps root (D:\ and LOCALAPPDATA both refused); falling back to `$env:$name. Toolchain caches will not persist across jobs."
+      return (Join-Path (Join-Path $candidate "codetracer") "windows-diy")
+    }
+  }
+
+  throw "Could not resolve any writable WINDOWS_DIY_INSTALL_ROOT (tried D:\, LOCALAPPDATA, RUNNER_TEMP, TEMP, TMP). Set WINDOWS_DIY_INSTALL_ROOT explicitly."
 }
 
 function ConvertTo-BoolFromEnv {

--- a/env.sh
+++ b/env.sh
@@ -21,9 +21,29 @@ source "$WINDOWS_DIR/toolchain-versions.env"
 WINDBG_REQUIRED_MIN_VERSION="${WINDBG_MIN_VERSION:-1.2601.12001.0}"
 TTD_REQUIRED_MIN_VERSION="${TTD_MIN_VERSION:-1.11.584.0}"
 
+# Bash mirror of env.ps1's Get-DefaultInstallRoot. Keep the two in step; the
+# static gate in ci/test/windows-install-root-test.sh fails if they diverge.
+#
+# `[[ -d $dir ]]` is NOT the question, and `[[ -w $dir ]]` is not either. On an
+# ephemeral eph-win-x64 runner `/d/` is the cloudbase-init config drive -- a
+# read-only CDFS mount -- which passes both tests under Git-Bash (Windows ACLs
+# do not survive the POSIX permission bits MSYS synthesises) and then refuses
+# every mkdir. Creating a directory is the only probe that answers the
+# question the caller is actually asking.
+_ct_dir_writable() {
+	local dir=$1
+	[[ -n $dir && -d $dir ]] || return 1
+	local probe="$dir/.codetracer-writable-probe-$$-${RANDOM}"
+	mkdir "$probe" 2>/dev/null || return 1
+	rmdir "$probe" 2>/dev/null || true
+	return 0
+}
+
 if [[ -z ${WINDOWS_DIY_INSTALL_ROOT:-} ]]; then
-	# Prefer D: drive root when available (more space, avoids C: bloat).
-	if [[ -d /d/ ]]; then
+	# A dev drive is an OPTIONAL performance feature (more space, avoids C:
+	# bloat). Prefer it when it is really there and really writable; never
+	# fail for want of one.
+	if _ct_dir_writable /d/; then
 		WINDOWS_DIY_INSTALL_ROOT="/d/metacraft-dev-deps"
 	else
 		if [[ -n ${LOCALAPPDATA:-} ]]; then
@@ -35,7 +55,28 @@ if [[ -z ${WINDOWS_DIY_INSTALL_ROOT:-} ]]; then
 		else
 			windows_diy_local_app_data="$HOME/AppData/Local"
 		fi
-		WINDOWS_DIY_INSTALL_ROOT="$windows_diy_local_app_data/codetracer/windows-diy"
+		# The documented default, and the right fallback for CI: it PERSISTS
+		# across jobs on the long-lived Windows runners. RUNNER_TEMP does not
+		# -- Actions wipes it between jobs -- so it is a last resort only,
+		# below, where the alternative is having no root at all.
+		if _ct_dir_writable "$windows_diy_local_app_data"; then
+			WINDOWS_DIY_INSTALL_ROOT="$windows_diy_local_app_data/codetracer/windows-diy"
+		else
+			for _ct_root_candidate in "${RUNNER_TEMP:-}" "${TEMP:-}" "${TMP:-}"; do
+				if _ct_dir_writable "$_ct_root_candidate"; then
+					echo "warning: no writable dev-deps root (/d/ and LOCALAPPDATA both refused); falling back to $_ct_root_candidate. Toolchain caches will not persist across jobs." >&2
+					WINDOWS_DIY_INSTALL_ROOT="$_ct_root_candidate/codetracer/windows-diy"
+					break
+				fi
+			done
+			unset _ct_root_candidate
+		fi
+		if [[ -z ${WINDOWS_DIY_INSTALL_ROOT:-} ]]; then
+			echo "error: could not resolve any writable WINDOWS_DIY_INSTALL_ROOT (tried /d/, LOCALAPPDATA, RUNNER_TEMP, TEMP, TMP). Set WINDOWS_DIY_INSTALL_ROOT explicitly." >&2
+			# `return`, not `exit`: this file is SOURCED, and `exit` would
+			# take the caller's interactive shell down with it.
+			return 1
+		fi
 	fi
 fi
 export WINDOWS_DIY_INSTALL_ROOT

--- a/non-nix-build/windows/setup-codetracer-runtime-env.sh
+++ b/non-nix-build/windows/setup-codetracer-runtime-env.sh
@@ -12,7 +12,35 @@ fi
 # on PATH by default in non-PowerShell shells.  We also add the native tool
 # bin directories as a fallback in case shims haven't been (re-)generated yet.
 # ---------------------------------------------------------------------------
-INSTALL_ROOT="${WINDOWS_DIY_INSTALL_ROOT:-D:/metacraft-dev-deps}"
+# This script is a CONSUMER of the root env.sh / env.ps1 resolved and
+# exported; it only builds PATH entries out of it. Its own fallback used to be
+# a bare `D:/metacraft-dev-deps` with no probe at all, so on any box without a
+# writable D: it disagreed with env.sh about where the toolchain lives and
+# silently produced a PATH of directories that do not exist. Mirror env.sh's
+# resolution instead of guessing: same probe, same order, same answer.
+if [[ -n ${WINDOWS_DIY_INSTALL_ROOT:-} ]]; then
+	INSTALL_ROOT="$WINDOWS_DIY_INSTALL_ROOT"
+else
+	_ct_runtime_dir_writable() {
+		local dir=$1
+		[[ -n $dir && -d $dir ]] || return 1
+		local probe="$dir/.codetracer-writable-probe-$$-${RANDOM}"
+		mkdir "$probe" 2>/dev/null || return 1
+		rmdir "$probe" 2>/dev/null || true
+		return 0
+	}
+	if _ct_runtime_dir_writable /d/; then
+		INSTALL_ROOT="/d/metacraft-dev-deps"
+	elif [[ -n ${LOCALAPPDATA:-} ]]; then
+		if command -v cygpath >/dev/null 2>&1; then
+			INSTALL_ROOT="$(cygpath -u "$LOCALAPPDATA")/codetracer/windows-diy"
+		else
+			INSTALL_ROOT="$LOCALAPPDATA/codetracer/windows-diy"
+		fi
+	else
+		INSTALL_ROOT="$HOME/AppData/Local/codetracer/windows-diy"
+	fi
+fi
 # Convert Windows drive-letter paths (D:/...) to MSYS2/Git-Bash form (/d/...)
 # so that `which` and other POSIX tools resolve executables correctly.
 if [[ $INSTALL_ROOT =~ ^([A-Za-z]):/(.*) ]]; then
@@ -24,8 +52,10 @@ fi
 # Source toolchain version pins so paths stay in sync with env.ps1.
 _tc_file="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/toolchain-versions.env"
 if [[ -f $_tc_file ]]; then
-	# shellcheck disable=SC1090
 	set -a
+	# The directive applies to the NEXT command, so it has to sit here rather
+	# than above `set -a`, where it was silently applying to nothing.
+	# shellcheck disable=SC1090
 	source "$_tc_file"
 	set +a
 fi

--- a/non-nix-build/windows/validate-install-root.ps1
+++ b/non-nix-build/windows/validate-install-root.ps1
@@ -1,0 +1,235 @@
+# Behavioural gate on env.ps1's Windows DIY install-root resolution.
+#
+# THE FIELD FAILURE THIS EXISTS TO PREVENT
+#
+# Every ephemeral `eph-win-x64` job died in `Ensure-Ttd` with
+#
+#     New-Item : Access to the path 'D:\metacraft-dev-deps\ttd' is denied.
+#
+# because `Get-DefaultInstallRoot` treated "D:\ exists" as "D:\ is a writable
+# dev drive". On those guests `D:` is the cloudbase-init config drive: a
+# read-only CDFS volume (`Win32_LogicalDisk` DriveType 5, VolumeName
+# `config-2`). It exists, so the probe said yes; it is read-only, so every
+# `Ensure-*` step underneath it failed. TTD is merely the first of them.
+#
+# WHAT IS PROVABLE HERE
+#
+# The two functions are extracted from env.ps1 by AST and executed in
+# isolation -- the same technique validate-env-path-entries.ps1 uses -- so
+# this runs on any Windows host without needing a read-only D:. The
+# unwritable case is synthesised from a deny ACE rather than assumed, and the
+# synthesis is itself checked before anything is concluded from it.
+#
+# Deliberately NOT proved here: that a real CDFS mount behaves this way. Only
+# a booted guest can say that, and it was confirmed on a CoW clone of
+# `golden-win11-cloudbase.qcow2` on 2026-08-23.
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $false)]
+  [string]$EnvScriptPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($EnvScriptPath)) {
+  $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+  $EnvScriptPath = Join-Path $repoRoot "env.ps1"
+}
+if (-not (Test-Path -LiteralPath $EnvScriptPath -PathType Leaf)) {
+  throw "Missing required file: $EnvScriptPath"
+}
+
+$parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+  $EnvScriptPath, [ref]$null, [ref]$parseErrors)
+if ($parseErrors.Count -gt 0) {
+  $parseErrors | ForEach-Object {
+    Write-Error "${EnvScriptPath}: $($_.Message)"
+  }
+  throw "PowerShell parser reported one or more errors."
+}
+
+function Get-FunctionText {
+  param([string]$Name)
+  $fn = $ast.Find({
+      param($node)
+      $node -is
+        [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -eq $Name
+    }, $true)
+  if ($null -eq $fn) { throw "env.ps1 does not define $Name." }
+  return $fn.Extent.Text
+}
+
+$writableFn = Get-FunctionText -Name "Test-DirectoryWritable"
+$rootFn = Get-FunctionText -Name "Get-DefaultInstallRoot"
+
+# --- static gate: the existence-only probe must not come back --------------
+# This is the mistake itself, not a proxy for it. `Get-DefaultInstallRoot`
+# asking Test-Path about D:\ is exactly the shipped defect, so the gate names
+# it. Anchored on the D: branch only: Test-Path is legitimate elsewhere.
+$rootLines = @(
+  $rootFn -split "`r?`n" | Where-Object { $_ -notmatch '^\s*#' })
+$dLines = @($rootLines | Where-Object { $_ -match '"D:\\' })
+if ($dLines.Count -eq 0) {
+  throw ("Get-DefaultInstallRoot no longer mentions D:\ at all. If the " +
+    "dev-drive preference was removed on purpose, update this gate; " +
+    "otherwise this is a vacuous pass.")
+}
+$badProbe = @($dLines | Where-Object { $_ -match 'Test-Path' })
+if ($badProbe.Count -gt 0) {
+  throw ("Get-DefaultInstallRoot probes D:\ with Test-Path, which cannot " +
+    "see a read-only mount. That is the eph-win-x64 failure. " +
+    "Offending line(s): " + ($badProbe -join ' | '))
+}
+$goodProbe = @($dLines | Where-Object { $_ -match 'Test-DirectoryWritable' })
+if ($goodProbe.Count -eq 0) {
+  throw ("Get-DefaultInstallRoot's D:\ branch does not go through " +
+    "Test-DirectoryWritable.")
+}
+
+# --- behavioural gate ------------------------------------------------------
+$tempRoot = Join-Path ([IO.Path]::GetTempPath()) (
+  "codetracer-install-root-" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+
+$saved = @{}
+foreach ($n in @("WINDOWS_DIY_INSTALL_ROOT", "RUNNER_TEMP", "TEMP", "TMP")) {
+  $saved[$n] = [Environment]::GetEnvironmentVariable($n)
+}
+
+try {
+  $probe = @'
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Assert-Equal($actual, $expected, $what) {
+  if ($actual -ne $expected) {
+    throw "$what : got '$actual', expected '$expected'"
+  }
+}
+function Assert-True($cond, $what) {
+  if (-not $cond) { throw "$what : expected true" }
+}
+function Assert-False($cond, $what) {
+  if ($cond) { throw "$what : expected false" }
+}
+
+# 1. A writable directory is writable, and the probe leaves nothing behind.
+$before = @(Get-ChildItem -LiteralPath $tempRoot -Force).Count
+Assert-True (Test-DirectoryWritable -Path $tempRoot) "writable temp dir"
+$after = @(Get-ChildItem -LiteralPath $tempRoot -Force).Count
+Assert-Equal $after $before "the probe left its directory behind"
+
+# 2. A path that does not exist is not writable (the old probe's other half).
+$missing = Join-Path $tempRoot "no-such-dir"
+Assert-False (Test-DirectoryWritable -Path $missing) "missing dir"
+Assert-False (Test-DirectoryWritable -Path "") "empty path"
+Assert-False (Test-DirectoryWritable -Path $null) "null path"
+
+# 3. A directory that EXISTS but refuses creation is not writable. This is
+#    the eph-win-x64 D: case in miniature. A CDFS mount cannot be conjured
+#    in a test, so a deny ACE stands in for it.
+#
+#    The setup is SELF-VALIDATING, deliberately. If the deny ACE silently
+#    fails to bite -- wrong SID, an elevated context that overrides it, a
+#    filesystem that ignores ACLs -- then Test-DirectoryWritable returning
+#    $true is the CORRECT answer, and asserting $false would be asserting a
+#    lie. So this first proves, with a direct New-Item, that the directory
+#    really does refuse creation, and only then asks the probe to agree. A
+#    setup that cannot be established is a hard failure, never a skip.
+#
+#    `$env:OS`, not `$IsWindows`: the goldens ship Windows PowerShell 5.1,
+#    where `$IsWindows` does not exist and `Set-StrictMode -Version Latest`
+#    turns reading it into a terminating error. `$env:OS` is `Windows_NT` on
+#    both 5.1 and pwsh 7, and an absent environment variable is $null rather
+#    than a throw under StrictMode.
+if ($env:OS -ne 'Windows_NT') {
+  throw ("This gate requires Windows: it needs real NTFS ACLs to build " +
+    "the 'exists but refuses creation' case that the eph-win-x64 D: " +
+    "drive represents.")
+}
+$denied = Join-Path $tempRoot "denied"
+New-Item -ItemType Directory -Path $denied -Force | Out-Null
+$acl = Get-Acl -LiteralPath $denied
+$me = [Security.Principal.WindowsIdentity]::GetCurrent().Name
+$ace = New-Object Security.AccessControl.FileSystemAccessRule(
+  $me,
+  "CreateDirectories,CreateFiles,Write",
+  "ContainerInherit,ObjectInherit",
+  "None",
+  "Deny")
+$acl.AddAccessRule($ace)
+Set-Acl -LiteralPath $denied -AclObject $acl
+try {
+  Assert-True (Test-Path -LiteralPath $denied -PathType Container) `
+    "the deny-ACL dir still EXISTS (why Test-Path is not enough)"
+
+  # Prove the setup before trusting the assertion that depends on it.
+  $reallyRefuses = $false
+  try {
+    $control = Join-Path $denied "control"
+    New-Item -ItemType Directory -Path $control -ErrorAction Stop | Out-Null
+  } catch {
+    $reallyRefuses = $true
+  }
+  Assert-True $reallyRefuses `
+    "the deny ACE bites (else the next assertion is vacuous)"
+
+  Assert-False (Test-DirectoryWritable -Path $denied) `
+    "a deny-ACL dir must not read as writable"
+} finally {
+  $acl2 = Get-Acl -LiteralPath $denied
+  $acl2.RemoveAccessRule($ace) | Out-Null
+  Set-Acl -LiteralPath $denied -AclObject $acl2
+}
+
+# 4. An explicit WINDOWS_DIY_INSTALL_ROOT is honoured verbatim and NOT
+#    second-guessed -- including when it points somewhere unwritable,
+#    because silently relocating an operator's pinned root is worse than
+#    failing.
+[Environment]::SetEnvironmentVariable(
+  "WINDOWS_DIY_INSTALL_ROOT", "  X:\pinned\root  ", "Process")
+Assert-Equal (Get-DefaultInstallRoot) "X:\pinned\root" `
+  "an explicit root wins and is trimmed"
+
+# 5. With no explicit root and no writable D:, resolution must still produce
+#    a usable root rather than throwing. D: is whatever this host has, so the
+#    assertion is that we get a non-empty root back, and that when D: is
+#    absent or read-only the answer is NOT under D:.
+[Environment]::SetEnvironmentVariable(
+  "WINDOWS_DIY_INSTALL_ROOT", $null, "Process")
+$resolved = Get-DefaultInstallRoot
+Assert-True ($resolved -is [string] -and $resolved.Length -gt 0) `
+  "resolution returns a root"
+if (-not (Test-DirectoryWritable -Path "D:\")) {
+  if ($resolved -like "D:*") {
+    throw "resolved to '$resolved' although D:\ is not writable"
+  }
+}
+
+# 6. Whatever it resolved to must itself be creatable -- the property the
+#    whole bootstrap depends on, and the one violated in the field.
+New-Item -ItemType Directory -Force -Path $resolved -ErrorAction Stop |
+  Out-Null
+Assert-True (Test-DirectoryWritable -Path $resolved) `
+  "the resolved root is writable"
+
+Write-Host "resolved install root: $resolved"
+'@
+
+  $scriptBlock = [scriptblock]::Create(
+    $writableFn + "`n" + $rootFn + "`n" + $probe)
+  & $scriptBlock
+} finally {
+  foreach ($n in $saved.Keys) {
+    [Environment]::SetEnvironmentVariable($n, $saved[$n], "Process")
+  }
+  if (Test-Path -LiteralPath $tempRoot) {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force `
+      -ErrorAction SilentlyContinue
+  }
+}
+
+Write-Host "Install-root resolution validation passed for '$EnvScriptPath'."

--- a/repro.nim
+++ b/repro.nim
@@ -134,8 +134,32 @@ const
     ("runquota", "RUNQUOTA_SRC"),
     ("reprobuild", "CODETRACER_REPROBUILD_REPO_PATH")
   ]
-  WindowsZlibRoot = "D:/metacraft-dev-deps/zlib/1.3.1"
-  WindowsZstdRoot = "D:/metacraft-dev-deps/zstd/1.5.6/zstd-v1.5.6-win64"
+  # Relative to the Windows DIY install root. `non-nix-build/windows/
+  # ensure-zlib.ps1` and `ensure-zstd.ps1` install into `$Root/zlib/<ver>` and
+  # `$Root/zstd/<ver>` where `$Root` is whatever `Get-DefaultInstallRoot`
+  # resolved — so these READERS have to follow that root rather than pin one.
+  # They used to hard-code `D:/metacraft-dev-deps/...`, which was already
+  # wrong on any machine whose root is not D: and only stayed invisible
+  # because the bootstrap died earlier, at Ensure-Ttd.
+  WindowsZlibRelative = "zlib/1.3.1"
+  WindowsZstdRelative = "zstd/1.5.6/zstd-v1.5.6-win64"
+  # The historical default, kept verbatim so a developer box with a real D:
+  # dev drive resolves exactly as before.
+  WindowsDefaultInstallRoot = "D:/metacraft-dev-deps"
+
+# NOTE: `getEnv` here is a RUNTIME read and therefore not a tracked solver
+# input — see the buildType note at the top of this file. That is acceptable
+# for this one value because it names a per-MACHINE toolchain location rather
+# than anything that changes what is built, and because no CI lane exercises
+# it (the Windows jobs do not run tup or this Nim build; `just build-once`
+# runs only on the Linux and macOS legs).
+let
+  WindowsInstallRoot = block:
+    let fromEnv = getEnv("WINDOWS_DIY_INSTALL_ROOT").strip()
+    if fromEnv.len > 0: fromEnv.replace('\\', '/').strip(leading = false, chars = {'/'})
+    else: WindowsDefaultInstallRoot
+  WindowsZlibRoot = WindowsInstallRoot & "/" & WindowsZlibRelative
+  WindowsZstdRoot = WindowsInstallRoot & "/" & WindowsZstdRelative
   WindowsExtraPassC = @[
     "-I" & WindowsZlibRoot & "/include",
     "-I" & WindowsZstdRoot & "/include",

--- a/src/Tuprules.tup
+++ b/src/Tuprules.tup
@@ -120,7 +120,16 @@ NIM_BIN = nim
 # contract). The path is matched to ensure-zstd's layout (version dir +
 # include/lib subdirs).
 ifeq (@(TUP_PLATFORM),win32)
+# `ensure-zlib.ps1` installs under whatever root `Get-DefaultInstallRoot`
+# resolved, which is only `D:/metacraft-dev-deps` on a box with a real,
+# WRITABLE D: dev drive. tup refuses environment reads at parse time by
+# design, so the seam is a tup.config entry: set `CONFIG_WINDOWS_ZLIB_DIR` in
+# `src/build-<variant>/tup.config` on a machine whose root is elsewhere. Unset
+# keeps the historical literal, so nothing moves for existing dev boxes.
+WINDOWS_ZLIB_DIR = @(WINDOWS_ZLIB_DIR)
+ifeq ($(WINDOWS_ZLIB_DIR),)
 WINDOWS_ZLIB_DIR = D:/metacraft-dev-deps/zlib/1.3.1
+endif
 # `-Wno-implicit-function-declaration` and the matching `-Wno-error` are
 # needed because the bundled `libs/zip/zip/private/libzip_all.c` uses POSIX
 # helpers (`getpid`, `unlink`, `mkstemp`) that MinGW UCRT either renames


### PR DESCRIPTION
## The failure

Every ephemeral `eph-win-x64` job died at the first bootstrap step:

```
ensure-ttd.ps1:189  New-Item -ItemType Directory -Force -Path $ttdCacheDir
                    Access to the path 'D:\metacraft-dev-deps\ttd' is denied.
```

`Ensure-Ttd` was not at fault. `env.ps1`'s `Get-DefaultInstallRoot` picked the
root, and its test for "there is a dev drive here" was
`Test-Path -LiteralPath "D:\" -PathType Container`.

## Why that test was wrong

There is no dev drive on these guests. `D:` is the cloudbase-init **config
drive** — a read-only CDFS volume. Measured on a CoW clone of
`golden-win11-cloudbase.qcow2`:

```
DeviceID  DriveType  FileSystem  VolumeName  SizeGB
C:                3  NTFS        Windows      79.58
D:                5  CDFS        config-2         0

Test-Path D:\ -PathType Container  =>  True
New-Item  D:\metacraft-dev-deps\ttd  =>  Access to the path ... is denied.
```

The guest's libvirt domain has exactly two block devices: the qcow2 system disk
and a read-only SATA CD-ROM. There is no third volume for `D:` to be.

TTD is simply the **first** `Ensure-*` step in `env.ps1`. Every one of them
would have failed on the same root.

## The fix

Existence was never the question. Ask whether the directory can be created in,
by creating one — `Test-Path` cannot see a read-only mount, and on the bash
side `[[ -w ]]` is no better, because Git-Bash synthesises POSIX permission
bits that do not carry Windows ACLs.

A dev drive is an **optional performance feature**, so its absence now costs
nothing. `LOCALAPPDATA` leads the fallbacks because it *persists* across jobs
on the long-lived Windows runners; `RUNNER_TEMP` is last resort only, since
Actions wipes it between jobs. An explicitly set `WINDOWS_DIY_INSTALL_ROOT` is
still honoured verbatim.

## The rest of the sweep

| site | before | after |
|---|---|---|
| `env.ps1` `Get-DefaultInstallRoot` | `Test-Path "D:\"` | writability probe, then LOCALAPPDATA, then RUNNER_TEMP/TEMP/TMP |
| `env.sh` | `[[ -d /d/ ]]` | same ladder, same order |
| `setup-codetracer-runtime-env.sh` | bare `D:/metacraft-dev-deps` default, **no probe at all** | mirrors `env.sh` |
| `repro.nim` zlib/zstd roots | hard-coded `D:/metacraft-dev-deps/...` | follows the resolved root, same literal default |
| `src/Tuprules.tup` `WINDOWS_ZLIB_DIR` | hard-coded | `@(WINDOWS_ZLIB_DIR)` tup.config seam, same literal default |

The last two are **readers** of a root that `ensure-zlib.ps1` / `ensure-zstd.ps1`
*write* under whatever root was resolved. They were already wrong on any machine
whose root is not `D:`; it only stayed invisible because the bootstrap died
earlier.

## Tests

- `ci/test/windows-install-root-test.sh` — static **and** behavioural, runs on
  the Linux verdict runner. It extracts the bash probe and executes it against
  a directory that exists and refuses creation (the CDFS case, reproduced with
  a `chmod`), so an inverted probe is caught — which no amount of grepping
  would manage.
- `non-nix-build/windows/validate-install-root.ps1` — the PowerShell half,
  extracting both functions from `env.ps1` by AST the way
  `validate-env-path-entries.ps1` already does, and synthesising the unwritable
  case from a deny ACE. The synthesis is self-checked before anything is
  concluded from it.

Against the pre-fix tree: **16 of 30 assertions fail**, naming the defect and
quoting the offending lines. **20 mutations of the fixed tree, all killed** —
including the two only the executed-probe section can see (a probe that always
says yes; one that always says no) and the two proving the suite cannot pass on
nothing (dev-drive branch deleted; `env.ps1` truncated).

## Two traps hit while writing this, both recorded in the code

- A scan whose glob is broken reads exactly like "the bad thing is absent".
  Every section first asserts it **found** what it means to check. The first red
  run caught two of my own broken patterns this way.
- `set -o pipefail` with `grep -q` is a trap: `grep -q` exits on first match,
  the upstream `sed` takes SIGPIPE, and the pipeline reports 141 — so a
  *successful* match can read as a failed test, depending on where in the file
  the match sits. Every scan matches with a here-string instead.
