### PR TITLE
fix(ci): stop the workspace-lock alarm reporting locks that had not arrived yet

### DIFF
--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -4164,6 +4164,11 @@ jobs:
     # not share the failure mode it watches for.
     runs-on: ubuntu-latest
     if: always()
+    # The check gives a missing lock a bounded 300s grace window to arrive (see
+    # the script header). This ceiling is far above that on purpose: it is the
+    # backstop that makes "this alarm can never hold a runner" true even if the
+    # window logic were broken, not the mechanism that bounds the wait.
+    timeout-minutes: 20
     steps:
       - name: Mint installation token for the manifests repo
         id: ci_token
@@ -4191,6 +4196,14 @@ jobs:
             "https://x-access-token:${GH_TOKEN}@github.com/metacraft-labs/metacraft-manifests.git" \
             "${RUNNER_TEMP}/metacraft-manifests"
 
+      - name: Self-test the lock-freshness alarm
+        # Same rule as `ci-verdict` and `queue-watchdog`: an alarm is only worth
+        # trusting if its own contracts hold. The decisive fixture here is a
+        # lock that arrives WHILE the check is running — the race that used to
+        # make this job intermittently red on commits that were in fact locked.
+        # Pure bash + git against local repositories; no network, no build.
+        run: bash ci/verdict/workspace-lock-freshness-test.sh
+
       - name: Assert this commit has a published workspace lock
         run: |
           set -uo pipefail
@@ -4198,6 +4211,14 @@ jobs:
           # probes. `git rev-parse HEAD^` is empty for a root commit or if the
           # fetch depth did not reach the parent; the script ignores empty and
           # all-zero candidates.
+          #
+          # The clone above is a snapshot, and the lock is published
+          # asynchronously by the pusher's pre-push hook — measured at 54s after
+          # the clone for 84a8b633. The check therefore re-fetches this
+          # checkout (the clone URL carries the installation token, so no extra
+          # credential plumbing is needed) until the lock appears or its grace
+          # window expires. It returns the moment a fetch finds the lock, so the
+          # healthy case is no slower than before.
           PARENT="$(git rev-parse --verify --quiet HEAD^ || true)"
           bash ci/verdict/workspace-lock-freshness.sh \
             --manifest-dir "${RUNNER_TEMP}/metacraft-manifests" \

