### PR TITLE
test(ct_test): expect the retained tail of bounded output (M16 gate fix)

### DIFF
--- a/src/ct_test/discovery_test.nim
+++ b/src/ct_test/discovery_test.nim
@@ -588,8 +588,10 @@ suite "ct-test workspace scoping guards":
 
   test "execCaptured reports truncation instead of hiding it":
     ## The guard above is only possible because `CapturedRun` surfaces the
-    ## truth. Pin the primitive too: `output` is a prefix, `outputBytes` is the
-    ## real length, and `truncated` says which.
+    ## truth. Pin the primitive too: `output` is the retained TAIL (runquota
+    ## keeps the newest bytes so a failed command's terminal diagnostic
+    ## survives the bound), `outputBytes` is the real length, and `truncated`
+    ## says which.
     const payload = "0123456789"
     let full = execCaptured(@["printf", "%s", payload])
     if full.exitCode != 0:
@@ -600,7 +602,10 @@ suite "ct-test workspace scoping guards":
       check not full.truncated
 
       let cut = execCaptured(@["printf", "%s", payload], captureLimit = 4)
-      check cut.output == payload[0 ..< 4]
+      # runquota's bounded capture retains the NEWEST bytes (the tail), not the
+      # prefix, so a truncated diagnostic keeps its terminal line. For a 10-byte
+      # payload bounded to 4 the retained bytes are the last four, "6789".
+      check cut.output == payload[payload.len - 4 ..< payload.len]
       check cut.outputBytes == uint64(payload.len)
       check cut.truncated
 

--- a/src/ct_test/process_exec.nim
+++ b/src/ct_test/process_exec.nim
@@ -33,7 +33,8 @@ type
     ## accounting ``runquota_process`` captures for free, so callers that want
     ## per-test wall time (e.g. for the CI-sharding cost model) or memory
     ## telemetry no longer have to time the call by hand.
-    output*: string                    ## combined stdout+stderr, possibly cut
+    output*: string                    ## combined stdout+stderr; when the bound
+                                       ## cut it, this is the retained TAIL
     exitCode*: int
     timedOut*: bool
     durationMs*: int


### PR DESCRIPTION
## Problem

`ct-test release gate (M16 provider matrix)` fails at `discovery_test.nim:603`:
`execCaptured reports truncation instead of hiding it` — `cut.output == "0123"` fails.

## Root cause — stale test expectation, not a regression

runquota deliberately changed bounded capture to retain the **newest** bytes (the tail) so a failed command keeps its terminal diagnostic (runquota `appendCapturedOutput`, commit `4358349`, with its own `t_bounded_output_tail.nim`). codetracer pins runquota at `f1ca742` which contains that change, so `execCaptured(payload, captureLimit=4)` on `"0123456789"` now returns the tail `"6789"`, and the test — written 12 days earlier asserting the prefix — fails.

Not a functional regression: every real consumer (`certificate_issuance.nim`, the discovery guards) rejects truncated output outright and relies only on `truncated` + `outputBytes`, both still correct. Only this over-specific unit assertion and two doc comments were stale.

## Fix

Assert the tail (`payload[payload.len-4 ..< payload.len]` = `"6789"`) and correct the "output is a prefix" comments in `discovery_test.nim` and `process_exec.nim`.

Verified: runquota `f1ca742` keeps `source[count-limit..]`; the Nim slice yields `"6789"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)