### PR TITLE
ci: migrate metacraft-github-actions action refs from @main to @dev

### DIFF
--- a/.github/actions/setup-db-backend-siblings/action.yml
+++ b/.github/actions/setup-db-backend-siblings/action.yml
@@ -81,7 +81,7 @@ runs:
       # no-op for them. The bespoke "direnv allow" fixup that used to live
       # here is left to the calling jobs (only the db-backend build.rs path
       # needs it, and those jobs already perform it).
-      uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+      uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
       with:
         env-flavor: ${{ inputs.env-flavor }}
         gh-token: ${{ inputs.gh-token }}

--- a/.github/actions/setup-isonim-siblings/action.yml
+++ b/.github/actions/setup-isonim-siblings/action.yml
@@ -69,7 +69,7 @@ runs:
   using: composite
   steps:
     - name: Clone isonim siblings
-      uses: metacraft-labs/metacraft-github-actions/clone-siblings@main
+      uses: metacraft-labs/metacraft-github-actions/clone-siblings@dev
       with:
         gh-token: ${{ inputs.gh-token }}
         # A BARE entry resolves its revision from the workspace lock. An entry

--- a/.github/workflows/beam-flow.yml
+++ b/.github/workflows/beam-flow.yml
@@ -100,7 +100,7 @@ jobs:
         # its pinned SHA is available for the in-repo
         # libs/codetracer-trace-format swap below (the beam recorder reads
         # the in-repo path, not the sibling).
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.ci_token.outputs.token }}

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -833,7 +833,7 @@ jobs:
         # Checkout-manifests / Resolve-lock / per-sibling clone-repo steps AND
         # the open-coded toolchain installs (dtolnay rust-toolchain, choco
         # capnproto, choco nim).
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: windows-diy
           gh-token: ${{ steps.ci_token.outputs.token }}
@@ -1057,7 +1057,7 @@ jobs:
         # AND the hand-rolled "Bootstrap Windows dev environment" env-export
         # (the composite captures the full env.ps1 delta, a superset of the
         # vars that step exported by hand).
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: windows-diy
           gh-token: ${{ steps.ci_token.outputs.token }}
@@ -1273,7 +1273,7 @@ jobs:
         # Nix steps. The direnv-allow + ct_emulator nimble steps below remain
         # bespoke because they operate inside the cloned native-recorder
         # sibling's own dev env.
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.ci_token.outputs.token }}
@@ -1562,7 +1562,7 @@ jobs:
         # same file omits RUNQUOTA_SRC, so the dev shell export cannot stand in
         # for it. Cloned here rather than via the two composite actions above
         # because neither owns this dependency (issue #641).
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/runquota
           ref: dev
@@ -1624,7 +1624,7 @@ jobs:
         # ``setup-dev-env`` -- that route additionally requires a published
         # workspace lock, which is a separate unresolved problem and
         # would make this job depend on it for no benefit.
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-trace-format-nim
           # That repo's default branch is `dev` (confirmed against the API);
@@ -1719,7 +1719,7 @@ jobs:
         # the workspace-sibling layout the tests resolve
         # (../codetracer-js-recorder/packages/cli/dist/index.js) per
         # codetracer-specs/Testing/Cross-Repo-CI-Integration.md.
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-js-recorder
           # `dev` is that repo's default branch; `main` trails it (15 commits
@@ -1745,7 +1745,7 @@ jobs:
         # Under tup the checkout is the only way those modules resolve --
         # NIM_REPO_PATH_FLAGS points at `$(ROOT)/../runquota/...` and tup's
         # environment allowlist omits RUNQUOTA_SRC (issue #641).
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/runquota
           ref: dev
@@ -2179,7 +2179,7 @@ jobs:
         # windows-diy provisions the DIY Windows toolchain via env.ps1's
         # ensure-* helpers (nim / rust / capnp / clingo / repro …) and clones the
         # recorder/trace siblings, persisting PATH to GITHUB_ENV/GITHUB_PATH.
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: windows-diy
           gh-token: ${{ steps.ci_token.outputs.token }}
