### PR TITLE
ci: satisfy eph-win-x64 + nix-provisioning guards for the new Windows installer jobs

### DIFF
--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -2190,6 +2190,16 @@ jobs:
           if (Test-Path -LiteralPath $gitForWindowsBin -PathType Container) {
             Add-Content -Path $env:GITHUB_PATH -Value $gitForWindowsBin
           }
+          # Whatever supplied it, `bash` must resolve now: the build step below
+          # is `shell: bash`, and a missing bash there reads as a build failure
+          # rather than as a missing tool.
+          $bash = Get-Command bash -CommandType Application -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+          if (-not $bash) {
+            throw "No bash on PATH. The 'Ensure Git and Git Bash are on PATH' step " +
+                  "should have provisioned Git Bash; every step below this one needs it."
+          }
+          Write-Host "Using bash from $($bash.Source)"
 
       - name: Build CodeTracer-Setup.exe
         shell: bash

--- a/ci/test/nix-provisioning-test.sh
+++ b/ci/test/nix-provisioning-test.sh
@@ -164,7 +164,7 @@ done
 # in the same spirit as EXPECTED_BUILD_SITES in
 # ci/test/sibling-provisioning-test.sh: "no unprovisioned job was found" is
 # also true of a scanner that has stopped finding jobs at all.
-readonly EXPECTED_NIX_JOBS=28
+readonly EXPECTED_NIX_JOBS=30
 
 if [ "${#nix_jobs[@]}" -eq "$EXPECTED_NIX_JOBS" ]; then
 	ok "the scanner still classifies the nix-using jobs (${#nix_jobs[@]})"


### PR DESCRIPTION
Follow-up to #675. Two static CI guards (run by `lint-bash`) flagged the new Windows installer jobs:

- **`windows-runner-bootstrap-test.sh`** requires every `eph-win-x64` job's WSL-stub-removal step to end by asserting `bash` resolves (and `throw` otherwise). `windows-installer-build` was missing that trailing guard — added, matching `windows-rust-components`.
- **`nix-provisioning-test.sh`** pins the nix-using job count. `windows-installer-publish` provisions Nix (setup-nix) before its `nix develop` steps, so bump `EXPECTED_NIX_JOBS` 28 → 30. (The base was already 29-vs-28 — a pre-existing off-by-one that left this assertion red on `dev`; 30 corrects both.)

Both guards now pass locally (bash 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)