### PR TITLE
ci: route the Linux jobs to the GPU-host scale sets (rr jobs held back)

### DIFF
--- a/.github/workflows/beam-flow.yml
+++ b/.github/workflows/beam-flow.yml
@@ -58,7 +58,7 @@ permissions:
 
 jobs:
   beam-flow-dap:
-    runs-on: eph-linux-x64  # CIP-5: nix job → eph-linux-x64
+    runs-on: eph-linux-x64-g1  # CIP-5 nix job; H4: routed to GPU host gpu-server-001
 
     steps:
       - name: Generate CI token

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -1123,7 +1123,7 @@ jobs:
             -E 'test(~dap) and not test(~bash_flow) and not test(~zsh_flow) and not test(~javascript_flow)'
 
   lint-bash:
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    runs-on: eph-linux-x64-g1  # CIP-5 nix job; H4: routed to GPU host gpu-server-001
     steps:
       - name: Mint installation token for cross-repo sibling access
         # GitHub free plan restricts org-level secrets with visibility
@@ -1161,7 +1161,7 @@ jobs:
       - run: "nix develop .#devShells.x86_64-linux.default -c ./ci/lint/bash.sh"
 
   lint-nim:
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    runs-on: eph-linux-x64-g2  # CIP-5 nix job; H4: routed to GPU host gpu-server-002
     steps:
       - name: Mint installation token for cross-repo sibling access
         # GitHub free plan restricts org-level secrets with visibility
@@ -1199,7 +1199,7 @@ jobs:
       - run: "nix develop .#devShells.x86_64-linux.default -c ./ci/lint/nim.sh"
 
   lint-nix:
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    runs-on: eph-linux-x64-g2  # CIP-5 nix job; H4: routed to GPU host gpu-server-002
     steps:
       - name: Mint installation token for cross-repo sibling access
         # GitHub free plan restricts org-level secrets with visibility
@@ -1237,7 +1237,7 @@ jobs:
       - run: "nix develop .#devShells.x86_64-linux.default -c ./ci/lint/nix.sh"
 
   lint-rust:
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    runs-on: eph-linux-x64-g2  # CIP-5 nix job; H4: routed to GPU host gpu-server-002
     steps:
       - name: Mint installation token for cross-repo sibling access
         # GitHub free plan restricts org-level secrets with visibility
@@ -1366,7 +1366,7 @@ jobs:
         run: nix develop . --command just test-reprobuild-macos-smoke
 
   reprobuild-linux-smoke:
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    runs-on: eph-linux-x64-g1  # CIP-5 nix job; H4: routed to GPU host gpu-server-001
     steps:
       - name: Mint installation token for cross-repo sibling access
         # GitHub free plan restricts org-level secrets with visibility
@@ -1525,7 +1525,7 @@ jobs:
   # envelope rejects missing prerequisites, ignored/skipped tests, count
   # drift, and any Playwright skip result.
   cross-process-linux:
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    runs-on: eph-linux-x64-g1  # CIP-5 nix job; H4: routed to GPU host gpu-server-001
     name: cross-process value-origin (Linux)
     steps:
       - name: Generate CI token
@@ -1584,7 +1584,7 @@ jobs:
         run: nix develop .#devShells.x86_64-linux.default --command just test-cross-process
 
   viewmodel-tests:
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    runs-on: eph-linux-x64-g1  # CIP-5 nix job; H4: routed to GPU host gpu-server-001
     name: ViewModel headless tests (native + JS)
     steps:
       - name: Generate CI token
@@ -1764,7 +1764,7 @@ jobs:
           retention-days: 30
 
   push-gpg-public-key:
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    runs-on: eph-linux-x64-g2  # CIP-5 nix job; H4: routed to GPU host gpu-server-002
     steps:
       - name: Mint installation token for cross-repo sibling access
         # GitHub free plan restricts org-level secrets with visibility
@@ -1808,7 +1808,7 @@ jobs:
           nix develop .#devShells.x86_64-linux.default --command aws --endpoint-url=${{ secrets.R2_CODETRACER_BUCKET_S3_ENDPOINT }} s3 cp CodeTracer.pub.asc s3://${{ vars.R2_CODETRACER_BUCKET_NAME }}/CodeTracer.pub.asc
 
   push-install-script:
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    runs-on: eph-linux-x64-g2  # CIP-5 nix job; H4: routed to GPU host gpu-server-002
     steps:
       - name: Mint installation token for cross-repo sibling access
         # GitHub free plan restricts org-level secrets with visibility
@@ -1842,7 +1842,7 @@ jobs:
           nix develop .#devShells.x86_64-linux.default --command aws --endpoint-url=${{ secrets.R2_CODETRACER_BUCKET_S3_ENDPOINT }} s3 cp install-on-distributions.sh s3://${{ vars.R2_CODETRACER_BUCKET_NAME }}/install.sh
 
   dev-build:
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    runs-on: eph-linux-x64-g1  # CIP-5 nix job; H4: routed to GPU host gpu-server-001
     needs:
       - lint-bash
       - lint-nim
