### PR TITLE
fix(review): let --list read the matrix without an npm install

### DIFF
--- a/tools/visual-review/capture-deepreview-views.mjs
+++ b/tools/visual-review/capture-deepreview-views.mjs
@@ -46,7 +46,31 @@
  *        [--sabotage KIND]
  */
 
-import { _electron } from "playwright";
+// Playwright is imported LAZILY, at the one call site that launches a browser.
+//
+// `--list` prints the view / size / theme matrix and nothing else -- it is
+// static data in this file, needs no driver, and is how three other scripts
+// (the shell wrapper, the review-prompt emitter and the contract suite) learn
+// the matrix. A top-level `import { _electron } from "playwright"` made all of
+// them depend on an npm package that no CI lane installs: `ci-verdict` runs
+// the contract suite on a stock runner and `lint-bash` runs it inside the dev
+// shell, and neither has a repo-root `node_modules`. Both died with
+//
+//     Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'playwright'
+//       imported from .../tools/visual-review/capture-deepreview-views.mjs
+//
+// in every completed `dev` run of the last three weeks -- a data listing
+// blocked by a browser driver it never used.
+//
+// Note for anyone reproducing this: node resolves bare specifiers by walking
+// the FILESYSTEM upward, so a `node_modules/playwright` anywhere above the
+// checkout (a sibling workspace's, say) makes `--list` succeed on a developer
+// machine while failing in CI. `deepreview-harness-test.sh` runs its
+// regression case from a temporary directory for exactly that reason.
+async function electron() {
+  const { _electron } = await import("playwright");
+  return _electron;
+}
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
@@ -689,7 +713,7 @@ async function launch(opts) {
     "--ozone-platform-hint=x11",
   ].join(" ");
 
-  const app = await _electron.launch({
+  const app = await (await electron()).launch({
     executablePath: opts.ct,
     // A directory with no `.config.yaml` above it, so `findConfig`'s upward
     // walk falls through to XDG_CONFIG_HOME and the requested theme wins.

--- a/tools/visual-review/deepreview-harness-test.sh
+++ b/tools/visual-review/deepreview-harness-test.sh
@@ -44,7 +44,7 @@ STYLES_TUPFILE="${REPO_ROOT}/src/frontend/styles/Tupfile"
 # Every contract this suite claims to check. A suite that silently runs fewer
 # assertions than it advertises is a suite that stops protecting anything, so
 # the count is asserted at the end and has to be changed deliberately.
-EXPECTED_ASSERTIONS=65
+EXPECTED_ASSERTIONS=66
 
 ASSERTIONS=0
 FAILURES=0
@@ -117,6 +117,62 @@ command -v node >/dev/null 2>&1 || {
 	echo "deepreview-harness-test: missing 'node'; the matrix cannot be read" >&2
 	exit 3
 }
+
+# ---------------------------------------------------------------------------
+section "--list needs no npm packages"
+#
+# `--list` prints static data out of the driver, and three scripts (the shell
+# wrapper, the review-prompt emitter and THIS SUITE) learn the matrix from it.
+# It used to be gated behind a top-level `import { _electron } from
+# "playwright"`, so it needed an npm package no CI lane installs: `ci-verdict`
+# runs this suite on a stock runner and `lint-bash` runs it inside the dev
+# shell, and neither has a repo-root `node_modules`. Both failed with
+#
+#     Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'playwright'
+#       imported from .../tools/visual-review/capture-deepreview-views.mjs
+#
+# in every completed `dev` run for three weeks -- and the suite exited 3 on its
+# FIRST assertion, so its other 65 contracts never ran either.
+#
+# THIS CASE MUST RUN SOMEWHERE WITH NO ANCESTOR node_modules. Node resolves a
+# bare specifier by walking the filesystem upward, so a checkout that sits
+# under a workspace with its own `node_modules/playwright` -- which is exactly
+# the layout this repo is developed in -- resolves the import and passes while
+# CI fails. Copying the driver into a temporary directory is what makes the
+# case honest, and the guard below refuses to pretend otherwise if even that
+# location turns out to be contaminated.
+# ---------------------------------------------------------------------------
+
+_probe_dir="${TEST_ROOT}/no-node-modules/tools/visual-review"
+mkdir -p "${_probe_dir}"
+cp "${DRIVER}" "${_probe_dir}/"
+_contaminated=""
+_d="${_probe_dir}"
+while [[ ${_d} != "/" ]]; do
+	if [[ -e ${_d}/node_modules/playwright ]]; then _contaminated="${_d}/node_modules"; fi
+	_d="$(dirname "${_d}")"
+done
+[[ -e /node_modules/playwright ]] && _contaminated="/node_modules"
+
+if [[ -n ${_contaminated} ]]; then
+	# Loud, and a FAILURE rather than a silent pass: a green here would claim
+	# the driver needs no npm packages while proving the opposite.
+	bad "--list runs with no node_modules anywhere above it" \
+		"cannot test: ${_contaminated}/playwright is visible from the probe directory," \
+		"so node would resolve the import regardless of how the driver is written." \
+		"Run this suite from a path with no ancestor node_modules."
+else
+	if _probe_out="$(node "${_probe_dir}/$(basename "${DRIVER}")" --list 2>&1)"; then
+		assert_contains "${_probe_out}" "review-shell" \
+			"--list runs with no node_modules anywhere above it"
+	else
+		bad "--list runs with no node_modules anywhere above it" \
+			"the driver imported an npm package before it had anything to launch;" \
+			"this is what fails ci-verdict and lint-bash on every run." \
+			"output: ${_probe_out:0:400}"
+	fi
+fi
+unset _probe_dir _contaminated _d _probe_out
 
 # ---------------------------------------------------------------------------
 section "the matrix covers what the campaign changes"


### PR DESCRIPTION
`tools/visual-review/capture-deepreview-views.mjs --list` prints the view /
size / theme matrix and nothing else — static data in that file, and the way
three other scripts learn the matrix (the shell wrapper, the review-prompt
emitter, and `deepreview-harness-test.sh`).

It was gated behind a top-level `import { _electron } from "playwright"`, so
reading that data required an npm package no CI lane installs. `ci-verdict`
runs the contract suite on a stock runner; `lint-bash` runs it inside the dev
shell; neither has a repo-root `node_modules`. Both died on the suite's **first**
assertion with

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'playwright'
  imported from .../tools/visual-review/capture-deepreview-views.mjs
```

taking the other 65 contracts with them — in **every** completed `dev` run for
the last three weeks (32857778312, 32847959326, 32847481559, 32832715434,
32830199542, 32827396362, 32791280386, 32756736614, 32756431815, 32740904706,
32722332136, 32722291314). The comment beside the `ci-verdict` step already
claims the suite "needs only bash, git, coreutils and node". This makes that
true.

The import moves to the one call site that launches a browser. Nothing is
skipped and no assertion is weakened: a capture run still needs Playwright and
still fails without it.

### The test, and why it is written oddly

The regression case copies the driver into a **temporary directory** before
running `--list`. Node resolves a bare specifier by walking the filesystem
upward, and this repo is developed inside a workspace that has its own
`node_modules/playwright` — so the obvious spelling of this test passes in a
developer checkout while CI fails. That was verified rather than assumed: the
same `--list` that succeeds in the checkout reproduces the CI error verbatim
from `/tmp`.

If even the temporary location turns out to have an ancestor
`node_modules/playwright`, the case **fails and says so** instead of claiming a
property it did not test.

Mutation results: restoring the top-level import fails the new case; pointing
the probe back at the checkout (where the ancestor `node_modules` is visible)
also fails it, via the contamination guard.