### PR TITLE
ci: repin metacraft-github-actions actions from @main to @dev

### DIFF
--- a/.github/workflows/beam-flow.yml
+++ b/.github/workflows/beam-flow.yml
@@ -74,7 +74,7 @@ jobs:
         # its workspace-locked SHA is available for the in-repo
         # libs/codetracer-trace-format swap below (the beam recorder reads
         # the in-repo path, not the sibling).
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -547,7 +547,7 @@ jobs:
         # Checkout-manifests / Resolve-lock / per-sibling clone-repo steps AND
         # the open-coded toolchain installs (dtolnay rust-toolchain, choco
         # capnproto, choco nim).
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: windows-diy
           gh-token: ${{ steps.app-token.outputs.token }}
@@ -712,7 +712,7 @@ jobs:
         # AND the hand-rolled "Bootstrap Windows dev environment" env-export
         # (the composite captures the full env.ps1 delta, a superset of the
         # vars that step exported by hand).
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: windows-diy
           gh-token: ${{ steps.app-token.outputs.token }}
@@ -908,7 +908,7 @@ jobs:
         # Nix steps. The direnv-allow + ct_emulator nimble steps below remain
         # bespoke because they operate inside the cloned native-recorder
         # sibling's own dev env.
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.app-token.outputs.token }}
@@ -1247,7 +1247,7 @@ jobs:
         # the workspace-sibling layout the tests resolve
         # (../codetracer-js-recorder/packages/cli/dist/index.js) per
         # codetracer-specs/Testing/Cross-Repo-CI-Integration.md.
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-js-recorder
           # `dev` is that repo's default branch; `main` trails it (15 commits
@@ -2063,7 +2063,7 @@ jobs:
 
       - name: Clone python-recorder (macOS)
         if: matrix.platform == 'macos'
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-python-recorder
           ref: main
@@ -2072,7 +2072,7 @@ jobs:
 
       - name: Clone ruby-recorder (macOS)
         if: matrix.platform == 'macos'
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-ruby-recorder
           ref: main
@@ -2098,7 +2098,7 @@ jobs:
       # nixos leg; setup-dev-env's nix install is idempotent.
       - name: Setup dev env (BEAM siblings, nixos)
         if: matrix.platform == 'nixos'
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.app-token.outputs.token }}
@@ -2174,7 +2174,7 @@ jobs:
 
       - name: Clone codetracer-beam-recorder (macOS)
         if: matrix.platform == 'macos'
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-beam-recorder
           ref: main
@@ -2268,7 +2268,7 @@ jobs:
         # ``./ci/test/ui-tests-db.sh`` invocations run at the top shell (the
         # explicitly *non-nix* macOS build path) and rely on those tools being
         # on the system PATH rather than inside codetracer's nix dev shell.
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.app-token.outputs.token }}
@@ -2349,7 +2349,7 @@ jobs:
         # ``--path:../codetracer-snapshot-codecs/src`` into the Nim
         # compile.  The build aborts with ``cannot open file:
         # snapshot_codecs`` without this checkout.
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-snapshot-codecs
           ref: main
@@ -2362,7 +2362,7 @@ jobs:
         # Companion sibling to codetracer-snapshot-codecs threaded via
         # the same ``config.nims`` --path; without it ST-M3 test
         # imports break the visual-replay build.
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-image-diff
           ref: main
@@ -2451,7 +2451,7 @@ jobs:
 
       - name: Clone python-recorder (macOS)
         if: matrix.platform == 'macos'
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-python-recorder
           ref: main
@@ -2460,7 +2460,7 @@ jobs:
 
       - name: Clone ruby-recorder (macOS)
         if: matrix.platform == 'macos'
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-ruby-recorder
           ref: main
@@ -2512,7 +2512,7 @@ jobs:
         # The flake build below reads the in-repo path
         # libs/codetracer-trace-format, so the sibling clone is mirrored
         # there by the next step.
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.app-token.outputs.token }}
@@ -2603,7 +2603,7 @@ jobs:
         # frontend's IsoNim/agent libraries, the incremental runner's trace and
         # I/O libraries, and visual replay's own native siblings. A missing
         # lock entry fails loudly before the build starts.
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.ci_token.outputs.token }}

