### PR TITLE
UI design improvements, part 2

### DIFF
--- a/src/frontend/styles/components/button.styl
+++ b/src/frontend/styles/components/button.styl
@@ -167,10 +167,28 @@ button
   background-image: ct-images-layout-tab
   background-size: 1em auto !important
 
+  // States match `.vcs-branch-current` (vcs.styl), the reference for anything
+  // that opens a menu: a 1px border, transparent at rest, grey on hover and
+  // blue while the menu is open, with the surface left alone throughout.
+  //
+  // Two inherited behaviours have to be undone for that. `ct-button-no-border`
+  // sets `border: none !important`, so the width has to come back with
+  // `!important`; and `[class*="-secondary"]:hover` lightens the background,
+  // which would double up on the border as a second state cue.
+  //
+  // The width lives on the base rule and `box-sizing: border-box` is already
+  // set on `button`, so the control stays 28x28 in every state and the centred
+  // icon does not move.  This replaces an inset `box-shadow` that drew a fake
+  // border in `em` — 0.0625em against a 16px button, so a hair under 1px.
+  border: 0.0625rem solid transparent !important
+
+  &:hover
+    border-color: colors-ui-border-primary-hover !important
+    background-color: colors-ui-surface-primary-default
+
   &.open
-    // background-image: ct-images-layout-tab-active !important
-    background-color: colors-ui-surface-input-default
-    box-shadow: inset 0 0 0 0.0625em colors-ui-border-action !important
+    border-color: colors-ui-border-action !important
+    background-color: colors-ui-surface-primary-default
 
 #close-element
   background-image: ct-images-close-button

--- a/src/frontend/styles/components/event_log.styl
+++ b/src/frontend/styles/components/event_log.styl
@@ -343,7 +343,10 @@
       margin: 0em 0em !important
       padding: 0 0.75em
       border-radius: 0.5em
-      border: 0.03125em solid transparent
+      // Matches the 0.0625rem (1px) field border in input.styl. This rule wins
+      // over `.ct-input-small` on specificity, so leaving it at the old 0.03125em
+      // kept this one field a hairline while every other field went to 1px.
+      border: 0.0625rem solid transparent
       background: colors-editor-surface-select
       color: colors-ui-text-primary-body !important
       font-family: "SpaceMono"

--- a/src/frontend/styles/components/golden_layout.styl
+++ b/src/frontend/styles/components/golden_layout.styl
@@ -219,6 +219,15 @@
   height: 0.6em !important
   position: static !important
   cursor: pointer
+  // `.lm_tab` is a flex row and `.lm_title` asks for `width: 100%`, so the row
+  // is always over-constrained and every shrinkable item gives up width. Without
+  // this the close box — the only child that could shrink, since `.lm_pin_tab`
+  // already opts out — collapsed with the tab: 9.6px nominal, but measured at
+  // 8.95px on a 421px tab and 2.01px on a 41.8px one. The mask keeps its fixed
+  // 0.6em size and stays centred, so the cross was cropped, not scaled, and read
+  // as an icon that shrinks with the tab. Opt out exactly as the pin does; the
+  // title absorbs the shortfall instead, which is what its ellipsis is for.
+  flex-shrink: 0
 
 .lm_header .lm_tab .lm_pin_tab
   tab-icon(LAYOUT_TAB_PIN_ICON_PATH, 0.85em 0.85em)

--- a/src/frontend/styles/components/input.styl
+++ b/src/frontend/styles/components/input.styl
@@ -24,7 +24,7 @@ input
     color: colors-ui-text-primary-body !important
 
   &:disabled
-    border: 0.03125rem solid colors-ui-border-disabled
+    border: 0.0625rem solid colors-ui-border-disabled
     background: colors-ui-surface-primary-disabled
     color: colors-ui-text-disabled-default !important
     pointer-events: none
@@ -63,7 +63,7 @@ input
   max-height: 2.25rem
   border-radius: 0.375rem
   background: colors-ui-surface-primary-secondary
-  border: 0.03125rem solid colors-ui-surface-primary-secondary
+  border: 0.0625rem solid colors-ui-surface-primary-secondary
 
   &:hover
     border-color: colors-ui-border-primary-hover
@@ -75,7 +75,7 @@ input
   width: -webkit-fill-available
   max-width: -webkit-fill-available
   border-radius: 0.375rem
-  border: 0.03125rem solid colors-ui-border-primary
+  border: 0.0625rem solid colors-ui-border-primary
   background: colors-ui-surface-primary-secondary
 
   &:hover