--- a/ci/verdict/workspace-lock-freshness-test.sh
+++ b/ci/verdict/workspace-lock-freshness-test.sh
@@ -1,0 +1,536 @@
+#!/usr/bin/env bash
+#
+# workspace-lock-freshness-test.sh — contract suite for
+# ci/verdict/workspace-lock-freshness.sh.
+#
+# # What this suite is really about
+#
+# The alarm asks "does a published workspace lock exist for this commit?".
+# Locks are published ASYNCHRONOUSLY, by the pusher's pre-push hook, into a
+# different repo than the one CI just checked out. So the alarm and the
+# publisher race, and the alarm was losing: for codetracer 84a8b633 the CI
+# clone of the manifests repo ran at 14:10:09 and the lock landed at 14:11:03,
+# 54 seconds later. The check had already answered "missing" from a snapshot
+# that was, by then, stale.
+#
+# The decisive fixture here is therefore NOT "a lock is absent" and NOT "a lock
+# is present". It is `arrival during the window`: at the instant the check is
+# launched the lock exists NOWHERE — not in the manifest-dir snapshot it was
+# handed, and not in the upstream it was cloned from — and it is pushed to that
+# upstream only after the check is already running. A check that answers from
+# one snapshot fails it; a check that re-fetches passes it. The fixture asserts
+# both halves of "nowhere" explicitly before it starts the clock, because a
+# race fixture that quietly degrades into "the lock was already there" proves
+# nothing at all.
+#
+# The suite is equally armed against the opposite cheat. A "fix" that simply
+# stopped reporting absence would make the race test green, so
+# `never arrives` requires the stall banner to still appear, and
+# `already present` and `untrusted lock` require it to appear PROMPTLY —
+# an implementation that waits out the grace window on every run, or that
+# waits before reporting a lock it already has, fails them on elapsed time.
+#
+# # Two guards can hide each other — a general hazard, recorded here because
+# # this suite is where it was caught
+#
+# The check's wait loop deliberately has exactly ONE deadline test. An earlier
+# draft had two: one at the top of the loop and one just before sleeping. Every
+# contract in this file passed, and mutation testing reported the top one as
+# REMOVABLE — deleting it changed no observable behaviour, because the second
+# one still ended the loop. Deleting the second alone was equally invisible.
+#
+# Two guards for one property, each of which makes the other untestable, are
+# strictly worse than one. The redundancy reads as belt-and-braces and is
+# actually the opposite: neither guard is covered, so neither is maintained,
+# and the property survives only as long as nobody removes BOTH — or removes
+# the one that was load-bearing for a case the other did not reach. Here the
+# two were not even equivalent: only the top check bounded the fast re-probe
+# path (the `continue` taken when a fetch moved the ref), so the bottom check
+# alone would have looped forever against a manifests repo that keeps moving —
+# which is its normal state, since several sessions push to it concurrently.
+#
+# The fix was to collapse them into one bound that both paths pass through, and
+# to add the `churn` contract, which is the only fixture that can tell the two
+# placements apart. If you find yourself adding a second check for a property
+# this file already covers, prefer moving the existing one.
+#
+# # No mocks
+#
+# Every fixture is a real git repository: a real bare upstream on `latest`, a
+# real clone standing in for the one the workflow makes, and a real second
+# clone standing in for the pusher. The lock files are real
+# `reprobuild.workspace.lock.v1` documents read by the real
+# `scripts/resolve-sibling-rev.sh`. Nothing is stubbed, and nothing touches the
+# network — the "remote" is a path on disk, which is what makes the race
+# reproducible in a second rather than observable once in production.
+#
+# Run directly:  bash ci/verdict/workspace-lock-freshness-test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK="${SCRIPT_DIR}/workspace-lock-freshness.sh"
+
+if ! command -v git >/dev/null 2>&1; then
+	echo "workspace-lock-freshness-test: SKIPPED — git is not on PATH, and every" >&2
+	echo "  fixture in this suite is a real git repository (there is no stub mode)." >&2
+	exit 3
+fi
+
+# The probe sibling the check hard-codes. A lock that does not name it is the
+# resolver's exit 4, which is a different report from "not locked".
+readonly PROBE_SIBLING="codetracer-trace-format"
+
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "${tmp_root}"' EXIT
+
+pass_count=0
+
+fail() {
+	echo "workspace-lock-freshness-test: FAIL: $*" >&2
+	exit 1
+}
+
+ok() {
+	pass_count=$((pass_count + 1))
+	echo "  ok — $1"
+}
+
+# hex40 <prefix> — a syntactically valid 40-hex commit id. The resolver rejects
+# anything that is not one as a malformed lock, so fixtures must be exact.
+hex40() {
+	local p="$1"
+	printf '%s' "${p}$(printf '0%.0s' $(seq 1 $((40 - ${#p}))))"
+}
+
+SHA_UNDER_TEST="$(hex40 84a8b633)"
+SHA_PARENT="$(hex40 c0ffee11)"
+SHA_UNRELATED="$(hex40 dead1234)"
+REV_TRACE_FORMAT="$(hex40 abcdef01)"
+REV_NATIVE_BACKEND="$(hex40 fedcba98)"
+
+for s in "$SHA_UNDER_TEST" "$SHA_PARENT" "$SHA_UNRELATED" "$REV_TRACE_FORMAT"; do
+	[ "${#s}" -eq 40 ] || fail "fixture bug: '${s}' is ${#s} chars, not a 40-hex commit id"
+done
+
+git_q() { git -c user.email=ci@example.invalid -c user.name=ci "$@"; }
+
+# write_lock <checkout> <sha> [--without-probe-sibling]
+# A real reprobuild.workspace.lock.v1 document at the nested layout the
+# resolver reads: locks/<project>/<trigger-repo>/<sha>.toml
+write_lock() {
+	local root="$1" sha="$2" mode="${3-}"
+	local dir="${root}/locks/codetracer/codetracer"
+	mkdir -p "$dir"
+	{
+		printf '%s\n' 'schema = "reprobuild.workspace.lock.v1"'
+		printf '%s\n' ''
+		printf '%s\n' '[lock]'
+		printf '%s\n' 'project = "codetracer"'
+		printf '%s\n' 'created_at = "2026-08-20T14:11:03Z"'
+		printf '%s\n' 'created_by = "repro workspace lock"'
+		printf '%s\n' ''
+		printf '%s\n' '[[repo]]'
+		printf '%s\n' 'name = "codetracer-native-backend"'
+		printf '%s\n' 'path = "codetracer-native-backend"'
+		printf '%s\n' 'remote = "metacraft-labs"'
+		printf '%s\n' "revision = \"${REV_NATIVE_BACKEND}\""
+		printf '%s\n' 'branch = "dev"'
+		if [ "$mode" != "--without-probe-sibling" ]; then
+			printf '%s\n' ''
+			printf '%s\n' '[[repo]]'
+			printf '%s\n' "name = \"${PROBE_SIBLING}\""
+			printf '%s\n' "path = \"${PROBE_SIBLING}\""
+			printf '%s\n' 'remote = "metacraft-labs"'
+			printf '%s\n' "revision = \"${REV_TRACE_FORMAT}\""
+			printf '%s\n' 'branch = "main"'
+		fi
+	} >"${dir}/${sha}.toml"
+	printf '%s\n' "${dir}/${sha}.toml"
+}
+
+# new_world <name> — a bare upstream on `latest` seeded with one unrelated
+# lock, plus a publisher clone. Echoes nothing; sets BARE / PUB.
+new_world() {
+	local name="$1"
+	BARE="${tmp_root}/${name}.git"
+	PUB="${tmp_root}/${name}-publisher"
+	git_q -c init.defaultBranch=latest init --quiet --bare "$BARE"
+	git_q clone --quiet "$BARE" "$PUB" 2>/dev/null
+	git_q -C "$PUB" checkout --quiet -b latest 2>/dev/null || true
+	write_lock "$PUB" "$SHA_UNRELATED" >/dev/null
+	git_q -C "$PUB" add -A
+	git_q -C "$PUB" commit --quiet -m "Publish 1 workspace lock entry"
+	git_q -C "$PUB" push --quiet origin HEAD:latest
+}
+
+# snapshot <name> — the clone the workflow's "Clone the manifests repo" step
+# makes: --branch latest, one shot, no further contact with the upstream.
+snapshot() {
+	local name="$1"
+	SNAP="${tmp_root}/${name}-snapshot"
+	git_q clone --quiet --branch latest "$BARE" "$SNAP"
+}
+
+# publish <sha> — the pusher's pre-push hook landing a lock upstream.
+publish() {
+	local sha="$1"
+	write_lock "$PUB" "$sha" >/dev/null
+	git_q -C "$PUB" add -A
+	git_q -C "$PUB" commit --quiet -m "Publish 1 workspace lock entry"
+	git_q -C "$PUB" push --quiet origin HEAD:latest
+}
+
+# The hard cap on any single invocation. Several contracts below are about the
+# check TERMINATING — "it ends at the bound instead of retrying forever". An
+# elapsed-time assertion cannot express that on its own, because a check that
+# never returns never reaches the assertion; the suite would hang rather than
+# fail, and a hung CI job reports nothing useful. So every invocation is capped
+# well above the largest window any fixture configures (40s), turning a hang
+# into a fast, legible failure (exit 124 matches no expected code).
+readonly HARD_CAP_SECONDS=75
+
+if ! command -v timeout >/dev/null 2>&1; then
+	echo "workspace-lock-freshness-test: SKIPPED — coreutils 'timeout' is not on PATH." >&2
+	echo "  Without it a non-terminating check would hang this suite instead of failing" >&2
+	echo "  it, and 'it terminates at the bound' is one of the contracts under test." >&2
+	exit 3
+fi
+
+# run_check ... -> sets RC, OUT, ELAPSED
+run_check() {
+	local start end
+	start="$(date +%s)"
+	OUT="$(timeout "${HARD_CAP_SECONDS}" bash "$CHECK" "$@" 2>&1)"
+	RC=$?
+	end="$(date +%s)"
+	ELAPSED=$((end - start))
+	if [ "$RC" -eq 124 ]; then
+		OUT="[timed out after ${HARD_CAP_SECONDS}s — the check did not terminate]
+${OUT}"
+	fi
+}
+
+expect_rc() {
+	local want="$1" desc="$2"
+	[ "$RC" -eq "$want" ] || fail "${desc}: expected exit ${want}, got ${RC}. Output:
+${OUT}"
+}
+
+expect_contains() {
+	local frag="$1" desc="$2"
+	case "$OUT" in
+	*"$frag"*) : ;;
+	*) fail "${desc}: expected output to contain '${frag}'. Output:
+${OUT}" ;;
+	esac
+}
+
+expect_not_contains() {
+	local frag="$1" desc="$2"
+	case "$OUT" in
+	*"$frag"*) fail "${desc}: expected output NOT to contain '${frag}'. Output:
+${OUT}" ;;
+	*) : ;;
+	esac
+}
+
+expect_elapsed_at_least() {
+	local want="$1" desc="$2"
+	[ "$ELAPSED" -ge "$want" ] ||
+		fail "${desc}: expected to take at least ${want}s, took ${ELAPSED}s. Output:
+${OUT}"
+}
+
+expect_elapsed_below() {
+	local want="$1" desc="$2"
+	[ "$ELAPSED" -lt "$want" ] ||
+		fail "${desc}: expected to finish in under ${want}s, took ${ELAPSED}s. Output:
+${OUT}"
+}
+
+readonly STALL_BANNER="WORKSPACE LOCK PUBLICATION HAS STALLED"
+
+echo "workspace-lock-freshness contracts (${CHECK})"
+
+# ---------------------------------------------------------------------------
+# 1. THE RACE. The decisive one.
+#
+# The lock for the commit under test exists nowhere when the check starts, and
+# is pushed upstream 4 seconds in. Both halves of "nowhere" are asserted before
+# the clock starts, so this cannot silently become the "already present" case.
+# ---------------------------------------------------------------------------
+echo "the race: a lock published while the check is running"
+
+new_world race
+snapshot race
+
+[ ! -e "${SNAP}/locks/codetracer/codetracer/${SHA_UNDER_TEST}.toml" ] ||
+	fail "fixture bug: the lock is already in the snapshot; this would not be a race"
+git_q -C "$BARE" cat-file -e "latest:locks/codetracer/codetracer/${SHA_UNDER_TEST}.toml" 2>/dev/null &&
+	fail "fixture bug: the lock is already upstream; this would not be a race"
+ok "fixture: the lock is in neither the snapshot nor the upstream at t=0"
+
+(
+	sleep 4
+	publish "$SHA_UNDER_TEST"
+) &
+publisher_pid=$!
+
+run_check --manifest-dir "$SNAP" --sha "$SHA_UNDER_TEST" \
+	--grace-seconds 40 --poll-seconds 2
+wait "$publisher_pid" 2>/dev/null || true
+
+expect_rc 0 "race"
+expect_contains "Workspace lock present for ${SHA_UNDER_TEST}" "race"
+expect_not_contains "$STALL_BANNER" "race"
+ok "a lock that arrives mid-window is found, not reported missing"
+
+# It must have actually waited — an implementation that answered 0 without
+# waiting could only be reading a lock that was already there.
+expect_elapsed_at_least 4 "race"
+ok "the check waited for the arrival rather than answering from its snapshot"
+
+# ...and it must have stopped as soon as the fetch found it, not idled to the
+# 40s ceiling. This is the "a fetch that finds the ref is faster than a fixed
+# wait" property.
+expect_elapsed_below 20 "race"
+ok "it returned on arrival, not at the grace ceiling"
+
+expect_contains "re-fetch" "race"
+ok "the report says the lock was found by re-fetching, not from the snapshot"
+
+# ---------------------------------------------------------------------------
+# 2. THE PARENT CANDIDATE still races correctly: the workflow passes HEAD and
+#    HEAD^, and arrival of EITHER must end the wait.
+# ---------------------------------------------------------------------------
+echo "the race: arrival of the parent candidate also ends the wait"
+
+new_world raceparent
+snapshot raceparent
+(
+	sleep 3
+	publish "$SHA_PARENT"
+) &
+publisher_pid=$!
+run_check --manifest-dir "$SNAP" --sha "$SHA_UNDER_TEST" --sha "$SHA_PARENT" \
+	--grace-seconds 40 --poll-seconds 2
+wait "$publisher_pid" 2>/dev/null || true
+
+expect_rc 0 "race/parent"
+expect_contains "Workspace lock present for ${SHA_PARENT}" "race/parent"
+ok "a lock arriving for HEAD^ ends the wait and reports that candidate"
+
+# ---------------------------------------------------------------------------
+# 3. NEVER ARRIVES. The mutation guard against "fix it by going quiet".
+#    The stall this alarm exists for must still be reported, in full, and the
+#    job must terminate rather than retry forever.
+# ---------------------------------------------------------------------------
+echo "absence: a lock that never arrives is still reported"
+
+new_world famine
+snapshot famine
+run_check --manifest-dir "$SNAP" --sha "$SHA_UNDER_TEST" \
+	--grace-seconds 6 --poll-seconds 2
+
+expect_rc 1 "famine"
+expect_contains "$STALL_BANNER" "famine"
+expect_contains "$SHA_UNDER_TEST" "famine"
+expect_contains "post-commit-lock.log" "famine"
+ok "the stall banner and its diagnostic survive the grace window"
+
+expect_elapsed_at_least 6 "famine"
+ok "it gave the lock the full grace window before concluding absence"
+
+expect_elapsed_below 30 "famine"
+ok "it terminates at the bound instead of retrying forever"
+
+expect_contains "6s" "famine"
+ok "the report states the window it waited, so the reader can judge it"
+
+# ---------------------------------------------------------------------------
+# 3b. NEVER ARRIVES, ON A BUSY REMOTE. The bound must hold against a manifests
+#     repo that keeps MOVING while our lock never appears — which is the normal
+#     state of the shared repo, not an exotic one: several live sessions push
+#     locks for other repos into it concurrently.
+#
+#     This is a distinct contract from the quiet case above, because the check
+#     deliberately re-probes IMMEDIATELY (skipping the poll interval) whenever a
+#     fetch moved the ref. That fast path is what makes an arriving lock cheap
+#     to notice, and it is also the one path that could loop indefinitely if the
+#     deadline were only consulted on the slow path. A steadily-advancing remote
+#     drives the check down the fast path every round, so this fixture is the
+#     only one that can tell the two placements of the deadline check apart.
+# ---------------------------------------------------------------------------
+echo "absence: the bound holds even while the remote keeps moving"
+
+new_world churn
+snapshot churn
+(
+	# One unrelated lock per second for well past the grace window — noise from
+	# other repos, never the lock under test.
+	i=0
+	while [ "$i" -lt 25 ]; do
+		publish "$(hex40 "$(printf 'bbbb%04x' "$i")")" 2>/dev/null || true
+		i=$((i + 1))
+		sleep 1
+	done
+) &
+churn_pid=$!
+
+run_check --manifest-dir "$SNAP" --sha "$SHA_UNDER_TEST" \
+	--grace-seconds 6 --poll-seconds 2
+kill "$churn_pid" 2>/dev/null || true
+wait "$churn_pid" 2>/dev/null || true
+
+expect_rc 1 "churn"
+expect_contains "$STALL_BANNER" "churn"
+ok "a remote advancing under it does not stop the check reporting absence"
+
+expect_elapsed_below 25 "churn"
+ok "the deadline bounds the fast re-probe path, not just the polling path"
+
+# ---------------------------------------------------------------------------
+# 4. ALREADY PRESENT. The guard against "fix it by always sleeping".
+# ---------------------------------------------------------------------------
+echo "presence: an existing lock is reported at once"
+
+new_world present
+publish "$SHA_UNDER_TEST"
+snapshot present
+run_check --manifest-dir "$SNAP" --sha "$SHA_UNDER_TEST" \
+	--grace-seconds 30 --poll-seconds 5
+
+expect_rc 0 "present"
+expect_contains "Workspace lock present for ${SHA_UNDER_TEST}" "present"
+expect_elapsed_below 5 "present"
+ok "a lock already in the snapshot is reported without entering the window"
+
+expect_contains "Newest commit touching locks/" "present"
+ok "the overall staleness line is still reported"
+
+# ---------------------------------------------------------------------------
+# 5. UNTRUSTED LOCK. Exit 4/5/6 from the resolver mean a lock EXISTS but cannot
+#    answer. That is not a publication stall, so waiting for one is wrong:
+#    it must be reported immediately and must not consume the window.
+# ---------------------------------------------------------------------------
+echo "untrusted: a lock that exists but cannot answer is not waited on"
+
+new_world untrusted
+write_lock "$PUB" "$SHA_UNDER_TEST" --without-probe-sibling >/dev/null
+git_q -C "$PUB" add -A
+git_q -C "$PUB" commit --quiet -m "Publish 1 workspace lock entry"
+git_q -C "$PUB" push --quiet origin HEAD:latest
+snapshot untrusted
+run_check --manifest-dir "$SNAP" --sha "$SHA_UNDER_TEST" \
+	--grace-seconds 30 --poll-seconds 5
+
+expect_rc 1 "untrusted"
+expect_contains "cannot be used" "untrusted"
+expect_not_contains "$STALL_BANNER" "untrusted"
+ok "an untrusted lock is reported as itself, not as a stall"
+
+expect_elapsed_below 5 "untrusted"
+ok "it does not spend the grace window on a condition waiting cannot fix"
+
+# ---------------------------------------------------------------------------
+# 6. NOTHING TO RE-FETCH. `--manifest-dir` also accepts a plain fixture
+#    directory (the documented offline mode). There is no upstream that could
+#    deliver a late lock, so waiting would be pure latency — it must answer at
+#    once, and must SAY that it answered from a single snapshot rather than
+#    let the reader assume a window was given.
+# ---------------------------------------------------------------------------
+echo "offline: a non-git fixture directory is answered at once, and says so"
+
+plain="${tmp_root}/plain"
+mkdir -p "$plain"
+run_check --manifest-dir "$plain" --sha "$SHA_UNDER_TEST" \
+	--grace-seconds 30 --poll-seconds 5
+
+expect_rc 1 "offline/absent"
+expect_contains "$STALL_BANNER" "offline/absent"
+expect_contains "single snapshot" "offline/absent"
+expect_elapsed_below 5 "offline/absent"
+ok "no upstream: absence is reported at once, and the report admits why"
+
+write_lock "$plain" "$SHA_UNDER_TEST" >/dev/null
+run_check --manifest-dir "$plain" --sha "$SHA_UNDER_TEST" \
+	--grace-seconds 30 --poll-seconds 5
+expect_rc 0 "offline/present"
+ok "no upstream: a present lock still resolves"
+
+# ---------------------------------------------------------------------------
+# 7. UNREACHABLE UPSTREAM. If every re-fetch failed we did not observe absence,
+#    we merely failed to look. The alarm must stay red — going quiet on a
+#    broken network is the failure mode this whole file guards against — but it
+#    must not claim the publication stalled when it never got to check.
+# ---------------------------------------------------------------------------
+echo "unreachable: a failing fetch is reported as such, not as a stall"
+
+new_world unreachable
+snapshot unreachable
+git_q -C "$SNAP" remote set-url origin "${tmp_root}/no-such-repo.git"
+run_check --manifest-dir "$SNAP" --sha "$SHA_UNDER_TEST" \
+	--grace-seconds 6 --poll-seconds 2
+
+expect_rc 1 "unreachable"
+expect_contains "could not be re-fetched" "unreachable"
+expect_not_contains "$STALL_BANNER" "unreachable"
+ok "an unreachable manifests remote is red, but is not called a stall"
+
+# The same report is owed when the fetch SUCCEEDS but the checkout cannot be
+# fast-forwarded onto it — the files the resolver reads are then exactly as
+# stale as if nothing had been fetched. (The check fast-forwards rather than
+# `reset --hard` precisely because `--manifest-dir` may be a developer's own
+# manifests checkout, so a divergent one must be reported, not overwritten.)
+echo "diverged: a fetch that cannot be fast-forwarded is not 'looked at'"
+
+new_world diverged
+snapshot diverged
+# The snapshot commits locally, so `latest` diverges from its upstream.
+write_lock "$SNAP" "$(hex40 aaaa1111)" >/dev/null
+git_q -C "$SNAP" add -A
+git_q -C "$SNAP" commit --quiet -m "local divergence"
+publish "$SHA_UNDER_TEST"
+run_check --manifest-dir "$SNAP" --sha "$SHA_UNDER_TEST" \
+	--grace-seconds 6 --poll-seconds 2
+
+expect_rc 1 "diverged"
+expect_contains "could not be re-fetched" "diverged"
+expect_not_contains "$STALL_BANNER" "diverged"
+ok "a refused fast-forward is reported as not having looked, not as a stall"
+
+# And the developer's local commit is still there: an alarm does not discard work.
+git_q -C "$SNAP" cat-file -e "HEAD:locks/codetracer/codetracer/$(hex40 aaaa1111).toml" 2>/dev/null ||
+	fail "diverged: the check destroyed the local commit in the manifest checkout"
+ok "the local commit in the manifest checkout survives the check"
+
+# ---------------------------------------------------------------------------
+# 8. USAGE. Unchanged contracts, plus validation of the new bounds — a
+#    mistyped window must not silently become an unbounded wait.
+# ---------------------------------------------------------------------------
+echo "usage"
+
+run_check --sha "$SHA_UNDER_TEST"
+expect_rc 2 "usage/no-manifest-dir"
+run_check --manifest-dir "$plain"
+expect_rc 2 "usage/no-sha"
+run_check --manifest-dir "$plain" --sha "$SHA_UNDER_TEST" --grace-seconds forever
+expect_rc 2 "usage/non-numeric-grace"
+run_check --manifest-dir "$plain" --sha "$SHA_UNDER_TEST" --poll-seconds -1
+expect_rc 2 "usage/negative-poll"
+ok "usage errors, including an unparseable grace window, exit 2"
+
+# The all-zero SHA (a branch's first push) is not a commit and must not be
+# probed — nor may it drag the check through the whole grace window.
+new_world zero
+snapshot zero
+run_check --manifest-dir "$SNAP" \
+	--sha "0000000000000000000000000000000000000000" \
+	--grace-seconds 4 --poll-seconds 2
+expect_rc 1 "usage/zero-sha"
+expect_contains "$STALL_BANNER" "usage/zero-sha"
+ok "the all-zero SHA is skipped and still yields a report"
+
+echo
+echo "workspace-lock-freshness-test summary: executed=${pass_count} failed=0"
+echo "workspace-lock-freshness-test: all contracts hold."

