### PR TITLE
fix(ci): make Cross-Repo Integration Tests able to pass on dev

### DIFF
--- a/.github/actions/setup-db-backend-siblings/action.yml
+++ b/.github/actions/setup-db-backend-siblings/action.yml
@@ -42,6 +42,29 @@ inputs:
     description: Optional Nix trusted-public-keys forwarded to setup-dev-env.
     required: false
     default: ""
+  extra-siblings:
+    description: >
+      Additional `siblings:` entries, in `clone-siblings` syntax
+      (`[owner/]name[=ref]`, whitespace- or newline-separated), appended to the
+      three db-backend siblings this action always provisions.
+
+      THIS EXISTS SO THAT A JOB WHICH NEEDS ONE MORE SIBLING DOES NOT HAND-ROLL
+      THE WHOLE LIST. `cross-repo-tests.yml`'s `shell-recorder-tests` did
+      exactly that: it needed `codetracer-shell-recorders`, so it called
+      `setup-dev-env` directly with a three-entry list derived from the shell
+      recorders' own path dependencies -- and omitted
+      `codetracer-native-recorder`, which is not a shell-recorder dependency at
+      all but an unconditional one of `src/db-backend/build.rs`. The job then
+      compiled the entire tree-sitter dependency tree before panicking with
+      "db-backend requires the sibling `codetracer-native-recorder` checkout,
+      and it was not found" (run 32995543471). Composing with this input keeps
+      the db-backend set defined in one place, which is this action's whole
+      reason to exist.
+
+      `ci/test/sibling-provisioning-test.sh` asserts that every job running
+      cargo against `src/db-backend` provisions `codetracer-native-recorder`.
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -64,7 +87,11 @@ runs:
         gh-token: ${{ inputs.gh-token }}
         substituters: ${{ inputs.substituters }}
         trusted-public-keys: ${{ inputs.trusted-public-keys }}
+        # `clone-siblings` tokenises this value on whitespace after stripping
+        # `#` comments, so an empty `extra-siblings` contributes nothing and a
+        # multi-line one needs no particular indentation.
         siblings: |
           codetracer-trace-format=dev
           codetracer-trace-format-nim=dev
           codetracer-native-recorder=dev
+          ${{ inputs.extra-siblings }}

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -3886,25 +3886,6 @@ jobs:
           git_config_global: true
           git_user_signingkey: true
           git_commit_gpgsign: true
-      - name: Install Nix
-        # WITHOUT THIS, THIS JOB USES WHATEVER NIX THE RUNNER IMAGE SHIPS.
-        # `eph-linux-x64`'s ambient nix.conf does not enable the experimental
-        # features `nix develop` / `nix shell` need, so the step below died with
-        #
-        #     error: experimental Nix feature 'nix-command' is disabled;
-        #     add '--extra-experimental-features nix-command' to enable it
-        #
-        # in every one of the last twelve completed `dev` runs. Every other nix
-        # job in this workflow provisions Nix first; these did not, and the
-        # omission is invisible in review because `nix develop` reads as
-        # self-contained. `ci/test/nix-provisioning-test.sh` now fails when a
-        # job runs nix without provisioning it.
-        uses: ./.github/actions/setup-nix
-        with:
-          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
-          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
-          gh-token: ${{ steps.ci_token.outputs.token }}
-
       - name: Create resource tarball
         run: |
           nix develop .#devShells.x86_64-linux.default --command bash -c "tar cfJ resources.tar.xz resources/"

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -1790,6 +1790,25 @@ jobs:
           # read gitconfig; its credentials come from netrc/access-tokens.)
           persist-credentials: false
           token: ${{ steps.ci_token.outputs.token }}
+      - name: Install Nix
+        # WITHOUT THIS, THIS JOB USES WHATEVER NIX THE RUNNER IMAGE SHIPS.
+        # `eph-linux-x64`'s ambient nix.conf does not enable the experimental
+        # features `nix develop` / `nix shell` need, so the step below died with
+        #
+        #     error: experimental Nix feature 'nix-command' is disabled;
+        #     add '--extra-experimental-features nix-command' to enable it
+        #
+        # in every one of the last twelve completed `dev` runs. Every other nix
+        # job in this workflow provisions Nix first; these did not, and the
+        # omission is invisible in review because `nix develop` reads as
+        # self-contained. `ci/test/nix-provisioning-test.sh` now fails when a
+        # job runs nix without provisioning it.
+        uses: ./.github/actions/setup-nix
+        with:
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
+
       - name: "Import GPG key for signing commits"
         id: import-gpg
         uses: crazy-max/ghaction-import-gpg@v6
@@ -1834,6 +1853,25 @@ jobs:
           # read gitconfig; its credentials come from netrc/access-tokens.)
           persist-credentials: false
           token: ${{ steps.ci_token.outputs.token }}
+      - name: Install Nix
+        # WITHOUT THIS, THIS JOB USES WHATEVER NIX THE RUNNER IMAGE SHIPS.
+        # `eph-linux-x64`'s ambient nix.conf does not enable the experimental
+        # features `nix develop` / `nix shell` need, so the step below died with
+        #
+        #     error: experimental Nix feature 'nix-command' is disabled;
+        #     add '--extra-experimental-features nix-command' to enable it
+        #
+        # in every one of the last twelve completed `dev` runs. Every other nix
+        # job in this workflow provisions Nix first; these did not, and the
+        # omission is invisible in review because `nix develop` reads as
+        # self-contained. `ci/test/nix-provisioning-test.sh` now fails when a
+        # job runs nix without provisioning it.
+        uses: ./.github/actions/setup-nix
+        with:
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
+
       - name: Upload script
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_CODETRACER_BUCKET_ACCESS_KEY_ID }}
@@ -2075,6 +2113,35 @@ jobs:
     needs:
       - dmg-build
     steps:
+      - name: Checkout
+        # Only so that `uses: ./.github/actions/setup-nix` below resolves; no
+        # other step in this job reads the tree. No submodules and no token:
+        # this repository is public and nothing here talks to a remote, and
+        # these runners reuse their work tree, so a persisted credential would
+        # outlive the job that minted nothing.
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        # WITHOUT THIS, THIS JOB USES WHATEVER NIX THE RUNNER IMAGE SHIPS.
+        # `eph-linux-x64`'s ambient nix.conf does not enable the experimental
+        # features `nix develop` / `nix shell` need, so the step below died with
+        #
+        #     error: experimental Nix feature 'nix-command' is disabled;
+        #     add '--extra-experimental-features nix-command' to enable it
+        #
+        # in every one of the last twelve completed `dev` runs. Every other nix
+        # job in this workflow provisions Nix first; these did not, and the
+        # omission is invisible in review because `nix develop` reads as
+        # self-contained. `ci/test/nix-provisioning-test.sh` now fails when a
+        # job runs nix without provisioning it.
+        uses: ./.github/actions/setup-nix
+        with:
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
+          gh-token: ${{ github.token }}
+
       - name: Download artifact
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_CODETRACER_BUCKET_ACCESS_KEY_ID }}
@@ -2108,6 +2175,35 @@ jobs:
     needs:
       - appimage-build
     steps:
+      - name: Checkout
+        # Only so that `uses: ./.github/actions/setup-nix` below resolves; no
+        # other step in this job reads the tree. No submodules and no token:
+        # this repository is public and nothing here talks to a remote, and
+        # these runners reuse their work tree, so a persisted credential would
+        # outlive the job that minted nothing.
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        # WITHOUT THIS, THIS JOB USES WHATEVER NIX THE RUNNER IMAGE SHIPS.
+        # `eph-linux-x64`'s ambient nix.conf does not enable the experimental
+        # features `nix develop` / `nix shell` need, so the step below died with
+        #
+        #     error: experimental Nix feature 'nix-command' is disabled;
+        #     add '--extra-experimental-features nix-command' to enable it
+        #
+        # in every one of the last twelve completed `dev` runs. Every other nix
+        # job in this workflow provisions Nix first; these did not, and the
+        # omission is invisible in review because `nix develop` reads as
+        # self-contained. `ci/test/nix-provisioning-test.sh` now fails when a
+        # job runs nix without provisioning it.
+        uses: ./.github/actions/setup-nix
+        with:
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
+          gh-token: ${{ github.token }}
+
       - name: Download artifact
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_CODETRACER_BUCKET_ACCESS_KEY_ID }}
@@ -2161,6 +2257,26 @@ jobs:
           # (`nix develop` is unaffected either way -- Nix's fetcher does not
           # read gitconfig; its credentials come from netrc/access-tokens.)
           persist-credentials: false
+
+      - name: Install Nix
+        # WITHOUT THIS, THIS JOB USES WHATEVER NIX THE RUNNER IMAGE SHIPS.
+        # `eph-linux-x64`'s ambient nix.conf does not enable the experimental
+        # features `nix develop` / `nix shell` need, so the step below died with
+        #
+        #     error: experimental Nix feature 'nix-command' is disabled;
+        #     add '--extra-experimental-features nix-command' to enable it
+        #
+        # in every one of the last twelve completed `dev` runs. Every other nix
+        # job in this workflow provisions Nix first; these did not, and the
+        # omission is invisible in review because `nix develop` reads as
+        # self-contained. `ci/test/nix-provisioning-test.sh` now fails when a
+        # job runs nix without provisioning it.
+        if: ${{ startsWith(github.ref, 'refs/tags/') && !github.event['codetracer-ci'] }}
+        uses: ./.github/actions/setup-nix
+        with:
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
+          gh-token: ${{ github.token }}
 
       - name: Install AWS CLI
         if: ${{ startsWith(github.ref, 'refs/tags/') && !github.event['codetracer-ci'] }}
@@ -3770,6 +3886,25 @@ jobs:
           git_config_global: true
           git_user_signingkey: true
           git_commit_gpgsign: true
+      - name: Install Nix
+        # WITHOUT THIS, THIS JOB USES WHATEVER NIX THE RUNNER IMAGE SHIPS.
+        # `eph-linux-x64`'s ambient nix.conf does not enable the experimental
+        # features `nix develop` / `nix shell` need, so the step below died with
+        #
+        #     error: experimental Nix feature 'nix-command' is disabled;
+        #     add '--extra-experimental-features nix-command' to enable it
+        #
+        # in every one of the last twelve completed `dev` runs. Every other nix
+        # job in this workflow provisions Nix first; these did not, and the
+        # omission is invisible in review because `nix develop` reads as
+        # self-contained. `ci/test/nix-provisioning-test.sh` now fails when a
+        # job runs nix without provisioning it.
+        uses: ./.github/actions/setup-nix
+        with:
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
+
       - name: Create resource tarball
         run: |
           nix develop .#devShells.x86_64-linux.default --command bash -c "tar cfJ resources.tar.xz resources/"