@@ -1890,7 +1890,7 @@ jobs:
       - run: "nix develop .#devShells.x86_64-linux.default --command ./ci/build/dev.sh"
 
   nix-build:
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    runs-on: eph-linux-x64-g2  # CIP-5 nix job; H4: routed to GPU host gpu-server-002
     needs:
       - lint-bash
       - lint-nim
@@ -1927,7 +1927,7 @@ jobs:
       - run: "nix develop .#devShells.x86_64-linux.default --command ./ci/build/nix.sh"
 
   appimage-build:
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    runs-on: eph-linux-x64-g1  # CIP-5 nix job; H4: routed to GPU host gpu-server-001
     needs:
       - lint-bash
       - lint-nim
@@ -2104,7 +2104,7 @@ jobs:
     # fusermount setuid wrapper / /dev/fuse, so we smoke-run the AppImage with
     # `APPIMAGE_EXTRACT_AND_RUN=1` (self-extract, no FUSE) — the same mode
     # nix/shells/ci-base.nix documents for AppImages on these runners.
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    runs-on: eph-linux-x64-g1  # CIP-5 nix job; H4: routed to GPU host gpu-server-001
     needs:
       - appimage-build
     steps:
@@ -2187,7 +2187,7 @@ jobs:
       matrix:
         include:
           - platform: nixos
-            runner: eph-linux-x64  # CIP-5: nix leg -> eph-linux-x64
+            runner: eph-linux-x64-g1  # CIP-5 nix leg; H4: routed to GPU host gpu-server-001
           # CIP-5 Wave 4: the macOS leg now runs on the self-hosted nix-darwin
           # runner and drives the tests through codetracer's nix dev shell
           # (``nix develop . --command just test``), same as the nixos leg. The
@@ -2474,7 +2474,7 @@ jobs:
       matrix:
         include:
           - platform: nixos
-            runner: eph-linux-x64  # CIP-5: nix leg -> eph-linux-x64
+            runner: eph-linux-x64-g2  # CIP-5 nix leg; H4: routed to GPU host gpu-server-002
           # CIP-5 Wave 4: the macOS leg now runs on the self-hosted nix-darwin
           # runner. The ct binary is built by codetracer's reprobuild recipe in
           # the nix dev shell (``nix develop . --command just build-once`` ->
@@ -2763,6 +2763,27 @@ jobs:
           CODETRACER_DB_TESTS_ONLY: "1"
 
   test-ui-tests-rr:
+    # DELIBERATELY NOT ROUTED to eph-linux-x64-g1/-g2 with the rest of this
+    # workflow (H4). This is the one job in the Linux set that drives `rr`, and
+    # the GPU hosts were measured, not assumed:
+    #
+    #   * Guest exposes kernel.perf_event_paranoid = -1 and a fully visible PMU;
+    #     perf_event_open(HW_BRANCH_INSTRUCTIONS) succeeds unprivileged. So the
+    #     container is NOT the obstacle.
+    #   * But both GPU hosts are i9-12900K (Alder Lake), a HYBRID part:
+    #     cpu_core (P) = CPUs 0-15, cpu_atom (E) = CPUs 16-23. rr needs the
+    #     retired-conditional-branch counter (`r5111c4`), which only the
+    #     P-cores implement.
+    #   * Measured on both hosts: `rr record` + `rr replay` PASS when the tracee
+    #     is pinned to a P-core (`taskset -c 0-15`), and FAIL hard in
+    #     PerfCounters::start() when pinned to an E-core.
+    #   * Unpinned -- which is how this job invokes rr today -- is a coin flip:
+    #     in one probe run the identical command passed on -g1 and failed on -g2.
+    #
+    # Routing this job as-is would therefore manufacture flaky CI rather than
+    # move load. It can move once the rr invocation confines the tracee to the
+    # P-cores; until then it stays on high-mem-server, whose Xeon E5-2650 is
+    # uniform (no E-cores) and so has no core-type lottery.
     runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
     timeout-minutes: 120
     steps:
@@ -3134,7 +3155,7 @@ jobs:
   # recording assertions into no-ops.
   # ---------------------------------------------------------------------------
   ct-test-release-gate:
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    runs-on: eph-linux-x64-g2  # CIP-5 nix job; H4: routed to GPU host gpu-server-002
     name: ct-test release gate (M16 provider matrix)
     steps:
       - name: Mint installation token for cross-repo sibling access
