### PR TITLE
flake: mirror the reprobuild pin bump to b5b88139

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5080,17 +5080,17 @@
         "stackable-hooks-src": "stackable-hooks-src"
       },
       "locked": {
-        "lastModified": 1787377162,
-        "narHash": "sha256-zRgRNpvnnGTJq5fGA45E7F25d8vHAmEWgycgYJWzdFI=",
+        "lastModified": 1787673032,
+        "narHash": "sha256-DR1cpkKod/ogdxA029eIMkBxv+TdvwJL7HwJXk3WSJk=",
         "owner": "metacraft-labs",
         "repo": "reprobuild",
-        "rev": "c81f0a07eb1938060e34740aed8d77d61600e1c2",
+        "rev": "b5b88139767d97e96ca646b6f83641d8bb2e69c5",
         "type": "github"
       },
       "original": {
         "owner": "metacraft-labs",
         "repo": "reprobuild",
-        "rev": "c81f0a07eb1938060e34740aed8d77d61600e1c2",
+        "rev": "b5b88139767d97e96ca646b6f83641d8bb2e69c5",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -128,7 +128,7 @@
       # against a different nixpkgs and against its own runquota /
       # native-recorder pins, producing a different `repro` binary than the one
       # this repo's shells are meant to ship.
-      url = "github:metacraft-labs/reprobuild/c81f0a07eb1938060e34740aed8d77d61600e1c2";
+      url = "github:metacraft-labs/reprobuild/b5b88139767d97e96ca646b6f83641d8bb2e69c5";
       inputs.nixos-modules.follows = "nix-blockchain-development/nixos-modules";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-parts.follows = "flake-parts";


### PR DESCRIPTION
Companion to [nixos-modules#616](https://github.com/metacraft-labs/nixos-modules/pull/616). **These must land together.**

`nixos-modules/flake.nix` is the single source of truth for the reprobuild revision, but `codetracer` is a documented exception that mirrors the SHA by hand: it overrides six of reprobuild's inputs to get a `repro` built with `ct_interpose`, which a bare `follows` cannot express. So a bump is a two-file edit, and leaving this side stale means the two disagree about which `repro` is installed.

## The bump

`c81f0a07` → **`b5b88139767d`** — the merge of [reprobuild#97](https://github.com/metacraft-labs/reprobuild/pull/97), the smallest revision on `dev` containing the fix (not the tip, which is 40 commits further).

It fixes `repro deploy-agent` failing **any** manifest with an empty `profileText`: the apply hook applied a `ProfileResolver` unconditionally, an empty Nim module compiles and prints nothing, and `parseJson("")` died with `input(1, 0) Error: { expected`.

Two files, and the lock diff is 8 lines touching only the `reprobuild` node. The `follows` overrides on this input are untouched.

## Base branch

Targets **`dev`**, not the GitHub default. `origin/HEAD` points at `stable`, but `origin/stable...origin/dev` is 0 behind / 188 ahead, `dev`'s tip is current while `stable` is from 2026-08-11, and **`dev`'s `flake.nix` is the one carrying the pinned SHA** — nothing on `stable` mirrors it. Verified rather than assumed.