--- a/.github/workflows/cross-repo-tests.yml
+++ b/.github/workflows/cross-repo-tests.yml
@@ -63,7 +63,7 @@ jobs:
         # lock). The native-backend submodule unfold below is still bespoke
         # because the path:-flake-input visibility fix is specific to this
         # repo's flake.
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.ci_token.outputs.token }}
@@ -210,7 +210,7 @@ jobs:
         # Checkout-manifests / Resolve-lock / clone-repo steps. The
         # shell_recorders_ref workflow_dispatch input overrides the locked
         # revision (empty => lock).
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.ci_token.outputs.token }}

--- a/.github/workflows/mcr-dap-flow.yml
+++ b/.github/workflows/mcr-dap-flow.yml
@@ -101,7 +101,7 @@ jobs:
         # src/db-backend/build.rs canonicalises ../../../codetracer-native-recorder
         # at compile time; ensure-ct-mcr builds ct_cli from it. No .gitmodules
         # in the recorder, so submodules: 'false' avoids clone-repo's sed step.
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-native-recorder
           ref: ${{ steps.refs.outputs.recorder-ref }}
@@ -112,7 +112,7 @@ jobs:
       - name: Clone codetracer-native-backend
         # ensure-ct-native-replay builds ct-native-replay from this sibling;
         # ct-native-replay drives the MCR DAP flow under test.
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-native-backend
           ref: ${{ steps.refs.outputs.backend-ref }}
@@ -123,7 +123,7 @@ jobs:
       - name: Clone codetracer-trace-format sibling
         # Required by src/db-backend/Cargo.toml's path deps
         # (../../../codetracer-trace-format/...).
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-trace-format
           ref: ${{ steps.refs.outputs.trace-format-ref }}
@@ -134,7 +134,7 @@ jobs:
       - name: Clone codetracer-trace-format-nim sibling
         # codetracer_trace_writer_nim's build.rs reads
         # ../codetracer-trace-format-nim at db-backend cargo build time.
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-trace-format-nim
           ref: ${{ steps.refs.outputs.trace-format-nim-ref }}

--- a/.github/workflows/request-panel-sidecar-retirement.yml
+++ b/.github/workflows/request-panel-sidecar-retirement.yml
@@ -91,7 +91,7 @@ jobs:
       # across the six: python is `stable`, beam is `main`, the rest are
       # `dev`. Pinning the wrong one silently tests a stale recorder.
       - name: Clone codetracer-python-recorder sibling
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-python-recorder
           ref: stable
@@ -100,7 +100,7 @@ jobs:
           submodules: 'false'
 
       - name: Clone codetracer-ruby-recorder sibling
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-ruby-recorder
           ref: dev
@@ -109,7 +109,7 @@ jobs:
           submodules: 'false'
 
       - name: Clone codetracer-php-recorder sibling
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-php-recorder
           ref: dev
@@ -118,7 +118,7 @@ jobs:
           submodules: 'false'
 
       - name: Clone codetracer-beam-recorder sibling
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-beam-recorder
           ref: main
@@ -127,7 +127,7 @@ jobs:
           submodules: 'false'
 
       - name: Clone codetracer-js-recorder sibling
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-js-recorder
           ref: dev
@@ -136,7 +136,7 @@ jobs:
           submodules: 'false'
 
       - name: Clone codetracer-native-recorder sibling
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-native-recorder
           ref: dev


### PR DESCRIPTION
After the org-wide `main`->`dev` rename of `metacraft-labs/metacraft-github-actions`, its old `main` branch no longer resolves for GitHub Actions (`git/ref/heads/main` 404s; `@main` fails at action-load). This repins every `uses: metacraft-labs/metacraft-github-actions/<action>@main` here to `@dev` (the new mainline).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>