### PR TITLE
flake(io-mon): re-lock to latest io-mon dev (e2ee15af)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2656,11 +2656,11 @@
     "io-mon": {
       "flake": false,
       "locked": {
-        "lastModified": 1783196280,
-        "narHash": "sha256-9bO+TbsTWeyAgMIKginK9YANeQOLlpsapMo0xXJRkkA=",
+        "lastModified": 1787917584,
+        "narHash": "sha256-oVj85ukC5bLmegp0gqmY1/HGs5ximDC5tUlBSJN3Pzc=",
         "owner": "metacraft-labs",
         "repo": "io-mon",
-        "rev": "dd97afa4feae23025f90b237b6a5e409ca9f5113",
+        "rev": "e2ee15afe8dd7f538ec2ce79af9a1aa512addce2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Re-lock codetracer's `io-mon` input (tracks io-mon/dev) from the stale `dd97afa4` (2026-07-04) to current io-mon `dev` HEAD `e2ee15af`, so ct_test/incremental/io_mon_capture.nim (imports `io_mon/depfile`) compiles against the same latest io-mon reprobuild now pins for its cross-repo Test. Both repos on one identical io-mon per user decision.

Paired with reprobuild#(io-mon-latest). Merge when green-modulo-GARM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)