--- a/.github/workflows/cross-repo-tests.yml
+++ b/.github/workflows/cross-repo-tests.yml
@@ -99,40 +99,29 @@ jobs:
 
       - name: Unfold native-backend submodules into parent index
         # codetracer-native-backend's flake.nix has
-        # ``rr-soft.url = "path:libs/rr"`` and ``delve-patched.url
-        # = "path:libs/delve"``.  Nix's path: flake-input resolver
-        # uses ``git ls-files`` to decide which files are visible,
-        # and the submodule contents aren't tracked in the parent
-        # (only the gitlink is), so ``nix develop <native-backend>``
-        # aborts with ``Path 'libs/delve/flake.nix' does not exist
-        # in Git repository``.  Drop the inner .git, remove the
-        # gitlink from the parent index, then ``git add -f`` the
-        # materialised files so ``git ls-files`` sees them.
+        # ``rr-soft.url = "path:libs/rr"`` and ``delve-patched.url =
+        # "path:libs/delve"``.  Nix's path: flake-input resolver decides which
+        # files are visible with ``git ls-files``, and a submodule contributes
+        # only a gitlink to its parent's index, so ``nix develop
+        # <native-backend>`` aborts with ``Path 'libs/rr/flake.nix' ... is not
+        # tracked by Git``.
+        #
+        # The two paths named here are exactly the two ``path:`` inputs that
+        # flake.nix declares.  Naming them turns "the unfold was incomplete"
+        # into a failure HERE, with a diagnostic, instead of a Nix evaluation
+        # stack trace four steps further on -- which is how this job failed on
+        # every run of `dev` before this.
+        #
+        # The logic moved to a script so it could be tested:
+        # ci/test/unfold-submodules-test.sh runs it against real repositories
+        # with real submodules, including the uninitialised-submodule state
+        # this job kept hitting.
         shell: bash
         run: |
-          set -uo pipefail
-          PARENT="$(pwd)/../codetracer-native-backend"
-          # The self-hosted nixos runner's bash-interactive shell
-          # starts with a minimal PATH that doesn't include awk, so
-          # parse the ``submodule status --recursive`` output with
-          # pure bash instead.
-          while IFS= read -r line; do
-            # ``git submodule status`` prints e.g. ``+abc1234 libs/rr (...)``
-            # or ``-abc1234 libs/rr``.  A leading ``-`` marks an
-            # uninitialised submodule which we don't want to touch.
-            [[ -z "$line" ]] && continue
-            [[ "${line:0:1}" == "-" ]] && continue
-            # Strip the leading status char + sha, then take field 2
-            # (the path).
-            rest="${line:1}"
-            rest="${rest#* }"   # drop the sha (up to first space)
-            sub="${rest%% *}"   # take everything up to the next space
-            [[ -z "$sub" ]] && continue
-            echo "  unfolding submodule native-backend/${sub}"
-            rm -rf "$PARENT/${sub}/.git"
-            git -C "$PARENT" rm -f --cached "${sub}" >/dev/null 2>&1 || true
-            git -C "$PARENT" add -f "${sub}" 2>/dev/null || true
-          done < <(git -C "$PARENT" submodule status --recursive 2>/dev/null)
+          ./ci/unfold-submodules.sh \
+            "$(pwd)/../codetracer-native-backend" \
+            libs/rr/flake.nix \
+            libs/delve/flake.nix
 
       - name: Allow direnv in cloned codetracer-native-recorder
         # db-backend's build.rs (and the integration tests that build

--- a/.github/workflows/cross-repo-tests.yml
+++ b/.github/workflows/cross-repo-tests.yml
@@ -226,56 +226,46 @@ jobs:
           token: ${{ steps.ci_token.outputs.token }}
 
       - name: Setup dev env
-        # setup-dev-env installs Nix (with the Attic substituter/keys) and
-        # clones codetracer-shell-recorders adjacent to this checkout at the
-        # pinned `dev` ref, replacing the former
-        # Checkout-manifests / Resolve-lock / clone-repo steps. The
-        # shell_recorders_ref workflow_dispatch input overrides the ref
-        # (empty => `dev`).
+        # THE SIBLING SET THIS JOB NEEDS IS NOT THE SHELL RECORDERS' SIBLING
+        # SET. The test command below runs `cargo test` from inside
+        # `src/db-backend`, so this job builds the db-backend crate and needs
+        # every sibling THAT build resolves by relative path -- which is what
+        # `.github/actions/setup-db-backend-siblings` names, in one place, for
+        # the eight jobs that build it.
         #
-        # codetracer-trace-format is listed because the shell recorders' Cargo
-        # workspace path-depends on it:
+        # This job used to call `setup-dev-env` directly with a hand-derived
+        # list, reasoning only about the shell recorders' own path
+        # dependencies. That list was right about those and silently omitted
+        # `codetracer-native-recorder`, which no shell recorder needs but
+        # `src/db-backend/build.rs` requires unconditionally: it compiles and
+        # links the recorder's Nim MCR emulator, and `src/lib.rs` exports
+        # `emulator_ffi` / `emulator_origin` / `emulator_session` / `data_watch`
+        # whether or not anything calls them. The job compiled the whole
+        # tree-sitter tree and then panicked at build.rs:170 --
         #
-        #   error: failed to load manifest for workspace member
-        #     `.../codetracer-shell-recorders/crates/ct-shell-trace-writer`
-        #   Caused by: failed to load manifest for dependency `codetracer_trace_types`
-        #   Caused by: failed to read `.../codetracer-trace-format/codetracer_trace_types/Cargo.toml`
-        #   Caused by: No such file or directory (os error 2)
+        #   db-backend requires the sibling `codetracer-native-recorder`
+        #   checkout, and it was not found.
         #
-        # It was missing from this list, not from the lock — the `rr-backend-tests`
-        # job above already names it for the same reason. The gap was invisible
-        # while this job could not get past `Setup dev env` at all.
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        # -- in run 32995543471 and in every run before it back to 2026-08-04.
+        # `ci/test/sibling-provisioning-test.sh` now fails when a job that runs
+        # cargo against `src/db-backend` does not provision it.
+        #
+        # `extra-siblings` carries the ONE sibling that is genuinely this job's
+        # own: the shell recorders under test. codetracer-trace-format /
+        # codetracer-trace-format-nim were in the hand-rolled list for the
+        # shell recorders' sake (`crates/ct-shell-trace-writer` path-depends on
+        # `codetracer_trace_types` and on `codetracer_trace_writer_nim`, whose
+        # build.rs resolves the Nim FFI entry point as a sibling of the Rust
+        # half) and the composite provisions both anyway -- db-backend needs
+        # the same matched pair for the same reason.
+        uses: ./.github/actions/setup-db-backend-siblings
         with:
           env-flavor: nix
           gh-token: ${{ steps.ci_token.outputs.token }}
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
-          # codetracer-trace-format-nim is the second half of a MATCHED FFI
-          # PAIR and is required whenever codetracer-trace-format is BUILT, not
-          # only when something imports the Nim library directly.
-          # `crates/ct-shell-trace-writer` path-depends on
-          # `codetracer-trace-format/codetracer_trace_writer_nim`, whose
-          # build.rs resolves the Nim entry point as a SIBLING of
-          # codetracer-trace-format and hard-errors when it is absent:
-          #
-          #   error: failed to run custom build command for
-          #     `codetracer_trace_writer_nim v0.1.0`
-          #   Nim FFI entry point not found at
-          #     .../codetracer-trace-format-nim/src/codetracer_trace_writer_ffi.nim
-          #     -- is the codetracer-trace-format-nim repo checked out as a
-          #     sibling? (override with CODETRACER_TRACE_FORMAT_NIM_DIR)
-          #
-          # Observed in run 31719867246, job 94513828226, step "Build shell
-          # trace writer" -- reached only because the `=dev` pins here got this
-          # job past `Setup dev env` for the first time since 2026-08-04.
-          # Pinned by the "codetracer-trace-format implies
-          # codetracer-trace-format-nim" assertion in
-          # ci/test/sibling-provisioning-test.sh.
-          siblings: |
+          extra-siblings: |
             codetracer-shell-recorders=${{ github.event.inputs.shell_recorders_ref || 'dev' }}
-            codetracer-trace-format=dev
-            codetracer-trace-format-nim=dev
 
       - name: Build shell trace writer
         run: |
@@ -283,7 +273,42 @@ jobs:
           nix develop .#devShells.x86_64-linux.default --command \
             bash -c "cd '$CLONE_DIR' && cargo build"
 
+      - name: Allow direnv in cloned codetracer-native-recorder
+        # `src/db-backend/build.rs` shells out to ``direnv exec <recorder-root>
+        # bash ct_emulator/build_native_api.sh`` to materialise the generated C
+        # sources before the Rust build. A fresh clone's `.envrc` is in the
+        # "blocked" state, so direnv refuses to run it and build.rs fails with
+        # ``build_native_api.sh exited with status exit status: 1``.
+        # `direnv allow` is idempotent and only writes this runner's local
+        # direnv state dir. Same step, same reason, as the `rr-backend-tests`
+        # job above and the six db-backend jobs in `codetracer.yml`; the
+        # composite action deliberately leaves it to the caller because only
+        # the jobs that actually compile build.rs need it.
+        run: |
+          nix develop .#devShells.x86_64-linux.default --command \
+            direnv allow "${{ github.workspace }}/../codetracer-native-recorder"
+
+      - name: Resolve ct_emulator nimble dependencies
+        # `build_native_api.sh` runs ``nim c ... ct_emulator.nim``, whose
+        # `.nimble` declares ``requires "results"``. A fresh nim install has no
+        # global `results` package, so the script aborts with ``cannot open
+        # file: results``. Resolve them once, inside the RECORDER's own direnv
+        # environment so nim/nimble come from the recorder's flake.
+        run: |
+          RECORDER_DIR="${{ github.workspace }}/../codetracer-native-recorder"
+          nix develop .#devShells.x86_64-linux.default --command \
+            direnv exec "$RECORDER_DIR" \
+              bash -c "cd '$RECORDER_DIR/ct_emulator' && nimble install --depsOnly -y"
+
       - name: Run shell-recorder integration tests