--- a/ci/verdict/workspace-lock-freshness.sh
+++ b/ci/verdict/workspace-lock-freshness.sh
@@ -61,11 +61,69 @@
 # `--manifest-dir` exists so the check can be exercised against a fixture
 # directory offline, not so CI can be handed a stub.
 #
+# # Why there is a grace window
+#
+# Locks are published ASYNCHRONOUSLY, by the pusher's pre-push hook, into a
+# different repo than the one CI checked out — so the alarm and the publisher
+# race, and this alarm used to lose. It answered from the single clone the
+# workflow handed it: for 84a8b633 that clone ran at 14:10:09 and the lock
+# landed at 14:11:03, 54 seconds later, by which time the check had already
+# said "missing". The workflow's two candidates (HEAD and HEAD^) blunted this
+# into intermittency rather than fixing it — which is worse, because an alarm
+# that is red on some commits and green on others with no change between them
+# teaches its readers to discount it, and that is the exact disease this whole
+# campaign is about.
+#
+# So absence is now something the check EARNS rather than assumes: it
+# re-fetches the manifests repo and re-probes until either a lock appears or a
+# bounded window expires.
+#
+# THE BOUND IS 300 SECONDS, and the reasoning matters more than the number.
+# The 54s instance is one sample, not a specification, and the mechanism that
+# sets this distribution's tail is not raw network latency — it is contention
+# on the shared manifests remote, which several live sessions write
+# concurrently, so a push can be refused as a non-fast-forward and retried
+# after a fetch/rebase. Five minutes covers several such rounds (~5.5x the one
+# observed sample, so it is not fitted to it) while costing nothing that
+# matters: this alarm does no build, runs on a stock hosted runner, and
+# RELEASES that runner the instant a fetch finds the lock, so the healthy case
+# pays nothing. Past ~5 minutes we would be buying vanishing race coverage with
+# real reporting delay, and a lock still absent after five minutes is far more
+# likely to be the publication stall this alarm was built for than a slow push.
+#
+# Three properties of the window are deliberate, and each is pinned by a
+# contract in the suite:
+#
+#   * It PREFERS FETCHING TO SLEEPING. Every round re-fetches; when the fetch
+#     moves the ref the check re-probes at once instead of sitting out the
+#     poll interval. A fetch that finds the ref is faster and more honest than
+#     a fixed wait.
+#   * It is only ever spent on a question waiting can answer. A lock that
+#     EXISTS but cannot be trusted (resolver 4/5/6), and a `--manifest-dir`
+#     with no upstream to re-fetch from, are both reported IMMEDIATELY —
+#     waiting could not change either.
+#   * It ends. When the lock is genuinely never coming the check still reports,
+#     in full, at the bound. Curing this flake by learning to say nothing would
+#     be a far worse defect than the flake.
+#
+# If every re-fetch failed, the check did not observe absence — it failed to
+# look — and it says so instead of blaming publication. It stays red either
+# way; an alarm must not go quiet because its own network broke.
+#
 # Usage:
 #   ci/verdict/workspace-lock-freshness.sh --manifest-dir DIR --sha SHA [--sha PARENT_SHA]