@@ -2631,7 +2631,7 @@ jobs:
         # ``clone-repo`` + ``ref: dev`` pattern the nixos leg's setup-dev-env
         # uses.
         if: matrix.platform == 'macos'
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-trace-format
           # `dev` is where this repo's work lands; its default branch is
@@ -2648,7 +2648,7 @@ jobs:
         # without this sibling. Same pairing the nixos leg's setup-dev-env
         # ``siblings:`` list encodes.
         if: matrix.platform == 'macos'
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-trace-format-nim
           ref: dev
@@ -2657,7 +2657,7 @@ jobs:
 
       - name: Clone python-recorder (macOS)
         if: matrix.platform == 'macos'
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-python-recorder
           ref: main
@@ -2666,7 +2666,7 @@ jobs:
 
       - name: Clone ruby-recorder (macOS)
         if: matrix.platform == 'macos'
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-ruby-recorder
           ref: main
@@ -2692,7 +2692,7 @@ jobs:
       # nixos leg; setup-dev-env's nix install is idempotent.
       - name: Setup dev env (BEAM siblings, nixos)
         if: matrix.platform == 'nixos'
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.ci_token.outputs.token }}
@@ -2782,7 +2782,7 @@ jobs:
 
       - name: Clone codetracer-beam-recorder (macOS)
         if: matrix.platform == 'macos'
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-beam-recorder
           ref: main
@@ -2884,7 +2884,7 @@ jobs:
         # input alone -- but scripts/require-siblings.sh requires the checkout
         # on every driver so there is a single workspace-completeness rule (the
         # tup driver has no other way in; see the notes in that script).
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.ci_token.outputs.token }}
@@ -2984,7 +2984,7 @@ jobs:
         # ``--path:../codetracer-snapshot-codecs/src`` into the Nim
         # compile.  The build aborts with ``cannot open file:
         # snapshot_codecs`` without this checkout.
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-snapshot-codecs
           ref: main
@@ -2997,7 +2997,7 @@ jobs:
         # Companion sibling to codetracer-snapshot-codecs threaded via
         # the same ``config.nims`` --path; without it ST-M3 test
         # imports break the visual-replay build.
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-image-diff
           ref: main
@@ -3099,7 +3099,7 @@ jobs:
 
       - name: Clone python-recorder (macOS)
         if: matrix.platform == 'macos'
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-python-recorder
           ref: main
@@ -3108,7 +3108,7 @@ jobs:
 
       - name: Clone ruby-recorder (macOS)
         if: matrix.platform == 'macos'
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-ruby-recorder
           ref: main
@@ -3185,7 +3185,7 @@ jobs:
         # The flake build below reads the in-repo path
         # libs/codetracer-trace-format, so the sibling clone is mirrored
         # there by the next step.
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.ci_token.outputs.token }}
@@ -3352,7 +3352,7 @@ jobs:
         # export of it never reaches `nim`. Its absence is what made this job
         # die on `cannot open file: runquota_process` (issue #641), fifteen
         # minutes into the Nim compile rather than here.
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.ci_token.outputs.token }}
@@ -3646,7 +3646,7 @@ jobs:
         # `visual-replay-regression-gate` already lists it. Same missing-sibling
         # class as the backend above, uncovered only because fixing the first
         # one let the build run far enough to hit the second.
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.ci_token.outputs.token }}

--- a/.github/workflows/cross-repo-tests.yml
+++ b/.github/workflows/cross-repo-tests.yml
@@ -90,7 +90,7 @@ jobs:
         # The native-backend submodule unfold below is still bespoke
         # because the path:-flake-input visibility fix is specific to this
         # repo's flake.
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.ci_token.outputs.token }}

--- a/.github/workflows/deploy-web-codetracer.yml
+++ b/.github/workflows/deploy-web-codetracer.yml
@@ -91,7 +91,7 @@ jobs:
         #   * codetracer-trace-format-nim  — build_wasm_api.sh's `nim c` adds
         #     ../codetracer-trace-format-nim/src to its --path search,
         #   * codetracer-trace-format      — the matched half of that FFI pair.
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.ci_token.outputs.token }}