+        # CT_EMULATOR_EXTRA_NIM_PATHS: the emulator's `syscall_replay.nim`
+        # imports `stew/endians2`, but `ct_emulator.nimble` does not declare
+        # `stew` as a dependency, so a fresh Nim build cannot resolve the
+        # module. Codetracer ships pinned copies as submodules under
+        # `libs/nim-stew` and `libs/nim-result`; injecting them here is what the
+        # other db-backend jobs in `codetracer.yml` do.
+        env:
+          CT_EMULATOR_EXTRA_NIM_PATHS: ${{ github.workspace }}/libs/nim-stew/stew:${{ github.workspace }}/libs/nim-stew:${{ github.workspace }}/libs/nim-result
         run: |
           CLONE_DIR="$(pwd)/../codetracer-shell-recorders"
           BASH_RECORDER="${CLONE_DIR}/bash-recorder/launcher.sh"

--- a/.github/workflows/cross-repo-tests.yml
+++ b/.github/workflows/cross-repo-tests.yml
@@ -129,9 +129,18 @@ jobs:
         # ct_emulator/build_native_api.sh`` to materialise generated C
         # sources.  A fresh clone's .envrc is in the "blocked" state,
         # so direnv refuses to run.  ``direnv allow`` whitelists it.
+        #
+        # THE HOST SHELL IS OURS, NOT THE SIBLING'S.  This ran
+        # ``nix develop "$CLONE_DIR"`` -- codetracer-native-backend's shell --
+        # which declares no direnv, so it died with ``exec: direnv: not found``
+        # and exit 127 (run 32489213400, the one run in months that got past
+        # the submodule unfold and reached this step at all).  direnv is a
+        # declared package of THIS repo's shell, in nix/shells/ci-base.nix,
+        # precisely because build.rs needs it; a sibling's flake is not ours to
+        # fix.  ci/test/direnv-provenance-test.sh keeps every direnv call site
+        # on a dev shell this repo defines.
         run: |
-          CLONE_DIR="$(pwd)/../codetracer-native-backend"
-          nix develop "$CLONE_DIR" --command \
+          nix develop .#devShells.x86_64-linux.default --command \
             direnv allow "$(pwd)/../codetracer-native-recorder"
 
       - name: Resolve ct_emulator nimble dependencies
@@ -140,9 +149,13 @@ jobs:
         # without ``nimble install --depsOnly`` the script aborts with
         # ``cannot open file: results`` and db-backend's build.rs
         # panics during the cross-repo integration test cargo runs.
+        #
+        # The outer shell only has to supply direnv (see the step above); nim
+        # and nimble come from the RECORDER's own flake, which is what
+        # ``direnv exec "$RECORDER_DIR"`` loads.
         run: |
           RECORDER_DIR="$(pwd)/../codetracer-native-recorder"
-          nix develop "$(pwd)/../codetracer-native-backend" --command \
+          nix develop .#devShells.x86_64-linux.default --command \
             direnv exec "$RECORDER_DIR" \
               bash -c "cd '$RECORDER_DIR/ct_emulator' && nimble install --depsOnly -y"
 

--- a/ci/lint/bash.sh
+++ b/ci/lint/bash.sh
@@ -107,6 +107,15 @@ lint_step "shellcheck: flake pin alignment guard" \
 lint_step "contract suite: flake pin alignment guard" \
 	bash ci/test/flake-pin-alignment-test.sh
 
+# ci/unfold-submodules.sh is what makes codetracer-native-backend's `path:`
+# flake inputs resolvable in `Cross-Repo Integration Tests`. Its suite is pure
+# bash + git against repositories it builds under mktemp -- no siblings, no
+# network, seconds -- and the defect it guards (an unfold that is PARTIAL and
+# reports success) is invisible until a Nix evaluation four steps later, so it
+# belongs in the cheapest lane that will run it.
+lint_step "contract suite: submodule unfold for path: flake inputs" \
+	bash ci/test/unfold-submodules-test.sh
+
 # The guard for this whole shape: no ci/lint script may let one failing step
 # hide another. It drives every ci/lint/*.sh with a PATH in which every
 # external command fails, and asserts each still reports every step it declares.

--- a/ci/lint/bash.sh
+++ b/ci/lint/bash.sh
@@ -123,6 +123,12 @@ lint_step "contract suite: submodule unfold for path: flake inputs" \
 lint_step "contract suite: direnv comes from a dev shell we define" \
 	bash ci/test/direnv-provenance-test.sh
 
+# push-gpg-public-key and push-install-script have failed in every completed
+# `dev` run for weeks with "experimental Nix feature 'nix-command' is disabled",
+# because they run `nix develop` without ever installing Nix. Static, pure bash.
+lint_step "contract suite: a job that runs nix installs Nix first" \
+	bash ci/test/nix-provisioning-test.sh
+
 # The guard for this whole shape: no ci/lint script may let one failing step
 # hide another. It drives every ci/lint/*.sh with a PATH in which every
 # external command fails, and asserts each still reports every step it declares.

--- a/ci/lint/bash.sh
+++ b/ci/lint/bash.sh
@@ -116,6 +116,13 @@ lint_step "contract suite: flake pin alignment guard" \
 lint_step "contract suite: submodule unfold for path: flake inputs" \
 	bash ci/test/unfold-submodules-test.sh
 
+# direnv is a declared package of this repo's dev shell because
+# src/db-backend/build.rs shells out to it. That declaration cannot put direnv
+# in a SIBLING's dev shell, and a step that reached for one died with
+# `exec: direnv: not found` / exit 127. Static, pure bash, no nix.
+lint_step "contract suite: direnv comes from a dev shell we define" \
+	bash ci/test/direnv-provenance-test.sh
+
 # The guard for this whole shape: no ci/lint script may let one failing step
 # hide another. It drives every ci/lint/*.sh with a PATH in which every
 # external command fails, and asserts each still reports every step it declares.

--- a/ci/test/direnv-provenance-test.sh
+++ b/ci/test/direnv-provenance-test.sh
@@ -186,7 +186,11 @@ done
 # stops matching it, "no foreign shells were found" would be true and
 # meaningless. Update it deliberately when a call site is added or removed --
 # that is the moment to confirm the new one names `.`.
-readonly EXPECTED_SITES=11
+# 11 -> 12: #659 added a shell-BUILD probe beside the direnv probe in
+# launcher-recorder-e2e.yml, so that "the shell did not build" and "the shell
+# has no direnv" stop being reported as the same thing. It names `.`, so the
+# rule below still holds; this count is what made the addition visible.
+readonly EXPECTED_SITES=12
 
 if [ "$sites" -eq "$EXPECTED_SITES" ]; then
 	ok "the scanner still matches the direnv call sites ($sites)"

