### PR TITLE
security(deps): close 2 of 3 critical Dependabot advisories on dev (basic-ftp, shell-quote) + the immutable CVSS 9.8, and unblock the yarn-cache hash

### DIFF
--- a/node-packages/yarn-project.nix
+++ b/node-packages/yarn-project.nix
@@ -49,9 +49,25 @@ let
   #
   # To add a new platform: build once, take the ``got:`` hash from the
   # "hash mismatch" error, and add it below.
+  #
+  # NOTE: any change to ``yarn.lock`` invalidates BOTH hashes below, so they
+  # have to be refreshed in the same commit range as the lockfile change or
+  # every nix build fails with a hash mismatch. Running *any* yarn command in
+  # this directory also makes the nixify plugin rewrite this file and DELETE
+  # this whole per-system block, collapsing it to a single ``outputHash`` for
+  # whichever machine happened to run yarn -- see commit 2c4b0a76, which had
+  # to restore it once already. It did it five more times while the security
+  # bumps in this branch were being prepared. Always check
+  # ``git diff node-packages/yarn-project.nix`` after invoking yarn.
   cacheOutputHashes = {
+    # STALE -- must be regenerated on an x86_64-linux builder before this
+    # branch merges. The security bumps here (tar, basic-ftp, shell-quote,
+    # immutable, ws) all changed yarn.lock, and `yarn nixify fetch` only
+    # populates the cache for the current architecture, so this value cannot
+    # be produced on macOS. Take the ``got:`` hash from the CI hash-mismatch
+    # error and paste it here.
     "x86_64-linux" = "sha512-2guUBYTPk7MUt9DfamxnVESTpzx06r7rPnl2GGenNdrXqw3wgIfMZ4dvGHubyj4Lj+m2XVtQNow9hRjUz0cCsg==";
-    "aarch64-darwin" = "sha512-mt7iF+4GNu9oGd42DeCMddB5bcemUYNdzj8g1gEKgzSIfGemBZxJCNC/u0k6kD1xwg7OfOwksHXWq88JBqA56A==";
+    "aarch64-darwin" = "sha512-HlfoP0GZumvRJeIlTYag3j+XU2FMT0i3wvrMUNNgEiwvDlO6G8MuSXxpUSgih+6hDA1KceAAgt1kPzRnpYkfFQ==";
   };
 
   cacheOutputHash =

--- a/node-packages/yarn-project.nix
+++ b/node-packages/yarn-project.nix
@@ -82,15 +82,14 @@ let
     "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
 
   cacheOutputHashes = {
-    # DELIBERATELY INVALIDATED -- this is the sentinel, not a stale hash.
-    # The security bumps here (tar, basic-ftp, shell-quote, immutable, ws) all
-    # changed yarn.lock, and `yarn nixify fetch` only populates the cache for
-    # the current architecture, so the Linux value cannot be produced on macOS.
-    # Leaving the *previous* Linux hash in place did not surface a mismatch:
-    # Nix substituted the old cache by that old hash and skipped the builder
-    # entirely (see the note above). The sentinel removes that escape hatch.
-    # Replace with the ``got:`` hash from the CI hash-mismatch error.
-    "x86_64-linux" = sentinelHash;
+    # Measured on CI (run 34233823494) after the sentinel above forced a real
+    # build of yarn-cache.drv on x86_64-linux. Six jobs on eph-linux-x64-g1 --
+    # ViewModel headless tests, test-non-gui (nixos), cross-process
+    # value-origin, ct-test cross-language provider gate, ct-test release gate
+    # and reprobuild-linux-smoke -- each built
+    # /nix/store/lciwdnrgfbdq3k7py1w2n0k58w35svfd-yarn-cache.drv and reported
+    # this identical ``got:`` value.
+    "x86_64-linux" = "sha512-pDrXJGQJBQ9JOXTLlYfA4r7ysQM9JOXoJUQL66a7EsOiyY064EoHKk/wVivpdl9J1PSTXbx19AmwVZDvzr/z6A==";
     "aarch64-darwin" = "sha512-HlfoP0GZumvRJeIlTYag3j+XU2FMT0i3wvrMUNNgEiwvDlO6G8MuSXxpUSgih+6hDA1KceAAgt1kPzRnpYkfFQ==";
   };
 

--- a/node-packages/yarn-project.nix
+++ b/node-packages/yarn-project.nix
@@ -47,8 +47,23 @@ let
   # the fixed-output hash - differs per build platform. Select the hash for the
   # host system; the Linux hash is what CI / the binary cache is built against.
   #