+#                                          [--grace-seconds N] [--poll-seconds N]
 #
-# Exit: 0 a lock exists · 1 no lock (the alarm) · 2 usage error
+#   --grace-seconds N  how long a missing lock may still arrive (default 300).
+#   --poll-seconds N   pause between re-fetches when the ref did not move
+#                      (default 15). Both exist so the contract suite can
+#                      compress the window into seconds; CI uses the defaults.
+#
+# Exit: 0 a lock exists · 1 no lock, or no trustworthy answer (the alarm)
+#     · 2 usage error
 # Lane: the `workspace-lock-freshness` job (stock ubuntu-latest, bash + git).
+# Contract suite: ./workspace-lock-freshness-test.sh — run it after any change
+# here; the decisive fixture is a lock that arrives while the check is running.
 # =============================================================================
 set -uo pipefail
 
@@ -81,6 +139,23 @@ readonly PROBE_SIBLING="codetracer-trace-format"
 
 MANIFEST_DIR=""
 SHAS=()
+GRACE_SECONDS=300
+POLL_SECONDS=15
+
+usage() {
+	echo "usage: workspace-lock-freshness.sh --manifest-dir DIR --sha SHA [--sha SHA]" \
+		"[--grace-seconds N] [--poll-seconds N]" >&2
+	exit 2
+}
+
+# A window that cannot be parsed must not silently become an unbounded wait, so
+# anything but a non-negative integer is a usage error rather than a default.
+require_uint() {
+	case "${1:-}" in
+	'' | *[!0-9]*) return 1 ;;
+	*) return 0 ;;
+	esac
+}
 
 while [ "$#" -gt 0 ]; do
 	case "$1" in
