### PR TITLE
ci: lock the mainline commits a pull request creates

### DIFF
--- a/.github/workflows/publish-workspace-lock.yml
+++ b/.github/workflows/publish-workspace-lock.yml
@@ -11,8 +11,15 @@
 # commit the pre-push gate structurally cannot reach: the one GitHub creates
 # server-side when a pull request lands. Merge, squash or rebase, the result is
 # a brand-new SHA that no hook ever saw. Measured on `dev`: of the last 30
-# first-parent commits, ZERO carry a lock, while every PR head that produced
-# them does.
+# first-parent commits, ZERO carry a lock.
+#
+# A SECOND GAP THIS DOES NOT CLOSE. Only a minority of pull request heads carry
+# a lock either — 4 of the last 24 merged here. That is a hook-COVERAGE gap: a
+# branch pushed from a checkout without the managed hooks (or with
+# `--no-verify`) never reaches the pre-push gate, and no server-side
+# re-anchoring can invent a record that was never produced. Such a merge fails
+# this job by name, with the remedy, rather than passing quietly — the same
+# policy `workspace-lock-freshness` already applies to the same condition.
 #
 # `clone-siblings` probes exactly those commits — `pull_request` ->
 # `base.sha`, `push` -> `github.sha` — with `--no-walk`, so until this workflow

--- a/.github/workflows/publish-workspace-lock.yml
+++ b/.github/workflows/publish-workspace-lock.yml
@@ -1,0 +1,115 @@
+# Publish the workspace lock for a mainline commit GitHub created.
+#
+# WHY THIS WORKFLOW EXISTS
+# ------------------------
+# Every commit that leaves a developer's workspace is locked by the local
+# pre-push gate, which publishes `locks/<project>/codetracer/<sha>.toml` to the
+# manifests repo. That gate is the reproducibility boundary and it stays the
+# boundary — this workflow creates no lock and resolves no sibling.
+#
+# It exists because this repo is PR-based, and there is exactly one class of
+# commit the pre-push gate structurally cannot reach: the one GitHub creates
+# server-side when a pull request lands. Merge, squash or rebase, the result is
+# a brand-new SHA that no hook ever saw. Measured on `dev`: of the last 30
+# first-parent commits, ZERO carry a lock, while every PR head that produced
+# them does.
+#
+# `clone-siblings` probes exactly those commits — `pull_request` ->
+# `base.sha`, `push` -> `github.sha` — with `--no-walk`, so until this workflow
+# ran, every job in this repo that needs a sibling revision died at
+# "No workspace lock for codetracer" before reaching a build. That is not a
+# theoretical loss: a five-site compile break sat on `dev` while every CI run
+# failed earlier, for this reason, and nothing ever reached the compiler that
+# would have reported it.
+#
+# WHAT IT PUBLISHES
+# -----------------
+# The PR HEAD's lock, re-anchored onto the mainline commit: every sibling pin
+# copied verbatim, and precisely one field changed — the record's own
+# coordinate. That is the sibling set the change was developed and pushed
+# against, and it is the one that carries a sibling bump the PR itself made.
+# Resolving the mainline commit against its ANCESTRY instead would answer with
+# pins that predate the merge, which is exactly wrong for such a PR.
+#
+# OPERATIONAL PREREQUISITE
+# ------------------------
+# The CI App token must have CONTENTS: WRITE on metacraft-labs/metacraft-manifests.
+# Everything else this workflow needs is read-only. Without it the action fails
+# at the push with git's own authentication error, which is loud but obscure —
+# so if this job starts failing on `git push` and nothing else changed, check
+# the App's repository permissions first.
+name: publish workspace lock
+
+on:
+  # `pull_request_target`, not `pull_request`: this repo is public, so a fork's
+  # pull request would otherwise run without the credential this job needs, and
+  # a merged fork PR is precisely a mainline commit that nothing locked. The
+  # usual objection to `pull_request_target` does not apply here — no PR
+  # content is checked out and none is executed. This workflow reads two SHAs
+  # from the event payload and calls a pinned action from the base branch; the
+  # workflow definition itself also comes from the base branch, so a fork
+  # cannot alter it.
+  pull_request_target:
+    types: [closed]
+    branches: [dev, stable]
+
+  # Backfill. Every mainline commit that landed before this workflow existed is
+  # still unlocked, and so is any commit whose publish failed transiently. This
+  # is how one is repaired, with both SHAs stated explicitly rather than
+  # guessed.
+  workflow_dispatch:
+    inputs:
+      source-sha:
+        description: "The PR head commit whose published lock supplies the sibling set (40-hex)."
+        required: true
+      target-sha:
+        description: "The mainline commit to publish the lock for (40-hex)."
+        required: true
+      base-ref:
+        description: "The mainline branch target-sha must be an ancestor of."
+        required: true
+        default: dev
+
+permissions:
+  contents: read
+
+# Serialise this repo's publishers. The action recovers from a lost push race
+# on its own — records are commit-addressed, so concurrent publishers write
+# disjoint paths — but a queue turns the common case into no race at all.
+# `cancel-in-progress` MUST stay false: two merges seconds apart must both end
+# up locked, and cancelling the first would leave its mainline commit unlocked
+# forever.
+concurrency:
+  group: publish-workspace-lock-codetracer
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    # A pull request that was CLOSED without merging created no mainline
+    # commit, and `merge_commit_sha` on such a payload names nothing that
+    # landed.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate CI token
+        id: ci_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CI_TOKEN_PROVIDER_APP_ID }}
+          private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
+          owner: metacraft-labs
+
+      - name: Publish the workspace lock
+        uses: metacraft-labs/metacraft-github-actions/publish-workspace-lock@main
+        with:
+          gh-token: ${{ steps.ci_token.outputs.token }}
+          repo: metacraft-labs/codetracer
+          source-sha: ${{ github.event.inputs.source-sha || github.event.pull_request.head.sha }}
+          target-sha: ${{ github.event.inputs.target-sha || github.event.pull_request.merge_commit_sha }}
+          base-ref: ${{ github.event.inputs.base-ref || github.event.pull_request.base.ref }}
+          provenance: >-
+            ${{ github.event_name == 'workflow_dispatch'
+                && 'a manual backfill'
+                || format('pull request #{0}', github.event.pull_request.number) }}