-  # To add a new platform: build once, take the ``got:`` hash from the
-  # "hash mismatch" error, and add it below.
+  # To add a new platform, or to refresh a stale one: you cannot simply build
+  # and wait for a "hash mismatch" error. ``cacheDrv`` is a *fixed-output*
+  # derivation, so its store path is a function of the hash written here, not
+  # of ``yarn.lock``. If the value below is a hash that was ever valid, Nix
+  # finds that exact path in the binary cache, substitutes it, and NEVER RUNS
+  # THE BUILDER -- so no mismatch is ever reported. What you get instead is a
+  # pile of ``YN0056: Cache entry required but missing`` from ``yarn install``
+  # further down the build, naming the packages whose lockfile entries changed.
+  #
+  # To force the real hash out, first invalidate the entry deliberately:
+  #
+  #   "x86_64-linux" = sentinelHash;   # see below
+  #
+  # No substitute can exist for the sentinel path, so the builder runs for
+  # real and the "hash mismatch" error reports the true ``got:`` value. Paste
+  # that in. (``nix-build --rebuild`` is not a substitute for this: it needs a
+  # local realisation of the path to compare against.)
   #
   # NOTE: any change to ``yarn.lock`` invalidates BOTH hashes below, so they
   # have to be refreshed in the same commit range as the lockfile change or
@@ -59,14 +74,23 @@ let
   # to restore it once already. It did it five more times while the security
   # bumps in this branch were being prepared. Always check
   # ``git diff node-packages/yarn-project.nix`` after invoking yarn.
+  # A hash that is valid in form but cannot match any real output, so the
+  # fixed-output store path it names has no substitute anywhere. Assigning it
+  # to a platform below forces that platform's cache to be built for real, and
+  # the resulting "hash mismatch" error prints the true ``got:`` value.
+  sentinelHash =
+    "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
+
   cacheOutputHashes = {
-    # STALE -- must be regenerated on an x86_64-linux builder before this
-    # branch merges. The security bumps here (tar, basic-ftp, shell-quote,
-    # immutable, ws) all changed yarn.lock, and `yarn nixify fetch` only
-    # populates the cache for the current architecture, so this value cannot
-    # be produced on macOS. Take the ``got:`` hash from the CI hash-mismatch
-    # error and paste it here.
-    "x86_64-linux" = "sha512-2guUBYTPk7MUt9DfamxnVESTpzx06r7rPnl2GGenNdrXqw3wgIfMZ4dvGHubyj4Lj+m2XVtQNow9hRjUz0cCsg==";
+    # DELIBERATELY INVALIDATED -- this is the sentinel, not a stale hash.
+    # The security bumps here (tar, basic-ftp, shell-quote, immutable, ws) all
+    # changed yarn.lock, and `yarn nixify fetch` only populates the cache for
+    # the current architecture, so the Linux value cannot be produced on macOS.
+    # Leaving the *previous* Linux hash in place did not surface a mismatch:
+    # Nix substituted the old cache by that old hash and skipped the builder
+    # entirely (see the note above). The sentinel removes that escape hatch.
+    # Replace with the ``got:`` hash from the CI hash-mismatch error.
+    "x86_64-linux" = sentinelHash;
     "aarch64-darwin" = "sha512-HlfoP0GZumvRJeIlTYag3j+XU2FMT0i3wvrMUNNgEiwvDlO6G8MuSXxpUSgih+6hDA1KceAAgt1kPzRnpYkfFQ==";
   };
 

--- a/node-packages/yarn.lock
+++ b/node-packages/yarn.lock
@@ -7683,9 +7683,9 @@ __metadata:
   linkType: hard
 
 "immutable@npm:^3":
-  version: 3.8.2
-  resolution: "immutable@npm:3.8.2"
-  checksum: 10c0/fb6a2999ad3bda9e51741721e42547076dd492635ee4df9241224055fe953ec843583a700088cc4915f23dc326e5084f4e17f1bbd7388c3e872ef5a242e0ac5e
+  version: 3.8.4
+  resolution: "immutable@npm:3.8.4"
+  checksum: 10c0/fffbd0bf4ecf6cfed6b3444d2da740f171dd7c228d913d2cc81fc2782c10df0f6f7d822c926d38dd5fb5d91fcfce5c5482a8027817f07a5ed870b057271a3b8a
   languageName: node
   linkType: hard
 

--- a/node-packages/yarn.lock
+++ b/node-packages/yarn.lock
@@ -4018,9 +4018,9 @@ __metadata:
   linkType: hard
 
 "basic-ftp@npm:^5.0.2":
