### PR TITLE
get: real Windows /pwsh installer + publish the win-x64 artifact

### DIFF
--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -2102,6 +2102,177 @@ jobs:
           nix shell nixpkgs#awscli2 --command aws --endpoint-url=${{ secrets.R2_CODETRACER_BUCKET_S3_ENDPOINT }} s3 cp ./non-nix-build/CodeTracer.dmg s3://${{ vars.R2_CODETRACER_BUCKET_NAME }}/CodeTracer-${{ github.ref_name }}-arm64.dmg --checksum-algorithm CRC32
           nix shell nixpkgs#awscli2 --command aws --endpoint-url=${{ secrets.R2_CODETRACER_BUCKET_S3_ENDPOINT }} s3 cp ./non-nix-build/CodeTracer.dmg.asc s3://${{ vars.R2_CODETRACER_BUCKET_NAME }}/CodeTracer-${{ github.ref_name }}-arm64.dmg.asc --checksum-algorithm CRC32
 
+  windows-installer-build:
+    # Builds the NSIS installer (non-nix-build/CodeTracer-Setup.exe) and hands
+    # it to windows-installer-publish (Linux) for signing + R2 upload. Split in
+    # two so all GPG/aws work stays on the proven Linux path; the Windows leg
+    # only produces the artifact.
+    #
+    # Gated to `main` (the release branch) because the -win-x64 artifact is a
+    # RELEASE artifact promoted to `-latest-` by create-release, exactly like the
+    # AppImage/dmg. Keeping it off PRs / `dev` also means the eph-win-x64 GARM
+    # outage cannot turn PR runs red. This job is NOT in push-tag's `needs`, so
+    # while GARM is down it can hang/fail without ever blocking a release —
+    # create-release simply skips the (absent) win artifact (see below).
+    runs-on: eph-win-x64  # CIP-5: DIY-Windows (env.ps1) -> eph-win-x64
+    if: ${{ github.ref == 'refs/heads/main' }}
+    steps:
+      # See the eph-win-x64 note at the top of this file: actions/checkout needs
+      # a real git for `submodules: recursive`, provisioned by this bootstrap.
+      - name: Ensure Git and Git Bash are on PATH
+        shell: powershell
+        env:
+          CODETRACER_GIT_BOOTSTRAP_REVISION: ${{ github.sha }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $revision = $env:CODETRACER_GIT_BOOTSTRAP_REVISION
+          if ($revision -cnotmatch '^[0-9a-f]{40}$') {
+            throw "The workflow did not supply an immutable bootstrap revision."
+          }
+          $bootstrapUrl =
+            "https://raw.githubusercontent.com/metacraft-labs/codetracer/" +
+            "$revision/ci/ensure-git-for-checkout.ps1"
+          $bootstrapScript = Join-Path $env:RUNNER_TEMP `
+            "codetracer-ensure-git-$revision-$([Guid]::NewGuid().ToString('N')).ps1"
+          [Net.ServicePointManager]::SecurityProtocol =
+            [Net.ServicePointManager]::SecurityProtocol -bor
+            [Net.SecurityProtocolType]::Tls12
+          try {
+            Invoke-WebRequest `
+              -Uri $bootstrapUrl `
+              -OutFile $bootstrapScript `
+              -UseBasicParsing
+            & $bootstrapScript
+          }
+          finally {
+            Remove-Item -LiteralPath $bootstrapScript -Force -ErrorAction SilentlyContinue
+          }
+
+      - name: Generate CI token
+        id: ci_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CI_TOKEN_PROVIDER_APP_ID }}
+          private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
+          owner: metacraft-labs
+
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          token: ${{ steps.ci_token.outputs.token }}
+
+      - name: Setup dev env
+        # windows-diy provisions the DIY Windows toolchain via env.ps1's
+        # ensure-* helpers (nim / rust / capnp / clingo / repro …) and clones the
+        # recorder/trace siblings, persisting PATH to GITHUB_ENV/GITHUB_PATH.
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        with:
+          env-flavor: windows-diy
+          gh-token: ${{ steps.ci_token.outputs.token }}
+          siblings: |
+            codetracer-trace-format=dev
+            codetracer-trace-format-nim=dev
+            codetracer-native-recorder=dev
+
+      - name: Remove WSL bash stub from System32
+        # As in the other eph-win-x64 jobs: let CreateProcessW fall through to
+        # Git Bash instead of the WSL launcher stub.
+        shell: pwsh
+        run: |
+          $wslStub = "$env:SystemRoot\System32\bash.exe"
+          if (Test-Path $wslStub) {
+            takeown /f $wslStub | Out-Null
+            icacls $wslStub /grant "Administrators:(F)" | Out-Null
+            Remove-Item -Force $wslStub
+          }
+          $gitForWindowsBin = "C:\Program Files\Git\bin"
+          if (Test-Path -LiteralPath $gitForWindowsBin -PathType Container) {
+            Add-Content -Path $env:GITHUB_PATH -Value $gitForWindowsBin
+          }
+
+      - name: Build CodeTracer-Setup.exe
+        shell: bash
+        env:
+          CODETRACER_REPROBUILD_TOOL_PROVISIONING: scoop
+          CODETRACER_REPROBUILD_LOG: quiet
+        run: |
+          set -euo pipefail
+          # Canonical installer build, mirroring the `test-windows-installer`
+          # justfile recipe: build the app once, then the NSIS `windows-installer`
+          # reprobuild target. build-once.sh resolves repro/repro.exe from the
+          # sibling checkout or PATH (env.ps1 puts it there).
+          bash scripts/build-once.sh
+          repro build windows-installer \
+            --tool-provisioning="${CODETRACER_REPROBUILD_TOOL_PROVISIONING}" \
+            --log="${CODETRACER_REPROBUILD_LOG}"
+          test -f non-nix-build/CodeTracer-Setup.exe \
+            || { echo "non-nix-build/CodeTracer-Setup.exe was not produced" >&2; exit 1; }
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: codetracer-setup-exe
+          path: non-nix-build/CodeTracer-Setup.exe
+          if-no-files-found: error
+          retention-days: 7
+
+  windows-installer-publish:
+    # Signs the Windows installer with the release key and publishes it to R2 as
+    # CodeTracer-main-win-x64.exe(.asc), the per-`main`-build key that
+    # create-release promotes to `-latest-`/`-<tag>-` — the exact shape as the
+    # AppImage/dmg (CodeTracer-main-amd64.AppImage etc.). Runs on Linux so gpg,
+    # aws and the imported release key all come from the proven nix path.
+    runs-on: eph-linux-x64  # CIP-5: nix job (self-hosted nixos) -> eph-linux-x64
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs: [ windows-installer-build ]
+    steps:
+      - name: Mint installation token for cross-repo sibling access
+        id: ci_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CI_TOKEN_PROVIDER_APP_ID }}
+          private-key: ${{ secrets.CI_TOKEN_PROVIDER_PRIVATE_KEY }}
+          owner: metacraft-labs
+
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          token: ${{ steps.ci_token.outputs.token }}
+
+      - name: Install Nix
+        uses: ./.github/actions/setup-nix
+        with:
+          trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
+          substituters: ${{ vars.ATTIC_SUBSTITUTER }}
+          gh-token: ${{ steps.ci_token.outputs.token }}
+
+      - name: "Import GPG key for signing"
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.CODETRACER_AUR_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.CODETRACER_AUR_GPG_PRIVATE_KEY_PASS }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Download installer artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: codetracer-setup-exe
+          path: .
+
+      - name: Sign and upload
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_CODETRACER_BUCKET_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_CODETRACER_BUCKET_ACCESS_KEY }}
+        run: |
+          set -euo pipefail
+          nix develop .#devShells.x86_64-linux.default --command gpg --armor --detach-sign CodeTracer-Setup.exe
+          nix develop .#devShells.x86_64-linux.default --command aws --endpoint-url=${{ secrets.R2_CODETRACER_BUCKET_S3_ENDPOINT }} s3 cp CodeTracer-Setup.exe s3://${{ vars.R2_CODETRACER_BUCKET_NAME }}/CodeTracer-${{ github.ref_name }}-win-x64.exe --checksum-algorithm CRC32
+          nix develop .#devShells.x86_64-linux.default --command aws --endpoint-url=${{ secrets.R2_CODETRACER_BUCKET_S3_ENDPOINT }} s3 cp CodeTracer-Setup.exe.asc s3://${{ vars.R2_CODETRACER_BUCKET_NAME }}/CodeTracer-${{ github.ref_name }}-win-x64.exe.asc --checksum-algorithm CRC32
+
   dmg-lib-check:
     # CIP-5 Wave 4: migrated to the self-hosted nix-darwin runner. The DIY
     # `brew install awscli` / `brew install sevenzip` steps are gone; `aws`
