### PR TITLE
ci(lint-nim): provision isonim + nim-everywhere siblings for the SDK facade guard

### DIFF
--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -1196,6 +1196,19 @@ jobs:
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ steps.ci_token.outputs.token }}
 
+      # ci/lint/nim.sh runs the SDK-facade-boundary guard, which since
+      # ada0a7ee walks the import graph INTO the `isonim` and `nim-everywhere`
+      # sibling packages (both REQUIRED siblings per scripts/require-siblings.sh)
+      # and fails `graph-walks-siblings` if it cannot resolve them. That commit
+      # added the sibling requirement to the guard but not to this job, so
+      # lint-nim went red with `cannot locate sibling package: isonim /
+      # nim-everywhere`. Provision the IsoNim-family siblings next to this
+      # checkout through the shared action, the same way the build/test jobs do.
+      - name: Setup isonim siblings
+        uses: ./.github/actions/setup-isonim-siblings
+        with:
+          gh-token: ${{ steps.ci_token.outputs.token }}
+
       - run: "nix develop .#devShells.x86_64-linux.default -c ./ci/lint/nim.sh"
 
   lint-nix:


### PR DESCRIPTION
## Problem

`lint-nim` is red on `dev`. `ci/lint/nim.sh` runs the SDK-facade-boundary guard, which since ada0a7ee (*"ci(sdk): walk sibling packages so the facade guard leaves this repository"*) follows the import graph **into** the `isonim` and `nim-everywhere` sibling packages and fails its `graph-walks-siblings` check when it cannot resolve them:

```
FAIL run with no --root, the guard performs the sibling walk and passes
    cannot locate sibling package: isonim (set ISONIM_SRC, or check out beside this repo)
    cannot locate sibling package: nim-everywhere (set NIM_EVERYWHERE_SRC, or check out beside this repo)
FAIL the printed graph contains IsoNim's own source files
--> FAILED (SDK facade boundary: contract suite, exit 1)
--> FAILED (SDK facade boundary: no reach past the facade ..., exit 1)
```

ada0a7ee added the sibling requirement to the guard but not to the `lint-nim` job, which — unlike the build/test jobs — uses the bare `setup-nix` action and never clones siblings.

## Fix

Add a `Setup isonim siblings` step (the shared, workspace-lock-resolved cloning action the build/test jobs already use) before the lint run, so `isonim` and `nim-everywhere` are checked out beside the repo and the guard can walk them. Both are already declared REQUIRED siblings in `scripts/require-siblings.sh` and pinned by codetracer's project lock.

## Dependency

Stacks on **#682** (`@main`→`@dev` action migration): `setup-isonim-siblings` calls `clone-siblings`, which is currently pinned at the deleted `@main`. This branch includes that commit; once #682 merges, rebasing leaves only the lint-nim commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)