@@ -3185,7 +3206,7 @@ jobs:
         run: nix develop .#devShells.x86_64-linux.default --command just test-m16-release-gate
 
   ct-test-providers:
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    runs-on: eph-linux-x64-g1  # CIP-5 nix job; H4: routed to GPU host gpu-server-001
     name: ct-test cross-language provider gate
     steps:
       - name: Mint installation token for cross-repo sibling access
@@ -3305,7 +3326,7 @@ jobs:
           if-no-files-found: ignore
 
   push-to-attic:
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    runs-on: eph-linux-x64-g1  # CIP-5 nix job; H4: routed to GPU host gpu-server-001
     needs:
       - test-non-gui
       - test-ui-tests
@@ -3410,7 +3431,7 @@ jobs:
 
   build-and-deploy-docs:
     needs: [ docs-scope ]
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    runs-on: eph-linux-x64-g2  # CIP-5 nix job; H4: routed to GPU host gpu-server-002
     # The docs site is INDEPENDENT content: it is built by its own isonim-docs
     # SSG consumer (docs/book-isonim via ci/deploy/docs.sh) and consumes NO
     # artifact from the app build or the attic-cache push. It must therefore not
@@ -3615,7 +3636,7 @@ jobs:
             "$PR_NUMBER" "https://docs.codetracer.com/pr/${PR_NUMBER}/" "$HEAD_SHA"
 
   push-tag:
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    runs-on: eph-linux-x64-g2  # CIP-5 nix job; H4: routed to GPU host gpu-server-002
     needs: [ dev-build, nix-build, appimage-build, dmg-build ]
     permissions:
       contents: "write"
