### PR TITLE
fix: unblock the dev shell (runquota pin) and stop the direnv misdiagnosis that hid it

### DIFF
--- a/.github/workflows/launcher-recorder-e2e.yml
+++ b/.github/workflows/launcher-recorder-e2e.yml
@@ -537,6 +537,26 @@ jobs:
         # PATH inside the shell used here; the check below turns a future
         # removal into a named failure instead of a bare "direnv: not found"
         # exit 127 deep inside the driver.
+        #
+        # THE TWO FAILURE MODES ARE SEPARATED ON PURPOSE, and the reason is a
+        # real misdiagnosis this step produced. `nix develop <shell> --command
+        # <probe>` exits non-zero for two unrelated reasons: the shell did not
+        # BUILD, or it built and the probe failed. A single `|| { echo direnv
+        # is not on PATH; }` reports the second for both.
+        #
+        # In run 33021054045 the `ci` shell failed to build — reprobuild would
+        # not compile against the runquota revision this repo pinned — and this
+        # step announced "direnv is not on PATH in the codetracer ci dev shell"
+        # while nix's own `Error: undeclared identifier: 'ExtensionCellWire'`
+        # scrolled past above it. The claim was not merely unhelpful, it was
+        # FALSE, and provably so from this file: the comment four lines up
+        # states direnv is declared in ci-base.nix, and it is. Anyone trusting
+        # the error would have gone looking for a missing package in a shell
+        # that never existed.
+        #
+        # So the shell is built first, on its own, and a failure there is
+        # reported as what it is. Only a shell that exists is then asked
+        # whether it has direnv.
         shell: bash
         env:
           CT_DIR: ${{ steps.plan.outputs.ct-dir }}
@@ -544,8 +564,12 @@ jobs:
         run: |
           set -euo pipefail
           cd "${CT_DIR}"
+          if ! nix develop '.?submodules=1#ci' --command true; then
+            echo "::error::the codetracer 'ci' dev shell FAILED TO BUILD (nix develop '.?submodules=1#ci'); nix's own diagnostic is above this line and names the derivation that failed. Nothing about direnv or the siblings has been established -- this step got no shell to look inside. Fix the shell first."
+            exit 1
+          fi
           nix develop '.?submodules=1#ci' --command bash -c 'command -v direnv' \
-            || { echo "::error::direnv is not on PATH in the codetracer ci dev shell; scripts/build-siblings.sh cannot build any sibling without it."; exit 1; }
+            || { echo "::error::the codetracer 'ci' dev shell builds, but direnv is not on PATH inside it; scripts/build-siblings.sh cannot build any sibling without it. direnv is declared in nix/shells/ci-base.nix -- check whether that declaration was removed."; exit 1; }
           for sib in "codetracer-launcher" "${RECORDER_REPO}" "codetracer-trace-format-nim"; do
             dir="$(cd .. && pwd)/${sib}"
             if [ -f "${dir}/.envrc" ]; then