-  version: 5.0.5
-  resolution: "basic-ftp@npm:5.0.5"
-  checksum: 10c0/be983a3997749856da87b839ffce6b8ed6c7dbf91ea991d5c980d8add275f9f2926c19f80217ac3e7f353815be879371d636407ca72b038cea8cab30e53928a6
+  version: 5.3.1
+  resolution: "basic-ftp@npm:5.3.1"
+  checksum: 10c0/03511b488cd292abfa82a8c0ea3b9573b40d12d2f1518d6f41a9461b012b3376d3e6d50679b38d9b2b4f48fd6e8e0418ac196312ee7e2da13cb801169940d1c3
   languageName: node
   linkType: hard
 

--- a/node-packages/yarn.lock
+++ b/node-packages/yarn.lock
@@ -9234,15 +9234,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "mkdirp@npm:3.0.1"
-  bin:
-    mkdirp: dist/cjs/src/bin.js
-  checksum: 10c0/9f2b975e9246351f5e3a40dcfac99fcd0baa31fbfab615fe059fb11e51f10e4803c63de1f384c54d656e4db31d000e4767e9ef076a22e12a641357602e31d57d
-  languageName: node
-  linkType: hard
-
 "monaco-editor-core@npm:^0.21.2":
   version: 0.21.3
   resolution: "monaco-editor-core@npm:0.21.3"
@@ -12245,30 +12236,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.4.3":
-  version: 7.4.3
-  resolution: "tar@npm:7.4.3"
-  dependencies:
-    "@isaacs/fs-minipass": "npm:^4.0.0"
-    chownr: "npm:^3.0.0"
-    minipass: "npm:^7.1.2"
-    minizlib: "npm:^3.0.1"
-    mkdirp: "npm:^3.0.1"
-    yallist: "npm:^5.0.0"
-  checksum: 10c0/d4679609bb2a9b48eeaf84632b6d844128d2412b95b6de07d53d8ee8baf4ca0857c9331dfa510390a0727b550fd543d4d1a10995ad86cdf078423fbb8d99831d
-  languageName: node
-  linkType: hard
-
-"tar@npm:^7.5.2":
-  version: 7.5.2
-  resolution: "tar@npm:7.5.2"
+"tar@npm:^7.4.3, tar@npm:^7.5.2":
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/a7d8b801139b52f93a7e34830db0de54c5aa45487c7cb551f6f3d44a112c67f1cb8ffdae856b05fd4f17b1749911f1c26f1e3a23bbe0279e17fd96077f13f467
+  checksum: 10c0/1311f6be85a8157ac4c9147bae43e13923d2a1aae15e4aa1bd5239e4e03d2cf53cfe103dde7f35832fbb4c938b042856bc8e9a0afd29abd05e2d1608788c4fea
   languageName: node
   linkType: hard
 

--- a/node-packages/yarn.lock
+++ b/node-packages/yarn.lock
@@ -13633,8 +13633,8 @@ __metadata:
   linkType: hard
 
 "ws@npm:^8.18.0, ws@npm:^8.18.3, ws@npm:^8.4.3, ws@npm:^8.8.0":
-  version: 8.18.3
-  resolution: "ws@npm:8.18.3"
+  version: 8.21.3
+  resolution: "ws@npm:8.21.3"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -13643,7 +13643,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/eac918213de265ef7cb3d4ca348b891a51a520d839aa51cdb8ca93d4fa7ff9f6ccb339ccee89e4075324097f0a55157c89fa3f7147bde9d8d7e90335dc087b53
+  checksum: 10c0/7b28dc2863ea0e2cece68d142a3eee90361021b73f750431e6d8076bb7dede5fdfdb75b3d29534b62f411261147b76b1bc80fb5cc63ab0aabd467280e85b22e0
   languageName: node
   linkType: hard
 

--- a/node-packages/yarn.lock
+++ b/node-packages/yarn.lock
@@ -11582,9 +11582,9 @@ __metadata:
   linkType: hard
 
 "shell-quote@npm:^1.6.1":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 10c0/bee87c34e1e986cfb4c30846b8e6327d18874f10b535699866f368ade11ea4ee45433d97bf5eada22c4320c27df79c3a6a7eb1bf3ecfc47f2c997d9e5e2672fd
+  version: 1.10.0
+  resolution: "shell-quote@npm:1.10.0"
+  checksum: 10c0/46ee59bfd972ce6a45500c44ed130dff2d0a7d6fbac9841e59d548518cad8060a06393c9a5dcbc0cede294ad80b2a2cd8c904679e09265f53efc0a0879f30961
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What this is

