### PR TITLE
ci: route the two rr jobs to the GPU scale sets as well

### DIFF
--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -2879,28 +2879,40 @@ jobs:
           CODETRACER_DB_TESTS_ONLY: "1"
 
   test-ui-tests-rr:
-    # DELIBERATELY NOT ROUTED to eph-linux-x64-g1/-g2 with the rest of this
-    # workflow (H4). This is the one job in the Linux set that drives `rr`, and
-    # the GPU hosts were measured, not assumed:
+    # ROUTED to the GPU hosts (H4). The earlier hold on this job -- "the GPU
+    # hosts are hybrid i9-12900Ks, so unpinned rr is a core-type lottery" --
+    # was wrong, and rr's own source says so: rr already confines itself to
+    # the P-cores without being asked.
     #
-    #   * Guest exposes kernel.perf_event_paranoid = -1 and a fully visible PMU;
-    #     perf_event_open(HW_BRANCH_INSTRUCTIONS) succeeds unprivileged. So the
-    #     container is NOT the obstacle.
-    #   * But both GPU hosts are i9-12900K (Alder Lake), a HYBRID part:
-    #     cpu_core (P) = CPUs 0-15, cpu_atom (E) = CPUs 16-23. rr needs the
-    #     retired-conditional-branch counter (`r5111c4`), which only the
-    #     P-cores implement.
-    #   * Measured on both hosts: `rr record` + `rr replay` PASS when the tracee
-    #     is pinned to a P-core (`taskset -c 0-15`), and FAIL hard in
-    #     PerfCounters::start() when pinned to an E-core.
-    #   * Unpinned -- which is how this job invokes rr today -- is a coin flip:
-    #     in one probe run the identical command passed on -g1 and failed on -g2.
+    #   * RecordCommand.cc:214 -- RecordFlags' default is
+    #     `bind_cpu(BindCPU::PREFER_PERF_CORE)`. Not ANY, not UNBOUND.
+    #   * util.cc:2166 -- choose_cpu() calls filter_for_perf_cores(cpus) for
+    #     that mode, and util.cc:2075-2081 keeps only CPUs whose CPUGroup kind
+    #     is P_CORE (CPUs.cc:106-112 maps /sys/devices/cpu_core -> P_CORE and
+    #     cpu_atom -> E_CORE).
+    #   * The chosen P-core is then recorded as the bound CPU
+    #     (RecordSession.cc:2579) and Session::do_bind_cpu (Session.cc:768)
+    #     sets affinity to it, so PerfCounters only ever sees a P-core PMU.
+    #   * PerfCounters.cc:216 -- "For hybrid products the data in this table is
+    #     for the P-cores of that product", i.e. the P-core PMU is the one rr's
+    #     counter table is written against.
     #
-    # Routing this job as-is would therefore manufacture flaky CI rather than
-    # move load. It can move once the rr invocation confines the tracee to the
-    # P-cores; until then it stays on high-mem-server, whose Xeon E5-2650 is
-    # uniform (no E-cores) and so has no core-type lottery.
-    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    # There is no "unpinned" path here to lose the lottery on: rr's UNBOUND
+    # mode is a hard CLEAN_FATAL on multi-PMU systems (PerfCounters.cc:325,
+    # "Multiple PMU types detected. Unbinding CPU is not supported."), and
+    # nothing on this job's path asks for it -- codetracer-native-backend's
+    # record_program_with_rr (src/record.rs:153-167) spawns
+    # `rr record [-W] -n -o <dir> ...` with no --bind-to-cpu and no -u, and
+    # codetracer's own E-core workaround (src/common/intel_fix.nim,
+    # workaroundIntelECoreProblem) is `discard` -- dead since rr fixed this
+    # upstream. The E-core abort the probe saw was manufactured by the probe
+    # explicitly binding to an E-core; that is not what CI does.
+    #
+    # The one host-side precondition is that the guest exposes
+    # /sys/devices/cpu_core and cpu_atom, or cpu_groups() comes back empty and
+    # the filter no-ops. Both GPU guests do expose them -- that was measured
+    # when the hold was written.
+    runs-on: eph-linux-x64-g2  # CIP-5 nix job; H4: routed to GPU host gpu-server-002
     timeout-minutes: 120
     steps:
       - name: Mint installation token for cross-repo sibling access