--- a/ci/test/launcher-recorder-e2e-workflow-test.sh
+++ b/ci/test/launcher-recorder-e2e-workflow-test.sh
@@ -773,6 +773,132 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 9b. "Allow direnv in the freshly cloned siblings" MUST NOT BLAME direnv FOR A
+#     SHELL THAT NEVER BUILT.
+#
+# `nix develop <shell> --command <probe>` exits non-zero for two unrelated
+# reasons: the shell did not BUILD, or it built and the probe failed. This step
+# used to funnel both into one message, "direnv is not on PATH in the codetracer
+# ci dev shell".
+#
+# Run 33021054045 is what that costs. The `ci` shell failed to build (reprobuild
+# would not compile against the runquota revision the flake pinned) and the gate
+# announced a missing direnv -- while `Error: undeclared identifier:
+# 'ExtensionCellWire'` sat in the log directly above. The message was false, not
+# just unhelpful: direnv is declared in nix/shells/ci-base.nix, as the step's own
+# comment says.
+#
+# So the step's script is EXECUTED here against a stub `nix`, once per failure
+# mode, and each must be named for what it is. Asserting this by grepping the
+# YAML for two `echo`s would pass on wiring that never reaches the second one.
+# ---------------------------------------------------------------------------
+echo
+echo "the direnv step distinguishes a shell that will not build from a missing direnv"
+
+# extract_step_script NAME FILE -> that step's `run: |` block, dedented.
+# Same scanner as extract_plan_script, parameterised by step name.
+extract_step_script() {
+	strip_cr "$2" | awk -v want="      - name: $1" '
+		$0 == want { in_step=1; next }
+		in_step && /^      - name: / { in_step=0 }
+		in_step && /^        run: \|[[:space:]]*$/ { in_run=1; next }
+		in_run && /^          / { sub(/^          /, ""); print; next }
+		in_run && /^[[:space:]]*$/ { print ""; next }
+		in_run { in_run=0; in_step=0 }
+	'
+}
+
+DV="$TMP/direnv-step"
+mkdir -p "$DV/bin" "$DV/ws/codetracer" \
+	"$DV/ws/codetracer-launcher" \
+	"$DV/ws/codetracer-ruby-recorder" \
+	"$DV/ws/codetracer-trace-format-nim"
+# Two siblings carry a .envrc, one does not -- the step must handle both.
+: >"$DV/ws/codetracer-launcher/.envrc"
+: >"$DV/ws/codetracer-ruby-recorder/.envrc"
+
+DIRENV_STEP="$DV/step.sh"
+extract_step_script "Allow direnv in the freshly cloned siblings" "$REUSABLE" >"$DIRENV_STEP"
+
+# A stub `nix` whose behaviour is chosen by $NIX_STUB_MODE, so the step's own
+# control flow -- not a re-implementation of it -- decides what is reported.
+cat >"$DV/bin/nix" <<'STUB'
+#!/usr/bin/env bash
+# Recognise the two shapes the step issues:
+#   nix develop '.?submodules=1#ci' --command true
+#   nix develop '.?submodules=1#ci' --command bash -c 'command -v direnv'
+#   nix develop '.?submodules=1#ci' --command direnv allow <dir>
+probe=""
+for a in "$@"; do probe="$probe $a"; done
+case "$NIX_STUB_MODE" in
+	shell-fails)
+		echo "error: Cannot build '/nix/store/deadbeef-nix-shell-env.drv'." >&2
+		echo "       Reason: 1 dependency failed." >&2
+		exit 1
+		;;
+	no-direnv)
+		case "$probe" in
+			*"command -v direnv"*) exit 1 ;;
+			*) exit 0 ;;
+		esac
+		;;
+	ok)
+		case "$probe" in
+			*"command -v direnv"*) echo "/nix/store/stub/bin/direnv"; exit 0 ;;
+			*" direnv allow "*) echo "STUB-ALLOW:${probe##* }"; exit 0 ;;
+			*) exit 0 ;;
+		esac
+		;;
+esac
+exit 0
+STUB
+chmod +x "$DV/bin/nix"
+
+# run_direnv_step MODE -> "<exit>|<combined output>"
+run_direnv_step() {
+	local out rc
+	out="$(
+		cd "$DV/ws/codetracer" &&
+			PATH="$DV/bin:$PATH" NIX_STUB_MODE="$1" \
+				CT_DIR="$DV/ws/codetracer" RECORDER_REPO="codetracer-ruby-recorder" \
+				bash "$DIRENV_STEP" 2>&1
+	)"
+	rc=$?
+	printf '%s|%s' "$rc" "$out"
+}
+
+dv_out="$(run_direnv_step shell-fails)"
+if [ "${dv_out%%|*}" != 0 ] &&
+	printf '%s' "$dv_out" | grep -q 'FAILED TO BUILD' &&
+	! printf '%s' "$dv_out" | grep -q 'direnv is not on PATH'; then
+	ok "a ci shell that will not build is reported as a shell build failure, not a missing direnv"
+else
+	fail "a ci shell that will not build is reported as a shell build failure, not a missing direnv" \
+		"got: ${dv_out}"
+fi
+
+dv_out="$(run_direnv_step no-direnv)"
+if [ "${dv_out%%|*}" != 0 ] &&
+	printf '%s' "$dv_out" | grep -q 'direnv is not on PATH inside it' &&
+	! printf '%s' "$dv_out" | grep -q 'FAILED TO BUILD'; then
+	ok "a shell that builds but lacks direnv is reported as a missing direnv"
+else
+	fail "a shell that builds but lacks direnv is reported as a missing direnv" \
+		"got: ${dv_out}"
+fi
+
+dv_out="$(run_direnv_step ok)"
+if [ "${dv_out%%|*}" = 0 ] &&
+	printf '%s' "$dv_out" | grep -q 'direnv allow: .*/codetracer-launcher' &&
+	printf '%s' "$dv_out" | grep -q 'direnv allow: .*/codetracer-ruby-recorder' &&
+	printf '%s' "$dv_out" | grep -q 'no .envrc in .*/codetracer-trace-format-nim'; then
+	ok "a healthy shell allows every sibling that has a .envrc and says so for the one that does not"
+else
+	fail "a healthy shell allows every sibling that has a .envrc and says so for the one that does not" \
+		"got: ${dv_out}"
+fi
+
+# ---------------------------------------------------------------------------
 # 10. THE CHECKER'S OWN MUTATION TEST.
 #
 # Everything above reports a defect by NOT finding something, which is the