--- a/.github/workflows/launcher-recorder-e2e.yml
+++ b/.github/workflows/launcher-recorder-e2e.yml
@@ -439,7 +439,7 @@ jobs:
         # one recorder per matrix row and because the triggering repo cannot be
         # its own sibling.  See "SIBLING PINNING" in this file's header, and
         # metacraft-dev-guidelines/policies/ci-shared-dev-env.md section 3.2.
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.ci_token.outputs.token }}

--- a/.github/workflows/mcr-dap-flow.yml
+++ b/.github/workflows/mcr-dap-flow.yml
@@ -109,7 +109,7 @@ jobs:
         # job. Every job that left it bare died in this step. When lock
         # publication resumes, dropping the `=dev` suffixes restores
         # per-commit pinning here along with everywhere else.
-        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@main
+        uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
           gh-token: ${{ steps.ci_token.outputs.token }}

--- a/.github/workflows/publish-workspace-lock.yml
+++ b/.github/workflows/publish-workspace-lock.yml
@@ -109,7 +109,7 @@ jobs:
           owner: metacraft-labs
 
       - name: Publish the workspace lock
-        uses: metacraft-labs/metacraft-github-actions/publish-workspace-lock@main
+        uses: metacraft-labs/metacraft-github-actions/publish-workspace-lock@dev
         with:
           gh-token: ${{ steps.ci_token.outputs.token }}
           repo: metacraft-labs/codetracer

--- a/.github/workflows/request-panel-sidecar-retirement.yml
+++ b/.github/workflows/request-panel-sidecar-retirement.yml
@@ -104,7 +104,7 @@ jobs:
       # across the six: python is `stable`, beam is `main`, the rest are
       # `dev`. Pinning the wrong one silently tests a stale recorder.
       - name: Clone codetracer-python-recorder sibling
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-python-recorder
           ref: stable
@@ -113,7 +113,7 @@ jobs:
           submodules: 'false'
 
       - name: Clone codetracer-ruby-recorder sibling
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-ruby-recorder
           ref: dev
@@ -122,7 +122,7 @@ jobs:
           submodules: 'false'
 
       - name: Clone codetracer-php-recorder sibling
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-php-recorder
           ref: dev
@@ -131,7 +131,7 @@ jobs:
           submodules: 'false'
 
       - name: Clone codetracer-beam-recorder sibling
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-beam-recorder
           ref: main
@@ -140,7 +140,7 @@ jobs:
           submodules: 'false'
 
       - name: Clone codetracer-js-recorder sibling
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-js-recorder
           ref: dev
@@ -149,7 +149,7 @@ jobs:
           submodules: 'false'
 
       - name: Clone codetracer-native-recorder sibling
-        uses: metacraft-labs/metacraft-github-actions/clone-repo@main
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
         with:
           repo: metacraft-labs/codetracer-native-recorder
           ref: dev


### PR DESCRIPTION
## Problem

`metacraft-labs/metacraft-github-actions` finished its `main`→`dev` default-branch migration and **deleted its `main` branch**. Every codetracer job that consumed one of its composite actions at `@main` now fails at action-resolution time, before any job body runs:

```
Unable to resolve action `metacraft-labs/metacraft-github-actions@main`, unable to find version `main`
```

This is the root cause behind most of `dev`'s red Linux CI. Confirmed failing on `dev` HEAD (97cc1262) at exactly this step:

- `cross-process value-origin (Linux)`
- `ct-test cross-language provider gate`
- `test-non-gui (nixos, eph-linux-x64-g1)`
- `visual-replay-regression-gate`
- `test-ui-tests-rr`

plus the cross-repo / flow / request-panel workflows.

## Fix

Point all `metacraft-github-actions/<action>@main` refs (`setup-dev-env`, `clone-repo`, `clone-siblings`, `publish-workspace-lock`) at `@dev`, matching the repo's new default branch and the convention the green sibling repos already use (e.g. reprobuild's `setup-dev-env@dev`). All four action paths verified present on `metacraft-github-actions@dev`.

`nixos-modules/.github/*@main` refs are **left untouched on purpose** — that repo still keeps a live `main` branch and `@main` is the org-wide convention for it (reprobuild references it the same way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)