### PR TITLE
web-codetracer: name ide.codetracer.com as the Embed SDK host

### DIFF
--- a/.github/workflows/deploy-web-codetracer.yml
+++ b/.github/workflows/deploy-web-codetracer.yml
@@ -3,7 +3,12 @@ name: Deploy web.codetracer.com
 # ---------------------------------------------------------------------------
 # Publishes the browser CodeTracer replay bundle (the "Embed SDK": db-backend
 # WASM + JS glue + replay worker) to the `web-codetracer` Cloudflare Pages
-# project, which serves https://web.codetracer.com.
+# project. That project serves the in-browser Cloud IDE at
+# https://ide.codetracer.com (a stable custom domain) and at
+# https://web-codetracer.pages.dev — the identical bundle on both. NOTE:
+# https://web.codetracer.com is a SEPARATE, authenticated application on its own
+# DNS record, NOT this Pages project; the IDE has its own `ide.` name so nothing
+# pointing at web.codetracer.com breaks.
 #
 # WHAT IS PUBLISHED
 #   browser-replay/build-dist.sh assembles browser-replay/dist/ =
@@ -27,7 +32,8 @@ name: Deploy web.codetracer.com
 #
 # ONE ENVIRONMENT / ONE PROJECT
 #   The `web-codetracer` Pages project's PRODUCTION branch is `cloud`. Merging
-#   to `cloud` publishes a production deployment served on web.codetracer.com.
+#   to `cloud` publishes a production deployment served on ide.codetracer.com
+#   (and web-codetracer.pages.dev).
 #   (Cloudflare decides production-vs-preview by comparing the deployed branch
 #   to the project's configured production branch — see metacraft-labs/web-site
 #   DEPLOY.md.) Create the project once with wrangler before the first run; this
@@ -148,7 +154,8 @@ jobs:
         # flake.lock — nix/shells/ci-base.nix). wrangler authenticates from
         # CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID in the environment.
         # The `web-codetracer` project's production branch is `cloud`, so a push
-        # to `cloud` publishes a production deployment on web.codetracer.com.
+        # to `cloud` publishes a production deployment on ide.codetracer.com
+        # (and web-codetracer.pages.dev).
         shell: bash
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/browser-replay/app/gateway-client.js
+++ b/browser-replay/app/gateway-client.js
@@ -66,7 +66,7 @@ const authToken = params.get("authToken") || "";
 const traceFolder = params.get("traceFolder") || "trace";
 const testMode = params.get("mode") || "basic";
 // `?trace=<absoluteUrl>` -- open an arbitrary cross-origin `.ct` container by
-// whole-file fetch into the WASM VFS. This is the public web.codetracer.com
+// whole-file fetch into the WASM VFS. This is the public ide.codetracer.com
 // entry point: no gateway, no auth token, no manifest -- just a direct URL to
 // a single CTFS `.ct` file. It is only honoured when the gateway config is
 // absent so it stays backward-compatible with the M40 gateway path.
@@ -89,10 +89,10 @@ appendLog(
 // Create the replay worker. In the same-origin case (traditional deploy,
 // `just test-wasm-replay`) this is a plain module worker pointing at the
 // sibling worker.js. In the CDN-split case -- this driver + the engine
-// assets (worker.js, pkg/*.js, *.wasm) are served from web.codetracer.com
+// assets (worker.js, pkg/*.js, *.wasm) are served from ide.codetracer.com
 // while the HTML page lives on a *different* origin (e.g. blocktracer.org) --
 // a dedicated worker's script URL is required to be same-origin with the
-// document, so `new Worker("https://web.codetracer.com/worker.js")` throws
+// document, so `new Worker("https://ide.codetracer.com/worker.js")` throws
 // even with `type:"module"` and permissive CORS. The workaround: build a tiny
 // *same-origin* blob module worker that statically `import`s the absolute
 // cross-origin worker.js. ES-module imports honour CORS (so the engine origin

--- a/browser-replay/build-dist.sh
+++ b/browser-replay/build-dist.sh
@@ -63,7 +63,7 @@ NGINX_EOF
 
 # Step 6b: Cloudflare Pages `_headers`.
 #
-# web.codetracer.com serves this bundle as a CROSS-ORIGIN engine: the HTML
+# ide.codetracer.com serves this bundle as a CROSS-ORIGIN engine: the HTML
 # page (e.g. blocktracer.org) lives on a different origin and loads worker.js
 # + pkg/*.js + *.wasm from here. Three things must be permitted cross-origin:
 #   * the ES-module `import` of worker.js (blob-bootstrap in gateway-client.js)


### PR DESCRIPTION
The browser replay bundle (Embed SDK) is served by the `web-codetracer` Cloudflare Pages project at the new stable product domain **https://ide.codetracer.com** — a custom domain on that same project (infra PR metacraft-labs/infra#1366), the identical bundle as `web-codetracer.pages.dev` with the same permissive CORS `_headers`.

## Change (comments only)
- `browser-replay/app/gateway-client.js`, `browser-replay/build-dist.sh`: the cross-origin engine-host references move from `web.codetracer.com` → `ide.codetracer.com`.
- `.github/workflows/deploy-web-codetracer.yml`: header/step comments describe the served host as `ide.codetracer.com` (+ `web-codetracer.pages.dev`).

This also corrects a **latent inaccuracy**: `web.codetracer.com` does not serve this bundle — it is a separate, authenticated application on its own DNS record — so the IDE was given its own `ide.` name rather than a breaking rename.

## Left as-is (deliberately)
The online-sharing / collab / upload references to `web.codetracer.com/api` (`src/ct/online_sharing/*`, `src/frontend/viewmodel/collab/*`, the `sharing` VM tests) are the auth/upload service headed for its own **api.codetracer.com** — not the in-browser IDE — so they are untouched. The deploy still targets the `web-codetracer` project (production branch `cloud`); no functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)