@@ -1007,7 +1133,7 @@ fi
 # reporting success on fewer checks than it claims.
 # ---------------------------------------------------------------------------
 echo
-readonly EXPECTED_ASSERTIONS=15
+readonly EXPECTED_ASSERTIONS=18
 if [ "$assertions" -ne "$EXPECTED_ASSERTIONS" ]; then
 	printf 'FAIL: ran %d assertions, expected %d\n' "$assertions" "$EXPECTED_ASSERTIONS"
 	failures=$((failures + 1))

--- a/flake.lock
+++ b/flake.lock
@@ -3069,6 +3069,22 @@
         "type": "github"
       }
     },
+    "nim-shm-lease": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787532379,
+        "narHash": "sha256-iGn2tdtIYKuAMkHOH0XT8KtLx5Fe0eFBXFieJyFgzrk=",
+        "owner": "metacraft-labs",
+        "repo": "nim-shm-lease",
+        "rev": "2e8b66fdd260ed356dca440fe6394e1f56fe0018",
+        "type": "github"
+      },
+      "original": {
+        "owner": "metacraft-labs",
+        "repo": "nim-shm-lease",
+        "type": "github"
+      }
+    },
     "nim-shm-queue-src": {
       "flake": false,
       "locked": {
@@ -5177,6 +5193,7 @@
         "git-hooks": [
           "git-hooks-nix"
         ],
+        "nim-shm-lease": "nim-shm-lease",
         "nixos-modules": [
           "nix-blockchain-development",
           "nixos-modules"
@@ -5186,17 +5203,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1783195639,
-        "narHash": "sha256-jB5wPpKIHWbWdLGDJJhjtcl2aecHe38DweyR1pKwJ0w=",
+        "lastModified": 1787618104,
+        "narHash": "sha256-93KLZF8xbw+MSF8Xxthe20IlZbCQcIpkdyJF/bSESEI=",
         "owner": "metacraft-labs",
         "repo": "runquota",
-        "rev": "f3382f579c31085c8b6d7eece97c78ee4617f8c8",
+        "rev": "b71e8e9061b479334d9b78638cfb828af2db938d",
         "type": "github"
       },
       "original": {
         "owner": "metacraft-labs",
-        "ref": "dev",
         "repo": "runquota",
+        "rev": "b71e8e9061b479334d9b78638cfb828af2db938d",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -108,7 +108,27 @@
     runquota = {
       # runquota/main is stale and lacks the bounded grant-stream API
       # (pollNextGrantBounded / GrantPollResult) that current reprobuild uses.
-      url = "github:metacraft-labs/runquota/dev";
+      #
+      # PINNED to the exact revision that the `reprobuild` input below locks as
+      # its own `runquota-src`, and it must be kept equal to it. This is NOT a
+      # "keep it recent" pin, and a branch is the wrong thing here: the
+      # `inputs.runquota-src.follows = "runquota"` line below means REPROBUILD
+      # IS COMPILED AGAINST WHATEVER THIS RESOLVES TO, so any drift in either
+      # direction is a compile error inside reprobuild's own sources, minutes
+      # into `nix develop`, naming an identifier nobody here has heard of:
+      #
+      #   behind  -> repro_runquota.nim(932): undeclared identifier: 'ExtensionCellWire'
+      #   ahead   -> repro_runquota.nim(501): undeclared identifier: 'LeaseFinishOutcome'
+      #
+      # Both were observed on this tree: `dev` had moved past the pinned
+      # reprobuild and REMOVED LeaseFinishOutcome, so tracking the branch tip
+      # was no more correct than lagging behind it.
+      #
+      # Bump this in lockstep with `reprobuild` below — read the new
+      # reprobuild revision's own flake.lock and mirror its `runquota-src`.
+      # `scripts/test-flake-pin-alignment.sh` (in `just test`) enforces the
+      # equality so the two pins cannot silently diverge again.
+      url = "github:metacraft-labs/runquota/b71e8e9061b479334d9b78638cfb828af2db938d";
       inputs.nixos-modules.follows = "nix-blockchain-development/nixos-modules";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-parts.follows = "flake-parts";

--- a/justfile
+++ b/justfile
@@ -14,6 +14,18 @@ build-once:
 test-build-alignment:
   bash scripts/test-build-alignment.sh
 
+# Assert this repo's `runquota` flake pin equals the `runquota-src` revision
+# its pinned `reprobuild` locks. `inputs.runquota-src.follows = "runquota"`
+# means reprobuild is COMPILED against whatever that input resolves to, so
+# drift in either direction breaks `nix develop` with an `undeclared
+# identifier` inside reprobuild's own sources, minutes in and attributed to
+# the wrong repo. Reads two flake.lock files; no toolchain, under a second.
+# Skips LOUDLY (never silently passes) when the sibling reprobuild checkout it
+# must read is absent; CT_FLAKE_PIN_ALIGNMENT_STRICT=1 makes that a failure.
+# See the header of scripts/test-flake-pin-alignment.sh.
+test-flake-pin-alignment:
+  bash scripts/test-flake-pin-alignment.sh
+
 # Build all sibling-recorder binaries that the GUI tests reach for.
 # Idempotent — already-built artefacts short-circuit, so this is cheap on
 # warm checkouts.  Pass `--force` to rebuild everything; `--check` to just
@@ -648,6 +660,7 @@ test:
   #!/usr/bin/env bash
   set -e
   just test-build-alignment
+  just test-flake-pin-alignment
   just test-agent-api-contract
   just test-rust
   just test-nimsuggest

--- a/scripts/test-flake-pin-alignment.sh
+++ b/scripts/test-flake-pin-alignment.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Flake pin alignment — this repo's `runquota` must be EXACTLY the `runquota`
+# its pinned `reprobuild` was locked against.
+#
+# ## The defect this exists to catch
+#
+# `flake.nix` pins `reprobuild` to an exact SHA (mirrored from nixos-modules,
+# which is the org's single source of truth) and then overrides SIX of
+# reprobuild's own inputs so the `repro` this repo ships is built against THIS
+# repo's nixpkgs and THIS repo's siblings. One of those overrides is
+#
+#     inputs.runquota-src.follows = "runquota";
+#
+# and that is the whole hazard: bumping the `reprobuild` SHA moves the code,
+# while `runquota` stays wherever `flake.lock` last left it. reprobuild is then
+# compiled against a runquota it was never developed against, and the failure
+# is an ordinary Nim `undeclared identifier` several minutes into a `nix
+# develop` — attributed to reprobuild, in a store path, with nothing naming the
+# pin that actually moved.
+#
+# That is not hypothetical. Commit c9cb186c ("build(deps): mirror the
+# nixos-modules reprobuild pin (b5b88139)") bumped reprobuild to b5b88139
+# while `runquota` stayed at f3382f5 (2026-07-04). reprobuild@b5b88139's OWN
+# flake.lock pins runquota-src at b71e8e9 — the commit that introduced
+# `ExtensionCellWire`. The result was that `nix develop` (and therefore
+# `just build-once`, `just test`, and every lane that needs the dev shell)
+# died with
+#
+#     libs/repro_runquota/src/repro_runquota.nim(932, 18)
+#       Error: undeclared identifier: 'ExtensionCellWire'
+#
+# on a tree whose own sources were fine.
+#
+# ## The invariant: EQUALITY, in both directions
+#
+# The revision this repo pins for `runquota` must EQUAL the `runquota-src`
+# revision that the pinned `reprobuild` locks. Not "at least" — equal.
+#
+# "At least" was the first thing tried here and it is wrong, which is worth
+# recording because it looks so reasonable. `runquota` was moved forward from
+# f3382f5 to its `dev` tip (6dea983) to acquire `ExtensionCellWire`; that fixed
+# the error above and produced a new one in the same file,
+#
+#     libs/repro_runquota/src/repro_runquota.nim(501, 52)
+#       Error: undeclared identifier: 'LeaseFinishOutcome'
+#
+# because `dev` had since REMOVED that type ("Make a self-contradicting finish
+# unrepresentable"). reprobuild@b5b88139 is source that compiles against
+# runquota@b71e8e9 and against nothing else; ahead breaks exactly as behind
+# does. So the check is `=`, and the remedy is to mirror, never to freshen.
+#
+# Only `runquota` is checked, because it is the only overridden input that is
+# a flake whose code reprobuild COMPILES AGAINST. The nixpkgs/flake-parts/
+# git-hooks overrides are environment, and `codetracer-native-recorder` is a
+# non-flake source input with no lock entry of its own to compare against.
+#
+# ## Why this is a static check and not "just build it"
+#
+# Building the dev shell does prove it, and takes minutes and a warm store.
+# This compares two strings read out of two flake.lock files: no toolchain, no
+# network, well under a second — so it can sit in `just test` and fail the
+# moment a pin is bumped alone, instead of at the far end of a lane.
+#
+# ## Skips are loud, never silent
+#
+# The check needs one thing it cannot synthesise: the sibling `reprobuild`
+# checkout, which is where the revision to compare against is read from (that
+# revision's own flake.lock). When it is absent, or is present but has not
+# fetched the pinned revision, this script prints a SKIP naming exactly what is
+# missing and the command that fixes it, and exits 0 — it never reports success
+# for a comparison it did not make. Set CT_FLAKE_PIN_ALIGNMENT_STRICT=1 to turn
+# those skips into failures, which is what a lane with a guaranteed workspace
+# should do.
+#
+# The sibling `runquota` checkout is OPTIONAL and its absence is not a skip:
+# comparing two SHAs needs no repository. It is consulted only to label a
+# failure "BEHIND" or "AHEAD of", which changes the message and never the
+# verdict.
+# =============================================================================
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORKSPACE_ROOT="$(cd "$REPO_ROOT/.." && pwd)"
+STRICT="${CT_FLAKE_PIN_ALIGNMENT_STRICT:-0}"
+
+fail() {
+	echo "FAIL: $*" >&2
+	exit 1
+}
+
+# A skip is a statement that the check did NOT run, and says why.
+skip() {
+	if [ "$STRICT" = "1" ]; then
+		echo "FAIL (CT_FLAKE_PIN_ALIGNMENT_STRICT=1): $*" >&2
+		exit 1
+	fi
+	echo "SKIP: $*" >&2
+	echo "SKIP: flake pin alignment was NOT verified by this run." >&2
+	exit 0
+}
+
+# Read <lock-file> <node-name> -> locked.rev, or empty when the node is absent.
+lock_rev() {
+	python3 -c '
+import json, sys
+try:
+    nodes = json.load(open(sys.argv[1]))["nodes"]
+except Exception:
+    sys.exit(0)
+node = nodes.get(sys.argv[2])
+if node:
+    print(node.get("locked", {}).get("rev", ""))
+' "$1" "$2"
+}
+
+CT_LOCK="$REPO_ROOT/flake.lock"
+[ -f "$CT_LOCK" ] || fail "$CT_LOCK does not exist; this script must run inside the codetracer checkout."
+
+CT_RUNQUOTA="$(lock_rev "$CT_LOCK" runquota)"
+REPROBUILD_REV="$(lock_rev "$CT_LOCK" reprobuild)"
+
+# These two nodes are the subject of the check. If either has stopped existing,
+# the flake was restructured and this script is asserting about a shape that is
+# gone — that is a failure to re-examine, not a pass and not a skip.
+[ -n "$CT_RUNQUOTA" ] || fail "flake.lock has no locked rev for input 'runquota'. If the input was renamed or dropped, update this check (scripts/test-flake-pin-alignment.sh) to match."
+[ -n "$REPROBUILD_REV" ] || fail "flake.lock has no locked rev for input 'reprobuild'. If the input was renamed or dropped, update this check (scripts/test-flake-pin-alignment.sh) to match."
+
+REPROBUILD_DIR="${CT_REPROBUILD_CHECKOUT:-$WORKSPACE_ROOT/reprobuild}"
+RUNQUOTA_DIR="${CT_RUNQUOTA_CHECKOUT:-$WORKSPACE_ROOT/runquota}"
+
+# Only the reprobuild checkout is REQUIRED: it is the sole source of the
+# revision this check compares against. The runquota checkout is optional —
+# comparing two SHAs for equality needs no repository; it is consulted purely
+# to label a failure "BEHIND" or "AHEAD of", and its absence weakens the
+# message, not the verdict.
+[ -d "$REPROBUILD_DIR/.git" ] || skip "no reprobuild checkout at $REPROBUILD_DIR (set CT_REPROBUILD_CHECKOUT, or clone it beside this repo) — cannot read the flake.lock of reprobuild@${REPROBUILD_REV}."
+
+git -C "$REPROBUILD_DIR" cat-file -e "${REPROBUILD_REV}^{commit}" 2>/dev/null ||
+	skip "reprobuild checkout at $REPROBUILD_DIR does not have revision ${REPROBUILD_REV}. Run: git -C '$REPROBUILD_DIR' fetch origin ${REPROBUILD_REV}"
+
+RB_LOCK_TMP="$(mktemp)"
+trap 'rm -f "$RB_LOCK_TMP"' EXIT HUP INT TERM
+git -C "$REPROBUILD_DIR" show "${REPROBUILD_REV}:flake.lock" >"$RB_LOCK_TMP" 2>/dev/null ||
+	fail "reprobuild@${REPROBUILD_REV} has no flake.lock. The pin cannot be validated; re-examine this check."
+
+# reprobuild calls its own input `runquota-src`; this repo calls the override
+# `runquota` and wires them with `inputs.runquota-src.follows = "runquota"`.
+RB_RUNQUOTA="$(lock_rev "$RB_LOCK_TMP" runquota-src)"
+[ -n "$RB_RUNQUOTA" ] || fail "reprobuild@${REPROBUILD_REV} flake.lock has no locked rev for 'runquota-src'; the input reprobuild expects has been renamed. Update this check to match."
+
+echo "reprobuild pinned here:       ${REPROBUILD_REV}"
+echo "  its runquota-src:           ${RB_RUNQUOTA}"
+echo "this repo's runquota:         ${CT_RUNQUOTA}"
+
+if [ "$CT_RUNQUOTA" = "$RB_RUNQUOTA" ]; then
+	echo "OK: runquota is pinned to exactly the revision reprobuild was locked against."
+	exit 0
+fi
+
+# Not equal. Say WHICH WAY it diverged when the checkout can tell us, because
+# the two directions read very differently in the resulting compile error even
+# though the remedy is the same.
+RELATION="diverged from"
+if [ -d "$RUNQUOTA_DIR/.git" ] &&
+	git -C "$RUNQUOTA_DIR" cat-file -e "${RB_RUNQUOTA}^{commit}" 2>/dev/null &&
+	git -C "$RUNQUOTA_DIR" cat-file -e "${CT_RUNQUOTA}^{commit}" 2>/dev/null; then
+	if git -C "$RUNQUOTA_DIR" merge-base --is-ancestor "$CT_RUNQUOTA" "$RB_RUNQUOTA"; then
+		RELATION="BEHIND"
+	elif git -C "$RUNQUOTA_DIR" merge-base --is-ancestor "$RB_RUNQUOTA" "$CT_RUNQUOTA"; then
+		RELATION="AHEAD of"
+	fi
+fi
+
+cat >&2 <<EOF
+FAIL: this repo's 'runquota' pin is ${RELATION} the runquota revision that the
+      pinned reprobuild was locked against. They must be EQUAL.
+
+  flake.lock          runquota     = ${CT_RUNQUOTA}
+  reprobuild@${REPROBUILD_REV}
+                      runquota-src = ${RB_RUNQUOTA}
+
+'inputs.runquota-src.follows = "runquota"' means reprobuild is COMPILED against
+the revision on the first line, while it was written against the second.
+Divergence in EITHER direction surfaces minutes later as an 'undeclared
+identifier' inside reprobuild's own sources — behind it loses types that were
+added, ahead of it loses types that were removed.
+
+Remedy — mirror, do not freshen. In flake.nix set the runquota input url to
+
+    github:metacraft-labs/runquota/${RB_RUNQUOTA}
+
+then 'nix flake update runquota' and confirm with 'nix develop --command true'.
+EOF
+exit 1


### PR DESCRIPTION
`dev` has produced no compiler run for days. Two defects, one behind the other.

## 1. The dev shell does not build: `runquota` is not the revision reprobuild is compiled against

`flake.nix` sets `inputs.runquota-src.follows = "runquota"`, so the pinned
reprobuild is COMPILED against whatever this repo's `runquota` input resolves
to. `reprobuild` is pinned to an exact SHA; `runquota` tracked the `dev`
branch. The two drifted.

c9cb186c mirrored the nixos-modules reprobuild pin to `b5b88139` without moving
`runquota`, which sat at `f3382f5` (2026-07-04). reprobuild@b5b88139's own
flake.lock pins `runquota-src` at `b71e8e9`. `nix develop` died with

```
libs/repro_runquota/src/repro_runquota.nim(932, 18)
  Error: undeclared identifier: 'ExtensionCellWire'
```

on a tree whose own sources were fine. Observed in CI (run 33021054045) and
reproduced locally at the identical derivation hash
`1r4xm2mvn6gydmm127a8j4j261v5fzs0-reprobuild-0.1.3.drv`.

Freshening `runquota` to its `dev` tip is **not** the fix: `dev` had since
REMOVED a type, and the tip merely trades one error for its mirror image
(`undeclared identifier: 'LeaseFinishOutcome'`, same file, line 501). Both
directions were observed here. The pin is now the exact SHA reprobuild locks.

`scripts/test-flake-pin-alignment.sh`, wired into `just test`, asserts the
equality from two flake.lock files — no toolchain, no network, well under a
second. It distinguishes BEHIND from AHEAD, and when the sibling `reprobuild`
checkout it must read is absent it SKIPS LOUDLY rather than reporting a pass it
did not earn.

## 2. The gate blamed `direnv` for a shell that never built

`nix develop <shell> --command <probe>` exits non-zero both when the shell fails
to BUILD and when the probe fails. The "Allow direnv in the freshly cloned
siblings" step funnelled both into `direnv is not on PATH in the codetracer ci
dev shell` — a claim that is false, and provably so from the step's own comment
four lines above, which correctly states direnv is declared in
`nix/shells/ci-base.nix`. In run 33021054045 that message sat directly beneath
nix's `Error: undeclared identifier: 'ExtensionCellWire'`.

The shell is now built on its own first and a failure there is reported as a
shell build failure. `ci/test/launcher-recorder-e2e-workflow-test.sh` extracts
the step's script from the YAML and RUNS it against a stub `nix`, once per
failure mode; reverting the step makes two of the three new assertions fail.

## Verification

Both changes are red-test-first and mutation-tested; the mutation tables are in
the commit messages and the test headers. `just test-flake-pin-alignment` and
`bash ci/test/launcher-recorder-e2e-workflow-test.sh` (18/18) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)