@@ -89,22 +89,28 @@ input
   background: colors-ui-surface-primary-default
 
   &:hover
-    border: 0.03125rem solid colors-ui-surface-primary-default
+    border: 0.0625rem solid colors-ui-surface-primary-default
     border-color: colors-ui-border-primary-hover
     color: colors-ui-text-primary-body
 
 
-// The resting border is `rem`, matching the `:hover` rule above and every other
-// border in this file. It was `em`, which resolved against each field's own
-// font-size and gave 0.4375px at 14px and 0.375px at 12px — never the 0.5px
-// intended, and never the width hover then swapped in.
+// Field borders are 0.0625rem — 1px at the 16px root — not the 0.5px they used
+// to be, and `rem` so the resting width and the `:hover` width cannot disagree.
+//
+// 0.5px is exactly one device pixel at DPR 2, which is crisp only while the edge
+// it paints lands on the device grid. Golden Layout sizes stacks proportionally,
+// so a panel is routinely a fractional number of pixels wide; `.ct-input-panel`
+// is `width: -webkit-fill-available` and inherits that fraction, leaving its
+// right edge off-grid while the left stays on it. The border was then spread
+// across two device pixels at partial opacity and read as thinner on that side
+// alone. `SELECTED_PANEL_BORDER` in golden_layout.styl carries the same note.
 .ct-input-small
   height: 1.5rem
   max-height: 1.75rem
-  border: 0.03125rem solid transparent
+  border: 0.0625rem solid transparent
 
 .ct-input-panel
   width: -webkit-fill-available
   height: 1.75rem
   max-height: 1.75rem
-  border: 0.03125rem solid transparent
+  border: 0.0625rem solid transparent

--- a/src/frontend/styles/components/input.styl
+++ b/src/frontend/styles/components/input.styl
@@ -94,13 +94,17 @@ input
     color: colors-ui-text-primary-body
 
 
+// The resting border is `rem`, matching the `:hover` rule above and every other
+// border in this file. It was `em`, which resolved against each field's own
+// font-size and gave 0.4375px at 14px and 0.375px at 12px — never the 0.5px
+// intended, and never the width hover then swapped in.
 .ct-input-small
   height: 1.5rem
   max-height: 1.75rem
-  border: 0.03125em solid transparent
+  border: 0.03125rem solid transparent
 
 .ct-input-panel
   width: -webkit-fill-available
   height: 1.75rem
   max-height: 1.75rem
-  border: 0.03125em solid transparent
+  border: 0.03125rem solid transparent

--- a/src/frontend/styles/components/shared_widgets.styl
+++ b/src/frontend/styles/components/shared_widgets.styl
@@ -1,8 +1,17 @@
 // File containing style for widgets that are shared across all other widgets
+
+// The app-wide scrollbar — every panel that scrolls.  8px at the 16px root, and
+// in `rem` on purpose: this is an unscoped `::-webkit-scrollbar`, so `em` here
+// resolved against whatever element the bar happened to appear on and the
+// thickness changed from panel to panel — measured 6px on a 12px container,
+// 7px at 14px, 12px at 24px.  A 12px panel landed on 6px, the same as a menu,
+// collapsing the distinction DROPDOWN_SCROLLBAR_SIZE exists to draw.
+PANEL_SCROLLBAR_SIZE = 0.5rem
+
 if !IS_EXTENSION
   ::-webkit-scrollbar
-    width: 0.5em
-    height: 0.5em
+    width: PANEL_SCROLLBAR_SIZE
+    height: PANEL_SCROLLBAR_SIZE
     background-color: transparent
 
   ::-webkit-scrollbar-corner
@@ -125,9 +134,9 @@ DROPDOWN_RADIUS = 0.375rem
 
 // Scrollbars inside a menu.
 //
-// The app-wide scrollbar (top of this file) is 0.5em, which is right for a
-// panel but heavy inside a menu a few rows tall — it takes a visible bite out
-// of a 12em-wide dropdown.  Its own constant rather than a reuse of
+// PANEL_SCROLLBAR_SIZE (top of this file) is 8px, which is right for a panel
+// but heavy inside a menu a few rows tall — it takes a visible bite out of a
+// 12em-wide dropdown.  Its own constant rather than a reuse of
 // DROPDOWN_TRIGGER_GAP: the two happen to be the same 6px, but a scrollbar's
 // thickness and a menu's offset answer to different things and should be free
 // to move apart.

--- a/src/frontend/styles/components/vcs.styl
+++ b/src/frontend/styles/components/vcs.styl
@@ -87,7 +87,12 @@ VCS_BRANCH_PICKER_INSET = 0.25em
   gap: 0.375em
   user-select: none
   border-radius: 0.375rem