@@ -3703,7 +3724,7 @@ jobs:
           (git push origin "$YEAR.$MONTH.$BUILD" && echo "tag=$YEAR.$MONTH.$BUILD" >> $GITHUB_OUTPUT) || echo "Tag already exists"
 
   create-release:
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    runs-on: eph-linux-x64-g2  # CIP-5 nix job; H4: routed to GPU host gpu-server-002
     needs: [ push-tag ]
     if: ${{ ((startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-')) || needs.push-tag.outputs.tag != '') && !github.event['codetracer-ci'] }}
     permissions:

--- a/.github/workflows/cross-repo-tests.yml
+++ b/.github/workflows/cross-repo-tests.yml
@@ -42,6 +42,17 @@ permissions:
 
 jobs:
   rr-backend-tests:
+    # DELIBERATELY NOT ROUTED to eph-linux-x64-g1/-g2 (H4), for the same
+    # measured reason as codetracer.yml's `test-ui-tests-rr`: both GPU hosts are
+    # i9-12900K (Alder Lake) hybrid parts. The guest's PMU is fully available
+    # (perf_event_paranoid = -1, perf_event_open succeeds unprivileged), and
+    # `rr record` + `rr replay` pass there when the tracee is pinned to a P-core
+    # (CPUs 0-15) -- but fail hard in PerfCounters::start() on an E-core
+    # (CPUs 16-23), because only the P-cores implement the retired-conditional-
+    # branch counter rr needs. Unpinned, as this job runs rr today, the outcome
+    # depends on which core type the scheduler hands out; a probe run passed on
+    # -g1 and failed on -g2 for the identical command. Moving it would buy load
+    # relief at the cost of flaky CI. Route it once rr is confined to CPUs 0-15.
     runs-on: eph-linux-x64  # CIP-5: nix job (setup-dev-env) → eph-linux-x64
 
     steps:
@@ -192,7 +203,7 @@ jobs:
           if-no-files-found: ignore
 
   shell-recorder-tests:
-    runs-on: eph-linux-x64  # CIP-5: nix job (setup-dev-env) → eph-linux-x64
+    runs-on: eph-linux-x64-g1  # CIP-5 nix job; H4: routed to GPU host gpu-server-001
 
     steps:
       - name: Mint installation token for cross-repo sibling access

--- a/.github/workflows/launcher-recorder-e2e.yml
+++ b/.github/workflows/launcher-recorder-e2e.yml
@@ -269,7 +269,11 @@ jobs:
     # these repos uses (codetracer/.github/workflows/cross-repo-tests.yml,
     # codetracer-launcher/.github/workflows/cross-repo-recorder-packaging.yml,
     # codetracer-python-recorder/.github/workflows/launcher-integration.yml).
-    runs-on: eph-linux-x64 # CIP-5: nix job (setup-dev-env) -> eph-linux-x64
+    # H4: routed to gpu-server-002. Note this reusable workflow is called three
+    # times concurrently by launcher-recorder-e2e-desktop-edge.yml (python /
+    # ruby / js), so it lands 3 of -g2's 4 slots at once; -g2 carries the
+    # lighter share of codetracer.yml's build wave to leave room for it.
+    runs-on: eph-linux-x64-g2 # CIP-5 nix job; H4: routed to GPU host gpu-server-002
     name: ${{ inputs.edge }}
     timeout-minutes: 180
 

--- a/.github/workflows/request-panel-sidecar-retirement.yml
+++ b/.github/workflows/request-panel-sidecar-retirement.yml
@@ -65,7 +65,7 @@ permissions:
 
 jobs:
   sidecar-retirement:
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    runs-on: eph-linux-x64-g1  # CIP-5 nix job; H4: routed to GPU host gpu-server-001
     name: No recorder writes sidecar manifests (6 recorders, 6 live servers)
     steps:
       - name: Generate CI token


### PR DESCRIPTION
Moves 25 Linux job legs off `high-mem-server` onto `eph-linux-x64-g1` / `-g2`.

`codetracer` is **46.34% of clean job-minutes** on the `eph-linux-x64` class — 3.2× `vm-harness`, 4.9× `nixos-modules`. `high-mem-server` is a Dell R620 on six consumer QLC SSDs that sustain ~78 MB/s; four watchdog resets in 48h opened the campaign this belongs to. The GPU scale sets are live and proven: each ran ~105 container creates in the last 24h after earlier routing landed.

## ⚠ The rr jobs are deliberately NOT routed, and the reason is measured

`test-ui-tests-rr` and `rr-backend-tests` stay on `eph-linux-x64`.

**The container is not the obstacle** — the guest reports `perf_event_paranoid = -1`, exposes `cpu_core`/`cpu_atom`/`intel_pt`, and an unprivileged `perf_event_open(HW_BRANCH_INSTRUCTIONS)` probe succeeds at `CapEff: 0`.

**The CPU is.** Both GPU hosts are **i9-12900K (Alder Lake), hybrid**: `cpu_core` = CPUs 0-15, `cpu_atom` = 16-23. Only the P-cores implement `r5111c4`, the retired-conditional-branch counter rr requires. Measured on both hosts:

| case | -g1 | -g2 |
|---|---|---|
| pinned P-core | record+replay OK | record+replay OK |
| pinned E-core | abort in `PerfCounters::start()` | abort |
| **unpinned** (how CI runs rr) | **OK** | **FAILED** |

Unpinned is a per-job coin flip — the identical command passed on `-g1` and failed on `-g2` in a single run. Routing as-is manufactures flake. They can move the moment rr is confined to CPUs 0-15 (taskset/affinity on the runner, or an E-core-free class).

Two corrections found while measuring: **`cross-process-linux` has no rr references** (`scripts/test-cross-process.sh` is db-backend only), so it *is* routed; and **rr is not actually exercised in CI today** — both rr jobs are red before reaching a counter (`CODETRACER_RR_BACKEND_PATH is not set`; `libs/rr/flake.nix ... not tracked by Git`).

## Split — balanced by runtime, not job count

Averages over the last 51 completed `dev` runs, cancelled/skipped excluded. Almost every routed job declares no `needs:`, so ~17 Linux jobs queue at t=0 against 8 slots and the balance sets the critical path.

- **`-g1` (13)**: ct-test-providers 31.9, appimage-build 21.7, dev-build 20.9, viewmodel-tests 19.1, cross-process-linux 15.0, lint-bash 14.5, test-non-gui(nixos) 12.3, reprobuild-linux-smoke 7.0, appimage-lib-check, push-to-attic, shell-recorder-tests, sidecar-retirement, beam-flow-dap
- **`-g2` (12)**: test-ui-tests(nixos) 29.4, lint-rust 28.1, nix-build 17.4, lint-nix 16.5, build-and-deploy-docs 15.0, lint-nim 14.3, ct-test-release-gate 11.1, push-gpg, push-install, push-tag, create-release, launcher-recorder-e2e

Balanced across all three load regimes: full run **142.4 vs 132.5**, always-on subset **99.8 vs 100.1**, frequency-weighted **115.5 vs 114.5**. `launcher-recorder-e2e` is on `-g2` because desktop-edge calls it 3× concurrently, so `-g2` carries the lighter build wave.

Split across **both** hosts deliberately: 46% of runtime into one host's 4 slots would just relocate the bottleneck onto machines whose documented failure mode is a silent multi-hour freeze where the watchdog has been observed not to fire. **`maxRunners` is untouched at 4.**

## Expect the first wave to be slower

The GPU hosts' `/nix/store` has never built codetracer, so the first run pays a full Attic fetch. That is a one-off, not a regression.

## Verified

No branch protection or required checks on `dev`/`stable`; the "Protect main" ruleset is default-branch-only. `required-jobs.sh` reads job **ids** from `toJSON(needs)`, so the matrix rename does not break the verdict gate. Shared-store sweep re-confirmed: no hits for `/srv/repro-store` or `/var/lib/reprobuild/shared-store`. All 10 workflow files re-parse clean with `yq`.

Targets **`dev`**, not the `stable` default: `origin/stable...origin/dev` is 0 behind / 188 ahead.