Five npm security bumps against `node-packages/yarn.lock`, rebased onto current
`dev`, plus the yarn-cache Nix hashes they invalidate.

**The title of this PR was wrong and has been corrected.** It said "closes all 3
critical advisories". It closes **two** of the three. The third — the `tar`
critical — cannot be closed by a lockfile bump of the 7.x resolution, for the
reason set out under "The tar critical does not close" below. That correction is
the most important thing in this description; the rest is bookkeeping.

## Why every nix job on this branch used to be red

The branch previously shipped with the instruction: *"the first CI run will fail
with a hash mismatch — copy the `got:` hash into `cacheOutputHashes."x86_64-linux"`."*

CI cannot produce that output. In run `33361543515`, across the nix-shell job
logs, `hash mismatch` occurs **zero** times — `lint-bash`'s 874-line log
(identity confirmed by `Complete job name: lint-bash`) has none. What it has is
five lines:

```
YN0056: Cache entry required but missing for basic-ftp@npm:5.3.1
YN0056: Cache entry required but missing for immutable@npm:3.8.4
YN0056: Cache entry required but missing for shell-quote@npm:1.10.0
YN0056: Cache entry required but missing for tar@npm:7.5.22
YN0056: Cache entry required but missing for ws@npm:8.21.3
```

— exactly the five packages this branch bumps.

`cacheDrv` in `node-packages/yarn-project.nix` is a **fixed-output derivation**.
Its store path is a function of the `outputHash` written in that file, not of
`yarn.lock`. Leaving the previous, once-valid `x86_64-linux` hash in place named
a path that already exists in the binary cache from `dev`, so Nix substituted
`dev`'s cache and **never ran the builder**. No builder run, no hash to compare,
no mismatch — and then `yarn install`, running against a cache built for the old
lockfile, died on the five entries that had moved.

The fix is to invalidate the entry rather than wait on it. `sentinelHash` is
valid in form and cannot match any real output, so no substitute for its path
can exist; the builder is forced to run and the mismatch reports the true
`got:`. The comment block in `yarn-project.nix` now documents this, because the
old comment sent every reader to an error that could not happen.

(`nix-build --rebuild` is not an alternative: it re-realises a path that is
already present *locally* and compares, so it still needs a local realisation of
a Linux path a macOS machine cannot produce.)

## The tar critical does not close

`GHSA-23hp-3jrh-7fpw` / `CVE-2026-59873` (critical) has vulnerable range
**`<= 7.5.18`** — unbounded below. `node-packages/yarn.lock` carries two `tar`
resolutions, and this PR only moves one of them:

| resolution | requested by | before | after |
|---|---|---|---|
| `tar@npm:^7.4.3, ^7.5.2` | workspace, `node-gyp@12`, `cacache` | 7.4.3 / 7.5.2 | **7.5.22** |
| `tar@npm:^6.0.5, ^6.1.2, ^6.1.11` | `cacache@^16.1.0`, `node-gyp@^9.0.0`, `electron-rebuild@^3.2.9` | 6.2.1 | **6.2.1 — unchanged** |

`6.2.1` satisfies `<= 7.5.18`. An earlier revision of this branch claimed "every
one of the 20 tar advisories is scoped to a 7.x range, so the 6.x branch is
clean". That is false, and it is checkable against this repository's own alert
set rather than by reading semver:

- `storybook/package-lock.json` contains **exactly one** `tar`, version
  **6.2.1** (pulled by `giget@^6.2.1`) — there is no 7.x anywhere in it.
- GitHub has **8 open `tar` Dependabot alerts against that manifest**, every one
  of them with a `<= 7.5.x` / `< 7.5.x` range.

So GitHub is, today, matching `tar` 6.2.1 against unbounded-below `<= 7.5.x`
ranges. Dependabot raises one alert per (advisory *range*, manifest) — confirmed
against `GHSA-rgw5-rvv9-x895`, which has four disjoint ranges and produces one
alert per range here, collapsing multiple resolutions into each. An alert
therefore closes only when **no** resolution in the manifest falls in its range.
`tar` 6.2.1 keeps all 12 of them open, the critical included.