-  border: 0.03125em solid transparent
+  // 0.0625rem (1px), tracking the field border in input.styl. `em` here resolved
+  // against this element's own 0.875rem text and gave 0.4375px — a sub-pixel
+  // stroke that antialiased to part strength whenever its edge fell off the
+  // device grid. Width lives on the base rule, so `:hover` and the open state
+  // below only swap colour and the control never changes size under the pointer.
+  border: 0.0625rem solid transparent
   background: colors-ui-surface-primary-default
   font-family: "SpaceGrotesk"
   font-size: 0.875rem
@@ -97,7 +102,7 @@ VCS_BRANCH_PICKER_INSET = 0.25em
     border-color: colors-ui-border-primary-hover
     color: colors-ui-text-primary-body
 
-  // Open/active state: thin blue border (like lm_controls active dropdown)
+  // Open/active state: blue border (like lm_controls active dropdown)
   &.vcs-branch-current-open
     border-color: colors-ui-border-action
     color: colors-ui-text-primary-body

--- a/src/frontend/styles/components/welcome_screen.styl
+++ b/src/frontend/styles/components/welcome_screen.styl
@@ -104,11 +104,12 @@
         align-items: center
         font-weight: BOLD_WEIGHT
         width: 19em
-        font-size: 2em
+        font-size: 2.3em
         letter-spacing: -0.02em
-        // In rem, not em: this element's own `font-size: 2em` makes 1em == 32px
-        // here, so `1em` would read as 16px and mean 32px.  2rem is 32px, plainly.
-        line-height: 2rem
+        // Both ems here are deliberate and resolve against different bases:
+        // `font-size` against `.welcome-title`'s 16px (36.8px), `line-height`
+        // against this element's own resolved size (1.2 * 36.8 == 44.16px).
+        line-height: 1.2em
 
       .welcome-version
         color: colors-ui-text-primary-disabled

--- a/src/frontend/styles/components/welcome_screen.styl
+++ b/src/frontend/styles/components/welcome_screen.styl
@@ -106,6 +106,9 @@
         width: 19em
         font-size: 2em
         letter-spacing: -0.02em
+        // In rem, not em: this element's own `font-size: 2em` makes 1em == 32px
+        // here, so `1em` would read as 16px and mean 32px.  2rem is 32px, plainly.
+        line-height: 2rem
 
       .welcome-version
         color: colors-ui-text-primary-disabled

--- a/src/frontend/styles/components/welcome_screen.styl
+++ b/src/frontend/styles/components/welcome_screen.styl
@@ -118,6 +118,11 @@
         font-weight: 400
         line-height: normal
         text-align: center
+        // Keep the version on one line. As a flex item it would otherwise be
+        // squeezed below its own text width by `.welcome-text`'s `width: 19em`,
+        // which scales with the title's font-size, and wrap onto a second row.
+        white-space: nowrap
+        flex-shrink: 0
 
     .welcome-content
       display: flex

--- a/src/frontend/styles/components/welcome_screen.styl
+++ b/src/frontend/styles/components/welcome_screen.styl
@@ -48,9 +48,11 @@
 
 .welcome-logo
   background-image: url('../../public/resources/shared/codetracer_welcome_logo.svg')
-  min-width: 3.875em
-  min-height: 3.875em
-  background-size: 3.875em 3.875em
+  // Sized in rem, not em: this sits inside `.welcome-text`, whose `font-size: 2em`
+  // makes 1em == 32px here.  5rem is 80px at the 16px root either way.
+  min-width: 5rem
+  min-height: 5rem
+  background-size: 5rem 5rem
   background-position: center
   margin-right: 0.75em
   background-repeat: no-repeat

--- a/src/frontend/styles/components/welcome_screen.styl
+++ b/src/frontend/styles/components/welcome_screen.styl
@@ -88,7 +88,7 @@
 
     .welcome-title
       position: relative
-      font-family: "SpaceMono"
+      font-family: "SpaceGrotesk"
       text-align: start
       display: flex
       align-items: flex-end
@@ -137,7 +137,7 @@
       display: flex
       width: -webkit-fill-available
       gap: 0.5em
-      justify-content: space-between
+      justify-content: flex-start
 
       .start-option
         position: relative
@@ -201,7 +201,6 @@
       padding: 0.5em
       margin-top: 3em
       margin-bottom: 3em
-      padding-right: 0
       overflow: visible
 
     .recent-traces-title
