### PR TITLE
fix(review): build the diff tab's Monaco decorations again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -297,6 +297,7 @@ test-programs/*/Cargo.lock
 src/db-backend/test-programs/*/Cargo.lock
 
 # Compiled Nim test binaries (built in-tree by `nim c -r`)
+src/ct/agent_session_api_contract_test
 src/ct/ci/bpf_monitor_test
 src/ct/ci/bpf_monitor_native_test
 src/ct/ci/bpf_native_integration_test

--- a/justfile
+++ b/justfile
@@ -648,6 +648,7 @@ test:
   #!/usr/bin/env bash
   set -e
   just test-build-alignment
+  just test-agent-api-contract
   just test-rust
   just test-nimsuggest
   if [ -n "${CODETRACER_RR_BACKEND_PATH:-}" ]; then
@@ -995,6 +996,15 @@ reset-layout:
               ~/.config/codetracer/auto_hide_state.json && \
     mkdir -p ~/.config/codetracer/ && \
     cp -r src/config/default_layout.json ~/.config/codetracer/default_layout.json
+
+# Cross-repo API contract: the `nim-agents` / `nim-acp` surface `ct` is built
+# against. Compiles the exact calls `src/ct/review_session.nim` makes, so a
+# sibling checkout at a revision that predates them fails in seconds with a
+# named remedy, instead of as a type mismatch fifteen minutes into a full `ct`
+# build that blames the caller. See the module header for why it asserts
+# signatures rather than behaviour.
+test-agent-api-contract:
+  nim c -r --hints:off src/ct/agent_session_api_contract_test.nim
 
 # originally by Pavel/Dimo in ci.sh
 test-nimsuggest:

--- a/src/ct/agent_session_api_contract_test.nim
+++ b/src/ct/agent_session_api_contract_test.nim
@@ -1,0 +1,183 @@
+## The `nim-agents` / `nim-acp` surface `ct` is built against (RV-6).
+##
+## Run:  nim c -r --hints:off src/ct/agent_session_api_contract_test.nim
+##       (or: just test-agent-api-contract)
+##
+## ## The failure this exists to catch
+##
+## `src/ct/review_session.nim` resolves a review's agent session through
+## `nim-agents`, which is a *sibling checkout*, not a vendored library: the
+## revision it compiles against is whatever the workspace, the CI
+## `siblings:` list or `repro.lock` happened to place at `../nim-agents`.
+## Those three do not always agree, and when the one in force predates the
+## API this repo calls, the build fails — but it fails as a type mismatch
+## roughly fifteen minutes into a full Nim compile of `ct`, naming a line
+## in `review_session.nim` and blaming the caller.  That diagnostic sends
+## you to read the caller, which is correct; the sibling is not.
+##
+## This module is the same claim, made in about a second, against a name it
+## can print.  It compiles the exact calls `review_session.nim` makes — the
+## real signatures, the real argument names, the real return type — so a
+## sibling that is behind fails *here*, with the remedy in the message,
+## before the expensive build starts.
+##
+## ## Why a compile-time contract and not a mock
+##
+## There is no double anywhere in this file, and nothing is stubbed: every
+## symbol below resolves to production `nim-agents` / `nim-acp` code in the
+## sibling checkout, and the assertions are the compiler's own overload
+## resolution.  That is the whole point — a test that *simulated* the
+## sibling would pass against a sibling that no longer exists in that
+## shape, which is precisely the failure being guarded.
+##
+## Nothing here performs I/O.  `loadSession` and `fromStdioAcpAgent` are
+## never *called*: spawning an agent or reaching a Harbor endpoint would
+## make this a slow, network-dependent test of somebody else's code.  What
+## is asserted is that the calls **type-check**, which is the entire
+## content of "the sibling is at the right revision".  The runtime
+## behaviour behind them is owned by `nim-agents/tests/
+## test_session_load_client.nim` and `nim-acp/tests/test_session_load.nim`.
+##
+## ## What must stay true here
+##
+## Every check below has to *positively find* something.  A contract test
+## that merely compiled an empty module would pass against any sibling at
+## all, which is the vacuous-green shape this file must not take: so the
+## call shapes are written out in full, the state spellings are compared to
+## literals, and the runtime suite at the bottom asserts values rather than
+## just the absence of a compile error.
+
+import std/json
+import std/unittest
+
+import nim_everywhere
+import nim_agents
+
+import review_session
+
+# ---------------------------------------------------------------------------
+# The call shapes `review_session.nim` makes.
+#
+# These procs are never invoked.  Their bodies are the contract: if any
+# signature in the sibling has drifted, this module does not compile, and
+# the message names this file rather than the caller.
+# ---------------------------------------------------------------------------
+
+proc acpCallShape(spec: ReviewSessionRefSpec): JsonNode {.used.} =
+  ## `resolveReviewSession`'s ACP branch, verbatim.
+  ##
+  ## `fromStdioAcpAgent` is native-only in `nim-agents` (it spawns a stdio
+  ## child), which is why this whole module is native-only too.
+  var client: AgentClient = fromStdioAcpAgent(spec.agentCommand, spec.agentArgs)
+  let loaded: AgentSessionLoad = client.loadSession(spec.sessionId,
+    cwd = spec.workspacePath, taskId = spec.taskId)
+  result = loaded.toJson()
+  client.shutdown()
+
+proc harborCallShape(spec: ReviewSessionRefSpec;
+                     transport: HttpTransport): JsonNode {.used.} =
+  ## `resolveReviewSession`'s Harbor branch, verbatim.
+  var client: AgentClient = fromHarbor(newHarborClient(spec.endpoint, transport))
+  let loaded: AgentSessionLoad = client.loadSession(spec.sessionId,
+    cwd = spec.workspacePath, taskId = spec.taskId)
+  result = loaded.toJson()
+  client.shutdown()
+
+suite "cross-repo API contract: nim-agents session loading":
+  test "ct_agent_session_api_contract_binds_every_call_review_session_makes":
+    ## The compile-time half, restated as a runtime assertion so this suite
+    ## cannot pass by having asserted nothing.  Taking the address of each
+    ## shape forces it to be instantiated rather than discarded as unused
+    ## generic scaffolding.
+    check acpCallShape != nil
+    check harborCallShape != nil
+
+  test "ct_agent_session_load_states_match_the_strings_ct_repeats":
+    ## `review_session.nim` repeats `nim-agents`' three state spellings as
+    ## its own string constants, because its pure half compiles on the
+    ## JavaScript backend where `nim-agents`' native transports do not
+    ## exist.  That duplication is only safe while the two agree, and
+    ## nothing else in this repo compares them — the renderer receives
+    ## strings that have already been through `toJson`.
+    ##
+    ## The enum is also walked in full, so a fourth state added upstream
+    ## without a decision here is a failure rather than something a
+    ## three-line check silently ignores.
+    check $aslsLoaded == ReviewSessionStateLoaded
+    check $aslsUnsupported == ReviewSessionStateUnsupported
+    check $aslsUnavailable == ReviewSessionStateUnavailable
+
+    var upstream: seq[string] = @[]
+    for state in AgentSessionLoadState:
+      upstream.add $state
+    check upstream == @[ReviewSessionStateLoaded, ReviewSessionStateUnsupported,
+      ReviewSessionStateUnavailable]
+
+  test "ct_agent_session_document_carries_the_keys_the_renderer_reads":
+    ## `resolveReviewSession` hands the renderer either `loaded.toJson()`
+    ## (from `nim-agents`) or `unresolvedSessionJson` (from this repo), and
+    ## the renderer decodes both with one path.  Every key that path reads
+    ## must therefore exist in **both** documents; a key present in only one
+    ## of them is a field the panel sees on a success and not on a failure,
+    ## which is how a renderer ends up reading null on exactly the paths
+    ## that matter.
+    ##
+    ## The five are asserted by name against both producers rather than by
+    ## comparing the two key sets for equality.  Set equality would be a
+    ## stricter rule than anything states: `nim-agents` serialises for more
+    ## consumers than this one, and it is entitled to carry a field this
+    ## renderer ignores.  It does today — see the `taskId` assertion below,
+    ## which pins that difference as *known* rather than letting it sit
+    ## undetected behind a count.
+    let unresolved = unresolvedSessionJson(
+      ReviewSessionRefSpec(sessionId: "session-abc", backend: "acp"),
+      ReviewSessionStateUnavailable, "unknown session: session-abc")
+
+    var localKeys: seq[string] = @[]
+    for key in unresolved.keys:
+      localKeys.add key
+
+    # The sibling's own document, built from a default value so this needs
+    # no agent: `toJson` is a pure projection of the object.
+    let fromSibling = AgentSessionLoad(state: aslsUnavailable).toJson()
+    var siblingKeys: seq[string] = @[]
+    for key in fromSibling.keys:
+      siblingKeys.add key
+
+    check localKeys.len == 5
+    for expected in ["state", "sessionId", "backend", "message", "events"]:
+      check expected in localKeys
+      check expected in siblingKeys
+
+    check unresolved["state"].getStr() == ReviewSessionStateUnavailable
+    check fromSibling["state"].getStr() == ReviewSessionStateUnavailable
+    check unresolved["events"].kind == JArray
+    check fromSibling["events"].kind == JArray
+
+  test "ct_agent_session_document_taskid_asymmetry_is_known_and_unread":
+    ## `nim-agents`' document carries `taskId` — Agent Harbor's id for the
+    ## task owning the session — and this repo's failure document does not.
+    ##
+    ## That asymmetry is deliberate on neither side; it is simply where the
+    ## two producers landed, and it is harmless *only for as long as nothing
+    ## in the renderer reads it*, because a review whose session failed to
+    ## load would find the field missing.  Pinning it here means the day
+    ## something wants `taskId` on a review, this test says so rather than
+    ## the field silently reading empty on every failure path.
+    let fromSibling = AgentSessionLoad(
+      session: AgentSession(id: "session-abc", taskId: "task-42",
+        backend: abkHarbor),
+      state: aslsLoaded).toJson()
+    let unresolved = unresolvedSessionJson(
+      ReviewSessionRefSpec(sessionId: "session-abc", backend: "harbor",
+        taskId: "task-42"),
+      ReviewSessionStateUnavailable, "unreachable")
+
+    check fromSibling.hasKey("taskId")
+    check fromSibling["taskId"].getStr() == "task-42"
+    # The reference this repo writes into a dataset *does* keep the task id;
+    # it is only the resolved-session document that drops it, so nothing is
+    # lost — the caller still holds the spec.
+    check not unresolved.hasKey("taskId")
+    check fromSibling["backend"].getStr() == "harbor"
+    check unresolved["backend"].getStr() == "harbor"

--- a/src/frontend/ui/unified_diff.nim
+++ b/src/frontend/ui/unified_diff.nim
@@ -542,19 +542,36 @@ proc monacoDecorations(doc: DiffDocument;
   ## line, with the `+` / `-` marker in the line-decorations lane.
   result = @[]
   for decoration in decorationsFor(doc, selected):
+    # Read the four fields into locals *before* building the descriptor.
+    #
+    # `js{...}` closes over every expression it is given, and `items` over the
+    # `seq[DiffDecoration]` `decorationsFor` returns yields `lent
+    # DiffDecoration` — a borrowed view of an element of a temporary seq.
+    # Capturing that view in a closure that outlives the loop iteration is
+    # exactly the lifetime error the compiler refuses ("'decoration' is of
+    # type <lent DiffDecoration> which cannot be captured"), and it refuses it
+    # on the JavaScript backend, where this proc actually runs.  Copying the
+    # scalars out first means the closure captures owned values, which is what
+    # it needs: the descriptor is handed to Monaco and kept, while the seq
+    # backing `decoration` is gone by the time this proc returns.
+    let
+      lineNumber = decoration.line
+      lineClass = cstring(decoration.className)
+      gutterClass = cstring(decoration.gutterClassName)
+      lineNumberClass = cstring(decoration.lineNumberClassName)
     result.add(js{
       range: js{
-        startLineNumber: decoration.line,
+        startLineNumber: lineNumber,
         startColumn: 1,
-        endLineNumber: decoration.line,
+        endLineNumber: lineNumber,
         endColumn: 1
       },
       options: js{
         isWholeLine: true,
-        className: cstring(decoration.className),
-        linesDecorationsClassName: cstring(decoration.gutterClassName),
+        className: lineClass,
+        linesDecorationsClassName: gutterClass,
         # Colours the `+` / `-` the gutter LABEL carries since UD-1.
-        lineNumberClassName: cstring(decoration.lineNumberClassName)
+        lineNumberClassName: lineNumberClass
       }
     })
 
@@ -721,16 +738,21 @@ proc monacoFlowDecorations(decorations: seq[ReviewFlowDecoration]):
   ## `MonacoLineStyle.inlineClass`.
   result = @[]
   for decoration in decorations:
+    # Owned copies before the descriptor — see `monacoDecorations` above for
+    # why a `lent` loop variable cannot cross into a `js{...}` closure.
+    let
+      lineNumber = decoration.modelLine
+      inlineClass = cstring(decoration.inlineClassName)
     result.add(js{
       range: js{
-        startLineNumber: decoration.modelLine,
+        startLineNumber: lineNumber,
         startColumn: 1,
-        endLineNumber: decoration.modelLine,
+        endLineNumber: lineNumber,
         endColumn: 100000
       },
       options: js{
         isWholeLine: false,
-        inlineClassName: cstring(decoration.inlineClassName)
+        inlineClassName: inlineClass
       }
     })
 
@@ -1116,6 +1138,11 @@ proc applyFlowValueBands(self: UnifiedDiffComponent; doc: DiffDocument) =
       continue
     if annotation.columns.len == 0:
       continue
+    # An OWNED copy of the anchor line, for the same reason `monacoDecorations`
+    # takes one: `items` over `annotations` yields `lent ReviewValueAnnotation`,
+    # and the view-zone descriptor below is a `js{...}` closure that outlives
+    # this iteration, so it cannot capture the borrow.
+    let modelLine = annotation.modelLine
     # ONE offset for every band, in both placements.
     #
     # `beside` was decided against the WIDEST annotated line, so a band at the
@@ -1230,7 +1257,7 @@ proc applyFlowValueBands(self: UnifiedDiffComponent; doc: DiffDocument) =
       # halves of this are deliberately kept next to each other in the comments.
       let lineHeight = self.editor.udLineHeight()
       self.flowValueZoneIds.add(self.editor.udAddViewZone(js{
-        afterLineNumber: annotation.modelLine,
+        afterLineNumber: modelLine,
         heightInPx: if lineHeight > 0: lineHeight else: self.data.ui.fontSize + 16,
         domNode: dom
       }))
@@ -1509,17 +1536,23 @@ proc rebuildInvocationZones(self: UnifiedDiffComponent; doc: DiffDocument) =
   # `div.ct-diff-expand-boundary`. The clearance moves the control out from
   # under it.
   let lineHeight = self.data.ui.fontSize + 22
+  # `afterLineNumber` is copied out of each `lent` zone before the descriptor
+  # closes over it — see `monacoDecorations` for the lifetime rule.
   for zone in self.reviewInvocationZonesFor(doc):
-    let dom = self.invocationZoneDom(zone)
+    let
+      dom = self.invocationZoneDom(zone)
+      afterLine = zone.afterLineNumber
     self.flowViewZoneIds.add(self.editor.udAddViewZone(js{
-      afterLineNumber: zone.afterLineNumber,
+      afterLineNumber: afterLine,
       heightInPx: lineHeight,
       domNode: dom
     }))
   for zone in self.reviewLoopZonesFor(doc):
-    let dom = self.loopZoneDom(zone)
+    let
+      dom = self.loopZoneDom(zone)
+      afterLine = zone.afterLineNumber
     self.flowViewZoneIds.add(self.editor.udAddViewZone(js{
-      afterLineNumber: zone.afterLineNumber,
+      afterLineNumber: afterLine,
       heightInPx: lineHeight,
       domNode: dom
     }))


### PR DESCRIPTION
## The break

The renderer bundle stopped compiling on `dev`:

```
src/frontend/ui/unified_diff.nim(434, 26) Error: 'decoration' is of type <lent DiffDecoration>
which cannot be captured as it would violate memory safety, declared here:
src/frontend/ui/unified_diff.nim(431, 7)
```

Every Monaco descriptor the unified diff tab builds — the per-line hunk
decorations, the Omniscience flow classes, the value band's view zone, and the
invocation and loop view zones — was constructed inside a loop over a sequence,
reading fields straight off the loop variable. Those descriptors are closures;
the loop variable is a borrowed view into a sequence that does not outlive the
loop. Capturing one is a lifetime error the compiler refuses outright on the
JavaScript backend, so `ui.js` never built and nothing rendered.

There are five such loops, not one. The compiler reports only the first, so
they surface one at a time. Rebased onto current `dev`, `--errorMax:50` names
them all at once: 19 diagnostics over the loops at lines 431 (`monacoDecorations`),
610 (`monacoFlowDecorations`), 984 (`applyFlowValueBands` — the value band that
replaced the inline value chips, and the one this change did not originally
carry), 1363 and 1370 (`rebuildInvocationZones`).

## The fix

Each descriptor copies the handful of scalars it needs into locals before
building the closure, so what gets captured is owned by it. Values, classes and
ordering are unchanged. Each site carries a comment saying why the copy is
load-bearing — inlining it back is a natural-looking edit that breaks the build
again.

## The contract test

Also adds `src/ct/agent_session_api_contract_test.nim` (`just
test-agent-api-contract`, wired into `just test`).

Resolving the agent session a review came from goes through `nim-agents`, a
*sibling checkout* rather than a vendored library, so the revision in force is
whichever one the workspace, the CI `siblings:` list or `repro.lock` happened to
place at `../nim-agents`. When that revision predates the API the review code
calls, the failure arrives as a type mismatch fifteen minutes into a full `ct`
build, naming `review_session.nim` — which sends you to read the caller, though
the caller is right and the sibling is old.

The test makes the same claim in ~14 s against a name it can print. It compiles
the exact calls `review_session.nim` makes, checks the load states still spell
themselves the way this repo repeats them as string constants, and checks that a
resolved session and a failed one carry the same keys, since the panel decodes
both with one path. It pins one known difference (`taskId`, present on the
sibling's document and absent from this repo's failure document) so it stays
known rather than sitting undetected.

Nothing is mocked: every symbol resolves to production sibling code, and the
assertions are the compiler's own overload resolution. `loadSession` is never
called — spawning an agent would make this a slow test of someone else's code.

## Verification

| Check | Result |
|---|---|
| `nim ... js src/frontend/ui_js.nim` (tup's flags) | green, 19.8 MB bundle |
| `nim check -d:ssl -d:useOpenssl3 -d:testing -d:ctEntrypoint src/ct/codetracer.nim` | green |
| `just test-agent-api-contract` | 4/4 green |

Mutation table for the contract test — each applied, run, reverted:

| # | Mutation | Result |
|---|---|---|
| 1 | `nim-agents` checked out at `348c7ca` (the revision `repro.lock` pins, pre-`loadSession`) | **red** |
| 2 | `ReviewSessionStateLoaded` `"loaded"` → `"loded"` | **red** |
| 3 | `unresolvedSessionJson` drops its `message` key | **red** |
| 4 | sibling `toJson` drops its `taskId` key | **red** |

For the `unified_diff.nim` fix the mutation is the diff itself: restoring
`dev`'s copy of the file and rebuilding under tup's flags reproduces the error
above verbatim — 19 diagnostics across the five loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
