### PR TITLE
Start the build's RunQuota daemon somewhere it can actually listen

### DIFF
--- a/ci/reprobuild/macos-daemon-build.sh
+++ b/ci/reprobuild/macos-daemon-build.sh
@@ -71,10 +71,16 @@ start_runquotad() {
 		fail "runquotad is required for e2e test; set RUNQUOTAD_BIN or RUNQUOTA_SOCKET"
 	fi
 
-	runquota_socket="/tmp/reprobuild-e2e.$$.$RANDOM.sock"
+	# A directory of its own, not a socket dropped into a shared /tmp --
+	# see the long note in scripts/build-once.sh. runquotad verifies the
+	# socket's parent directory before binding and refuses a root-owned
+	# 1777 /tmp; a directory that does not exist yet it creates itself,
+	# with the mode it requires.
+	runquota_dir="/tmp/reprobuild-e2e.$$.$RANDOM"
+	runquota_socket="$runquota_dir/runquota.sock"
 	runquota_log=".repro/runquota/macos-daemon-build-runquotad.log"
 	mkdir -p .repro/runquota
-	rm -f "$runquota_socket"
+	rm -rf "$runquota_dir"
 
 	"$runquotad_bin" \
 		--socket "$runquota_socket" \
@@ -83,7 +89,7 @@ start_runquotad() {
 		--pool console=1 \
 		>"$runquota_log" 2>&1 &
 	runquotad_pid="$!"
-	trap 'if [ -n "${runquotad_pid:-}" ]; then kill "$runquotad_pid" 2>/dev/null || true; wait "$runquotad_pid" 2>/dev/null || true; fi' EXIT
+	trap 'if [ -n "${runquotad_pid:-}" ]; then kill "$runquotad_pid" 2>/dev/null || true; wait "$runquotad_pid" 2>/dev/null || true; fi; rm -rf "${runquota_dir:-}"' EXIT
 
 	for _ in {1..300}; do
 		if grep -q "runquotad listening" "$runquota_log" 2>/dev/null; then
@@ -91,11 +97,13 @@ start_runquotad() {
 			return
 		fi
 		if ! kill -0 "$runquotad_pid" 2>/dev/null; then
+			sed 's/^/  runquotad: /' "$runquota_log" >&2 2>/dev/null || true
 			fail "runquotad exited before becoming ready. See $runquota_log"
 		fi
 		sleep 0.05
 	done
 
+	sed 's/^/  runquotad: /' "$runquota_log" >&2 2>/dev/null || true
 	fail "runquotad did not become ready. See $runquota_log"
 }
 

--- a/scripts/build-once.sh
+++ b/scripts/build-once.sh
@@ -249,9 +249,29 @@ if [ -n "$ct_reprobuild_host" ]; then
 		fi
 
 		mkdir -p .repro/runquota
-		runquota_socket="${TMPDIR:-/tmp}/codetracer-reprobuild-$$.sock"
+		# THE SOCKET GOES IN A DIRECTORY OF ITS OWN, never straight into
+		# $TMPDIR. The socket's parent directory is the rendezvous point,
+		# and runquotad verifies it on every start -- and its client on
+		# every connect -- before it will bind: owned by this user, and
+		# never group- or world-writable. A shared /tmp is root-owned 1777
+		# and fails both halves, so a socket placed directly in it is
+		# refused with "refusing a path owned by uid 0 with mode 1777" and
+		# the daemon exits before it ever listens.
+		#
+		# That refusal is correct rather than something to work around: a
+		# rendezvous point any local user can write is a rendezvous point
+		# any local user can replace, and this daemon hands out the
+		# machine's whole build budget. The per-PID directory below does
+		# not exist yet, so runquotad CREATES it with the mode it requires
+		# (0700 here, 0750 on a host with a `runquota` group) -- it only
+		# refuses directories it found already there. The published stats
+		# table lands beside the socket for the same reason, so this also
+		# keeps it out of a shared /tmp where concurrent builds would
+		# collide on one file.
+		runquota_dir="${TMPDIR:-/tmp}/codetracer-reprobuild-$$"
+		runquota_socket="$runquota_dir/runquota.sock"
 		runquota_log=".repro/runquota/runquotad.log"
-		rm -f "$runquota_socket"
+		rm -rf "$runquota_dir"
 		"$runquotad_bin" \
 			--socket "$runquota_socket" \
 			--cpu-milli "${CODETRACER_RUNQUOTA_CPU_MILLI:-8000}" \
@@ -259,7 +279,7 @@ if [ -n "$ct_reprobuild_host" ]; then
 			--pool console=1 \
 			>"$runquota_log" 2>&1 &
 		runquotad_pid="$!"
-		trap 'if [ -n "$runquotad_pid" ]; then kill "$runquotad_pid" 2>/dev/null || true; wait "$runquotad_pid" 2>/dev/null || true; fi' EXIT
+		trap 'if [ -n "$runquotad_pid" ]; then kill "$runquotad_pid" 2>/dev/null || true; wait "$runquotad_pid" 2>/dev/null || true; fi; rm -rf "$runquota_dir"' EXIT
 		for _ in {1..300}; do
 			if grep -q "runquotad listening" "$runquota_log" 2>/dev/null; then
 				export RUNQUOTA_SOCKET="$runquota_socket"
@@ -267,12 +287,17 @@ if [ -n "$ct_reprobuild_host" ]; then
 			fi
 			if ! kill -0 "$runquotad_pid" 2>/dev/null; then
 				echo "Error: runquotad exited before becoming ready. See $runquota_log" >&2
+				# Print it too. A build that dies here is usually a build on
+				# a machine nobody can log into afterwards, and a log the
+				# reader has to go and find is a log they never read.
+				sed 's/^/  runquotad: /' "$runquota_log" >&2 2>/dev/null || true
 				exit 1
 			fi
 			sleep 0.05
 		done
 		if [ -z "${RUNQUOTA_SOCKET:-}" ]; then
 			echo "Error: runquotad did not become ready. See $runquota_log" >&2
+			sed 's/^/  runquotad: /' "$runquota_log" >&2 2>/dev/null || true
 			exit 1
 		fi
 	fi


### PR DESCRIPTION
## The failure

Every `Test` run that drives `scripts/build-once.sh` down its Reprobuild
path dies here:

```
Error: runquotad exited before becoming ready. See .repro/runquota/runquotad.log
error: Recipe `build-once` failed on line 5 with exit code 1
```

The log the message points at — which CI discarded — says:

```
runquota endpoint directory /tmp: refusing a path owned by uid 0 with mode 1777;
this process runs as uid 1000, and a rendezvous point another user owns is a
rendezvous point another user controls
```

## Root cause

The socket's **parent directory** is the rendezvous point. `runquotad`
verifies it before it will bind, and every client verifies it again
before it will connect: owned by the calling user, correct mode, and
never group- or world-writable. `build-once.sh` put the socket straight
into `$TMPDIR`, and a shared `/tmp` is root-owned `1777` — it fails on
ownership and on mode. The daemon exits before it ever prints its
listening line.

Nothing in this repo changed. RunQuota's daemon began verifying the
rendezvous directory, and this caller had always been binding in a
directory it does not own.

## The fix

Not a laxer check, a correct location. A rendezvous point any local
account can write is a rendezvous point any local account can *replace*,
and what this daemon hands out is the machine's whole build budget.

The socket now goes in a per-run directory of its own. `runquotad`
**creates** a directory that is not there yet, with exactly the mode it
requires — it refuses only directories it finds already made — so this
needs no privileged provisioning step. The directory is removed on exit.

It also moves the daemon's published stats table, which lands beside the
socket, out of a shared directory where concurrent builds collided on
one file.

`ci/reprobuild/macos-daemon-build.sh` had the same defect and gets the
same fix.

Finally: when the daemon does fail to start, its log is now **printed**
rather than merely pointed at. A build that dies here usually dies on a
machine nobody logs into afterwards.

## Evidence

Against `runquotad` built from runquota's current `dev` (`b71e8e9`),
running the daemon-start block extracted verbatim from each version of
`build-once.sh`:

| | result |
|---|---|
| `dev` (before) | exit 1, `refusing a path owned by uid 0 with mode 1777` — the CI failure, reproduced |
| this branch | exit 0, `runquotad listening /tmp/codetracer-reprobuild-<pid>/runquota.sock`, directory `drwx------` |

Client round-trip through the new endpoint: `runquota status` answers,
and `runquota acquire --cpu 1000 --mem 1G -- /bin/echo` runs the leased
command. Both halves re-verify the directory, so this exercises the
check that was failing.

`shellcheck` clean; `bash -n` clean.