--- a/ci/test/direnv-provenance-test.sh
+++ b/ci/test/direnv-provenance-test.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Contract: `direnv` is run from THIS repo's dev shell, never from a sibling's.
+#
+# # The defect
+#
+# `src/db-backend/build.rs` shells out to `direnv exec <recorder-root> bash
+# ct_emulator/build_native_api.sh`, and several CI steps run `direnv allow` on a
+# freshly cloned sibling before that. `direnv` therefore has to be on PATH, and
+# `nix/shells/ci-base.nix` declares it for exactly that reason -- with a comment
+# recording the last time it was missing (run 30726348404, `direnv: not found`,
+# exit 127).
+#
+# What that declaration cannot do is put direnv in SOMEBODY ELSE'S dev shell.
+# `cross-repo-tests.yml`'s `rr-backend-tests` ran
+#
+#     nix develop "$CLONE_DIR" --command direnv allow ...
+#
+# where `$CLONE_DIR` is the cloned `codetracer-native-backend`. That repo's
+# flake declares no direnv, so the step died the same way:
+#
+#     /tmp/nix-shell.gzS6Kp: line 2685: exec: direnv: not found
+#     ##[error]Process completed with exit code 127.
+#
+# (run 32489213400, job `rr-backend-tests` -- the one run in months that got
+# past the submodule unfold, which is what made this reachable at all.) Every
+# other direnv call site in this repository already uses `nix develop .` /
+# `.#ci` / `.?submodules=1#ci`; this one job was the exception, and it was
+# invisible because an earlier step failed first.
+#
+# A sibling's dev shell is not this repository's to fix. So the contract is not
+# "every shell must provide direnv" -- it is "reach for direnv in the shell
+# whose flake we control".
+#
+# # What is asserted
+#
+#   1. `nix/shells/ci-base.nix` still declares `direnv`, and `devShells.default`
+#      still composes ci-base. Both `devShells.ci` and `devShells.default` are
+#      used as direnv hosts by the workflows, so if either premise stops
+#      holding, the rule below is pointing people at a shell that cannot serve
+#      them and this suite must fail rather than keep enforcing it.
+#   2. No `nix develop <ref> ... direnv ...` in any workflow names a `<ref>`
+#      outside this repository.
+#   3. The scanner still matches real call sites (an exact count, so a rename
+#      that silently stops matching is a failure and not a vacuous pass).
+#
+# # No mocks
+#
+# `.github/workflows/*.yml` and `nix/shells/*.nix` as committed are the input.
+#
+# Run: bash ci/test/direnv-provenance-test.sh
+# Lane: a step of `lint-bash` (pure bash, no nix, no network).
+# =============================================================================
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+readonly REPO_ROOT
+WORKFLOW_DIR="${1:-$REPO_ROOT/.github/workflows}"
+readonly WORKFLOW_DIR
+
+assertions=0
+failures=0
+
+ok() {
+	assertions=$((assertions + 1))
+	printf '  ok   %s\n' "$1"
+}
+
+fail() {
+	assertions=$((assertions + 1))
+	failures=$((failures + 1))
+	printf '  FAIL %s\n' "$1"
+	if [ "$#" -gt 1 ]; then
+		shift
+		printf '         %s\n' "$@"
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# 1. The premise: our own shells really do carry direnv.
+# ---------------------------------------------------------------------------
+echo "this repo's dev shells provide direnv"
+
+CI_BASE="$REPO_ROOT/nix/shells/ci-base.nix"
+MAIN_SHELL="$REPO_ROOT/nix/shells/main.nix"
+CI_SHELL="$REPO_ROOT/nix/shells/ci.nix"
+
+# A bare `direnv` on its own line is how ci-base.nix lists a package; the many
+# comment lines that discuss direnv must not satisfy this.
+if grep -qE '^[[:space:]]*direnv[[:space:]]*$' "$CI_BASE" 2>/dev/null; then
+	ok "nix/shells/ci-base.nix declares direnv as a package"
+else
+	fail "nix/shells/ci-base.nix declares direnv as a package" \
+		"Without it every 'nix develop . -c direnv ...' step in the workflows fails" \
+		"with 'direnv: not found' / exit 127, and the rule this suite enforces --" \
+		"'use OUR shell, not a sibling's' -- stops being true."
+fi
+
+for _s in "$MAIN_SHELL" "$CI_SHELL"; do
+	_n="${_s#"$REPO_ROOT"/}"
+	# `import ./ci-base.nix`, not a comment that mentions it. Both files open
+	# with a header paragraph naming ci-base.nix, so a substring search here
+	# is satisfied by prose and keeps passing after the import is changed --
+	# which is exactly how this check first failed to catch its own mutation.
+	if grep -qE '^[^#]*import[[:space:]]+\./ci-base\.nix' "$_s" 2>/dev/null; then
+		ok "$_n composes ci-base.nix (so it inherits direnv)"
+	else
+		fail "$_n composes ci-base.nix (so it inherits direnv)" \
+			"devShells.default and devShells.ci are both used as direnv hosts by the" \
+			"workflows; one that no longer builds on ci-base may not carry direnv."
+	fi
+done
+unset _s _n
+
+# ---------------------------------------------------------------------------
+# 2. Every direnv call site names one of THIS repo's dev shells.
+#
+# The scan joins bash line continuations first: the call sites are written
+# across two or three lines, e.g.
+#
+#     nix develop "$CLONE_DIR" --command \
+#       direnv allow "$(pwd)/../codetracer-native-recorder"
+#
+# so a line-at-a-time scanner sees `nix develop` and `direnv` separately and
+# matches neither.
+#
+# A flake reference belonging to this repository starts with `.` -- `.`,
+# `.#ci`, `.#devShells.x86_64-linux.default`, `.?submodules=1#ci`. Anything
+# else (a variable holding a sibling path, an absolute path, a `github:` URL)
+# is a shell this repository does not define and cannot add direnv to.
+# ---------------------------------------------------------------------------
+echo
+echo "direnv is invoked from a dev shell this repo defines"
+
+sites=0
+foreign=()
+
+for wf in "$WORKFLOW_DIR"/*.yml "$WORKFLOW_DIR"/*.yaml; do
+	[ -f "$wf" ] || continue
+	wf_name="${wf##*/}"
+	line_no=0
+	joined=""
+	start_line=0
+	while IFS= read -r line || [ -n "$line" ]; do
+		line_no=$((line_no + 1))
+		stripped="${line#"${line%%[![:space:]]*}"}"
+		# YAML comments are prose. Several of them quote the very command
+		# this scanner looks for.
+		case "$stripped" in '#'*) continue ;; esac
+		if [ -z "$joined" ]; then start_line="$line_no"; fi
+		case "$stripped" in
+		*\\)
+			joined="$joined ${stripped%\\}"
+			continue
+			;;
+		esac
+		joined="$joined $stripped"
+
+		case "$joined" in
+		*'nix develop'*direnv*)
+			sites=$((sites + 1))
+			# The token after `nix develop` is the flake reference. `nix
+			# develop` with no reference at all means `.`, which is fine.
+			ref="${joined#*nix develop}"
+			ref="${ref#"${ref%%[![:space:]]*}"}"
+			ref="${ref%% *}"
+			# `nix develop '.?submodules=1#ci'` -- the shell quoting is
+			# part of the workflow text, not part of the reference.
+			ref="${ref#\'}"
+			ref="${ref#\"}"
+			case "$ref" in
+			.* | '' | -*) ;;
+			*)
+				foreign+=("$wf_name:$start_line: 'nix develop $ref ... direnv' -- $ref is not a dev shell this repo defines")
+				;;
+			esac
+			;;
+		esac
+		joined=""
+	done <"$wf"
+done
+
+# The number of `nix develop ... direnv` call sites this repository is expected
+# to have. An exact count, in the same spirit as EXPECTED_BUILD_SITES in
+# ci/test/sibling-provisioning-test.sh: if a step is reworded and the scanner
+# stops matching it, "no foreign shells were found" would be true and
+# meaningless. Update it deliberately when a call site is added or removed --
+# that is the moment to confirm the new one names `.`.
+readonly EXPECTED_SITES=11
+
+if [ "$sites" -eq "$EXPECTED_SITES" ]; then
+	ok "the scanner still matches the direnv call sites ($sites)"
+else
+	fail "the scanner still matches the direnv call sites" \
+		"expected $EXPECTED_SITES 'nix develop ... direnv' call site(s), found $sites." \
+		"If one was added or removed, check it names one of this repo's dev shells" \
+		"and update EXPECTED_SITES. If neither, this scanner has stopped matching."
+fi
+
+if [ "${#foreign[@]}" -eq 0 ]; then
+	ok "no direnv call site reaches for a sibling repo's dev shell"
+else
+	fail "no direnv call site reaches for a sibling repo's dev shell" \
+		"A sibling's flake is not this repository's to fix, and codetracer-native-backend's" \
+		"declares no direnv: 'exec: direnv: not found', exit 127 (run 32489213400)." \
+		"${foreign[@]}"
+fi
+
+echo
+readonly EXPECTED_ASSERTIONS=5
+if [ "$assertions" -ne "$EXPECTED_ASSERTIONS" ]; then
+	printf 'FAIL: ran %d assertions, expected %d\n' "$assertions" "$EXPECTED_ASSERTIONS"
+	failures=$((failures + 1))
+fi
+
+if [ "$failures" -ne 0 ]; then
+	printf '%d of %d assertions failed\n' "$failures" "$assertions"
+	exit 1
+fi
+printf 'all %d assertions passed\n' "$assertions"

--- a/ci/test/nix-provisioning-test.sh
+++ b/ci/test/nix-provisioning-test.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Contract: a job that runs `nix` installs Nix first.
+#
+# # The defect
+#
+# `push-gpg-public-key` and `push-install-script` go straight from
+# `actions/checkout` to
+#
+#     nix develop .#devShells.x86_64-linux.default --command aws ... s3 cp ...
+#
+# with no Nix-provisioning step in between. Every other nix job in this
+# repository has one -- `./.github/actions/setup-nix`, or a `setup-dev-env`
+# with `env-flavor: nix`, or one of the composites that wraps it. Those two do
+# not, so they use whatever `nix` the runner image happens to have, configured
+# however the image happens to configure it. On `eph-linux-x64` that
+# configuration does not enable the experimental features `nix develop` needs:
+#
+#     error: experimental Nix feature 'nix-command' is disabled;
+#     add '--extra-experimental-features nix-command' to enable it
+#     ##[error]Process completed with exit code 1.
+#
+# Both jobs have failed this way in every one of the last twelve completed
+# `dev` runs. It reads as a runner defect and is not one: `setup-nix` writes
+# the experimental-features line (along with the Attic substituter and its
+# public key), and these two jobs never call it.
+#
+# The fix is one step each. This contract is what stops the next
+# nix-using job from being written without it -- the omission is invisible in
+# review precisely because `nix develop` looks self-contained.
+#
+# # What is asserted
+#
+#   1. Every workflow job that invokes `nix` in a `run:` step has a
+#      Nix-provisioning step earlier in the SAME job.
+#   2. The scanner still finds the jobs it scans for (an exact count), so a
+#      rewording that stops it matching is a failure rather than a vacuous pass.
+#
+# # Scope
+#
+# `run:` steps only, and only `nix` as the first word of a command. A composite
+# action that runs nix is provisioned by its caller, which assertion 1 covers
+# from the caller's side.
+#
+# # No mocks
+#
+# `.github/workflows/*.yml` as committed is the input.
+#
+# Run: bash ci/test/nix-provisioning-test.sh
+# Lane: a step of `lint-bash` (pure bash, no nix, no network).
+# =============================================================================
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+readonly REPO_ROOT
+WORKFLOW_DIR="${1:-$REPO_ROOT/.github/workflows}"
+readonly WORKFLOW_DIR
+
+assertions=0
+failures=0
+
+ok() {
+	assertions=$((assertions + 1))
+	printf '  ok   %s\n' "$1"
+}
+
+fail() {
+	assertions=$((assertions + 1))
+	failures=$((failures + 1))
+	printf '  FAIL %s\n' "$1"
+	if [ "$#" -gt 1 ]; then
+		shift
+		printf '         %s\n' "$@"
+	fi
+}
+
+echo "every job that runs nix installs Nix first"
+
+# The step spellings that leave a configured Nix behind. `setup-nix` is the
+# direct one; `setup-dev-env` installs Nix when its `env-flavor` is `nix`, and
+# the two local composites are thin wrappers over it. `nix-installer-action` is
+# what all of them ultimately call, named here so a job that calls it directly
+# is not reported.
+is_provisioning_step() { # $1 = a stripped YAML line
+	case "$1" in
+	*'.github/actions/setup-nix'*) return 0 ;;
+	*'metacraft-github-actions/setup-dev-env'*) return 0 ;;
+	*'.github/actions/setup-db-backend-siblings'*) return 0 ;;
+	*'.github/actions/setup-isonim-siblings'*) return 0 ;;
+	*'DeterminateSystems/nix-installer-action'*) return 0 ;;
+	esac
+	return 1
+}
+
+nix_jobs=()
+unprovisioned=()
+
+for wf in "$WORKFLOW_DIR"/*.yml "$WORKFLOW_DIR"/*.yaml; do
+	[ -f "$wf" ] || continue
+	wf_name="${wf##*/}"
+	job=""
+	provisioned=0
+	job_reported=""
+	line_no=0
+	while IFS= read -r line || [ -n "$line" ]; do
+		line_no=$((line_no + 1))
+		stripped="${line#"${line%%[![:space:]]*}"}"
+		# YAML comments quote both `nix develop ...` and the action names
+		# below all over this repository. Prose provisions nothing and
+		# invokes nothing.
+		case "$stripped" in '#'*) continue ;; esac
+
+		# Job boundaries are two-space-indented keys under `jobs:`; anything
+		# deeper belongs to the job above.
+		case "$line" in
+		'  '[a-zA-Z0-9_-]*':'*)
+			case "$line" in
+			'   '*) ;;
+			*)
+				job="${line#  }"
+				job="${job%%:*}"
+				provisioned=0
+				job_reported=""
+				;;
+			esac
+			;;
+		esac
+
+		if is_provisioning_step "$stripped"; then
+			provisioned=1
+			continue
+		fi
+
+		# A `nix` invocation: `nix` as the first word, either as the whole of
+		# a `run:` value or as a line of a `run: |` block.
+		case "$stripped" in
+		'run: nix '* | 'nix '*)
+			# Only the subcommands that need the experimental features.
+			case "$stripped" in
+			*'nix develop'* | *'nix build'* | *'nix eval'* | *'nix run'* | *'nix shell'* | *'nix flake'* | *'nix profile'*) ;;
+			*) continue ;;
+			esac
+			case " ${nix_jobs[*]-} " in
+			*" $wf_name:$job "*) ;;
+			*) nix_jobs+=("$wf_name:$job") ;;
+			esac
+			if [ "$provisioned" -eq 0 ] && [ "$job_reported" != "$job" ]; then
+				job_reported="$job"
+				unprovisioned+=("$wf_name:$line_no: job '$job' runs nix with no Nix-provisioning step before it")
+			fi
+			;;
+		esac
+	done <"$wf"
+done
+
+# The number of jobs this scanner is expected to classify as nix-using. Exact,
+# in the same spirit as EXPECTED_BUILD_SITES in
+# ci/test/sibling-provisioning-test.sh: "no unprovisioned job was found" is
+# also true of a scanner that has stopped finding jobs at all.
+readonly EXPECTED_NIX_JOBS=28
+
+if [ "${#nix_jobs[@]}" -eq "$EXPECTED_NIX_JOBS" ]; then
+	ok "the scanner still classifies the nix-using jobs (${#nix_jobs[@]})"
+else
+	fail "the scanner still classifies the nix-using jobs" \
+		"expected $EXPECTED_NIX_JOBS nix-using job(s), found ${#nix_jobs[@]}." \
+		"If a job was added or removed, confirm the new one provisions Nix and update" \
+		"EXPECTED_NIX_JOBS. If neither, this scanner has stopped matching what it scans." \
+		"found: ${nix_jobs[*]-<none>}"
+fi
+
+if [ "${#unprovisioned[@]}" -eq 0 ]; then
+	ok "every nix-using job provisions Nix first"
+else
+	fail "every nix-using job provisions Nix first" \
+		"Without it the job uses whatever nix the runner image ships, configured" \
+		"however that image configures it -- on eph-linux-x64 that means" \
+		"\"error: experimental Nix feature 'nix-command' is disabled\"." \
+		"${unprovisioned[@]}"
+fi
+
+echo
+readonly EXPECTED_ASSERTIONS=2
+if [ "$assertions" -ne "$EXPECTED_ASSERTIONS" ]; then
+	printf 'FAIL: ran %d assertions, expected %d\n' "$assertions" "$EXPECTED_ASSERTIONS"
+	failures=$((failures + 1))
+fi
+
+if [ "$failures" -ne 0 ]; then
+	printf '%d of %d assertions failed\n' "$failures" "$assertions"
+	exit 1
+fi
+printf 'all %d assertions passed\n' "$assertions"