### PR DESCRIPTION
Cross-repo CI resolves a sibling repo's revision from the workspace lock published for the commit under test, and refuses to build when that commit has no lock.

Mainline commits here are created by GitHub when a pull request lands, so no local hook ever sees them. Measured on `dev`: **none of the last thirty first-parent commits carried a lock**. Every job needing a sibling revision therefore died at `No workspace lock for codetracer` before reaching a build — which is how a five-site compile break sat on `dev` unreported.

Reproduction (real data, PR #652):

```
$ resolve-sibling-rev.sh --repo codetracer --sibling nim-agents --sha a820eb1df... --no-walk   # the PR head
a4bc08c21fa53ca9f5de324fbaa938373b916a54
rc=0
$ resolve-sibling-rev.sh --repo codetracer --sibling nim-agents --sha d4c09c320... --no-walk   # the commit that landed it
resolve-sibling-rev: no workspace lock found for codetracer
rc=3
```

This workflow calls the new shared `metacraft-github-actions/publish-workspace-lock` action on merge. It re-anchors the lock already published for the pull request's head onto the mainline commit that landed it: every sibling pin copied verbatim, only the record's own coordinate moved (required — a lock record is bound to the commit it is filed under). The recorded sibling set is thus the one the change was developed and pushed against, including any sibling bump the pull request itself made.

Ancestry walking was considered and rejected: it answers a merge with pins that *predate* it, which is exactly wrong for a PR whose content is a sibling bump.

A `workflow_dispatch` entry point repairs a mainline commit that predates this workflow.

### A second gap this does NOT close

Surveying the last 24 merged PRs here, only **4** had a lock for their own head. The rest were pushed from a checkout without the managed hooks, so the pre-push gate that publishes the record never ran. No server-side re-anchoring can invent a record that was never produced, so those merges fail this job by name with the remedy (`repro hooks ensure --vcs`, then `repro ws lock` and push), rather than passing quietly. That is the same policy `workspace-lock-freshness` already applies to the same condition.

**Operational prerequisite:** the CI App token needs `contents: write` on `metacraft-labs/metacraft-manifests`. Nothing has ever pushed there from CI, so this is untested in production; without it the action fails at the push with git's own auth error.

### Pre-existing red checks

`visual-replay-regression-gate` and `workspace-lock-freshness` both fail on `dev` itself (runs 32995542998, 32985039809) and are untouched by this change, which adds one workflow file that does not run on `pull_request`. `workspace-lock-freshness` is the org's own alarm for exactly the defect fixed here and should go green on `dev` once this lands and the publisher runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)