### PR TITLE
fix(windows): verify the WinDbg/TTD bundle before executing it

### DIFF
--- a/non-nix-build/windows/ensure-ttd.ps1
+++ b/non-nix-build/windows/ensure-ttd.ps1
@@ -138,15 +138,30 @@ function Install-TtdViaMsixBundle {
       $ProgressPreference = $progressPreference
     }
 
-    if (-not [string]::IsNullOrWhiteSpace($BundleSha256)) {
-      $actual = (Get-FileHash -LiteralPath $bundlePath -Algorithm SHA256).Hash
-      if ($actual -ne $BundleSha256.ToUpper()) {
-        throw "Downloaded windbg.msixbundle SHA256 mismatch. Expected: $BundleSha256, got: $actual"
-      }
-      Write-Host "msixbundle SHA256 verified."
-    } else {
-      Write-Host "WARNING: TTD_BUNDLE_SHA256 not pinned for $BundleVersion - skipping integrity check."
+    # An unpinned digest is a HARD FAILURE, not a warning.
+    #
+    # This used to warn and carry on. The result shipped: TTD_BUNDLE_SHA256
+    # sat empty in toolchain-versions.env, and every Windows CI job that
+    # reached this path downloaded ~767 MB over the network and then executed
+    # code out of it with no integrity check at all, announcing the fact in a
+    # line nobody reads. A warning that does not stop the build is
+    # indistinguishable from no check.
+    #
+    # Verification happens HERE -- before the archive is expanded and long
+    # before TTD.exe is copied into the cache and run. Ordering is the whole
+    # point: a digest checked after extraction protects nothing.
+    if ([string]::IsNullOrWhiteSpace($BundleSha256)) {
+      throw ("TTD_BUNDLE_SHA256 is not pinned for $BundleVersion. Refusing to execute an " +
+             "unverified $BundleUrl download. Pin the digest in " +
+             "non-nix-build/windows/toolchain-versions.env -- and establish its provenance " +
+             "the way the comment there describes (verify the package's Authenticode " +
+             "signature); do not paste the sha256sum of your own unverified download.")
     }
+    $actual = (Get-FileHash -LiteralPath $bundlePath -Algorithm SHA256).Hash
+    if ($actual -ne $BundleSha256.ToUpper()) {
+      throw "Downloaded windbg.msixbundle SHA256 mismatch. Expected: $BundleSha256, got: $actual"
+    }
+    Write-Host "msixbundle SHA256 verified."
 
     # Layer 1: msixbundle (a zip of per-architecture .msix files).
     $bundleExtractDir = Join-Path $workDir "bundle"

--- a/non-nix-build/windows/toolchain-versions.env
+++ b/non-nix-build/windows/toolchain-versions.env
@@ -20,14 +20,45 @@ TTD_MIN_VERSION=1.11.584.0
 # unzipped (msixbundle → per-arch .msix → TTD.exe + DLLs), and copied
 # to the DIY cache. URL pattern follows
 # https://windbg.download.prss.microsoft.com/dbazure/prod/<dashed-ver>/windbg.msixbundle
-# Sourced from https://aka.ms/windbg/download for the pinned version
-# below. SHA256 is verified on download when set; leave empty to skip
-# (warns only). To pin: download once, run
-# `Get-FileHash windbg.msixbundle -Algorithm SHA256` on Windows or
-# `sha256sum windbg.msixbundle` on Linux, paste the upper-case hex.
+# Sourced from https://aka.ms/windbg/download for the pinned version below.
+# TTD_BUNDLE_SHA256 is MANDATORY (validate-toolchain-versions.ps1 rejects an
+# empty or malformed value) and Ensure-Ttd refuses to run without it.
+#
+# HOW THIS DIGEST WAS ESTABLISHED -- do not "re-pin" it by re-downloading.
+#
+# Hashing your own download proves only that you fetched the same bytes
+# twice; it cannot distinguish Microsoft's build from whatever a hostile
+# mirror, proxy or CDN edge chose to serve. Microsoft does not publish a
+# SHA-256 for this asset, so the digest is anchored to the package's own
+# Authenticode signature instead, which is the provenance Microsoft *does*
+# publish:
+#
+#   * windbg.msixbundle carries AppxSignature.p7x, a PKCS#7 SignedData whose
+#     Authenticode SpcIndirectDataContent holds four SHA-256 digests over the
+#     package: AXPC (all zip content), AXCD (central directory), AXCT
+#     ([Content_Types].xml) and AXBM (AppxBlockMap.xml).
+#   * AXPC, AXCT and AXBM recompute EXACTLY from the bytes hashed below.
+#     AXPC alone covers all 804,362,637 bytes of payload -- every one of the
+#     three per-arch .msix packages, hence TTD.exe itself.
+#   * That signature verifies (RSA-2048/SHA-256) under a leaf certificate
+#     `CN=Microsoft Corporation` which chains to `Microsoft Code Signing PCA
+#     2011` and on to `Microsoft Root Certificate Authority 2011`, SHA-1
+#     thumbprint 8F43288AD272F3103B6FB1428485EA3014C0BCFE -- Microsoft's
+#     published, independently checkable root.
+#   * AppxBundleManifest.xml inside the signed payload declares
+#     Name="Microsoft.WinDbg" Version="1.2601.12001.0", matching
+#     WINDBG_BUNDLE_VERSION below.
+#
+# So the digest below is a change-detector on top of a signature-verified
+# artifact, not a self-attested hash. To move the pin to a new version,
+# repeat that verification -- do not simply paste a fresh sha256sum.
+#
+# Verified 2026-08-23. Get-FileHash emits upper-case; the comparison in
+# ensure-ttd.ps1 upper-cases the pin before comparing, so lower-case here
+# matches the convention used by the other digests in this file.
 WINDBG_BUNDLE_VERSION=1.2601.12001.0
 TTD_BUNDLE_URL=https://windbg.download.prss.microsoft.com/dbazure/prod/1-2601-12001-0/windbg.msixbundle
-TTD_BUNDLE_SHA256=
+TTD_BUNDLE_SHA256=4aea6f79d6721e75aae37764eebe0a0bea2eac896f8bc84485fa367afadee8c0
 NIM_VERSION=2.2.8
 NIM_WIN_X64_SHA256=11fe2415a64a791b899cc78e2eeacdde93b5f122f2fabc447db36d38002bfb8c
 # Version reported by nimble.exe in the pinned official Nim archive.

--- a/non-nix-build/windows/validate-toolchain-versions.ps1
+++ b/non-nix-build/windows/validate-toolchain-versions.ps1
@@ -38,7 +38,14 @@ $requiredKeys = @(
   "TUP_MSYS2_BASE_VERSION",
   "TUP_MSYS2_BASE_X64_SHA256",
   "TUP_MSYS2_PACKAGES",
-  "LDC_WIN_X64_SHA256"
+  "LDC_WIN_X64_SHA256",
+  # TTD/WinDbg msixbundle. Absent from this list until 2026-08-23, which is
+  # exactly how TTD_BUNDLE_SHA256 shipped EMPTY: Ensure-Ttd downloaded ~767 MB
+  # and executed it with only a warning, and nothing here objected. A pin that
+  # is not enforced is a comment.
+  "WINDBG_BUNDLE_VERSION",
+  "TTD_BUNDLE_URL",
+  "TTD_BUNDLE_SHA256"
 )
 
 $valuePatterns = @{
@@ -73,6 +80,9 @@ $valuePatterns = @{
   "TUP_MSYS2_BASE_X64_SHA256" = '^[A-Fa-f0-9]{64}$'
   "TUP_MSYS2_PACKAGES" = '^[A-Za-z0-9+_.-]+(?: [A-Za-z0-9+_.-]+)*$'
   "LDC_WIN_X64_SHA256" = '^[A-Fa-f0-9]{64}$'
+  "WINDBG_BUNDLE_VERSION" = '^[0-9]+(?:\.[0-9]+)*$'
+  "TTD_BUNDLE_URL" = '^https://\S+$'
+  "TTD_BUNDLE_SHA256" = '^[A-Fa-f0-9]{64}$'
 }
 
 if (-not (Test-Path -LiteralPath $FilePath)) {


### PR DESCRIPTION
## The defect

`TTD_BUNDLE_SHA256` was **empty** in `non-nix-build/windows/toolchain-versions.env`. On every Windows SKU without AppX support, `Ensure-Ttd` therefore downloaded a ~767 MB WinDbg msixbundle, printed

```
WARNING: TTD_BUNDLE_SHA256 not pinned for <version> - skipping integrity check.
```

and then unpacked it and executed `TTD.exe` out of it. A warning that does not stop the build is indistinguishable from no check at all.

Observed live.

## How provenance was established

This is the part worth reviewing, because the obvious fix is wrong.

Hashing your own download proves only that you fetched the same bytes twice — it cannot tell Microsoft's build apart from whatever a hostile mirror, proxy or CDN edge chose to serve. Microsoft publishes no SHA-256 for this asset, so a self-computed digest is **not** a pin.

The digest is instead anchored to the package's own **Authenticode signature**:

- `windbg.msixbundle` carries `AppxSignature.p7x`, a PKCS#7 `SignedData` whose Authenticode `SpcIndirectDataContent` holds four SHA-256 digests over the package: `AXPC` (all zip content), `AXCD` (central directory), `AXCT` (`[Content_Types].xml`) and `AXBM` (`AppxBlockMap.xml`).
- **`AXPC`, `AXCT` and `AXBM` recompute exactly** from the pinned bytes. `AXPC` alone covers all **804,362,637 bytes** of payload — all three per-architecture `.msix` packages, hence `TTD.exe` itself.
- The signature verifies (RSA-2048/SHA-256 over the signed attributes, whose `messageDigest` matches the eContent) under a leaf `CN=Microsoft Corporation`, chaining through `Microsoft Code Signing PCA 2011` to `Microsoft Root Certificate Authority 2011` — SHA-1 thumbprint `8F43288AD272F3103B6FB1428485EA3014C0BCFE`, Microsoft's published root. A negative control against an unrelated root fails to chain, so the positive result is not vacuous.
- The signed `AppxBundleManifest.xml` declares `Name="Microsoft.WinDbg" Version="1.2601.12001.0"`, matching `WINDBG_BUNDLE_VERSION`.

`AXCD` was **not** independently reproduced: its exact recipe normalizes the end-of-directory records after excluding the signature entry, and I did not want to guess at it. It covers only zip metadata, and `AXPC` already covers every content byte, so the conclusion does not rest on it. Noted here rather than quietly omitted.

## The changes

1. **Pin the digest**, with the provenance argument recorded next to the value so the next person does not "re-pin" it from a fresh unverified download.
2. **Make an unpinned digest fatal.** Verification already ran before extraction — the right place; it just did not refuse. It does now.
3. **Enforce it.** `TTD_BUNDLE_SHA256` was absent from `validate-toolchain-versions.ps1`'s required keys, which is exactly how an empty value shipped past a gate whose whole job is catching that. `WINDBG_BUNDLE_VERSION`, `TTD_BUNDLE_URL` and `TTD_BUNDLE_SHA256` now join the required set with value patterns; the URL pattern requires `https`.

## Verification

Gate run against the pre-fix file and the fixed file:

| | result |
|---|---|
| pre-fix (empty pin) | **rejected** — `Key 'TTD_BUNDLE_SHA256' has an empty value` |
| fixed | **accepted** |

Mutations, all behaving correctly:

| # | mutation | expected | actual |
|---|---|---|---|
| C1 | empty digest (the state that shipped) | reject | reject |
| C2 | non-hex digest | reject | reject |
| C3 | 63-char truncated digest | reject | reject |
| C4 | upper-case digest | accept | accept |
| C5 | empty `TTD_BUNDLE_URL` | reject | reject |
| C6 | empty `WINDBG_BUNDLE_VERSION` | reject | reject |
| C7 | digest key deleted entirely | reject | reject |
| C8 | plaintext `http://` URL | reject | reject |

🤖 Generated with [Claude Code](https://claude.com/claude-code)