--- a/ci/test/nix-provisioning-test.sh
+++ b/ci/test/nix-provisioning-test.sh
@@ -84,6 +84,13 @@ echo "every job that runs nix installs Nix first"
 is_provisioning_step() { # $1 = a stripped YAML line
 	case "$1" in
 	*'.github/actions/setup-nix'*) return 0 ;;
+	# What `.github/actions/setup-nix` wraps, and the OTHER upstream action
+	# beside it: `push-tag` and `create-release` call `install-nix@main`
+	# directly. Leaving this spelling out made the scanner report
+	# `create-release` as unprovisioned when it was not -- a false positive
+	# that nearly had a redundant second Install Nix step committed to it.
+	*'nixos-modules/.github/setup-nix'*) return 0 ;;
+	*'nixos-modules/.github/install-nix'*) return 0 ;;
 	*'metacraft-github-actions/setup-dev-env'*) return 0 ;;
 	*'.github/actions/setup-db-backend-siblings'*) return 0 ;;
 	*'.github/actions/setup-isonim-siblings'*) return 0 ;;

--- a/ci/test/sibling-provisioning-test.sh
+++ b/ci/test/sibling-provisioning-test.sh
@@ -208,7 +208,7 @@ readonly LOCK_RESOLVED_REPOS='isonim isonim-tui isonim-gpui nim-everywhere nim-t
 # `<=`, never `==`: converting more of them must not fail the suite, and adding
 # one must. Lower this number as blocks are converted; there is no legitimate
 # reason to raise it.
-readonly BRANCH_TIP_CEILING=61
+readonly BRANCH_TIP_CEILING=59
 
 # Classify one sibling entry's ref text. Factored out of the scanner so it can
 # be exercised directly by the self-test below: a detector that silently stops
@@ -760,6 +760,179 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 2b. Every job that runs cargo against `src/db-backend` provisions
+#     codetracer-native-recorder.
+#
+# `src/db-backend/build.rs` resolves the Nim MCR emulator as a SIBLING of the
+# codetracer checkout and PANICS when it is absent -- it is not an optional
+# feature, because `src/lib.rs` exports `emulator_ffi`, `emulator_origin`,
+# `emulator_session` and `data_watch` unconditionally:
+#
+#   thread 'main' panicked at build.rs:170:5:
+#   db-backend requires the sibling `codetracer-native-recorder` checkout,
+#   and it was not found.
+#     workspace sibling: .../src/db-backend/../../../codetracer-native-recorder/ct_emulator
+#
+# Observed in run 32995543471, job `shell-recorder-tests`, step "Run
+# shell-recorder integration tests", after twenty minutes of tree-sitter
+# compilation -- the panic is the LAST thing cargo reaches, so the job burns a
+# full build before reporting a defect that is visible in the workflow file.
+#
+# The sibling list of `cross-repo-tests.yml`'s `rr-backend-tests` job names
+# codetracer-native-recorder; `shell-recorder-tests`, added later and reasoning
+# only about the shell recorders' own path dependencies, did not -- yet it runs
+# `cargo test` from inside `src/db-backend`, so it compiles the same build.rs.
+# `.github/actions/setup-db-backend-siblings/action.yml` exists precisely to
+# stop this being re-derived per job, and a job that hand-rolls the list
+# instead has to get it right by hand.
+#
+# This is the same shape as assertion 2: a call site, and the provisioning that
+# must precede it IN THE SAME JOB. Comment lines are skipped, so a job that
+# merely NAMES the recorder in prose (this one has several such comments) does
+# not thereby satisfy the contract.
+# ---------------------------------------------------------------------------
+echo
+echo "db-backend cargo legs provision codetracer-native-recorder"
+
+# The call site this scanner is known to match, named explicitly. If the
+# detector regresses -- a step is reworded, the scanner stops matching -- this
+# anchor turns "nothing forbidden was found" into a FAILURE instead of a
+# vacuous pass. Two vacuous greens have already been paid for in this file.
+readonly DB_BACKEND_ANCHOR='cross-repo-tests.yml:shell-recorder-tests'
+
+# A job satisfies this contract by naming the composite instead of the repo --
+# which is the shape this contract WANTS, and also a way to launder the defect
+# past it. If `setup-db-backend-siblings` ever stops provisioning
+# codetracer-native-recorder, every caller silently stops provisioning it too,
+# and a scanner that accepted `uses:` on faith would keep saying "ok". So the
+# delegation is only honoured while the delegate actually does the work. The
+# per-block repo lists collected by assertion 1 are the evidence.
+readonly DB_BACKEND_COMPOSITE='setup-db-backend-siblings/action.yml'
+composite_provisions_recorder=0
+for _i in "${!BLOCK_WHERE[@]}"; do
+	case "${BLOCK_WHERE[$_i]}" in
+	"$DB_BACKEND_COMPOSITE":*)
+		case " ${BLOCK_REPOS[$_i]} " in
+		*" codetracer-native-recorder "*) composite_provisions_recorder=1 ;;
+		esac
+		;;
+	esac
+done
+unset _i
+
+if [ "$composite_provisions_recorder" -eq 1 ]; then
+	ok "$DB_BACKEND_COMPOSITE provisions codetracer-native-recorder"
+else
+	fail "$DB_BACKEND_COMPOSITE provisions codetracer-native-recorder" \
+		"Every job that delegates its db-backend siblings to this composite is" \
+		"credited with provisioning the recorder BECAUSE this block names it. With the" \
+		"entry gone, that credit is a fiction and the assertion below would pass while" \
+		"every one of those jobs panicked in build.rs."
+fi
+
+db_backend_sites=()
+db_backend_missing=()
+
+for wf in "${SIBLING_SOURCE_FILES[@]}"; do
+	case "$wf" in
+	"$ACTIONS_DIR"/*) wf_name="${wf#"$ACTIONS_DIR"/}" ;;
+	*) wf_name="${wf##*/}" ;;
+	esac
+	job=""
+	seen_recorder=0
+	line_no=0
+	while IFS= read -r line || [ -n "$line" ]; do
+		line_no=$((line_no + 1))
+		stripped_line="${line#"${line%%[![:space:]]*}"}"
+		# Job boundaries are two-space-indented keys under `jobs:`; anything
+		# deeper belongs to the job above it. (Composite actions have no
+		# `jobs:` at all, so `job` stays empty and the whole file is one
+		# scope -- which is correct: a composite IS one step sequence.)
+		case "$line" in
+		'  '[a-zA-Z0-9_-]*':'*)
+			case "$line" in
+			'   '*) ;;
+			*)
+				job="${line#  }"
+				job="${job%%:*}"
+				seen_recorder=0
+				;;
+			esac
+			;;
+		esac
+		# A YAML comment naming the repo is prose, not provisioning. Skipping
+		# these is what keeps this assertion from being satisfied by the very
+		# comments that explain the failure it guards against.
+		case "$stripped_line" in
+		'#'*) ;;
+		*)
+			case "$stripped_line" in
+			'codetracer-native-recorder='* | 'codetracer-native-recorder')
+				seen_recorder=1
+				;;
+			*'setup-db-backend-siblings'*)
+				# The composite provisions the three db-backend siblings --
+				# but only credit the caller while it demonstrably still
+				# names the recorder (checked above).
+				[ "$composite_provisions_recorder" -eq 1 ] && seen_recorder=1
+				;;
+			esac
+			;;
+		esac
+		# A quoted YAML sequence item is a `paths:` filter, not a command --
+		# `.github/workflows/cross-repo-tests.yml` lists
+		# `- 'scripts/run-cross-repo-tests.sh'` among its triggers. Matching
+		# those would attribute a call site to the `on:`/`push:` pseudo-jobs.
+		case "$stripped_line" in
+		"- '"* | '- "'*) continue ;;
+		esac
+		# The cargo invocations that compile `src/db-backend/build.rs`: a `run:`
+		# step that `cd`s in, an out-of-tree invocation naming the manifest, and
+		# the cross-repo driver, whose `run_db_backend_test` does
+		# `cd "$REPO_ROOT/src/db-backend"; cargo test` (scripts/
+		# run-cross-repo-tests.sh:446).
+		case "$stripped_line" in
+		'cd src/db-backend' | 'cd src/db-backend '* | "cd 'src/db-backend'"* | \
+			*'--manifest-path src/db-backend'* | *'--manifest-path=src/db-backend'* | \
+			*'run-cross-repo-tests.sh'*)
+			db_backend_sites+=("$wf_name:$job")
+			if [ "$seen_recorder" -eq 0 ]; then
+				db_backend_missing+=("$wf_name:$line_no: job '$job' builds src/db-backend with no codetracer-native-recorder sibling before it")
+			fi
+			;;
+		esac
+	done <"$wf"
+done
+
+_anchor_found=0
+for _s in "${db_backend_sites[@]}"; do
+	[ "$_s" = "$DB_BACKEND_ANCHOR" ] && _anchor_found=1
+done
+unset _s
+
+if [ "$_anchor_found" -eq 1 ]; then
+	ok "the db-backend cargo scanner still matches its anchor (${#db_backend_sites[@]} call site(s))"
+else
+	fail "the db-backend cargo scanner still matches its anchor" \
+		"expected to find a db-backend cargo call site at '$DB_BACKEND_ANCHOR'," \
+		"and did not. Either that job was removed -- in which case move the anchor to" \
+		"another real call site -- or this scanner has stopped matching the steps it" \
+		"scans, which would make the assertion below a vacuous pass." \
+		"found: ${db_backend_sites[*]:-<none>}"
+fi
+unset _anchor_found
+
+if [ "${#db_backend_missing[@]}" -eq 0 ]; then
+	ok "every db-backend cargo leg provisions codetracer-native-recorder first"
+else
+	fail "every db-backend cargo leg provisions codetracer-native-recorder first" \
+		"src/db-backend/build.rs panics at build.rs:170 with 'db-backend requires the" \
+		"sibling codetracer-native-recorder checkout, and it was not found' -- after the" \
+		"whole tree-sitter dependency tree has been compiled." \
+		"${db_backend_missing[@]}"
+fi
+
+# ---------------------------------------------------------------------------
 # 3. Every `ci/setup-rr-backend.sh` step overrides the ref explicitly.
 # ---------------------------------------------------------------------------
 echo
