### PR TITLE
fix: make the RR-backend prerequisite satisfiable (dead repo name)

### DIFF
--- a/ci/test/sibling-backend-path-test.sh
+++ b/ci/test/sibling-backend-path-test.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Regression test: sourcing detect-siblings.sh must EXPORT
+# CODETRACER_RR_BACKEND_PATH when the native-backend sibling is checked out.
+#
+# Why this test exists
+# --------------------
+# `src/backend-manager/tests/real_recording_integration.rs` gates 48 RR-based
+# integration tests on the native-backend sibling being detected, and its
+# failure message instructs the operator to "Run detect-siblings.sh".  That
+# instruction was false: detect-siblings.sh only ever set the derived
+# `CODETRACER_RR_BACKEND_PRESENT` flag, never `_PATH`.  The only place that
+# ever set `_PATH` was one GitHub Actions step, because the dev-shell path
+# (`repro.nim`) keyed the variable on a sibling directory named
+# `codetracer-rr-backend` — a repository that does not exist and never did in
+# this workspace layout (GitHub redirects that slug to
+# `codetracer-native-backend`, which is what `projects/codetracer.toml`
+# actually declares).  So `just cross-test`, gated on `_PATH` alone, could
+# never fire outside Actions.
+#
+# The property under test is deliberately END-TO-END rather than "the variable
+# is non-empty".  The half-configured state that produced the original bug was
+# exactly `_PRESENT=1` sitting next to an unset `_PATH`, so a test that merely
+# checks a name now resolves would not have caught it.  We assert that the
+# variable is set, that it points at something real and identifiable as the
+# native-backend checkout, and that the `just test` gate it feeds actually
+# opens.
+#
+# Mocking note (per the workspace policy on justified mocks): case A builds a
+# synthetic workspace tree on the real filesystem — real directories, a real
+# executable file, the real detect-siblings.sh sourced in a real subshell.
+# Nothing is stubbed; the fixture only substitutes a cheap placeholder for the
+# multi-crate ct-native-replay build, because the property under test is path
+# detection, not anything the binary does.  Case B then re-runs the identical
+# assertions against the genuine sibling checkout when one is present, so the
+# synthetic layout can never be the only evidence.
+# =============================================================================
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DETECT="$REPO_ROOT/scripts/detect-siblings.sh"
+
+failures=0
+pass() { printf '  ok   — %s\n' "$1"; }
+fail() {
+	printf '  FAIL — %s\n' "$1" >&2
+	failures=$((failures + 1))
+}
+skip() { printf '  SKIP — %s\n' "$1" >&2; }
+
+[ -f "$DETECT" ] || {
+	echo "ERROR: detect-siblings.sh not found at $DETECT" >&2
+	exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Run detect-siblings.sh against $1 (a codetracer repo root) in a clean
+# subshell and echo the resulting values of the two variables we care about.
+# Isolating this in a subshell keeps each case from leaking exports into the
+# next, and keeps the harness's own environment out of the result.
+# ---------------------------------------------------------------------------
+probe_detect() {
+	local ct_root="$1"
+	# shellcheck disable=SC2016  # $1/$2 inside the single-quoted script below
+	# are that inner shell's positional args (passed after the `_` argv[0]
+	# placeholder); they must NOT expand here.
+	env -u CODETRACER_RR_BACKEND_PATH \
+		-u CODETRACER_RR_BACKEND_PRESENT \
+		-u CODETRACER_REPO_ROOT_PATH \
+		-u CT_CODETRACER_NATIVE_BACKEND_SIBLING \
+		DETECT_SIBLINGS_QUIET=1 \
+		bash -c '
+			set -u
+			# shellcheck disable=SC1090
+			source "$1" "$2" >/dev/null 2>&1
+			printf "PATH_VAL=%s\n" "${CODETRACER_RR_BACKEND_PATH:-}"
+			printf "PRESENT_VAL=%s\n" "${CODETRACER_RR_BACKEND_PRESENT:-}"
+		' _ "$DETECT" "$ct_root"
+}
+
+# ---------------------------------------------------------------------------
+# The four-part end-to-end property, applied to one detection result.
+#   $1 label, $2 PATH_VAL, $3 PRESENT_VAL, $4 expected backend dir (or "" to
+#   only require that it be a real directory named codetracer-native-backend)
+# ---------------------------------------------------------------------------
+assert_backend_path_usable() {
+	local label="$1" path_val="$2" present_val="$3" expect_dir="$4"
+
+	# (1) The variable is set at all.  This is the assertion that was red.
+	if [ -n "$path_val" ]; then
+		pass "$label: CODETRACER_RR_BACKEND_PATH is exported"
+	else
+		fail "$label: CODETRACER_RR_BACKEND_PATH is empty/unset after sourcing detect-siblings.sh"
+		return
+	fi
+
+	# (2) It points at something that exists — a name that resolves to nothing
+	#     is the defect this whole test guards against.
+	if [ -d "$path_val" ]; then
+		pass "$label: it points at an existing directory ($path_val)"
+	else
+		fail "$label: CODETRACER_RR_BACKEND_PATH=$path_val is not a directory"
+	fi
+
+	# (3) It is the native-backend checkout, not the retired name.  Guards
+	#     against 'fixing' this by resurrecting codetracer-rr-backend.
+	if [ "$(basename "$path_val")" = "codetracer-native-backend" ]; then
+		pass "$label: it names the codetracer-native-backend sibling"
+	else
+		fail "$label: expected basename codetracer-native-backend, got '$(basename "$path_val")'"
+	fi
+	if [ -n "$expect_dir" ] && [ "$path_val" != "$expect_dir" ]; then
+		fail "$label: expected exactly $expect_dir, got $path_val"
+	fi
+
+	# (4) The gate it feeds actually opens.  This is the literal condition
+	#     from the `test` recipe in the justfile; if that expression is ever
+	#     rewritten, this test should be updated in lockstep.
+	if [ -n "${path_val:-}" ]; then
+		pass "$label: the 'just test' cross-test gate opens"
+	else
+		fail "$label: the 'just test' cross-test gate stays closed"
+	fi
+
+	# (5) The two variables answer DIFFERENT questions and must stay
+	#     consistent with each other.  _PATH means "the sibling repo is
+	#     checked out"; _PRESENT means "its ct-native-replay is built and on
+	#     PATH".  A checkout that has not been built yet is a legitimate
+	#     state (_PATH set, _PRESENT unset) — check_rr_prerequisites then
+	#     passes its detection gate and hard-fails a step later in
+	#     find_ct_native_replay with the accurate "build it" reason.
+	#
+	#     What must NEVER happen is the converse, _PRESENT=1 beside an unset
+	#     _PATH: that is the half-configured state the original bug produced,
+	#     where detection reported success while the variable every consumer
+	#     gates on stayed empty.  That invariant is asserted globally below,
+	#     since it has to hold whether or not a sibling exists.
+	if [ -x "$path_val/target/debug/ct-native-replay" ]; then
+		if [ "$present_val" = "1" ]; then
+			pass "$label: backend is built and _PRESENT=1 accompanies _PATH"
+		else
+			fail "$label: ct-native-replay is built under \$_PATH but _PRESENT='$present_val'"
+		fi
+	else
+		skip "$label: ct-native-replay is not built under $path_val, so the _PRESENT=1 pairing cannot be exercised — _PATH alone is the correct state for an unbuilt checkout, and the prerequisite gate still hard-fails on the missing binary"
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# The invariant that the original bug violated, in whichever direction.
+# ---------------------------------------------------------------------------
+assert_no_half_configured() {
+	local label="$1" path_val="$2" present_val="$3"
+	if [ "$present_val" = "1" ] && [ -z "$path_val" ]; then
+		fail "$label: CODETRACER_RR_BACKEND_PRESENT=1 with _PATH unset — the half-configured state that hid the original bug"
+	else
+		pass "$label: no _PRESENT-without-_PATH half-configured state"
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# Case A — synthetic workspace.  Hermetic: runs identically on any host, in
+# any CI lane, with no sibling checkout and no network.
+# ---------------------------------------------------------------------------
+echo "case A: synthetic workspace with a codetracer-native-backend sibling"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/ws/codetracer"
+mkdir -p "$TMP/ws/codetracer-native-backend/target/debug"
+cat >"$TMP/ws/codetracer-native-backend/target/debug/ct-native-replay" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$TMP/ws/codetracer-native-backend/target/debug/ct-native-replay"
+
+eval "$(probe_detect "$TMP/ws/codetracer")"
+assert_backend_path_usable "case A" "${PATH_VAL:-}" "${PRESENT_VAL:-}" \
+	"$TMP/ws/codetracer-native-backend"
+assert_no_half_configured "case A" "${PATH_VAL:-}" "${PRESENT_VAL:-}"
+
+# ---------------------------------------------------------------------------
+# Case A-negative — no sibling at all.  The variable must stay UNSET rather
+# than be set to a stale or empty-but-present value; `check_rr_prerequisites`
+# treats "set and non-empty" as proof the sibling is there, so a spurious
+# export here would be worse than no export at all.
+# ---------------------------------------------------------------------------
+echo "case A-negative: workspace with no native-backend sibling"
+mkdir -p "$TMP/bare/codetracer"
+mkdir -p "$TMP/bare/codetracer-python-recorder" # a sibling, so the root resolves
+eval "$(probe_detect "$TMP/bare/codetracer")"
+if [ -z "${PATH_VAL:-}" ]; then
+	pass "case A-negative: CODETRACER_RR_BACKEND_PATH stays unset with no sibling"
+else
+	fail "case A-negative: _PATH=${PATH_VAL} exported despite no native-backend sibling"
+fi
+assert_no_half_configured "case A-negative" "${PATH_VAL:-}" "${PRESENT_VAL:-}"
+
+# ---------------------------------------------------------------------------
+# Case B — the real checkout.  Skips LOUDLY (with the reason) when the sibling
+# is not present, e.g. in the non-gui CI lane, which deliberately runs without
+# it.  A skip here never masks case A, which is unconditional.
+# ---------------------------------------------------------------------------
+echo "case B: real codetracer-native-backend checkout"
+REAL_WS="$(cd "$REPO_ROOT/.." && pwd)"
+if [ -d "$REAL_WS/codetracer-native-backend" ]; then
+	eval "$(probe_detect "$REPO_ROOT")"
+	assert_backend_path_usable "case B" "${PATH_VAL:-}" "${PRESENT_VAL:-}" ""
+	assert_no_half_configured "case B" "${PATH_VAL:-}" "${PRESENT_VAL:-}"
+else
+	skip "case B: no codetracer-native-backend checkout at $REAL_WS — this lane runs without the sibling, so the real-checkout leg cannot be exercised here (case A still ran and is authoritative for the detection logic)"
+fi
+
+# ---------------------------------------------------------------------------
+# Case C — the retired repository name must not be reintroduced as a
+# filesystem lookup.  `codetracer-rr-backend` does not exist as a repo;
+# `projects/codetracer.toml` declares `codetracer-native-backend`.
+# ---------------------------------------------------------------------------
+echo "case C: retired directory name absent from live lookup sites"
+for f in "$REPO_ROOT/scripts/detect-siblings.sh" "$REPO_ROOT/repro.nim"; do
+	rel="${f#"$REPO_ROOT"/}"
+	# Comments may still mention the old name (e.g. "formerly ..."); only
+	# non-comment lines constitute a live lookup.
+	if hits="$(grep -n 'codetracer-rr-backend' "$f" | grep -vE ':[[:space:]]*(#|##|--)' || true)"; [ -z "$hits" ]; then
+		pass "case C: $rel has no live codetracer-rr-backend lookup"
+	else
+		fail "case C: $rel still looks up the retired name:"$'\n'"$hits"
+	fi
+done
+
+echo
+if [ "$failures" -eq 0 ]; then
+	echo "sibling-backend-path-test: PASS"
+	exit 0
+fi
+echo "sibling-backend-path-test: $failures assertion(s) FAILED" >&2
+exit 1

--- a/justfile
+++ b/justfile
@@ -26,6 +26,17 @@ test-build-alignment:
 test-flake-pin-alignment:
   bash scripts/test-flake-pin-alignment.sh
 
+# Assert that detect-siblings.sh can actually satisfy the prerequisite the
+# RR-based backend-manager integration tests demand. Those 48 tests gate on
+# CODETRACER_RR_BACKEND_PATH and tell the operator to run detect-siblings.sh
+# when it is unset; that instruction was false for as long as both the script
+# and the repro dev shell keyed the variable on a sibling directory named
+# `codetracer-rr-backend`, which is not a repository that exists. Hermetic and
+# fast (no build, no network) -- the real-checkout leg skips loudly when the
+# sibling is absent, as in the non-gui lane.
+test-sibling-backend-path:
+  bash ci/test/sibling-backend-path-test.sh
+
 # Assert that the built output tree carries the assets `ct` reads on startup
 # (`<prefix>/config/default_config.yaml` and `default_layout.json`). A tup
 # build exits 0 when a runtime asset is simply never published -- there is no
@@ -677,11 +688,12 @@ test:
   set -e
   just test-build-alignment
   just test-flake-pin-alignment
+  just test-sibling-backend-path
   just test-agent-api-contract
   just test-rust
   just test-nimsuggest
   if [ -n "${CODETRACER_RR_BACKEND_PATH:-}" ]; then
-    echo "codetracer-rr-backend detected — running cross-repo tests..."
+    echo "codetracer-native-backend detected — running cross-repo tests..."
     just cross-test
   else
     echo "CODETRACER_RR_BACKEND_PATH not set — skipping cross-repo tests"

--- a/libs/ct-dap-client/src/test_support/mod.rs
+++ b/libs/ct-dap-client/src/test_support/mod.rs
@@ -88,7 +88,6 @@ pub(crate) fn find_ct_native_replay() -> Result<PathBuf, BoxError> {
         let manifest = PathBuf::from(&manifest_dir);
         let names_and_repos: &[(&str, &str)] = &[
             ("ct-native-replay", "codetracer-native-backend"),
-            ("ct-native-replay", "codetracer-rr-backend"), // legacy repo name
         ];
         for &(bin, repo) in names_and_repos {
             let exe_name = format!("{bin}{}", std::env::consts::EXE_SUFFIX);

--- a/repro.nim
+++ b/repro.nim
@@ -73,7 +73,6 @@ const
   ]
   CodeTracerKnownSiblingDirs = [
     "codetracer-native-backend",
-    "codetracer-rr-backend",
     "codetracer-native-recorder",
     "codetracer-native-test-programs",
     "codetracer-python-recorder",
@@ -117,7 +116,12 @@ const
   ]
   CodeTracerRepoEnvAliases = [
     ("codetracer-native-backend", "CODETRACER_NATIVE_BACKEND_REPO_PATH"),
-    ("codetracer-rr-backend", "CODETRACER_RR_BACKEND_PATH"),
+    # Second alias for the SAME sibling: the RR-era variable name is what
+    # `just test` and check_rr_prerequisites still gate on. Keyed on
+    # "codetracer-rr-backend" until now, i.e. on a directory that never
+    # exists, so the dev shell never set it. The loop over this table is flat,
+    # so two entries for one repo simply export both names.
+    ("codetracer-native-backend", "CODETRACER_RR_BACKEND_PATH"),
     ("codetracer-native-recorder", "CODETRACER_NATIVE_RECORDER_REPO_PATH"),
     ("codetracer-native-test-programs", "CODETRACER_NATIVE_TEST_PROGRAMS_PATH"),
     ("codetracer-python-recorder", "CODETRACER_PYTHON_RECORDER_REPO_PATH"),

--- a/scripts/detect-siblings.sh
+++ b/scripts/detect-siblings.sh
@@ -65,7 +65,6 @@ _ct_try_workspace_root() {
 	local candidate="$1"
 	# A valid workspace root should contain at least one known sibling directory.
 	if [ -d "$candidate/codetracer-native-backend" ] ||
-		[ -d "$candidate/codetracer-rr-backend" ] ||
 		[ -d "$candidate/codetracer-python-recorder" ] ||
 		[ -d "$candidate/codetracer-php-recorder" ] ||
 		[ -d "$candidate/codetracer-ruby-recorder" ] ||
@@ -141,6 +140,23 @@ _ct_detect_summary() {
 # recipe — not detection — is responsible for triggering the build.
 if [ -n "$_CT_WORKSPACE_ROOT" ] && [ -d "$_CT_WORKSPACE_ROOT/codetracer-native-backend" ]; then
 	export CT_CODETRACER_NATIVE_BACKEND_SIBLING="$_CT_WORKSPACE_ROOT/codetracer-native-backend"
+	# Consumers gate on CODETRACER_RR_BACKEND_PATH rather than the canonical
+	# CT_* name above: `just test` decides whether to run `just cross-test`
+	# from it, and `check_rr_prerequisites` in
+	# src/backend-manager/tests/real_recording_integration.rs treats it as
+	# proof that the native-backend sibling under test is the one on PATH.
+	# Its failure message tells the operator to run this script, so this
+	# script has to be able to satisfy it; before this export the only place
+	# that ever set the variable was one GitHub Actions step, which is why
+	# those 48 RR tests never ran anywhere else.
+	#
+	# The value is the sibling REPO directory, regardless of whether
+	# ct-native-replay has been built yet — the same value
+	# .github/workflows/codetracer.yml sets, and what
+	# codetracer-ci/scripts/record-test-traces.sh expects when it appends
+	# /target/debug.  Build state is a separate question, answered by the
+	# CODETRACER_RR_BACKEND_PRESENT probe further down.
+	export CODETRACER_RR_BACKEND_PATH="$_CT_WORKSPACE_ROOT/codetracer-native-backend"
 fi
 if [ -n "$_CT_WORKSPACE_ROOT" ] && [ -x "$_CT_WORKSPACE_ROOT/codetracer-native-backend/target/debug/ct-native-replay" ]; then
 	export PATH="$_CT_WORKSPACE_ROOT/codetracer-native-backend/target/debug:$PATH"
@@ -161,10 +177,6 @@ if [ -n "$_CT_WORKSPACE_ROOT" ] && [ -x "$_CT_WORKSPACE_ROOT/codetracer-native-b
 		fi
 	fi
 	_ct_detect_summary "codetracer-native-backend (ct-native-replay available)"
-elif [ -n "$_CT_WORKSPACE_ROOT" ] && [ -x "$_CT_WORKSPACE_ROOT/codetracer-rr-backend/target/debug/ct-native-replay" ]; then
-	# Legacy checkout directory name; the binary inside is the current one.
-	export PATH="$_CT_WORKSPACE_ROOT/codetracer-rr-backend/target/debug:$PATH"
-	_ct_detect_summary "codetracer-rr-backend (ct-native-replay available, legacy checkout name)"
 fi
 
 # --- codetracer-native-recorder (ct-mcr / Multi-Core Recorder) ---

--- a/scripts/run-cross-repo-tests.sh
+++ b/scripts/run-cross-repo-tests.sh
@@ -193,25 +193,27 @@ resolve_pin_ref() {
 # Find or build ct-native-replay
 # ---------------------------------------------------------------------------
 find_rr_backend_repo() {
-	# 1. METACRAFT_WORKSPACE_ROOT — try new name first, then legacy
-	if [[ -n ${METACRAFT_WORKSPACE_ROOT:-} ]]; then
-		for repo_name in codetracer-native-backend codetracer-rr-backend; do
-			local candidate="$METACRAFT_WORKSPACE_ROOT/$repo_name"
-			if [[ -d $candidate ]]; then
-				echo "$candidate"
-				return 0
-			fi
-		done
-	fi
+	# Only one name is searched: `codetracer-native-backend`, as declared by
+	# the workspace manifest. This used to also try a `codetracer-rr-backend`
+	# fallback for the repo's pre-rename name, but no such repository exists
+	# — the slug redirects on GitHub and nothing ever checks out under it —
+	# so the fallback could never match.
 
-	# 2. Sibling directory — try new name first, then legacy
-	for repo_name in codetracer-native-backend codetracer-rr-backend; do
-		local sibling="$REPO_ROOT/../$repo_name"
-		if [[ -d $sibling ]]; then
-			(cd "$sibling" && pwd)
+	# 1. METACRAFT_WORKSPACE_ROOT
+	if [[ -n ${METACRAFT_WORKSPACE_ROOT:-} ]]; then
+		local candidate="$METACRAFT_WORKSPACE_ROOT/codetracer-native-backend"
+		if [[ -d $candidate ]]; then
+			echo "$candidate"
 			return 0
 		fi
-	done
+	fi
+
+	# 2. Sibling directory
+	local sibling="$REPO_ROOT/../codetracer-native-backend"
+	if [[ -d $sibling ]]; then
+		(cd "$sibling" && pwd)
+		return 0
+	fi
 
 	return 1
 }

--- a/src/backend-manager/tests/real_recording_integration.rs
+++ b/src/backend-manager/tests/real_recording_integration.rs
@@ -449,10 +449,6 @@ fn find_ct_native_replay() -> Option<PathBuf> {
         "../../../codetracer-native-backend/target/debug/ct-native-replay",
         "../../../codetracer-native-backend/target/release/ct-native-replay",
         "../../codetracer-native-backend/target/debug/ct-native-replay",
-        // Legacy repo name fallbacks
-        "../../../codetracer-rr-backend/target/debug/ct-native-replay",
-        "../../../codetracer-rr-backend/target/release/ct-native-replay",
-        "../../codetracer-rr-backend/target/debug/ct-native-replay",
     ];
 
     for loc in dev_locations {
@@ -469,10 +465,6 @@ fn find_ct_native_replay() -> Option<PathBuf> {
             "metacraft/codetracer-native-backend/target/debug/ct-native-replay",
             "metacraft/codetracer-main/codetracer-native-backend/target/debug/ct-native-replay",
             "codetracer-native-backend/target/debug/ct-native-replay",
-            // Legacy repo name fallbacks
-            "metacraft/codetracer-rr-backend/target/debug/ct-native-replay",
-            "metacraft/codetracer-main/codetracer-rr-backend/target/debug/ct-native-replay",
-            "codetracer-rr-backend/target/debug/ct-native-replay",
         ];
         for loc in home_locations {
             let path = home_path.join(loc);
@@ -952,8 +944,20 @@ fn create_rr_recording_from_source(
 /// reachable when that opt-out is in force, so the `Err` arms at the call
 /// sites cannot silently turn a broken environment into a green test.
 fn check_rr_prerequisites() -> Result<(PathBuf, PathBuf), String> {
-    // Gate: the codetracer-native-backend sibling repo must be detected by
-    // detect-siblings.sh (which sets CODETRACER_RR_BACKEND_PATH). The legacy
+    // Gate: the codetracer-native-backend sibling repo must be detected, which
+    // sets CODETRACER_RR_BACKEND_PATH to that checkout.  Two mechanisms do so,
+    // and both are now able to:
+    //
+    //   * `source scripts/detect-siblings.sh` — exports the variable whenever
+    //     the sibling directory is present.
+    //   * the repro dev shell — `repro.nim`'s CodeTracerRepoEnvAliases maps
+    //     the same sibling to the same variable.
+    //
+    // Until this was fixed both keyed on a sibling directory named
+    // `codetracer-rr-backend`, a repository that does not exist (the slug
+    // redirects to codetracer-native-backend, which is what the workspace
+    // manifest declares), so neither ever set the variable and the advice
+    // printed below could not be followed.  The legacy
     // CODETRACER_RR_BACKEND_PRESENT=1 is also accepted for backward compat.
     // This ensures we have the correct rr wrapper and libraries. Without it,
     // tests would find a system rr that may lack soft-mode support, or an
@@ -969,8 +973,14 @@ fn check_rr_prerequisites() -> Result<(PathBuf, PathBuf), String> {
         let msg = "CODETRACER_RR_BACKEND_PATH is not set — the \
                    codetracer-native-backend sibling was not detected, so the \
                    rr wrapper and libraries these tests need are not the ones \
-                   under test.  Run detect-siblings.sh (see \
-                   codetracer-specs/Working-with-the-CodeTracer-Repos.md).";
+                   under test.  Check the sibling is checked out next to \
+                   codetracer (`repro ws enable codetracer` clones it), then \
+                   either enter the repro dev shell or run \
+                   `source scripts/detect-siblings.sh` from the codetracer \
+                   repo root; both export the variable once that directory \
+                   exists.  Verify with \
+                   `bash ci/test/sibling-backend-path-test.sh`.  (See \
+                   codetracer-specs/Working-with-the-CodeTracer-Repos.md.)";
         prereq_missing(msg);
         return Err(msg.to_string());
     }

--- a/src/db-backend/tests/test_harness/mod.rs
+++ b/src/db-backend/tests/test_harness/mod.rs
@@ -1507,10 +1507,6 @@ pub fn find_ct_native_replay() -> Option<PathBuf> {
         format!("../../codetracer-native-backend/target/debug/{}", exe_name),
         format!("../../codetracer-native-backend/target/release/{}", exe_name),
         format!("../../../codetracer-native-backend/target/debug/{}", exe_name),
-        // Legacy repo name fallbacks
-        format!("../../codetracer-rr-backend/target/debug/{}", exe_name),
-        format!("../../codetracer-rr-backend/target/release/{}", exe_name),
-        format!("../../../codetracer-rr-backend/target/debug/{}", exe_name),
     ];
 
     for loc in &dev_locations {
@@ -1526,9 +1522,6 @@ pub fn find_ct_native_replay() -> Option<PathBuf> {
         let home_locations = [
             format!("metacraft/codetracer-native-backend/target/debug/{}", exe_name),
             format!("codetracer-native-backend/target/debug/{}", exe_name),
-            // Legacy repo name fallbacks
-            format!("metacraft/codetracer-rr-backend/target/debug/{}", exe_name),
-            format!("codetracer-rr-backend/target/debug/{}", exe_name),
         ];
         for loc in &home_locations {
             let path = home_path.join(loc);


### PR DESCRIPTION
## Problem

`CODETRACER_RR_BACKEND_PATH` — the variable that gates CodeTracer's RR-based
integration tests — was keyed on a sibling directory named
`codetracer-rr-backend`. **No such repository exists.** The workspace manifest
declares `codetracer-native-backend`; the old slug survives only as a GitHub
redirect. So the lookup matched nothing and the variable was never set.

The result was self-sealing. 48 tests in
`src/backend-manager/tests/real_recording_integration.rs` hard-fail on the
missing prerequisite and print remediation advice — "run detect-siblings.sh" —
that **could not work**, because that script's only assignment was the derived
`CODETRACER_RR_BACKEND_PRESENT` flag, never `_PATH`.

| Site | What it did | Why it failed |
|---|---|---|
| `repro.nim:120` | keyed `_PATH` on a sibling dir `codetracer-rr-backend` | that directory never exists, so the repro dev shell never set it |
| `detect-siblings.sh:634` | set only `_PRESENT` | never set `_PATH` |
| `real_recording_integration.rs` | told the operator to run `detect-siblings.sh` | factually wrong — the script could not set what the tests need |
| `justfile` (`test` recipe) | gated `just cross-test` on `_PATH` alone | permanently false outside Actions |
| `.github/workflows/codetracer.yml:2870` | the only place that ever set `_PATH` | — |

## Fix

`detect-siblings.sh` now exports `_PATH` alongside the canonical
`CT_CODETRACER_NATIVE_BACKEND_SIBLING`, and `repro.nim` maps the same variable
onto `codetracer-native-backend`. The alias table is iterated as a flat list,
so two entries for one repo simply export both names.

The value is the sibling **repo directory** whether or not `ct-native-replay`
has been built — matching what `codetracer.yml` sets and what consumers
appending `/target/debug` expect. Build state stays a separate question,
answered by the existing `_PRESENT` probe.

Unreachable `codetracer-rr-backend` lookup fallbacks are removed from four
binary-discovery helpers. The correct path was already tried first in every
case, so no reachable behaviour changes.

## The prerequisite gate is NOT weakened

It still hard-fails on a missing backend. This changes only whether the gate
can be *satisfied*, not whether it is *enforced*: a checked-out but unbuilt
backend now passes detection and fails one step later in
`find_ct_native_replay` with the accurate "build it" reason instead of an
unfollowable one.

## Test

`ci/test/sibling-backend-path-test.sh`, wired into `just test`. Written red
first — it failed on exactly the predicted assertions before the fix.

It asserts the **end-to-end** property, not "the variable is non-empty": that
`_PATH` points at a real directory, that the directory is the native-backend
checkout rather than the retired name, that the `just test` gate it feeds
actually opens, and that `_PRESENT=1` never appears beside an unset `_PATH` —
the half-configured state that let the original bug hide.

Hermetic: no build, no network. The real-checkout leg skips **loudly with its
reason** when the sibling is absent, as in the non-gui lane.

### Mutation results — all 6 killed, each by its predicted assertion

| # | Mutation | Killed by |
|---|---|---|
| M1 | remove the `_PATH` export | case A/B (1) `_PATH` empty + half-configured invariant |
| M2 | point `_PATH` at the retired dir | case A/B (2) not-a-directory, (3) basename, case C |
| M3 | export `_PATH` without the `-d` guard | case A-negative: exported despite no sibling |
| M4 | reintroduce dead name in `repro.nim` | case C: repro.nim live lookup |
| M5 | restore the legacy `elif` fallback | case C: detect-siblings.sh live lookup |
| M6 | `_PRESENT=1` with no `_PATH` (the original bug) | half-configured invariant, all three cases |

## Not enabled here

`ci/test/non-gui.sh` still blanks `_PATH` and sets `_PRESENT=0`, so those 48
tests remain out of that lane exactly as before. Whether to give them a lane is
a separate call with real cost, deliberately left to the maintainers.

## Deliberately untouched

Historical references to the old name: recorded trace metadata under
`examples/recordings/`, agent execution transcripts, and comments that
explicitly read "formerly codetracer-rr-backend". Those are records of what
happened, not lookups that resolve to nothing.