Closing it needs the 6.x resolution gone, not overridden — which is what
**#716** does on `stable`: its lockfile has a single `tar@npm:^7.4.3, ^7.5.2,
^7.5.4 → 7.5.22` and no 6.x entry at all. That is the model for the follow-up on
`dev`, and it is a larger change than this PR: it moves `cacache@16`,
`node-gyp@9` and `electron-rebuild@3`, all of which drive native-module builds.

## Alerts this PR actually closes: 6

All counts below are over the **149 open alerts whose `manifest_path` is
`node-packages/yarn.lock`** (of 194 open repo-wide: 3 critical / 92 high /
73 moderate / 26 low).

| package | resolutions after this PR | alerts open | closes | left open |
|---|---|---|---|---|
| `basic-ftp` | 5.3.1 (sole) | 2 | **2** — incl. critical `GHSA-5rq4-664w-9x2c` (`< 5.2.0`) | 0 |
| `shell-quote` | 1.10.0 (sole) | 2 | **2** — incl. critical `GHSA-w7jw-789q-3m8p` (`<= 1.8.3`) | 0 |
| `immutable` | 3.8.4 (sole) | 3 | **2** — `GHSA-wf6x-7x77-mvgw` (`< 3.8.3`, CVSS 9.8) and `GHSA-xvcm-6775-5m9r` (`< 3.8.4`) | 1 — `GHSA-v56q-mh7h-f735` needs 4.3.9 |
| `ws` | 8.21.3 **and** 8.17.1 | 2 | **0** | 2 — both ranges cover the `~8.17.1` resolution pinned by `engine.io` / `socket.io-adapter` |
| `tar` | 7.5.22 **and** 6.2.1 | 12 | **0** | 12 — see above |

Two earlier claims in this description were wrong and are withdrawn: "closes 21
alerts" (it is 6) and "`ws` closes 2" (it closes 0). The `ws` bump is still worth
having — see below — but it does not move an alert.

## Reachability

Unchanged from the earlier analysis, and it is the reason this PR is still worth
landing despite the smaller alert count:

- **`ws` is the one bump here that fixes something genuinely exploitable.** It is
  a direct runtime dependency loaded by shipped code — `src/lsp/bridge_reduced.nim:55`
  does `require("ws")` for the LSP bridge's websocket transport, and that
  `require` resolves to the direct dependency, i.e. to **8.21.3** after this PR.
  The memory-exhaustion DoS is fixed in the code users run even though the alert
  stays open on account of the unrelated `~8.17.1` resolution.
- `tar` — declared a direct *runtime* dependency but nothing imports it; no
  `require "tar"` in any `.nim`/`.js`/`.ts`/`.mjs` under `src/`. Archive handling
  shells out to the system `tar`. npm `tar` is reached only by node-gyp at
  native-build time. The direct dependency line looks vestigial.
- `immutable` — reached only via `browser-sync`, required by
  `src/frontend/browsersync_serv.nim`, whose sole importer is
  `src/frontend/lsp.nim`, which is not a shipped build target (the built JS
  entrypoints are `ui_js.nim`, `index.nim`, `subwindow.nim`, `middleware.nim`,
  `storybook_components.nim`); it is compiled only as a nimsuggest canary in
  `ci/test/nimsuggest-check.sh`.
- `basic-ftp` — WebDriver/Puppeteer e2e tooling only, reachable solely via an
  `ftp://` PAC URL, which nothing configures.
- `shell-quote` — only via `npm-run-all` (devDependency), quoting repo-authored
  `package.json` scripts.
- The browser-replay bundle contains no npm code at all: `browser-replay/build-dist.sh`
  ships hand-written vanilla JS plus `db_backend.js` / `db_backend_bg.wasm` from
  wasm-bindgen, and `src/db-backend/Cargo.lock` has zero open alerts.

## Still open after this, and worth a human

- **`tar` 6.2.1** — 12 alerts including the remaining critical. Needs the
  `cacache@16` / `node-gyp@9` / `electron-rebuild@3` chain moved, as #716 did.
- **`dompurify`** (20 alerts, max CVSS 6.9) — the one reachable-and-unfixed item.
  It is bundled inside `node_modules/monaco-editor/min/vs/editor.api-i0YVFWkl.js`,
  and `src/public/third_party/monaco-editor/min` symlinks to that directory — the
  path the renderer serves. `monaco-editor@0.54.0` pins `dompurify` at an exact
  `3.1.7`, so no lockfile bump can move it; it needs a `monaco-editor` upgrade.
  CodeTracer renders attacker-supplied trace content in the editor, so the
  mutation-XSS advisories deserve a real look.
- `immutable` 4.3.9 — `browser-sync ^3` pins `immutable: ^3`. The better fix is
  probably dropping `browser-sync` from `dependencies` (it is a dev livereload
  server sitting in the runtime dependency set).
- `ws` 8.17.1 — pinned by `engine.io` / `engine.io-client` / `socket.io-adapter`
  via `~8.17.1`; needs a socket.io major upgrade.
- `extract-zip` — no patched version exists in either lockfile.