@@ -1248,7 +1421,10 @@ fi
 # this script reporting success on fewer checks than it claims.
 # ---------------------------------------------------------------------------
 echo
-readonly EXPECTED_ASSERTIONS=23
+# 23 -> 26: assertion 2b ("db-backend cargo legs provision
+# codetracer-native-recorder") contributes the composite-integrity check, the
+# scanner-anchor check, and the contract itself.
+readonly EXPECTED_ASSERTIONS=26
 if [ "$assertions" -ne "$EXPECTED_ASSERTIONS" ]; then
 	printf 'FAIL: ran %d assertions, expected %d\n' "$assertions" "$EXPECTED_ASSERTIONS"
 	failures=$((failures + 1))

--- a/ci/test/unfold-submodules-test.sh
+++ b/ci/test/unfold-submodules-test.sh
@@ -1,0 +1,363 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Contract: `ci/unfold-submodules.sh` makes EVERY submodule's contents visible
+# to `git ls-files`, or fails saying so.
+#
+# # The defect this suite was written against
+#
+# `Cross-Repo Integration Tests` has never been green on `dev`. Its
+# `rr-backend-tests` job died four steps after an "Unfold native-backend
+# submodules into parent index" step that reported SUCCESS. The step's entire
+# output was one line:
+#
+#     unfolding submodule native-backend/libs/delve
+#     <step succeeds, 0.13s>
+#     ...
+#     error: Path 'libs/rr/flake.nix' in the repository
+#     "/.../codetracer-native-backend" is not tracked by Git.
+#
+# (run 32995543471.) `libs/rr` is never mentioned. The step's loop skipped any
+# submodule `git submodule status` marks `-` -- UNINITIALISED, which the
+# sibling clone can legitimately leave behind because it fetches submodules
+# with `--submodules-optional` -- and it had no diagnostic on that branch. The
+# git calls also carried `2>/dev/null` and `|| true`, and the enumerating
+# command sat in a process substitution whose exit status `set -e` cannot see,
+# so an aborted walk would have looked identical. Three independent silences
+# over one state.
+#
+# That is the shape of bug this file exists to catch: not "the unfold is
+# wrong" but "the unfold is PARTIAL and says it succeeded".
+#
+# A CORRECTION worth recording, since it cost time: the first diagnosis here
+# was that the walk aborted -- that deleting a submodule's `.git` mid-stream
+# made `git submodule status --recursive` fail and stop. It does not.
+# git 2.50 reports such a submodule as `-` and carries on to the next one
+# (verified directly). The uninitialised branch is the reachable path, and the
+# fixture below reproduces it deterministically rather than depending on
+# stdio buffering.
+#
+# # No mocks
+#
+# Real `git init`, real `git submodule add`, real working trees on the real
+# filesystem, and the real `ci/unfold-submodules.sh` as committed. Nothing is
+# stubbed. The fixtures are built under `mktemp -d` and removed on exit.
+#
+# The fixture reproduces the properties that made the original bug possible:
+# MORE THAN ONE submodule (a partial unfold is indistinguishable from a
+# complete one when there is only one), one of them UNINITIALISED, and a NESTED
+# submodule (a `git add -f` of the outer path while an inner `.git` survives
+# re-adds the inner one as another gitlink -- the same defect, one level down).
+#
+# Run: bash ci/test/unfold-submodules-test.sh
+# =============================================================================
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+readonly REPO_ROOT
+readonly UNFOLD="$REPO_ROOT/ci/unfold-submodules.sh"
+
+assertions=0
+failures=0
+
+ok() {
+	assertions=$((assertions + 1))
+	printf '  ok   %s\n' "$1"
+}
+
+fail() {
+	assertions=$((assertions + 1))
+	failures=$((failures + 1))
+	printf '  FAIL %s\n' "$1"
+	if [ "$#" -gt 1 ]; then
+		shift
+		printf '         %s\n' "$@"
+	fi
+}
+
+if ! command -v git >/dev/null 2>&1; then
+	# A check that cannot run must say so and fail, not pass quietly: a
+	# vacuous green here is worse than a red, because this suite guards a
+	# lane that was silently broken for months.
+	echo "SKIP-FATAL: git is not on PATH, so this contract proved nothing." >&2
+	exit 1
+fi
+
+WORK="$(mktemp -d)"
+readonly WORK
+# shellcheck disable=SC2064  # expand $WORK now.
+trap "rm -rf '$WORK'" EXIT
+
+# Submodule adds from a local path need this on modern git.
+export GIT_ALLOW_PROTOCOL="${GIT_ALLOW_PROTOCOL:-file:ssh:https}"
+GIT_CFG=(-c protocol.file.allow=always -c user.name=ci -c user.email=ci@example.invalid
+	-c init.defaultBranch=main -c advice.detachedHead=false -c commit.gpgsign=false)
+
+# Create a standalone repo containing a flake.nix, the file a `path:` input
+# resolves. $1 = directory, $2 = a marker written into flake.nix.
+make_repo() {
+	local dir="$1" marker="$2"
+	mkdir -p "$dir"
+	git "${GIT_CFG[@]}" init -q "$dir"
+	printf '{ description = "%s"; }\n' "$marker" >"$dir/flake.nix"
+	git "${GIT_CFG[@]}" -C "$dir" add -A
+	git "${GIT_CFG[@]}" -C "$dir" commit -qm "$marker"
+}
+
+# Build the fixture: a parent with two submodules, the second of which itself
+# has one. Mirrors codetracer-native-backend's libs/delve + libs/rr shape.
+build_fixture() {
+	local root="$1"
+	rm -rf "$root"
+	mkdir -p "$root"
+	make_repo "$root/upstream-delve" delve
+	make_repo "$root/upstream-inner" inner
+	make_repo "$root/upstream-rr" rr
+	git "${GIT_CFG[@]}" -C "$root/upstream-rr" submodule add -q "$root/upstream-inner" third-party/inner
+	git "${GIT_CFG[@]}" -C "$root/upstream-rr" commit -qm "add nested submodule"
+
+	git "${GIT_CFG[@]}" init -q "$root/parent"
+	printf '{ inputs.rr.url = "path:libs/rr"; }\n' >"$root/parent/flake.nix"
+	git "${GIT_CFG[@]}" -C "$root/parent" add -A
+	git "${GIT_CFG[@]}" -C "$root/parent" commit -qm init
+	git "${GIT_CFG[@]}" -C "$root/parent" submodule add -q "$root/upstream-delve" libs/delve
+	git "${GIT_CFG[@]}" -C "$root/parent" submodule add -q "$root/upstream-rr" libs/rr
+	git "${GIT_CFG[@]}" -C "$root/parent" commit -qm "add submodules"
+	git "${GIT_CFG[@]}" -C "$root/parent" submodule update -q --init --recursive
+}
+
+tracked() { # $1 = repo, $2 = path -> 0 when git ls-files reports it
+	git -C "$1" ls-files --error-unmatch -- "$2" >/dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# 0. THE ORIGINAL BUG, REPRODUCED.
+#
+# The CI state was a repository whose `libs/rr` was UNINITIALISED -- the clone
+# asked for submodules optionally, so a submodule that did not fetch leaves an
+# empty directory and a successful clone. Running the loop the workflow used to
+# inline against exactly that state reproduces the CI log character for
+# character: one `unfolding` line, exit 0, and `libs/rr/flake.nix` untracked.
+#
+# If this ever stops reproducing, the fixture no longer exercises the failure
+# and every assertion below is measuring nothing, so it is asserted rather than
+# assumed.
+# ---------------------------------------------------------------------------
+echo "the pre-fix inline loop is still reproducibly broken (fixture is honest)"
+
+build_fixture "$WORK/regression"
+# The state the sibling clone left behind: one submodule present, one not.
+git "${GIT_CFG[@]}" -C "$WORK/regression/parent" submodule deinit -q -f libs/rr
+
+buggy_rc=0
+buggy_out="$(
+	set -uo pipefail
+	PARENT="$WORK/regression/parent"
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		[[ "${line:0:1}" == "-" ]] && continue
+		rest="${line:1}"
+		rest="${rest#* }"
+		sub="${rest%% *}"
+		[[ -z "$sub" ]] && continue
+		echo "  unfolding submodule ${sub}"
+		rm -rf "$PARENT/${sub}/.git"
+		git -C "$PARENT" rm -f --cached "${sub}" >/dev/null 2>&1 || true
+		git -C "$PARENT" add -f "${sub}" 2>/dev/null || true
+	done < <(git -C "$PARENT" submodule status --recursive 2>/dev/null)
+	exit 0
+)" || buggy_rc=$?
+
+if [ "$buggy_rc" -eq 0 ]; then
+	ok "the pre-fix loop still exits 0 (it never reported its own failure)"
+else
+	fail "the pre-fix loop still exits 0 (it never reported its own failure)" \
+		"got exit $buggy_rc; the point of the original defect was that it did NOT fail."
+fi
+
+case "$buggy_out" in
+*"libs/rr"*)
+	fail "the pre-fix loop never mentions the submodule it skipped" \
+		"The fixture no longer reproduces the defect this suite exists for, so the" \
+		"assertions below prove nothing about it: the loop was supposed to be SILENT" \
+		"about the uninitialised submodule, which is what made the CI log a single" \
+		"'unfolding libs/delve' line and a green step." \
+		"$buggy_out"
+	;;
+*) ok "the pre-fix loop never mentions the submodule it skipped" ;;
+esac
+
+if tracked "$WORK/regression/parent" libs/rr/flake.nix; then
+	fail "the pre-fix loop leaves libs/rr/flake.nix untracked" \
+		"which is the exact precondition of the Nix error four steps later:" \
+		"error: Path 'libs/rr/flake.nix' ... is not tracked by Git."
+else
+	ok "the pre-fix loop leaves libs/rr/flake.nix untracked, silently"
+fi
+
+# ---------------------------------------------------------------------------
+# 0b. THE FIX, AGAINST THE SAME STATE.
+#
+# The script's job is not to REPORT that state -- reporting it would only move
+# the red four steps earlier. An uninitialised submodule is repairable, so the
+# script repairs it and the lane goes green.
+# ---------------------------------------------------------------------------
+echo
+echo "ci/unfold-submodules.sh repairs the state the pre-fix loop skipped"
+
+build_fixture "$WORK/deinit"
+git "${GIT_CFG[@]}" -C "$WORK/deinit/parent" submodule deinit -q -f libs/rr
+out="$(bash "$UNFOLD" "$WORK/deinit/parent" libs/rr/flake.nix libs/delve/flake.nix 2>&1)"
+rc=$?
+
+if [ "$rc" -eq 0 ]; then
+	ok "it exits 0 against a repository with an uninitialised submodule"
+else
+	fail "it exits 0 against a repository with an uninitialised submodule" "exit $rc" "$out"
+fi
+
+if tracked "$WORK/deinit/parent" libs/rr/flake.nix; then
+	ok "the deinitialised submodule is re-initialised and unfolded"
+else
+	fail "the deinitialised submodule is re-initialised and unfolded" \
+		"This is the case the whole lane has been failing on since 2026-06-08." "$out"
+fi
+
+# ---------------------------------------------------------------------------
+# 1. The script unfolds EVERY submodule, including the nested one.
+# ---------------------------------------------------------------------------
+echo
+echo "ci/unfold-submodules.sh unfolds every submodule"
+
+build_fixture "$WORK/happy"
+out="$(bash "$UNFOLD" "$WORK/happy/parent" libs/rr/flake.nix libs/delve/flake.nix 2>&1)"
+rc=$?
+
+if [ "$rc" -eq 0 ]; then
+	ok "it exits 0 on a fully-initialised repository"
+else
+	fail "it exits 0 on a fully-initialised repository" "exit $rc" "$out"
+fi
+
+for p in libs/delve/flake.nix libs/rr/flake.nix libs/rr/third-party/inner/flake.nix; do
+	if tracked "$WORK/happy/parent" "$p"; then
+		ok "git ls-files reports $p"
+	else
+		fail "git ls-files reports $p" \
+			"This is exactly what Nix asks for when resolving a 'path:' flake input." \
+			"$out"
+	fi
+done
+
+# A nested submodule that survives as a gitlink is the original bug one level
+# down: `git ls-files` shows the PATH but Nix still cannot see inside it.
+inner_mode="$(git -C "$WORK/happy/parent" ls-files --stage -- libs/rr/third-party/inner | { read -r m _ || true; printf '%s' "${m:-}"; })"
+if [ "$inner_mode" != "160000" ]; then
+	ok "the nested submodule is not re-added as a gitlink (mode '${inner_mode:-<none>}')"
+else
+	fail "the nested submodule is not re-added as a gitlink" \
+		"mode 160000 means 'git add -f' recorded another submodule reference," \
+		"so the files under it remain invisible to Nix."
+fi
+
+# ---------------------------------------------------------------------------
+# 2. It FAILS LOUDLY when a required path cannot be produced.
+#
+# The property the original step lacked. Asserted against a repository with no
+# submodules at all, which is the state a non-recursive clone leaves behind --
+# the realistic way this precondition breaks.
+# ---------------------------------------------------------------------------
+echo
+echo "it fails loudly rather than passing a partial unfold downstream"
+
+make_repo "$WORK/bare-parent" parent-only
+out="$(bash "$UNFOLD" "$WORK/bare-parent" libs/rr/flake.nix 2>&1)"
+rc=$?
+
+if [ "$rc" -ne 0 ]; then
+	ok "a required path that cannot be produced is a non-zero exit"
+else
+	fail "a required path that cannot be produced is a non-zero exit" \
+		"It exited 0 having not tracked libs/rr/flake.nix -- the same silent partial" \
+		"success the inline loop had." "$out"
+fi
+
+case "$out" in
+*"libs/rr/flake.nix"*) ok "the diagnostic names the path that is missing" ;;
+*) fail "the diagnostic names the path that is missing" "$out" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 3. An UNREPAIRABLE submodule fails loudly, and does not take the others with
+#    it.
+#
+# Repair is a fetch, and a fetch can fail -- an upstream that is gone, an
+# unauthenticated private submodule, a full disk. The contract is that this
+# ends as a named failure here rather than as a Nix stack trace later, and that
+# the submodules that COULD be unfolded still were, so the diagnostic is about
+# one repo and not about the whole set.
+# ---------------------------------------------------------------------------
+echo
+echo "an unrepairable submodule is a named failure, not a silent skip"
+
+build_fixture "$WORK/broken"
+git "${GIT_CFG[@]}" -C "$WORK/broken/parent" submodule deinit -q -f libs/rr
+# Make the repair impossible. `submodule deinit` leaves the objects behind in
+# `.git/modules/<name>`, so a re-init succeeds offline -- which is realistic
+# for a warm runner and useless as a test of the failure path. Removing the
+# module store as well as the upstream is what a FRESH clone of a repository
+# whose submodule cannot be fetched actually looks like.
+rm -rf "$WORK/broken/upstream-rr" "$WORK/broken/parent/.git/modules/libs/rr"
+out="$(bash "$UNFOLD" "$WORK/broken/parent" libs/rr/flake.nix libs/delve/flake.nix 2>&1)"
+rc=$?
+
+if [ "$rc" -ne 0 ]; then
+	ok "an unfetchable submodule is a non-zero exit"
+else
+	fail "an unfetchable submodule is a non-zero exit" \
+		"exit 0 here is the original defect: a green step and a Nix failure downstream." \
+		"$out"
+fi
+
+case "$out" in
+*"libs/rr/flake.nix"*) ok "the diagnostic names the path that could not be produced" ;;
+*) fail "the diagnostic names the path that could not be produced" "$out" ;;
+esac
+
+if tracked "$WORK/broken/parent" libs/delve/flake.nix; then
+	ok "the submodules that could be unfolded still were"
+else
+	fail "the submodules that could be unfolded still were" \
+		"One unfetchable submodule must not abandon the rest; the report is about" \
+		"libs/rr, and saying nothing about libs/delve would make it ambiguous." "$out"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Idempotence: CI re-runs on a warm self-hosted runner re-enter this step
+#    against a tree a previous run already unfolded.
+# ---------------------------------------------------------------------------
+echo
+echo "running it twice is the same as running it once"
+
+out="$(bash "$UNFOLD" "$WORK/happy/parent" libs/rr/flake.nix libs/delve/flake.nix 2>&1)"
+rc=$?
+if [ "$rc" -eq 0 ] && tracked "$WORK/happy/parent" libs/rr/flake.nix; then
+	ok "a second run over an already-unfolded tree still succeeds"
+else
+	fail "a second run over an already-unfolded tree still succeeds" "exit $rc" "$out"
+fi
+
+# ---------------------------------------------------------------------------
+# Self-accounting.
+# ---------------------------------------------------------------------------
+echo
+readonly EXPECTED_ASSERTIONS=16
+if [ "$assertions" -ne "$EXPECTED_ASSERTIONS" ]; then
+	printf 'FAIL: ran %d assertions, expected %d\n' "$assertions" "$EXPECTED_ASSERTIONS"
+	failures=$((failures + 1))
+fi
+
+if [ "$failures" -ne 0 ]; then
+	printf '%d of %d assertions failed\n' "$failures" "$assertions"
+	exit 1
+fi
+printf 'all %d assertions passed\n' "$assertions"