@@ -3271,7 +3283,11 @@ jobs:
   # recording assertions into no-ops.
   # ---------------------------------------------------------------------------
   ct-test-release-gate:
-    runs-on: eph-linux-x64-g2  # CIP-5 nix job; H4: routed to GPU host gpu-server-002
+    # Moved -g2 -> -g1 as the counterweight to test-ui-tests-rr (22.1 min)
+    # landing on -g2 in this same commit; without it the always-on subset skews
+    # 103.4 vs 122.2. Lands next to ct-test-providers, which it shares a closure
+    # with, so the move is locality-positive as well as arithmetic.
+    runs-on: eph-linux-x64-g1  # CIP-5 nix job; H4: routed to GPU host gpu-server-001
     name: ct-test release gate (M16 provider matrix)
     steps:
       - name: Mint installation token for cross-repo sibling access

--- a/.github/workflows/cross-repo-tests.yml
+++ b/.github/workflows/cross-repo-tests.yml
@@ -42,18 +42,23 @@ permissions:
 
 jobs:
   rr-backend-tests:
-    # DELIBERATELY NOT ROUTED to eph-linux-x64-g1/-g2 (H4), for the same
-    # measured reason as codetracer.yml's `test-ui-tests-rr`: both GPU hosts are
-    # i9-12900K (Alder Lake) hybrid parts. The guest's PMU is fully available
-    # (perf_event_paranoid = -1, perf_event_open succeeds unprivileged), and
-    # `rr record` + `rr replay` pass there when the tracee is pinned to a P-core
-    # (CPUs 0-15) -- but fail hard in PerfCounters::start() on an E-core
-    # (CPUs 16-23), because only the P-cores implement the retired-conditional-
-    # branch counter rr needs. Unpinned, as this job runs rr today, the outcome
-    # depends on which core type the scheduler hands out; a probe run passed on
-    # -g1 and failed on -g2 for the identical command. Moving it would buy load
-    # relief at the cost of flaky CI. Route it once rr is confined to CPUs 0-15.
-    runs-on: eph-linux-x64  # CIP-5: nix job (setup-dev-env) → eph-linux-x64
+    # ROUTED to the GPU hosts (H4), reversing the hold that was placed here for
+    # the same wrong reason as codetracer.yml's `test-ui-tests-rr`: rr does not
+    # run "unpinned" on a hybrid part. Its default bind mode is
+    # BindCPU::PREFER_PERF_CORE (rr RecordCommand.cc:214), choose_cpu() filters
+    # the candidate set down to CPUGroup::P_CORE before picking
+    # (util.cc:2166 -> util.cc:2075), and truly unbound recording is refused
+    # outright on multi-PMU systems (PerfCounters.cc:325). See the longer note
+    # on test-ui-tests-rr in codetracer.yml.
+    #
+    # This job additionally pins on its own: codetracer-native-backend's
+    # `just test-hw` reads /sys/bus/event_source/devices, and when it finds
+    # cpu_core + cpu_atom it taskset's the suite onto the high-base-frequency
+    # cores. So on a 12900K the tracee is confined to CPUs 0-15 twice over.
+    #
+    # Placed on -g1 rather than -g2 to balance the split; see the routing
+    # commit for the runtime figures.
+    runs-on: eph-linux-x64-g1  # CIP-5 nix job; H4: routed to GPU host gpu-server-001
 
     steps:
       - name: Mint installation token for cross-repo sibling access


### PR DESCRIPTION
Follow-up to #660, which routed 25 Linux legs but **held back `test-ui-tests-rr` and `rr-backend-tests`** on my analysis that the GPU hosts' hybrid CPUs (i9-12900K) would break rr. **That analysis was wrong.**

## rr pins to P-cores itself

Verified in the vendored `codetracer-rr`:

- `src/RecordCommand.cc:214` — `bind_cpu(BindCPU::PREFER_PERF_CORE)` is the **default**. `ANY` is opt-in (`--bind-to-cpu=any`, `:377`); `UNBOUND` is `-u` (`:549`).
- `src/util.cc:2166` — `choose_cpu()` calls `filter_for_perf_cores(cpus)` for that mode.
- `src/util.cc:2075-2081` — the filter keeps only CPUs whose `CPUGroup.kind == P_CORE`.
- `src/CPUs.cc:106-112` — `/sys/devices/cpu_core` → `P_CORE`, `cpu_atom`/`lowpower` → `E_CORE`. This is what makes `P_CORE` mean CPUs 0-15 on a 12900K.
- `src/RecordSession.cc:2579` → `src/Session.cc:760-782` — the chosen core is written to the trace and read back as `SPECIFIED_CORE`, then applied with `set_affinity_to_cpu()`. So `PerfCounters` only ever sees a specified P-core.
- `src/PerfCounters.cc:216` — *"For hybrid products the data in this table is for the P-cores of that product."*

The E-core abort behind the original hold is real but **only reachable by explicitly binding to an E-core**, which is what my probe did — the failure was manufactured by the test. The "unpinned failed" result cannot be the CI path either: `PerfCounters.cc:325` makes `UNBOUND` a hard fatal on multi-PMU systems, and nothing on this path passes `--bind-to-cpu=any` or `-u` (`codetracer-native-backend/src/record.rs:153-167` spawns a bare `rr record`).

Corroboration in the opposite direction: `codetracer/src/common/intel_fix.nim`'s `workaroundIntelECoreProblem` is now a bare `discard` — its old body pinned to `0..15` and cites rr issue 3338, dead since rr fixed this upstream. And `codetracer-native-backend/justfile`'s `test-hw` `taskset`s onto high-base-frequency cores. Every layer moves toward P-cores; none toward E-cores.

**One precondition, stated so it can be falsified:** the filter is a no-op if `cpu_groups()` is empty, i.e. if the guest does not expose `/sys/devices/cpu_core` and `cpu_atom`. Both guests were measured to expose them.

## Placement

Mean wall time over the last 51 completed `dev` runs, cancelled and skipped excluded (GitHub stamps `completed_at` at cancellation — that error has already corrupted this campaign's numbers once).

| job | measured | placed |
|---|---|---|
| `test-ui-tests-rr` | 22.1 min | `-g2` |
| `rr-backend-tests` | 3.6 min | `-g1` |

**Third hunk, beyond the two-job scope:** 22.1 min is too large a lump to absorb without skewing the always-on subset that governs every PR run (it would go from Δ0.3 to Δ18.8). So `ct-test-release-gate` (11.1 min) moves `-g2` → `-g1` as a counterweight. It also belongs there on locality grounds — it shares the M16 provider closure with `ct-test-providers`, already on `-g1`.

|  | -g1 | -g2 | Δ | (before) |
|---|---|---|---|---|
| full run | 157.1 | 143.5 | 13.6 | Δ9.9 |
| always-on | 114.5 | 111.1 | 3.4 | Δ0.3 |
| frequency-weighted | 130.0 | 125.3 | 4.7 | Δ1.0 |

`-g2` stays the lighter host on all three, preserving the intent (`launcher-recorder-e2e` takes 3 of its 4 slots).

After this there is **no bare `runs-on: eph-linux-x64` left in any workflow**; the only other Linux label is `appimage-cross-distro`'s `eph-linux-x64-nested`, deliberately untouched.

## ⚠ Neither job goes green from this — and the reasons have changed

Not a regression from this PR; stated so it isn't mistaken for one.

- `libs/rr/flake.nix … not tracked by Git` is **already fixed on `dev`**.
- **`rr-backend-tests`** now fails at `cargo build`: `failed to authenticate when downloading` the private `lldb-sys.rs` dep. `codetracer.yml:2190-2199` already solves this for the same dependency (`CARGO_NET_GIT_FETCH_WITH_CLI=true` plus two `url.…insteadOf` rewrites); `cross-repo-tests.yml`'s `Build ct-native-replay` has none of it, despite the job already minting a token. Three lines. **Deliberately not bundled here.**
- **`test-ui-tests-rr`** fails with `CODETRACER_RR_BACKEND_PATH is not set` *inside a nix build sandbox*, where `real_recording_integration` reports 4 passed / 75 failed / 7 ignored — all 75 on the missing-prerequisite guard. A hermetic build structurally cannot see a sibling-repo path, so no CI env change fixes it; those tests need `#[ignore]` or env-gating in `backend-manager`. That is a judgment call for someone who owns that suite.