@@ -92,17 +167,29 @@ while [ "$#" -gt 0 ]; do
 		[ -n "${2:-}" ] && SHAS+=("$2")
 		shift 2
 		;;
+	--grace-seconds)
+		require_uint "${2:-}" || usage
+		GRACE_SECONDS="$2"
+		shift 2
+		;;
+	--poll-seconds)
+		require_uint "${2:-}" || usage
+		POLL_SECONDS="$2"
+		shift 2
+		;;
 	*)
-		echo "usage: workspace-lock-freshness.sh --manifest-dir DIR --sha SHA [--sha SHA]" >&2
-		exit 2
+		usage
 		;;
 	esac
 done
 
 if [ -z "$MANIFEST_DIR" ] || [ "${#SHAS[@]}" -eq 0 ]; then
-	echo "usage: workspace-lock-freshness.sh --manifest-dir DIR --sha SHA [--sha SHA]" >&2
-	exit 2
+	usage
 fi
+# A zero poll with a non-zero window would spin the loop as fast as git can
+# fetch, hammering the shared remote for no extra coverage.
+[ "$POLL_SECONDS" -lt 1 ] && POLL_SECONDS=1
+readonly GRACE_SECONDS POLL_SECONDS
 
 # The all-zero SHA is what GitHub reports for a branch's first push; it is not a
 # commit and must not be probed.