--- a/ci/unfold-submodules.sh
+++ b/ci/unfold-submodules.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Make a repository's submodule contents visible to Nix's `path:` flake inputs.
+#
+# # The problem this solves
+#
+# `codetracer-native-backend/flake.nix` declares
+#
+#     rr-soft.url      = "path:libs/rr";
+#     delve-patched.url = "path:libs/delve";
+#
+# Nix resolves a `path:` flake input inside a git repository by asking `git
+# ls-files` which files exist. A submodule contributes exactly one entry to its
+# parent's index -- a gitlink -- so none of the files INSIDE it are listed, and
+# `nix develop <native-backend>` aborts with
+#
+#     error: Path 'libs/rr/flake.nix' in the repository "<dir>" is not tracked
+#     by Git.
+#
+# The fix is to "unfold" each submodule: drop its inner `.git`, remove the
+# gitlink from the parent's index, and `git add -f` the materialised files so
+# `git ls-files` reports them. This is a destructive, CI-only operation on a
+# throwaway clone -- it turns submodules into plain directories.
+#
+# # Why it is a script and not six lines inline in a workflow
+#
+# It was six lines inline, and it was silently broken for the entire life of
+# the `Cross-Repo Integration Tests` workflow on `dev`. Its whole output was
+# one line, and it succeeded:
+#
+#     unfolding submodule native-backend/libs/delve
+#     <step succeeds, 0.13s>
+#     ... four steps later ...
+#     error: Path 'libs/rr/flake.nix' ... is not tracked by Git.
+#
+# (run 32995543471, job `rr-backend-tests`; the same shape in every run of that
+# job on `dev` back to 2026-06-08.) `libs/rr` never appeared. The loop skipped
+# any submodule `git submodule status` marks `-` -- UNINITIALISED -- which is
+# right, since an empty directory cannot be unfolded, and then said nothing at
+# all about having skipped it.
+#
+# It could not say which of two things had happened, either, because it was
+# silent in three separate ways: the `-` branch had no diagnostic, the git
+# calls carried `2>/dev/null` and `|| true`, and the enumerating command sat in
+# a PROCESS SUBSTITUTION, whose exit status `set -e` cannot see. A walk that
+# reported an uninitialised submodule and a walk that ABORTED partway both
+# produced exactly this log and exit 0.
+#
+# So this script, in that order: MAKE the submodules exist -- uninitialised is
+# a fixable state, not a fact about the world -- then enumerate completely
+# before mutating anything, then verify the postcondition out loud. Being a
+# file also makes it testable: `ci/test/unfold-submodules-test.sh` runs this
+# exact script against real git repositories with real submodules.
+#
+# # Usage
+#
+#     ci/unfold-submodules.sh <repo-dir> [required-path ...]
+#
+# Each `required-path` is a repo-relative file that MUST be tracked when the
+# unfold finishes -- name the `flake.nix` of every `path:` input, so the failure
+# is reported here, by this script, instead of four steps later inside a Nix
+# stack trace.
+#
+# Requires only git and bash: the self-hosted nixos runner's shell has a
+# minimal PATH with no awk and no coreutils to spare.
+# =============================================================================
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+	echo "usage: $0 <repo-dir> [required-path ...]" >&2
+	exit 2
+fi
+
+PARENT="$1"
+shift
+REQUIRED=("$@")
+
+if [ ! -d "$PARENT/.git" ] && [ ! -f "$PARENT/.git" ]; then
+	echo "::error::unfold-submodules: '$PARENT' is not a git repository." >&2
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 0. MAKE THE SUBMODULES EXIST.
+#
+# The clone that produced $PARENT already asked for submodules -- and
+# `clone-siblings` asks for them OPTIONALLY (`authenticated-clone.sh
+# --submodules-optional`), so a submodule that failed to fetch leaves an empty
+# directory and the clone still succeeds. That is the state this script kept
+# finding and silently accepting.
+#
+# `submodule update --init --recursive` is a no-op when everything is already
+# checked out, so this costs nothing in the normal case and repairs the case
+# that has kept this lane red. It is NOT fatal on its own: whether the repair
+# was needed at all is answered by the postcondition check at the bottom, which
+# can say something far more useful than git's own error.
+# ---------------------------------------------------------------------------
+if ! git -C "$PARENT" submodule update --init --recursive; then
+	echo "::warning::unfold-submodules: 'git submodule update --init --recursive' failed in '$PARENT'. Continuing; the postcondition check below decides whether it mattered." >&2
+fi
+
+# ---------------------------------------------------------------------------
+# 1. ENUMERATE, COMPLETELY, BEFORE TOUCHING ANYTHING.
+#
+# Through a temporary file rather than a pipe or a process substitution, for
+# two reasons: git finishes its walk before the first `rm -rf` runs, and its
+# exit status is actually observable. Under `set -e` a failed walk stops the
+# script here instead of being mistaken for "no submodules".
+# ---------------------------------------------------------------------------
+listing="$(mktemp)"
+# shellcheck disable=SC2064  # expand $listing now: that is the point.
+trap "rm -f '$listing'" EXIT
+
+git -C "$PARENT" submodule status --recursive >"$listing"
+
+# `git submodule status` prints `<status-char><sha> <path> (<describe>)`, where
+# the status char is ' ' (in sync), '+' (checked out at a different commit),
+# 'U' (merge conflict) or '-' (NOT INITIALISED). An uninitialised submodule is
+# an empty directory: there is nothing to unfold and nothing to add, and
+# treating it as unfoldable would produce an empty `libs/rr` that Nix would
+# reject in a more confusing way than the original error.
+all_subs=()
+uninitialised=()
+while IFS= read -r line || [ -n "$line" ]; do
+	[ -z "$line" ] && continue
+	rest="${line:1}"    # drop the status char
+	rest="${rest#* }"   # drop the sha
+	sub="${rest%% *}"   # take the path
+	[ -z "$sub" ] && continue
+	if [ "${line:0:1}" = "-" ]; then
+		uninitialised+=("$sub")
+		continue
+	fi
+	all_subs+=("$sub")
+done <"$listing"
+
+if [ "${#uninitialised[@]}" -gt 0 ]; then
+	echo "unfold-submodules: skipping ${#uninitialised[@]} uninitialised submodule(s): ${uninitialised[*]}"
+fi
+
+if [ "${#all_subs[@]}" -eq 0 ]; then
+	echo "unfold-submodules: $PARENT has no initialised submodules; nothing to unfold."
+else
+	# -------------------------------------------------------------------
+	# 2. Drop EVERY inner `.git` -- at every depth -- before adding anything.
+	#
+	# Nested submodules are why this is a separate pass. `git add -f libs/rr`
+	# while `libs/rr/third-party/x/.git` still exists records the nested
+	# submodule as another gitlink ("adding embedded git repository") and the
+	# files under it stay invisible to `git ls-files`: the original bug, one
+	# level down. `--recursive` lists a parent before its children, so the
+	# reverse order is deepest-first -- which is the natural order for a
+	# removal pass even though, with the add deferred to step 3, either order
+	# would do.
+	# -------------------------------------------------------------------
+	for ((i = ${#all_subs[@]} - 1; i >= 0; i--)); do
+		sub="${all_subs[$i]}"
+		echo "  unfolding ${PARENT##*/}/${sub}"
+		rm -rf "${PARENT:?}/${sub}/.git"
+	done
+
+	# -------------------------------------------------------------------
+	# 3. Replace each TOP-LEVEL gitlink with the files beneath it.
+	#
+	# Only the top-level submodules appear in this repository's index; the
+	# nested ones lived in their parent submodule's index, which step 2 just
+	# deleted, so they are plain directories now and `git add -f <top-level>`
+	# sweeps them in with everything else.
+	# -------------------------------------------------------------------
+	top_level=()
+	for sub in "${all_subs[@]}"; do
+		mode="$(git -C "$PARENT" ls-files --stage -- "$sub" | { read -r m _ || true; printf '%s' "${m:-}"; })"
+		# 160000 is git's gitlink mode; anything else is not a submodule
+		# entry of THIS index.
+		[ "$mode" = "160000" ] && top_level+=("$sub")
+	done
+
+	for sub in "${top_level[@]}"; do
+		git -C "$PARENT" rm -f --cached -- "$sub" >/dev/null
+		git -C "$PARENT" add -f -- "$sub"
+	done
+fi
+
+# ---------------------------------------------------------------------------
+# 4. VERIFY THE POSTCONDITION, HERE, WHERE IT CAN BE EXPLAINED.
+#
+# Without this the next four steps run and the failure surfaces as a Nix
+# evaluation stack trace with the real cause on its last line.
+# ---------------------------------------------------------------------------
+missing=()
+for path in ${REQUIRED[@]+"${REQUIRED[@]}"}; do
+	git -C "$PARENT" ls-files --error-unmatch -- "$path" >/dev/null 2>&1 ||
+		missing+=("$path")
+done
+
+if [ "${#missing[@]}" -gt 0 ]; then
+	echo "::error::unfold-submodules: after unfolding, these paths are still not tracked by git in '$PARENT': ${missing[*]}" >&2
+	{
+		echo "Nix resolves a 'path:' flake input through 'git ls-files', so it will fail with"
+		echo "    error: Path '${missing[0]}' in the repository \"$PARENT\" is not tracked by Git."
+		echo "Initialised submodules seen: ${all_subs[*]:-<none>}"
+		echo "Uninitialised (skipped):     ${uninitialised[*]:-<none>}"
+		echo "If the submodule is simply absent, the clone step did not fetch it recursively."
+	} >&2
+	exit 1
+fi
+
+if [ "${#REQUIRED[@]}" -gt 0 ]; then
+	echo "unfold-submodules: all ${#REQUIRED[@]} required path(s) are tracked: ${REQUIRED[*]}"
+fi

--- a/ci/unfold-submodules.sh
+++ b/ci/unfold-submodules.sh
@@ -107,7 +107,13 @@ fi
 # exit status is actually observable. Under `set -e` a failed walk stops the
 # script here instead of being mistaken for "no submodules".
 # ---------------------------------------------------------------------------
-listing="$(mktemp)"
+# Not `mktemp`: this script runs as a plain workflow `run:` step, on a
+# self-hosted runner whose ambient PATH is minimal -- the inline version this
+# replaced carried a comment saying it had no awk, and it is not worth
+# discovering in CI which other coreutils are missing. `$$` and `$RANDOM` are
+# bash builtins, `RUNNER_TEMP` is set by the runner, and the directory is
+# per-job, so a fixed-name collision is not reachable.
+listing="${RUNNER_TEMP:-/tmp}/unfold-submodules.$$.$RANDOM.list"
 # shellcheck disable=SC2064  # expand $listing now: that is the point.
 trap "rm -f '$listing'" EXIT
 


### PR DESCRIPTION
Replaces #661, which became unmergeable: it carried #659's commits via a merge
commit, and once #659 landed on `dev` the branch could no longer be
rebase-merged (this repo allows rebase-merge only). This branch is the same
five fixes, linearised onto current `dev`.

Four defects in `Cross-Repo Integration Tests`, each with a red test first and a
mutation table (see the individual commits):

1. `shell-recorder-tests` ran `cargo test` in `src/db-backend`, whose
   `build.rs:170` panics without the `codetracer-native-recorder` sibling — its
   hand-rolled `siblings:` list was derived from the shell recorders' deps and
   omitted it. Failed after ~20 min of tree-sitter compilation, every run since
   2026-08-04.
2. `rr-backend-tests`' unfold step reported success having unfolded 1 of 2
   submodules; `libs/rr` was uninitialised and the loop's `-` branch had no
   diagnostic, so Nix failed four steps later on `libs/rr/flake.nix … not
   tracked by Git`.
3. `nix develop "$CLONE_DIR" --command direnv allow` used the *sibling's* dev
   shell, which declares no direnv → `exec: direnv: not found`, exit 127.
4. Five jobs ran `nix develop` with no Nix-provisioning step, hitting the runner
   image's nix where `nix-command` is disabled.

Conflict resolution against `dev` kept both sides: `dev`'s `test-sibling-backend-path`
recipe and its python3 hard-failure guard in `scripts/test-flake-pin-alignment.sh`,
plus this branch's three new lint steps (16 total). All six affected contract
suites pass locally after the rebase.