@@ -4006,6 +4177,27 @@ jobs:
             promote CodeTracer-main-amd64.AppImage     "$slot-amd64.AppImage"
             promote CodeTracer-main-amd64.AppImage.asc "$slot-amd64.AppImage.asc"
           done
+
+          # Windows installer (CodeTracer-latest-win-x64.exe, consumed by
+          # https://get.codetracer.com/pwsh). windows-installer-build /
+          # windows-installer-publish upload CodeTracer-main-win-x64.exe(.asc)
+          # when they run on `main`. That leg needs the eph-win-x64 GARM runner;
+          # while that fleet is down the key is simply absent, so this promotion
+          # is TOLERANT: it publishes the win artifact when present and skips it
+          # (without failing the release) when it is not. The moment a Windows
+          # build lands the key, the next release promotes it with zero further
+          # changes.
+          if aws_cmd s3 cp "s3://$BUCKET/CodeTracer-main-win-x64.exe" CodeTracer-main-win-x64.exe \
+             && aws_cmd s3 cp "s3://$BUCKET/CodeTracer-main-win-x64.exe.asc" CodeTracer-main-win-x64.exe.asc; then
+            nix develop .#devShells.x86_64-linux.default --command \
+              gpg --verify CodeTracer-main-win-x64.exe.asc CodeTracer-main-win-x64.exe
+            for slot in "$TAG" latest; do
+              promote CodeTracer-main-win-x64.exe     "$slot-win-x64.exe"
+              promote CodeTracer-main-win-x64.exe.asc "$slot-win-x64.exe.asc"
+            done
+          else
+            echo "::warning::CodeTracer-main-win-x64.exe not found in R2 — skipping the Windows installer for this release (eph-win-x64 build not yet published)."
+          fi
 
       - name: Get changelog text
         id: changelog

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,128 @@
+# CodeTracer Windows installer (PowerShell).
+#
+# Served as https://get.codetracer.com/pwsh. Typical use:
+#
+#   irm https://get.codetracer.com/pwsh | iex
+#
+# Inspect before running:  irm https://get.codetracer.com/pwsh | more
+#
+# It downloads the signed NSIS installer (CodeTracer-Setup.exe) from the release
+# store, verifies its GPG signature against the CodeTracer signing key when gpg
+# is available, then runs it silently (`/S`) and confirms `ct` is installed.
+#
+# Artifacts come from the release store (GitHub Releases / downloads.codetracer.com).
+# This mirrors the POSIX installer (install-on-distributions.sh -> /sh): same
+# CodeTracer.pub.asc key, same "verify-or-refuse" posture with a
+# CODETRACER_INSTALL_ALLOW_UNVERIFIED=1 escape hatch.
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$DownloadBase = 'https://downloads.codetracer.com'
+$Arch         = 'win-x64'
+$InstallerKey = "CodeTracer-latest-$Arch.exe"
+
+function Write-Note { param([string]$Message) Write-Host "[CodeTracer installer] $Message" }
+function Write-Warn { param([string]$Message) Write-Host "[CodeTracer installer Warning]: $Message" -ForegroundColor Yellow }
+
+function Stop-Fatal {
+    param([string]$Message)
+    Write-Host "[CodeTracer installer Error]: $Message" -ForegroundColor Red
+    exit 1
+}
+
+# Refuse-by-default when integrity cannot be established at all (gpg missing, key
+# import failed) -- distinct from a signature that was checked and did NOT match,
+# which is always fatal below with no opt-out. This is an irm|iex path, so
+# silently proceeding is how an unsigned or substituted download gets executed.
+function Deny-Unverified {
+    param([string]$Reason, [string]$InstallerPath, [string]$SignaturePath)
+    if ($env:CODETRACER_INSTALL_ALLOW_UNVERIFIED -eq '1') {
+        Write-Warn "Installing CodeTracer WITHOUT verifying its integrity: $Reason.`n  Proceeding because CODETRACER_INSTALL_ALLOW_UNVERIFIED=1 is set."
+        return
+    }
+    Remove-Item -Force -ErrorAction SilentlyContinue $InstallerPath, $SignaturePath
+    Stop-Fatal ("Cannot verify the integrity of $InstallerKey`: $Reason.`n" +
+        "  Refusing to install an unverified bundle, and the download has been deleted.`n" +
+        "  Install gnupg (e.g. ``winget install GnuPG.GnuPG``) and retry, or re-run with`n" +
+        "  `$env:CODETRACER_INSTALL_ALLOW_UNVERIFIED='1' if you accept the risk.")
+}
+
+function Get-File {
+    param([string]$Url, [string]$OutFile, [string]$What, [switch]$Optional)
+    try {
+        [Net.ServicePointManager]::SecurityProtocol =
+            [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+        Invoke-WebRequest -Uri $Url -OutFile $OutFile -UseBasicParsing
+    } catch {
+        if ($Optional) { return $false }
+        Stop-Fatal "Couldn't download $What from $Url`n  ($($_.Exception.Message))`n  The Windows build may not be published yet -- see https://get.codetracer.com."
+    }
+    return $true
+}
+
+$workDir = Join-Path ([IO.Path]::GetTempPath()) ("codetracer-install-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force -Path $workDir | Out-Null
+$installer = Join-Path $workDir 'CodeTracer-Setup.exe'
+$signature = "$installer.asc"
+$pubKey    = Join-Path $workDir 'CodeTracer.pub.asc'
+
+try {
+    Write-Note "Downloading $InstallerKey"
+    [void](Get-File -Url "$DownloadBase/$InstallerKey" -OutFile $installer -What 'the CodeTracer installer')
+
+    # Integrity verification is a security control: a present-but-mismatched
+    # signature is never tolerated; only "could not verify at all" has the
+    # explicit opt-out above.
+    $gpg = Get-Command gpg -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($gpg) {
+        $haveKey = Get-File -Url "$DownloadBase/CodeTracer.pub.asc" -OutFile $pubKey -What 'the CodeTracer signing key' -Optional
+        $haveSig = Get-File -Url "$DownloadBase/$InstallerKey.asc" -OutFile $signature -What 'the GPG signature' -Optional
+        if (-not ($haveKey -and $haveSig)) {
+            Deny-Unverified -Reason 'the signing key or detached signature could not be downloaded' -InstallerPath $installer -SignaturePath $signature
+        } else {
+            & $gpg.Source --import $pubKey 2>&1 | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                Deny-Unverified -Reason 'the CodeTracer signing key could not be imported' -InstallerPath $installer -SignaturePath $signature
+            } else {
+                & $gpg.Source --verify $signature $installer 2>&1 | Out-Null
+                if ($LASTEXITCODE -ne 0) {
+                    Remove-Item -Force -ErrorAction SilentlyContinue $installer, $signature
+                    Stop-Fatal ("SIGNATURE VERIFICATION FAILED for $InstallerKey.`n" +
+                        "  The download does not match the CodeTracer signing key. It may be corrupt`n" +
+                        "  or tampered with. Refusing to install, and the download has been deleted.")
+                }
+                Write-Note 'Successfully verified installer signature'
+            }
+        }
+    } else {
+        Deny-Unverified -Reason 'gpg is not installed' -InstallerPath $installer -SignaturePath $signature
+    }
+
+    Write-Note 'Running the CodeTracer installer (silent)'
+    # NSIS silent-install flag is `/S` (must be upper-case, before other args).
+    $proc = Start-Process -FilePath $installer -ArgumentList '/S' -Wait -PassThru
+    if ($proc.ExitCode -ne 0) {
+        Stop-Fatal "The CodeTracer installer exited with code $($proc.ExitCode)."
+    }
+
+    # The installer edits the persistent PATH, but this session's PATH was
+    # captured at launch. Refresh it from the registry so we can confirm the
+    # install in-place instead of telling every user to reopen their terminal.
+    $machinePath = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+    $userPath    = [Environment]::GetEnvironmentVariable('Path', 'User')
+    $env:Path = (@($machinePath, $userPath) | Where-Object { $_ }) -join ';'
+
+    $ct = Get-Command ct -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($ct) {
+        Write-Note "CodeTracer installed: $($ct.Source)"
+        Write-Note 'Run `ct` in a new terminal to get started.'
+    } else {
+        Write-Warn ("CodeTracer was installed, but ``ct`` is not on PATH in this session.`n" +
+            "  Open a new terminal and run ``ct``. If it is still missing, check the`n" +
+            '  install directory (default: %LOCALAPPDATA%\Programs\CodeTracer).')
+    }
+    Write-Host '[CodeTracer installer] Done.' -ForegroundColor Green
+} finally {
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $workDir
+}


### PR DESCRIPTION
## What

Turns `https://get.codetracer.com/pwsh` from a coming-soon stub into a real Windows installer, and wires the Windows installer's publish into the release pipeline.

### `install.ps1` (new)
A real PowerShell installer, mirroring `install-on-distributions.sh` (`/sh`):
- Downloads `CodeTracer-latest-win-x64.exe` (the NSIS installer) from `downloads.codetracer.com`.
- Verifies its detached GPG signature against `CodeTracer.pub.asc` when `gpg` is available — **verify-or-refuse**, with the same `CODETRACER_INSTALL_ALLOW_UNVERIFIED=1` escape hatch as the POSIX installer. A present-but-mismatched signature is always fatal.
- Runs it silently (NSIS `/S`), refreshes PATH from the registry, and confirms `ct`.
- `get/build-get.sh` already serves `install.ps1` verbatim as `/pwsh` when present, so no `get/` change is needed here. (get/ lives on `stable`; companion PR adds `install.ps1` there so it goes live.)

### Release pipeline (`codetracer.yml`)
Publishes the Windows installer to R2 alongside the AppImage/dmg:
- `windows-installer-build` (eph-win-x64) builds `CodeTracer-Setup.exe` and uploads it as an artifact.
- `windows-installer-publish` (Linux) signs it with the release key and uploads `CodeTracer-main-win-x64.exe(.asc)`.
- `create-release` promotes it to `CodeTracer-latest-win-x64.exe` / `-<tag>-` — the key `install.ps1` downloads.

## GARM constraint
Building a fresh Windows installer needs the `eph-win-x64` GARM runner, which is **structurally down org-wide** right now. So:
- Both Windows-side jobs are gated to `main` and kept **out of** `push-tag`/`create-release` `needs`, and the `create-release` promotion is **tolerant** of a missing artifact — the outage cannot turn PR/`dev` runs red or block a release.
- The moment the Windows fleet is back, the first `main` build publishes `CodeTracer-latest-win-x64.exe` and `/pwsh` works with **zero further changes**.

Green-modulo-GARM: the new Windows jobs do not run on this PR (gated to `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)