@@ -110,22 +197,117 @@ readonly ZERO_SHA="0000000000000000000000000000000000000000"
 
 locked_sha=""
 untrusted=""
-for sha in "${SHAS[@]}"; do
-	[ "$sha" = "$ZERO_SHA" ] && continue
-	rc=0
-	"$RESOLVER" --repo codetracer --sibling "$PROBE_SIBLING" \
-		--manifest-dir "$MANIFEST_DIR" --sha "$sha" --no-walk >/dev/null 2>&1 || rc=$?
-	if [ "$rc" -eq 0 ]; then
-		locked_sha="$sha"
-		break
+
+# One pass over the candidate SHAs against whatever is on disk right now.
+probe_candidates() {
+	local sha rc
+	locked_sha=""
+	untrusted=""
+	for sha in "${SHAS[@]}"; do
+		[ "$sha" = "$ZERO_SHA" ] && continue
+		rc=0
+		"$RESOLVER" --repo codetracer --sibling "$PROBE_SIBLING" \
+			--manifest-dir "$MANIFEST_DIR" --sha "$sha" --no-walk >/dev/null 2>&1 || rc=$?
+		if [ "$rc" -eq 0 ]; then
+			locked_sha="$sha"
+			return 0
+		fi
+		# 3 is "not locked" (try the next candidate). 4/5/6 mean a lock EXISTS
+		# but cannot be trusted — a different report, and not the stall this
+		# watches for. Waiting cannot turn a broken lock into a good one, so
+		# this ends the window immediately rather than spending it.
+		if [ "$rc" -ne 3 ]; then
+			untrusted="$sha (resolver exit $rc)"
+			return 0
+		fi
+	done
+	return 1
+}
+
+# Can this manifest dir even receive a late lock? A real clone can; the offline
+# fixture directory `--manifest-dir` also accepts cannot, and giving one a
+# grace window would be pure latency in exchange for nothing.
+manifest_remote=""
+manifest_branch=""
+if git -C "$MANIFEST_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+	manifest_branch="$(git -C "$MANIFEST_DIR" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+	manifest_remote="$(git -C "$MANIFEST_DIR" remote 2>/dev/null | head -n1)"
+fi
+refreshable=0
+if [ -n "$manifest_remote" ] && [ -n "$manifest_branch" ]; then
+	refreshable=1
+fi
+
+fetch_attempts=0
+# Counts only rounds where the fetch AND the fast-forward both landed, i.e.
+# where the files the resolver reads were actually brought up to date. A fetch
+# whose fast-forward was refused left the checkout as stale as before, so
+# counting it as a success would let the check claim it looked when it did not.
+refresh_successes=0
+
+# refresh_manifest — bring the checkout up to date with its upstream.
+# Exit: 0 the ref moved · 1 the fetch or the fast-forward failed
+#     · 2 fetched, nothing new.
+#
+# Fast-forward, never `reset --hard`: `--manifest-dir` may legitimately be a
+# developer's own manifests checkout, and an alarm has no business discarding
+# work there. A refused fast-forward is reported, not forced.
+refresh_manifest() {
+	local before after
+	before="$(git -C "$MANIFEST_DIR" rev-parse HEAD 2>/dev/null || true)"
+	fetch_attempts=$((fetch_attempts + 1))
+	if ! git -C "$MANIFEST_DIR" fetch --quiet "$manifest_remote" "$manifest_branch" >/dev/null 2>&1; then
+		return 1
 	fi
-	# 3 is "not locked" (try the next candidate). 4/5/6 mean a lock EXISTS but
-	# cannot be trusted — a different report, and not the stall this watches for.
-	if [ "$rc" -ne 3 ]; then
-		untrusted="$sha (resolver exit $rc)"
-		break
+	if ! git -C "$MANIFEST_DIR" merge --ff-only --quiet FETCH_HEAD >/dev/null 2>&1; then
+		return 1
+	fi
+	refresh_successes=$((refresh_successes + 1))
+	after="$(git -C "$MANIFEST_DIR" rev-parse HEAD 2>/dev/null || true)"
+	[ "$before" != "$after" ] && return 0
+	return 2
+}
+
+started_at="$(date +%s)"
+deadline=$((started_at + GRACE_SECONDS))
+waited=0  # set once the loop exits, from started_at
+
+while :; do
+	probe_candidates && break
+
+	# Nothing upstream could deliver a late lock — answer from what we have,
+	# and say further down that that is what happened.
+	[ "$refreshable" -eq 0 ] && break
+
+	# THE ONE BOUND. Deliberately the only deadline test in this loop: both
+	# ways round the loop pass back through here, so there is a single place
+	# that can end the wait and a single place to get right. An earlier draft
+	# also re-tested the deadline just before sleeping; that second test made
+	# each one individually removable without any fixture noticing, which is
+	# how a bound stops being a bound. One check, and the suite's `churn`
+	# contract drives the fast path through it.
+	now="$(date +%s)"
+	[ "$now" -ge "$deadline" ] && break
+
+	refresh_rc=0
+	refresh_manifest || refresh_rc=$?
+	# The ref moved: re-probe at once rather than sitting out the interval —
+	# this is what makes an arriving lock cheap to notice. It loops back to the
+	# bound above, and each round costs a real fetch, so it cannot spin.
+	[ "$refresh_rc" -eq 0 ] && continue
+
+	# `now` predates the fetch, and the bound above guarantees it was still
+	# before the deadline, so this is always >= 1. Overshoot is at most one
+	# fetch's duration, and the bound catches it on the next pass.
+	remaining=$((deadline - now))
+	if [ "$remaining" -lt "$POLL_SECONDS" ]; then
+		sleep "$remaining"
+	else
+		sleep "$POLL_SECONDS"
 	fi
 done
+
+waited=$(($(date +%s) - started_at))
 
 # How stale is the shared repo overall? Reported either way: a lock for THIS
 # commit does not prove publication is healthy for everyone else.
@@ -139,8 +321,34 @@ fi
 
 if [ -n "$locked_sha" ]; then
 	echo "Workspace lock present for ${locked_sha}."
+	if [ "$fetch_attempts" -gt 0 ]; then
+		echo "Found by re-fetching the manifests repo ${fetch_attempts} time(s) over ${waited}s:" \
+			"the lock was NOT in the snapshot this job cloned, so a single-snapshot" \
+			"check would have called this commit unlocked."
+	fi
 	echo "Newest commit touching locks/ in the manifests repo: ${newest_lock_date}."
 	exit 0
+fi
+
+# Not one round brought the checkout up to date. We did not observe absence, we
+# failed to look — which is still red (an alarm must not go quiet because its
+# own network broke) but it is emphatically not a report about publication.
+if [ "$refreshable" -eq 1 ] && [ "$fetch_attempts" -gt 0 ] && [ "$refresh_successes" -eq 0 ]; then
+	echo "::error::The manifests repo could not be re-fetched (${fetch_attempts} attempts over ${waited}s, none brought '${MANIFEST_DIR}' up to date), so no lock could be confirmed either way for: ${SHAS[*]}. This is a report about THIS job's access to '${manifest_remote}/${manifest_branch}' — an unreachable remote, or a checkout that cannot fast-forward — not about workspace-lock publication. Fix that, then read the result."
+	exit 1
+fi
+
+# How the window was spent, stated so the reader can judge the verdict rather
+# than take it on trust.
+if [ "$refreshable" -eq 1 ]; then
+	window_note="Re-fetched the manifests repo ${fetch_attempts} time(s) over a ${GRACE_SECONDS}s grace
+window (waited ${waited}s) before concluding this, so the lock is absent
+rather than merely late."
+else
+	window_note="NOTE: '${MANIFEST_DIR}' has no upstream to re-fetch, so this was answered
+from a single snapshot with no grace window. A late-arriving lock could
+not have been seen. In CI this directory is a fresh clone and IS
+re-fetched; this wording means the check was pointed at a fixture."
 fi
 
 cat <<EOF
@@ -154,6 +362,8 @@ No workspace lock exists in the shared manifests repo for any of:
 $(printf '  - %s\n' "${SHAS[@]}")
 
 Newest commit touching locks/ in that repo: ${newest_lock_date}.
+
+${window_note}
 
 This is NOT a CI failure and it does not affect the test jobs — they
 stopped depending on the lock deliberately. It is a statement about


### PR DESCRIPTION
## The defect

`ci/verdict/workspace-lock-freshness.sh` cloned the shared manifests repo **once** and answered "no lock for this commit" from that snapshot. It contained no `sleep`, `retry`, `fetch`, or grace logic of any kind.

But locks are published **asynchronously**, by the pusher's pre-push hook, into a different repo than the one CI checked out. Measured instance: for `84a8b633` the manifests clone ran at **14:10:09** and the lock was pushed at **14:11:03** — 54 seconds later. The check had already answered "missing".

The two candidates the workflow passes (`GITHUB_SHA` and `HEAD^`) softened this into *intermittency* rather than fixing it, which is worse: an alarm that reads red on some commits and green on others with no code change between them teaches its readers to discount it. That is the exact disease this campaign is about.

## The fix

Absence is now **earned rather than assumed**. The check re-fetches the manifests checkout and re-probes until a lock appears or a bounded window expires, and returns the moment a fetch finds the lock — so the healthy case pays nothing.

**The bound is 300s.** The 54s instance is one sample, not a specification. The tail of this distribution is set by contention on the shared manifests remote (several sessions write it concurrently, so a push can be refused as a non-fast-forward and retried after a fetch/rebase), not by raw network latency. Five minutes covers several such rounds at ~5.5x the observed sample. It is affordable because this alarm does no build, runs on a stock hosted runner, and releases that runner the instant it succeeds. Past ~5 minutes we would be buying vanishing race coverage with real reporting delay.

Three properties are deliberate, each pinned by a contract:

- **It prefers fetching to sleeping.** A fetch that moves the ref re-probes at once instead of sitting out the poll interval.
- **It is only ever spent where waiting can help.** An untrusted lock (resolver exit 4/5/6) and a `--manifest-dir` with no upstream are both reported *immediately* — waiting could not change either.
- **It ends.** A lock that never arrives is still reported, in full, at the bound. Curing a flake by learning to say nothing would be a far worse defect than the flake.

If no round brought the checkout up to date — unreachable remote, or a checkout that cannot fast-forward — the check reports that it *failed to look* rather than blaming publication. It stays red either way; an alarm must not go quiet because its own network broke. It fast-forwards and never `reset --hard`s, because `--manifest-dir` may be a developer's own manifests checkout.

## It is still an alarm, not a gate

Unchanged and verified: **no** `needs:` on this job, **nothing** declares `needs:` on it across all 39 jobs, and it remains absent from `ci/verdict/required-jobs.txt` (60 entries). `required-jobs-test.sh` passes 12/12, including "ci-verdict declares every manifest job in needs:". Added `timeout-minutes: 20` purely as a backstop far above the 300s window, so the job can never hold a runner even if the window logic were broken.

## Tests

Adds `ci/verdict/workspace-lock-freshness-test.sh` — 23 contracts, run in the job as `ci-verdict` and `queue-watchdog` already do. Every fixture is a **real git repository** (bare upstream on `latest`, a clone standing in for the workflow's, a second clone standing in for the pusher) with real `reprobuild.workspace.lock.v1` documents read by the real resolver. No mocks, no network — the "remote" is a path on disk.

The decisive fixture is **arrival-during-the-window**: the lock exists in neither the snapshot nor the upstream when the check starts (both halves asserted explicitly, so it cannot silently degrade into "it was already there"), and is pushed 4s in.

### Mutation testing — 15/15 killed

| # | Mutation | Killed by |
|---|---|---|
| M1 | no re-fetch (the original defect) | race: exit 0→1 |
| **M2** | **never reports absence (exit 0 silently)** | **famine: exit 1→0** |
| M3 | always waits the full window | race: 40s vs <20s |
| M4 | window spent on an untrusted lock | untrusted: 31s vs <5s |
| M5 | unbounded window (the one bound removed) | famine: exit 124 (hang) |
| M6 | fetches but never fast-forwards | race: exit 0→1 |
| M7 | unreachable remote reported as a stall | unreachable: missing message |
| M8 | offline fixture burns the window | offline: exit 124 |
| M9 | drops the "single snapshot" caveat | offline: missing caveat |
| M10 | hides that the lock was late | race: missing "re-fetch" |
| M11 | ignores the `HEAD^` candidate | race/parent: exit 0→1 |
| M12 | unparseable `--grace-seconds` defaults | usage: exit 2→0 |
| M13 | counts a fetch as a refresh pre-ff | diverged: wrong message |
| M14 | hard-resets instead of fast-forwarding | diverged: destroys local work |
| M15 | fast re-probe path escapes the deadline | churn: exit 124 |

M1 is what proves the race fixture is real rather than passing on a lock that was already present. M2 is the guard against "fix the flake by never reporting absence".

## A finding worth reading: two guards can hide each other

The wait loop has **exactly one** deadline check, on purpose. An earlier draft had two — one at the top of the loop, one before sleeping. Every contract passed, and mutation testing reported **each** as removable, because the other still ended the loop. Two guards for one property, neither of them covered.

They were not even equivalent: only the top one bounded the *fast re-probe path* (the `continue` taken when a fetch moved the ref), so the bottom one alone would have looped forever against a manifests repo that keeps moving — which is its normal state, since several sessions push to it concurrently.

Collapsed into one bound both paths pass through, plus the `churn` contract (a remote advancing under the check while our lock never arrives), which is the only fixture that can tell the two placements apart. This is recorded as a general hazard in the test file's header comment, since it is not a quirk of this script.

## Note for reviewers: a tooling side effect, reverted

While validating the workflow YAML I ran `nix-shell -p python3Packages.pyyaml`. Its shell hook installed a `prek` **`pre-commit` hook into the shared `.git/hooks`**, which is common to the main checkout and five sibling worktrees. That hook fails on already-committed files (`ci/verdict/queue-watchdog.sh` alone produces 41 editorconfig errors — this repo's shell scripts are tab-indented against an `.editorconfig` demanding spaces), so it would have blocked other in-flight branches; all five were last committed *before* the hook's install timestamp, confirming it was newly introduced.

I removed it, restoring the exact prior hook listing. Reprobuild's `pre-push` gate was never touched. A `prettier` run during the blocked commit attempt also reformatted 91 unrelated lines of `codetracer.yml`; that was discarded.

**None of this touched the committed tree.** The diff is exactly three files: the check, its new test, and the two workflow additions.