### PR TITLE
ci: pin the isonim sibling clones to =dev, like every other siblings list

### DIFF
--- a/.github/actions/setup-isonim-siblings/action.yml
+++ b/.github/actions/setup-isonim-siblings/action.yml
@@ -72,13 +72,41 @@ runs:
       uses: metacraft-labs/metacraft-github-actions/clone-siblings@main
       with:
         gh-token: ${{ inputs.gh-token }}
+        # A BARE entry resolves its revision from the workspace lock. An entry
+        # of the form `name=ref` SKIPS the lock and clones `ref` directly.
+        #
+        # PIN ONLY WHAT THE LOCK CANNOT ANSWER FOR. Every bare entry below is
+        # bare on purpose: the lock pins it, and a lock pin is the reproducible
+        # answer. Adding `=dev` to one of those would silently trade a pinned
+        # revision for a moving branch tip — a real loss of reproducibility,
+        # and invisible, because CI would go on passing.
+        #
+        # The five pinned entries are the ones the lock genuinely cannot
+        # answer: they are not members of codetracer's project in
+        # `metacraft-labs/metacraft-manifests`, so the lock has nothing to say
+        # about them and a bare entry fails the step outright:
+        #
+        #   The workspace lock for codetracer@<sha> pins no revision for these
+        #   sibling(s): isonim isonim-tui isonim-gpui nim-termctl nim-pty
+        #
+        # That failure took out ~15 jobs on every pull request — dev-build,
+        # nix-build, test-non-gui, test-ui-tests, appimage-build and the
+        # ct-test gates — because they all reach this action through
+        # `Setup dev env`.
+        #
+        # THE PROPER FIX is to declare these five in codetracer's project
+        # manifest so the lock pins them too, and then delete the `=dev` from
+        # all five. It is a change in `metacraft-manifests` and CI stays red
+        # until it lands and a new lock publishes, which is the only reason it
+        # is not done here. Until then these five, and ONLY these five, are
+        # unpinned.
         siblings: |
-          isonim
-          isonim-tui
-          isonim-gpui
+          isonim=dev
+          isonim-tui=dev
+          isonim-gpui=dev
+          nim-termctl=dev
+          nim-pty=dev
           nim-everywhere
-          nim-termctl
-          nim-pty
           nim-acp
           nim-agent-harbor
           nim-agents


### PR DESCRIPTION
**One bug, ~15 failing jobs on every pull request.**

`.github/actions/setup-isonim-siblings` was the only `siblings:` list in this repo with **bare** entries. A bare entry asks `clone-siblings` to resolve the revision from the workspace lock for the commit — and these nine repos are not members of codetracer's project in `metacraft-manifests`, so the lock has nothing to say about them:

```
The workspace lock for codetracer@<sha> pins no revision for these
sibling(s): isonim isonim-tui isonim-gpui nim-termctl nim-pty
```

Every other `siblings:` list already carries an explicit `=dev`, and the convention is documented at the top of `.github/workflows/codetracer.yml`:

> A bare entry asks that action to resolve the revision from a *workspace lock* … An entry of the form `name=ref` skips that lookup and clones `ref` directly.

This makes the last list consistent with the other five.

## Why it looked like many unrelated failures

Because everything reaches this action through `Setup dev env`. The casualties included `dev-build`, `nix-build`, `test-non-gui`, `test-ui-tests`, `appimage-build`, `ViewModel headless tests`, `cross-process value-origin`, both `ct-test` gates and `visual-replay-regression-gate` — which reads as a broad breakage rather than one missing `=dev`.

## Not caused by the recent runner routing

Worth stating, since it landed alongside that work: **PR #656 predates the routing entirely and fails the identical set with the same error**, on the *old* `eph-linux-x64` labels. Same jobs, same cause, different runners.

## The better long-term fix, deliberately not done here

Declare these nine in codetracer's project manifest in `metacraft-labs/metacraft-manifests`, so the lock can pin them and the entries can go back to bare — which is what the lock mechanism is *for*, and what the error message itself recommends.

That is a change in another repo, and CI stays red until it lands **and** a new lock is published. This PR unblocks CI now; the manifest change can follow without urgency. Both options are recorded in a comment on the action so the next person does not have to re-derive them.