@@ -331,7 +330,6 @@
       padding: 0.5em
       margin-top: 3em
       margin-bottom: 3em
-      padding-right: 0
 
     .recent-folders-title
       text-align: start


### PR DESCRIPTION
Second round of UI design improvements, following #646. Stylesheets only — no
markup, no logic, seven `.styl` files.

Every change was measured in the running app over CDP rather than eyeballed;
the numbers below are from those measurements, and each commit body carries
the reasoning in full.

## Welcome screen

- Title in SpaceGrotesk. It was SpaceMono, the code face, while `body` sets
  SpaceGrotesk for everything that is not code.
- `.recent-traces` and `.recent-folders` zeroed their `padding-right` after
  setting `padding: 0.5em`, so rows sat flush against the panel's right edge
  with 8px on the left. Now even on both sides.
- The five start buttons were spread by `justify-content: space-between`, which
  made the `gap: 0.5em` beside them moot. Packed left, so the declared 8px gap
  is the real one.
- Logo at 5rem (80px). It read as `3.875em` but rendered at 124px: it sits
  inside `.welcome-text`, whose `font-size: 2em` makes 1em 32px there.
- Title at 2.3em over a 1.2em line-height, replacing an unset `line-height`
  that resolved to `normal` and moved with the font face.
- The version label wrapped to two rows once the title grew — the row came out
  1px over — so it is pinned to one line.

## Panel tabs

The close icon shrank with its tab while the pin held its size. `.lm_tab` is a
flex row and `.lm_title` asks for `width: 100%`, so the row is permanently
over-constrained; `.lm_pin_tab` opts out with `flex-shrink: 0` and the close box
did not, leaving it the only child able to absorb the shortfall.

It was never scaling — `tab-icon` keeps a fixed centred mask, so the cross was
cropped from both sides. Measured 9.6px nominal, 8.95px on a 421px tab, 2.01px
at 42px, and 0.00px when forced narrower: a live hit target with no visible
mark. Now a constant 9.59px down to a 16px tab.

## Field borders

Two separate problems behind one symptom.

`.ct-input-small` and `.ct-input-panel` declared their resting border in `em`
while the `:hover` rule they share used `rem`, so rest and hover disagreed —
0.4375px at 14px, 0.375px at 12px.

Separately, 0.5px is exactly one device pixel at DPR 2 and crisp only while the
edge it paints lands on the device grid. Golden Layout sizes stacks
proportionally, so a panel is routinely a fractional width; `.ct-input-panel` is
`width: -webkit-fill-available`, inherits that fraction, and its right edge falls
off-grid while the left stays on it — antialiased to part strength on one side
only, and changing as a splitter is dragged.

Every border in `input.styl` is now `0.0625rem` (1px), the value
`SELECTED_PANEL_BORDER` settled on for the same reason. `.data-tables-footer-input`
in `event_log.styl` needed the same change: it re-declares the border above
`.ct-input-small` on specificity and would have stayed a hairline.
`.vcs-branch-current` follows, since it is commented as matching `.ct-input-small`.

Resting and hover move together throughout, so no field changes size under the
pointer.

## Scrollbars

The app-wide `::-webkit-scrollbar` was `0.5em` on an unscoped selector, so it
measured whatever element it landed on: 6px on a 12px container, 7px at 14px,
12px at 24px. The 12px case produced exactly the 6px dropdown size, collapsing
the distinction `DROPDOWN_SCROLLBAR_SIZE` exists to draw.

Pinned at `0.5rem` behind a named `PANEL_SCROLLBAR_SIZE`, sitting beside the
dropdown constant. Same 8px today, so nothing shifts. Menus stay 6px.

## Event-log filter trigger

`#category-image` drew its states differently from `.vcs-branch-current` despite
both being menu triggers: hover lightened the surface, and the open state paired
a background change with an inset `box-shadow` faking a border in `em`. It now
uses the branch picker's treatment — a 1px border, transparent at rest, grey on
hover, blue while open, surface untouched. The two report identical values in
all three states.

## Not addressed

- Monaco's own scrollbars remain 14px (`0.875rem`). They are its `.scrollbar`
  divs rather than the pseudo-element, and were set deliberately — so the editor
  is a panel with a bar nearly twice every other panel's. Worth a decision.
- Half-pixel borders remain in `button.styl`, `shared_widgets.styl` and
  `golden_layout.styl`. Same latent softness, but outside input fields.

## Testing

Verified by measuring computed styles and element geometry in the running app
over CDP, against a recorded `fibonacci.rb` trace, for each change. No automated
tests were added: these are presentational values with no existing visual-
regression harness to extend.
