### PR TITLE
ci(rr-backend-tests): let cargo use the credential the job already has

### DIFF
--- a/.github/workflows/cross-repo-tests.yml
+++ b/.github/workflows/cross-repo-tests.yml
@@ -166,6 +166,32 @@ jobs:
 
       - name: Build ct-native-replay
         run: |
+          # Cargo's default libgit2 transport does NOT read gitconfig, so the
+          # private `lldb-sys.rs` dependency fails to authenticate and the
+          # build dies with:
+          #
+          #   failed to load source for dependency `lldb-sys`
+          #   failed to authenticate when downloading repository
+          #   attempted to find username/password via git's `credential.helper`
+          #
+          # Forcing the git CLI makes cargo use the credential `Setup dev env`
+          # has ALREADY installed job-wide: that step runs the shared
+          # `setup-nix`, which exports
+          #
+          #   GIT_CONFIG_KEY_0=http.https://github.com/metacraft-labs/.extraHeader
+          #
+          # through $GITHUB_ENV. So nothing is configured here — the one
+          # missing piece was the transport. This mirrors the identical
+          # single-line fix on codetracer.yml's `just build-ct-mcr` step, which
+          # fetches this same dependency.
+          #
+          # Deliberately NOT the `git config --global url.…insteadOf` form:
+          # that was removed from this repo on purpose because `--global` IS
+          # inherited by `git clone`, putting the token into argv, into the
+          # `.git/config` of every clone it touches, and into git's own error
+          # messages — for nixpkgs and every third-party fetch too, none of
+          # which the token is for. The scoped extraHeader avoids all of that.
+          export CARGO_NET_GIT_FETCH_WITH_CLI=true
           CLONE_DIR="$(pwd)/../codetracer-native-backend"
           nix develop "$CLONE_DIR" --command \
             bash -c "cd '$CLONE_DIR' && cargo build"


### PR DESCRIPTION
`Build ct-native-replay` in `rr-backend-tests` fails at `cargo build`:

```
failed to load source for dependency `lldb-sys`
  Unable to update https://github.com/metacraft-labs/lldb-sys.rs.git#7db09513
  failed to authenticate when downloading repository
  * attempted to find username/password via git's `credential.helper` support, but failed
```

## Cause

Cargo's default libgit2 transport **does not read gitconfig**, so it never sees the credential this job already has. `Setup dev env` runs the shared `setup-nix`, which exports

```
GIT_CONFIG_KEY_0=http.https://github.com/metacraft-labs/.extraHeader
```

through `$GITHUB_ENV` — job-wide, before this step. Nothing needed configuring; the only missing piece was the transport.

**One line**, mirroring the identical fix already on `codetracer.yml`'s `just build-ct-mcr` step, which fetches this same private dependency.

## Deliberately not the `--global insteadOf` form

The obvious-looking fix is the three `git config --global url."https://x-access-token:…@github.com/".insteadOf` lines. **This repo removed that pattern on purpose**, and `codetracer.yml` documents why: `--global` config *is* inherited by `git clone`, so it puts the token into argv, into the `.git/config` of every clone it touches, and into git's own error messages — for nixpkgs and every third-party fetch as well, none of which the token is for. `setup-nix` explicitly evicts that pattern from a reused `~/.gitconfig` at job start.

The scoped `extraHeader` already in place is the intended mechanism, matched by scheme + host + port + path prefix. This change just lets cargo reach it.

## Scope

- **Does not fix `test-ui-tests-rr`**, which fails for an unrelated reason: `CODETRACER_RR_BACKEND_PATH is not set` *inside a nix build sandbox*, where `real_recording_integration` reports 4 passed / 75 failed / 7 ignored, all on the missing-prerequisite guard. A hermetic build structurally cannot see a sibling-repo path, so no CI env change fixes it — those tests need `#[ignore]` or env-gating in `backend-manager`. Separate judgment call, separate change.
- The **two other `cargo build` steps in this file** are in `shell-recorder-tests`, build a different repo with no private dependency, and are currently green. Left untouched rather than given a flag they do not need.