### PR TITLE
UI design improvements, part 3

### DIFF
--- a/scripts/build-once.sh
+++ b/scripts/build-once.sh
@@ -405,6 +405,19 @@ ct_tup_config="${CODETRACER_CONFIG:-debug}"
 ct_tup_variant="build-${ct_tup_config}"
 ct_publish_build_env "" "$ct_tup_config" "$ct_tup_variant" "src/$ct_tup_variant"
 
+# Mirror the reprobuild branch's env-var setup so cargo build scripts work
+# without network access on the Linux tup path (Linux keeps tup as default):
+#   * CODETRACER_TRACE_FORMAT_NIM_SKIP_NIMBLE_INSTALL=1 prevents nimble from
+#     trying to download nim-stew over the network.
+#   * CODETRACER_TRACE_FORMAT_NIM_EXTRA_PATHS injects the vendored stew tree
+#     so `nim c` can resolve `results`/`stew` without a nimble package store.
+export CODETRACER_TRACE_FORMAT_NIM_SKIP_NIMBLE_INSTALL="${CODETRACER_TRACE_FORMAT_NIM_SKIP_NIMBLE_INSTALL:-1}"
+if [ -z "${CT_EMULATOR_EXTRA_NIM_PATHS:-}" ] && [ -d "$PWD/libs/nim-stew/stew" ]; then
+	ct_nim_paths_lib="$PWD/libs/nim-stew/stew:$PWD/libs/nim-stew:$PWD/libs/nim-result"
+	export CT_EMULATOR_EXTRA_NIM_PATHS="$ct_nim_paths_lib"
+	export CODETRACER_TRACE_FORMAT_NIM_EXTRA_PATHS="${CODETRACER_TRACE_FORMAT_NIM_EXTRA_PATHS:-$ct_nim_paths_lib}"
+fi
+
 # tup's dependency tracking is a FUSE mount, and libfuse can only obtain
 # /dev/fuse through a setuid helper at a path compiled into the binary. When
 # that helper is missing, tup reports a mount timeout three layers away from

--- a/src/ct_test/nim.cfg
+++ b/src/ct_test/nim.cfg
@@ -49,6 +49,8 @@
 # worktree / CI layouts where the relative siblings do not resolve.
 --path:"../../../io-mon/src"
 --path:"../../../nim-stackable-hooks/src"
+--path:"../../../nim-shm-gset/src"
+--path:"../../../nim-shm-queue/src"
 
 --path:"../../../runquota/libs/runquota_process/src"
 --path:"../../../runquota/libs/runquota_core/src"

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -67,7 +67,7 @@
           <div id="auto-hide-layout-row">
             <div id="auto-hide-strip-left"></div>
             <!-- Docked left sidebar: shown when user clicks a left strip tab -->
-            <div id="auto-hide-docked-left">
+            <div id="auto-hide-docked-left" class="auto-hide-docked">
               <div id="auto-hide-docked-left-content"></div>
               <div id="auto-hide-docked-left-resize" class="auto-hide-docked-resize-handle"></div>
             </div>
@@ -81,7 +81,7 @@
               </div>
             </div>
             <!-- Docked right sidebar: shown when user clicks a right strip tab -->
-            <div id="auto-hide-docked-right">
+            <div id="auto-hide-docked-right" class="auto-hide-docked">
               <div id="auto-hide-docked-right-resize" class="auto-hide-docked-resize-handle"></div>
               <div id="auto-hide-docked-right-content"></div>
             </div>
@@ -90,7 +90,7 @@
 
           <!-- Docked bottom panel: shown when a bottom strip tab is clicked.
                Sits between the layout row and the footer so it pushes GL up. -->
-          <div id="auto-hide-docked-bottom">
+          <div id="auto-hide-docked-bottom" class="auto-hide-docked">
             <div id="auto-hide-docked-bottom-resize" class="auto-hide-docked-resize-handle auto-hide-docked-resize-handle-bottom"></div>
             <div id="auto-hide-docked-bottom-content"></div>
           </div>

--- a/src/frontend/styles/components/auto_hide.styl
+++ b/src/frontend/styles/components/auto_hide.styl
@@ -87,7 +87,12 @@
   flex-direction: column
   flex-shrink: 0
   flex-grow: 0
-  background-color: transparent
+  // The panel surface, the same token `.lm_content` paints a GoldenLayout
+  // panel with — a docked panel is the same surface, just parked at an edge.
+  // Transparent here let the window background show through instead, so a
+  // docked panel came up darker than every other panel; the bottom docked
+  // container below always had this and the side ones did not.
+  background-color: colors-ui-surface-base-panel
   border-radius: 0.36em
   position: relative
   // z-index: 5 creates a stacking context so GL children with high z-index
@@ -109,6 +114,37 @@
 
 // No border on docked panels — the resize handle acts as the divider,
 // matching GL's .lm_splitter which is a solid-background 4px wide element.
+
+// ---------------------------------------------------------------------------
+// Selected docked panel
+//
+// A docked panel is a panel like any other, so it carries the same selection
+// cue: one 1px line, on the same tokens as the GoldenLayout outline
+// (`SELECTED_PANEL_BORDER` / `_COLOR` in golden_layout.styl, imported ahead of
+// this file).  It needs no SVG — a docked panel is a plain rounded rectangle,
+// with none of the tab and connector geometry the GL path exists to trace, so
+// an inset shadow follows the shape exactly and costs nothing to keep in step
+// on resize.
+//
+// Inset rather than a border: the container's width is what the resize drag
+// writes to, and a border would add to it and shift the panel by a pixel on
+// every dock.  The class is set in `ui/auto_hide.nim` (on open) and
+// `ui/layout.nim` (on click), and only ever on one panel at a time.
+// ---------------------------------------------------------------------------
+// The outline itself is one stroked SVG path built in `ui/layout.nim`
+// (`setupSelectedPanelOutline`), exactly as it is for a GoldenLayout stack: the
+// strip tab and the docked panel are traced as a single shape so the line runs
+// around the tab rather than stopping at the panel's edge.  An inset shadow
+// cannot do that — it can only follow the one box it is set on.
+.ct-docked-outline
+  position: fixed
+  top: 0
+  left: 0
+  pointer-events: none
+  // Above the docked panel (101) and the side strip (100), so the line is not
+  // painted over by either of the two elements it runs around.
+  z-index: 202
+  overflow: visible
 
 #auto-hide-docked-left-content,
 #auto-hide-docked-right-content
@@ -591,8 +627,16 @@
 
 #auto-hide-overlay
   position: fixed
-  // z-index: 101 — above the backdrop (98) and the strips (100).
-  z-index: 101
+  // Above the backdrop (98), the strips (100), a docked panel (101) and the
+  // outline that traces one (202).
+  //
+  // It has to clear the outline, not just the panel: that outline must paint
+  // above the docked panel or the panel's own background hides it, and a docked
+  // panel and this overlay are both 101 — so no value sits between them.  The
+  // overlay is the transient thing floating over the layout, so it goes on top
+  // and the outline is occluded where the two meet, rather than the outline
+  // being drawn across a hovered panel's content.
+  z-index: 203
   background-color: colors-ui-surface-primary-default
   border: none
   border-radius: 0.36em

--- a/src/frontend/styles/components/button.styl
+++ b/src/frontend/styles/components/button.styl
@@ -167,10 +167,28 @@ button
   background-image: ct-images-layout-tab
   background-size: 1em auto !important
 
+  // States match `.vcs-branch-current` (vcs.styl), the reference for anything
+  // that opens a menu: a 1px border, transparent at rest, grey on hover and
+  // blue while the menu is open, with the surface left alone throughout.
+  //
+  // Two inherited behaviours have to be undone for that. `ct-button-no-border`
+  // sets `border: none !important`, so the width has to come back with
+  // `!important`; and `[class*="-secondary"]:hover` lightens the background,
+  // which would double up on the border as a second state cue.
+  //
+  // The width lives on the base rule and `box-sizing: border-box` is already
+  // set on `button`, so the control stays 28x28 in every state and the centred
+  // icon does not move.  This replaces an inset `box-shadow` that drew a fake
+  // border in `em` — 0.0625em against a 16px button, so a hair under 1px.
+  border: 0.0625rem solid transparent !important
+
+  &:hover
+    border-color: colors-ui-border-primary-hover !important
+    background-color: colors-ui-surface-primary-default
+
   &.open
-    // background-image: ct-images-layout-tab-active !important
-    background-color: colors-ui-surface-input-default
-    box-shadow: inset 0 0 0 0.0625em colors-ui-border-action !important
+    border-color: colors-ui-border-action !important
+    background-color: colors-ui-surface-primary-default
 
 #close-element
   background-image: ct-images-close-button

--- a/src/frontend/styles/components/event_log.styl
+++ b/src/frontend/styles/components/event_log.styl
@@ -343,7 +343,10 @@
       margin: 0em 0em !important
       padding: 0 0.75em
       border-radius: 0.5em
-      border: 0.03125em solid transparent
+      // Matches the 0.0625rem (1px) field border in input.styl. This rule wins
+      // over `.ct-input-small` on specificity, so leaving it at the old 0.03125em
+      // kept this one field a hairline while every other field went to 1px.
+      border: 0.0625rem solid transparent
       background: colors-editor-surface-select
       color: colors-ui-text-primary-body !important
       font-family: "SpaceMono"

--- a/src/frontend/styles/components/golden_layout.styl
+++ b/src/frontend/styles/components/golden_layout.styl
@@ -219,6 +219,15 @@
   height: 0.6em !important
   position: static !important
   cursor: pointer
+  // `.lm_tab` is a flex row and `.lm_title` asks for `width: 100%`, so the row
+  // is always over-constrained and every shrinkable item gives up width. Without
+  // this the close box — the only child that could shrink, since `.lm_pin_tab`
+  // already opts out — collapsed with the tab: 9.6px nominal, but measured at
+  // 8.95px on a 421px tab and 2.01px on a 41.8px one. The mask keeps its fixed
+  // 0.6em size and stays centred, so the cross was cropped, not scaled, and read
+  // as an icon that shrinks with the tab. Opt out exactly as the pin does; the
+  // title absorbs the shortfall instead, which is what its ellipsis is for.
+  flex-shrink: 0
 
 .lm_header .lm_tab .lm_pin_tab
   tab-icon(LAYOUT_TAB_PIN_ICON_PATH, 0.85em 0.85em)

--- a/src/frontend/styles/components/golden_layout.styl
+++ b/src/frontend/styles/components/golden_layout.styl
@@ -1,3 +1,15 @@
+// The space between two tabs.
+LAYOUT_TAB_GAP = 0.25em
+
+// The radius of the curve that joins a tab to its panel.
+//
+// This is the *painted* radius.  The connectors on a GoldenLayout tab are
+// box-shadows with a -0.25em spread, and a negative spread shrinks a shadow's
+// corners, so their 0.625em border-radius reaches the screen as 0.375em.  The
+// stroked outline used to trace the 0.625em instead and cut across the curve it
+// was meant to follow.  One value now, read by the CSS below and by the path
+// builder in `ui/layout.nim` through the custom property.
+LAYOUT_TAB_CONNECTOR_RADIUS = 0.375em
 
 .lm_goldenlayout
   background: colors-ui-surface-primary-default !important
@@ -30,6 +42,19 @@
 .lm_tabs
   width: 100%
   display: flex
+  // Tabs are separated with the flex container's `gap`, NOT margin-right.
+  //
+  // GoldenLayout totals the strip by reading the ACTIVE tab's `margin-right`
+  // and charging it to every tab, so any margin at all pushes the sum over the
+  // header width and a nested tab is banished to the overflow list (see
+  // `stackCreated` in `ui/layout.nim`).  Zeroing the active tab's margin to
+  // dodge that is what left it with no gap to its right neighbour — the two
+  // read as one fused tab.  `gap` is invisible to GL's arithmetic and applies
+  // to every pair regardless of which tab is active, so it settles both.
+  //
+  // `gap` also sits only BETWEEN tabs, so the last one still ends flush with
+  // the panel's right edge — which is what keeps that corner square.
+  gap: LAYOUT_TAB_GAP
 
 .lm_splitter.lm_dragging
   background: #444444;
@@ -56,7 +81,7 @@
   overflow: hidden
   border-radius: 0.36em
   // margin-left: 2px !important
-  margin-right: 0.24em !important
+  margin-right: 0 !important
   margin-bottom: 0px !important
   flex: 1
   text-align: center
@@ -134,7 +159,11 @@
   border-bottom-left-radius: 0em
   box-shadow: 0em 0.48em 0em 0em colors-ui-surface-base-panel !important
   overflow: visible !important
-
+  // The concave connectors that flare the active tab into its panel — the
+  // curve is part of the product's identity, so it is deliberate geometry, not
+  // decoration.  Each is a box-shadow bled off the side of the tab; where a tab
+  // is flush against the panel's edge there is no room for one and the rules
+  // further down switch that side off.
   &::before
     content: " ";
     pointer-events: none;
@@ -245,8 +274,8 @@
 // Selected panel
 //
 // Selection is shown by the outline alone — one stroked path around the tab,
-// both curved connectors and the panel body.  The surface is deliberately left
-// at its resting colour: the line carries the state on its own.
+// its connectors and the panel body.  The surface is deliberately left at its
+// resting colour: the line carries the state on its own.
 //
 // The geometry is generated in `ui/layout.nim` (`setupSelectedPanelOutline`),
 // because the tab's width and position are only known at runtime; the colour
@@ -258,10 +287,27 @@
 SELECTED_PANEL_BORDER = 0.0625rem
 SELECTED_PANEL_BORDER_COLOR = colors-ui-border-primary
 
+// A last tab sits flush with its panel's right edge, so it runs straight down
+// into the body: there is no corner to round, and no room to its right for a
+// connector to curve into.  This is the rule that was missing — the right-hand
+// connector was drawn anyway, flaring past the panel's edge into the corner of
+// the window, which is the stray curl that showed at the end of the tab.
+//
+// The mirror of the first-child rule below; between them they switch off only
+// the connector that has nowhere to go.  A tab with panel either side keeps
+// both curves.
+.lm_stack:has(> .lm_header .lm_tabs > .lm_tab.lm_active:last-child)
+  > .lm_items,
+  > .lm_items .lm_content
+    border-top-right-radius: 0
+
+  > .lm_header .lm_tabs > .lm_tab.lm_active:last-child::after
+    display: none
+
 // A first tab sits flush with its panel's left edge, so the tab runs straight
-// down into the body and there is no corner to round and nothing for the left
-// connector to reach.  Leaving both in place puts a curve where the two meet —
-// the panel bending away from a tab that does not bend with it.
+// down into the body and there is nothing for the left connector to reach.
+// Leaving both in place puts a curve where the two meet — the panel bending
+// away from a tab that does not bend with it.
 //
 // Applies to every stack, not only the selected one: the seam is there whether
 // or not the panel is highlighted.
@@ -275,10 +321,10 @@ SELECTED_PANEL_BORDER_COLOR = colors-ui-border-primary
   > .lm_header .lm_tabs > .lm_tab.lm_active:first-child::before
     display: none
 
-// The selected panel's outline — one stroked path covering the tab, both curved
-// connectors and the panel body as a single shape.  The geometry is generated in
-// `ui/layout.nim` (`setupSelectedPanelOutline`) because the tab's width and
-// position are only known at runtime; colour and weight stay here, on tokens.
+// The selected panel's outline — one stroked path covering the tab and the panel
+// body as a single shape.  The geometry is generated in `ui/layout.nim`
+// (`setupSelectedPanelOutline`) because the tab's width and position are only
+// known at runtime; colour and weight stay here, on tokens.
 //
 // The path is inset by half the stroke width, so the line falls inside the shape
 // rather than straddling its edge.  Unlike a CSS border, an SVG stroke is not
@@ -291,9 +337,19 @@ SELECTED_PANEL_BORDER_COLOR = colors-ui-border-primary
   z-index: 6
   overflow: visible
 
+// Both outlines — the one around a GL stack and the one around a docked
+// auto-hide panel and its strip tab (`.ct-docked-outline`, positioned in
+// auto_hide.styl) — are the same line, so they are stroked from one rule.
+.ct-selected-outline,
+.ct-docked-outline
   path
     fill: none
     stroke: SELECTED_PANEL_BORDER_COLOR
     stroke-width: SELECTED_PANEL_BORDER
     // Rounded joins keep the corners continuous where the arcs meet the lines.
     stroke-linejoin: round
+    // Carries the connector radius to the path builder already resolved to
+    // pixels.  It has to ride on a real length property: `getComputedStyle`
+    // hands back a custom property's `em` token unresolved, and the builder
+    // needs pixels.  Draws nothing — an SVG path has no border to round.
+    border-top-left-radius: LAYOUT_TAB_CONNECTOR_RADIUS

--- a/src/frontend/styles/components/input.styl
+++ b/src/frontend/styles/components/input.styl
@@ -24,7 +24,7 @@ input
     color: colors-ui-text-primary-body !important
 
   &:disabled
-    border: 0.03125rem solid colors-ui-border-disabled
+    border: 0.0625rem solid colors-ui-border-disabled
     background: colors-ui-surface-primary-disabled
     color: colors-ui-text-disabled-default !important
     pointer-events: none
@@ -63,7 +63,7 @@ input
   max-height: 2.25rem
   border-radius: 0.375rem
   background: colors-ui-surface-primary-secondary
-  border: 0.03125rem solid colors-ui-surface-primary-secondary
+  border: 0.0625rem solid colors-ui-surface-primary-secondary
 
   &:hover
     border-color: colors-ui-border-primary-hover
@@ -75,7 +75,7 @@ input
   width: -webkit-fill-available
   max-width: -webkit-fill-available
   border-radius: 0.375rem
-  border: 0.03125rem solid colors-ui-border-primary
+  border: 0.0625rem solid colors-ui-border-primary
   background: colors-ui-surface-primary-secondary
 
   &:hover
@@ -89,22 +89,28 @@ input
   background: colors-ui-surface-primary-default
 
   &:hover
-    border: 0.03125rem solid colors-ui-surface-primary-default
+    border: 0.0625rem solid colors-ui-surface-primary-default
     border-color: colors-ui-border-primary-hover
     color: colors-ui-text-primary-body
 
 
-// The resting border is `rem`, matching the `:hover` rule above and every other
-// border in this file. It was `em`, which resolved against each field's own
-// font-size and gave 0.4375px at 14px and 0.375px at 12px — never the 0.5px
-// intended, and never the width hover then swapped in.
+// Field borders are 0.0625rem — 1px at the 16px root — not the 0.5px they used
+// to be, and `rem` so the resting width and the `:hover` width cannot disagree.
+//
+// 0.5px is exactly one device pixel at DPR 2, which is crisp only while the edge
+// it paints lands on the device grid. Golden Layout sizes stacks proportionally,
+// so a panel is routinely a fractional number of pixels wide; `.ct-input-panel`
+// is `width: -webkit-fill-available` and inherits that fraction, leaving its
+// right edge off-grid while the left stays on it. The border was then spread
+// across two device pixels at partial opacity and read as thinner on that side
+// alone. `SELECTED_PANEL_BORDER` in golden_layout.styl carries the same note.
 .ct-input-small
   height: 1.5rem
   max-height: 1.75rem
-  border: 0.03125rem solid transparent
+  border: 0.0625rem solid transparent
 
 .ct-input-panel
   width: -webkit-fill-available
   height: 1.75rem
   max-height: 1.75rem
-  border: 0.03125rem solid transparent
+  border: 0.0625rem solid transparent

--- a/src/frontend/styles/components/input.styl
+++ b/src/frontend/styles/components/input.styl
@@ -94,13 +94,17 @@ input
     color: colors-ui-text-primary-body
 
 
+// The resting border is `rem`, matching the `:hover` rule above and every other
+// border in this file. It was `em`, which resolved against each field's own
+// font-size and gave 0.4375px at 14px and 0.375px at 12px — never the 0.5px
+// intended, and never the width hover then swapped in.
 .ct-input-small
   height: 1.5rem
   max-height: 1.75rem
-  border: 0.03125em solid transparent
+  border: 0.03125rem solid transparent
 
 .ct-input-panel
   width: -webkit-fill-available
   height: 1.75rem
   max-height: 1.75rem
-  border: 0.03125em solid transparent
+  border: 0.03125rem solid transparent

--- a/src/frontend/styles/components/shared_widgets.styl
+++ b/src/frontend/styles/components/shared_widgets.styl
@@ -623,61 +623,6 @@ input:checked ~ .checkmark:after
 .hamburger-dropdown + .dropdown-list.active
   width: fit-content
 
-// .layout-buttons-container-wrapper
-//   outline: 4px solid colors-ui-surface-primary-tertiary
-
-.layout-buttons-container
-  // Always render last in the .lm_tabs flex container, pinned to the right.
-  // GL2's tryUpdateTabSizes re-appends tab elements via appendChild (moving
-  // them after our button in the DOM); the CSS order overrides DOM order so
-  // the button stays visually at the far right after collapse/expand.
-  order: 9999
-  margin-left: auto
-  width: 1.7em !important
-  height: 1.7em !important
-  background-color: colors-ui-surface-base-panel
-  border-radius: 0.36em
-  background-image: ct-images-layout-tab
-  background-size:  1em
-  background-repeat: no-repeat
-  background-position: center
-  cursor: pointer
-  border: 0.0625em solid colors-ui-surface-base-panel
-
-  &:focus
-    outline: none !important
-    box-shadow: none !important
-
-  &:focus-visible
-    outline: none !important
-    box-shadow: inset 0 0 0 0.125em colors-ui-border-focus !important
-
-  &:hover
-    background-color: colors-ui-surface-input-default
-
-  &.active
-    // background-image: ct-images-layout-tab-active
-    background-color: colors-ui-surface-input-default
-    border: 0.0625em solid colors-ui-surface-action-primary !important
-
-  .layout-dropdown
-    dropdown-surface()
-    width: fit-content;
-    z-index: 100
-    position: absolute;
-    // Opened flush against the button; now the shared 6px, like every other
-    // menu.
-    top: DROPDOWN_TRIGGER_OFFSET
-    right: 0 !important
-
-    .layout-dropdown-node
-      dropdown-surface-row()
-
-      &:hover
-        background-color: colors-ui-surface-primary-default-hover
-
-
-
 .run-trace-button
   .custom-tooltip
     right: 0px

--- a/src/frontend/styles/components/shared_widgets.styl
+++ b/src/frontend/styles/components/shared_widgets.styl
@@ -1,8 +1,17 @@
 // File containing style for widgets that are shared across all other widgets
+
+// The app-wide scrollbar — every panel that scrolls.  8px at the 16px root, and
+// in `rem` on purpose: this is an unscoped `::-webkit-scrollbar`, so `em` here
+// resolved against whatever element the bar happened to appear on and the
+// thickness changed from panel to panel — measured 6px on a 12px container,
+// 7px at 14px, 12px at 24px.  A 12px panel landed on 6px, the same as a menu,
+// collapsing the distinction DROPDOWN_SCROLLBAR_SIZE exists to draw.
+PANEL_SCROLLBAR_SIZE = 0.5rem
+
 if !IS_EXTENSION
   ::-webkit-scrollbar
-    width: 0.5em
-    height: 0.5em
+    width: PANEL_SCROLLBAR_SIZE
+    height: PANEL_SCROLLBAR_SIZE
     background-color: transparent
 
   ::-webkit-scrollbar-corner
@@ -125,9 +134,9 @@ DROPDOWN_RADIUS = 0.375rem
 
 // Scrollbars inside a menu.
 //
-// The app-wide scrollbar (top of this file) is 0.5em, which is right for a
-// panel but heavy inside a menu a few rows tall — it takes a visible bite out
-// of a 12em-wide dropdown.  Its own constant rather than a reuse of
+// PANEL_SCROLLBAR_SIZE (top of this file) is 8px, which is right for a panel
+// but heavy inside a menu a few rows tall — it takes a visible bite out of a
+// 12em-wide dropdown.  Its own constant rather than a reuse of
 // DROPDOWN_TRIGGER_GAP: the two happen to be the same 6px, but a scrollbar's
 // thickness and a menu's offset answer to different things and should be free
 // to move apart.

--- a/src/frontend/styles/components/vcs.styl
+++ b/src/frontend/styles/components/vcs.styl
@@ -87,7 +87,12 @@ VCS_BRANCH_PICKER_INSET = 0.25em
   gap: 0.375em
   user-select: none
   border-radius: 0.375rem
-  border: 0.03125em solid transparent
+  // 0.0625rem (1px), tracking the field border in input.styl. `em` here resolved
+  // against this element's own 0.875rem text and gave 0.4375px — a sub-pixel
+  // stroke that antialiased to part strength whenever its edge fell off the
+  // device grid. Width lives on the base rule, so `:hover` and the open state
+  // below only swap colour and the control never changes size under the pointer.
+  border: 0.0625rem solid transparent
   background: colors-ui-surface-primary-default
   font-family: "SpaceGrotesk"
   font-size: 0.875rem
@@ -97,7 +102,7 @@ VCS_BRANCH_PICKER_INSET = 0.25em
     border-color: colors-ui-border-primary-hover
     color: colors-ui-text-primary-body
 
-  // Open/active state: thin blue border (like lm_controls active dropdown)
+  // Open/active state: blue border (like lm_controls active dropdown)
   &.vcs-branch-current-open
     border-color: colors-ui-border-action
     color: colors-ui-text-primary-body

--- a/src/frontend/styles/components/welcome_screen.styl
+++ b/src/frontend/styles/components/welcome_screen.styl
@@ -104,11 +104,12 @@
         align-items: center
         font-weight: BOLD_WEIGHT
         width: 19em
-        font-size: 2em
+        font-size: 2.3em
         letter-spacing: -0.02em
-        // In rem, not em: this element's own `font-size: 2em` makes 1em == 32px
-        // here, so `1em` would read as 16px and mean 32px.  2rem is 32px, plainly.
-        line-height: 2rem
+        // Both ems here are deliberate and resolve against different bases:
+        // `font-size` against `.welcome-title`'s 16px (36.8px), `line-height`
+        // against this element's own resolved size (1.2 * 36.8 == 44.16px).
+        line-height: 1.2em
 
       .welcome-version
         color: colors-ui-text-primary-disabled

--- a/src/frontend/styles/components/welcome_screen.styl
+++ b/src/frontend/styles/components/welcome_screen.styl
@@ -106,6 +106,9 @@
         width: 19em
         font-size: 2em
         letter-spacing: -0.02em
+        // In rem, not em: this element's own `font-size: 2em` makes 1em == 32px
+        // here, so `1em` would read as 16px and mean 32px.  2rem is 32px, plainly.
+        line-height: 2rem
 
       .welcome-version
         color: colors-ui-text-primary-disabled

--- a/src/frontend/styles/components/welcome_screen.styl
+++ b/src/frontend/styles/components/welcome_screen.styl
@@ -118,6 +118,11 @@
         font-weight: 400
         line-height: normal
         text-align: center
+        // Keep the version on one line. As a flex item it would otherwise be
+        // squeezed below its own text width by `.welcome-text`'s `width: 19em`,
+        // which scales with the title's font-size, and wrap onto a second row.
+        white-space: nowrap
+        flex-shrink: 0
 
     .welcome-content
       display: flex

--- a/src/frontend/styles/components/welcome_screen.styl
+++ b/src/frontend/styles/components/welcome_screen.styl
@@ -48,9 +48,11 @@
 
 .welcome-logo
   background-image: url('../../public/resources/shared/codetracer_welcome_logo.svg')
-  min-width: 3.875em
-  min-height: 3.875em
-  background-size: 3.875em 3.875em
+  // Sized in rem, not em: this sits inside `.welcome-text`, whose `font-size: 2em`
+  // makes 1em == 32px here.  5rem is 80px at the 16px root either way.
+  min-width: 5rem
+  min-height: 5rem
+  background-size: 5rem 5rem
   background-position: center
   margin-right: 0.75em
   background-repeat: no-repeat

--- a/src/frontend/styles/components/welcome_screen.styl
+++ b/src/frontend/styles/components/welcome_screen.styl
@@ -88,7 +88,7 @@
 
     .welcome-title
       position: relative
-      font-family: "SpaceMono"
+      font-family: "SpaceGrotesk"
       text-align: start
       display: flex
       align-items: flex-end
@@ -137,7 +137,7 @@
       display: flex
       width: -webkit-fill-available
       gap: 0.5em
-      justify-content: space-between
+      justify-content: flex-start
 
       .start-option
         position: relative
@@ -201,7 +201,6 @@
       padding: 0.5em
       margin-top: 3em
       margin-bottom: 3em
-      padding-right: 0
       overflow: visible
 
     .recent-traces-title
@@ -331,7 +330,6 @@
       padding: 0.5em
       margin-top: 3em
       margin-bottom: 3em
-      padding-right: 0
 
     .recent-folders-title
       text-align: start

--- a/src/frontend/ui/auto_hide.nim
+++ b/src/frontend/ui/auto_hide.nim
@@ -319,6 +319,17 @@ proc edgeOverlayCssClass*(edge: AutoHideEdge): cstring =
 
 # Forward declarations — defined in the docked sidebar section below.
 # Placed here so pinPanel / unpinPanel can call them before they are defined.
+proc clearDockedFocusClass() =
+  ## Drop the selection class from every docked container.
+  ##
+  ## Only one panel is ever selected, and the three edges are independent
+  ## containers, so opening one must clear whichever other one held it.
+  for id in [cstring"auto-hide-docked-left", cstring"auto-hide-docked-right",
+             cstring"auto-hide-docked-bottom"]:
+    let el = document.getElementById(id)
+    if not el.isNil:
+      el.classList.remove(cstring"ct-docked-focused")
+
 proc hideDockedPanel*()
 proc cancelHoverPreview*()
 proc hideOverlay*()
@@ -643,6 +654,10 @@ proc hideDockedPanel*() =
     let containerEl = document.getElementById(dockedContainerId(panel.edge))
     if not containerEl.isNil:
       containerEl.classList.remove(cstring"docked-open")
+      # Hand the selection back to GoldenLayout: with no docked panel selected
+      # the outline builder resumes and re-outlines the focused stack.
+      containerEl.classList.remove(cstring"ct-docked-focused")
+      containerEl.removeAttribute(cstring"data-ct-docked-title")
 
   autoHideState.dockedPanel = nil
   autoHideState.dockedVisible = false
@@ -695,6 +710,22 @@ proc showDockedPanel*(panel: AutoHidePanel) =
     console.warn cstring"auto_hide: no live element for docked panel"
 
   containerEl.classList.add(cstring"docked-open")
+
+  # Opening a docked panel selects it — the user clicked its tab to work in it.
+  # `ct-docked-focused` is this panel's equivalent of GoldenLayout's
+  # `.lm_header.lm_focused`: the outline builder in `ui/layout.nim` stands down
+  # while it is set, so the docked panel carries the only selection outline.
+  clearDockedFocusClass()
+  containerEl.classList.add(cstring"ct-docked-focused")
+
+  # Which panel is docked here, for the outline builder in `ui/layout.nim`.
+  #
+  # It cannot read that off the strip: a tab is marked `active` when its panel
+  # is docked *or* when it is being previewed in the hover overlay, so during a
+  # hover two tabs carry the class and the outline would follow whichever came
+  # first.  The border marks the docked panel only, so the docked tab has to be
+  # named outright.
+  containerEl.setAttribute(cstring"data-ct-docked-title", panel.title)
 
   # Restore the remembered size so docked and overlay share the same dimensions.
   # Without this the CSS default (360px/280px) always wins on first dock.
@@ -1284,8 +1315,14 @@ when defined(js):
           showDockedPanel(target),
       onHoverEnter: proc(index: int) =
         if index >= 0 and index < panels.len:
-          # Don't show a hover preview for the panel that's already docked.
+          # Its panel is already on screen, docked, so there is nothing to
+          # preview here — and any preview still up belongs to another tab.
+          # Returning alone left that one hanging open while the pointer sat
+          # on the docked tab.
           if autoHideState.dockedVisible and autoHideState.dockedPanel == panels[index]:
+            cancelHoverPreview()
+            if autoHideState.overlayVisible and not autoHideState.pinnedOpen:
+              hideOverlay()
             return
           # Suppress re-open if the panel was just explicitly closed; wait for
           # the mouse to leave and re-enter before allowing the hover preview.
@@ -1373,7 +1410,14 @@ when defined(js):
           unpinPanel(autoHideLayout, panels[index]),
       onHoverEnter: proc(index: int) =
         if index >= 0 and index < panels.len:
+          # Its panel is already on screen, docked, so there is nothing to
+          # preview here — and any preview still up belongs to another tab.
+          # Returning alone left that one hanging open while the pointer sat
+          # on the docked tab.
           if autoHideState.dockedVisible and autoHideState.dockedPanel == panels[index]:
+            cancelHoverPreview()
+            if autoHideState.overlayVisible and not autoHideState.pinnedOpen:
+              hideOverlay()
             return
           if suppressHoverAfterClose:
             return

--- a/src/frontend/ui/auto_hide.nim
+++ b/src/frontend/ui/auto_hide.nim
@@ -1241,27 +1241,32 @@ proc revealOverlay*(panel: AutoHidePanel) =
 proc contentIcon*(content: Content): cstring =
   ## Return a Unicode icon character for a Content type, used in the
   ## status bar icon zone when strips are in collapsed mode.
+  ##
+  ## The characters are written out, NOT as `\x` escapes: `cstring"..."`
+  ## is a generalized RAW string literal (`ident"..."` means `ident(r"...")`),
+  ## so an escape here is never decoded — it reached the status bar as the
+  ## literal text `\xF0\x9F\x93\x81`.
   case content
   of Content.Filesystem:
-    cstring"\xF0\x9F\x93\x81" # file folder
+    cstring"📁" # file folder
   of Content.Calltrace:
-    cstring"\xF0\x9F\x94\x8D" # magnifying glass
+    cstring"🔍" # magnifying glass
   of Content.EventLog:
-    cstring"\xF0\x9F\x93\x8B" # clipboard
+    cstring"📋" # clipboard
   of Content.State:
-    cstring"\xF0\x9F\x94\xA2" # input numbers
+    cstring"🔢" # input numbers
   of Content.Build:
-    cstring"\xE2\x9A\x99" # gear
+    cstring"⚙" # gear
   of Content.BuildErrors:
-    cstring"\xE2\x9A\xA0" # warning sign
+    cstring"⚠" # warning sign
   of Content.SearchResults:
-    cstring"\xF0\x9F\x94\x8E" # magnifying glass right
+    cstring"🔎" # magnifying glass right
   of Content.TerminalOutput:
-    cstring"\xF0\x9F\x96\xA5" # desktop computer
+    cstring"🖥" # desktop computer
   of Content.Shell:
-    cstring"\xF0\x9F\x92\xBB" # laptop
+    cstring"💻" # laptop
   else:
-    cstring"\xE2\x96\xA3" # square with dot
+    cstring"▣" # square with dot
 
 
 proc sideAutoHideTabsModel*(edge: AutoHideEdge): tuple[

--- a/src/frontend/ui/auto_hide_overlay.nim
+++ b/src/frontend/ui/auto_hide_overlay.nim
@@ -127,21 +127,71 @@ proc attachHoverZone(el: Element) =
     startDismissal())
   el.addEventListener(cstring"mouseenter", proc(ev: Event) = cancelDismissal())
 
+proc setupZoneTracking() =
+  ## Hold the overlay open while the pointer is anywhere in the hover zone — a
+  ## strip tab or the overlay itself — and dismiss it once the pointer is in
+  ## neither.
+  ##
+  ## By delegation on `document`, not a listener per strip.  The bottom strip
+  ## lives in the status bar and is rebuilt whenever that re-renders, so a
+  ## listener bound to the element is dropped without warning — which is why
+  ## leaving a status-bar tab never closed the preview while leaving a
+  ## side-strip tab did.  `mouseover` bubbles from every element the pointer
+  ## enters, so this sees the whole zone and never needs rebinding.
+  {.emit: """
+    // The tabs themselves, not the strips that hold them: a strip runs the
+    // full height (or width) of the window, so treating the whole thing as
+    // the zone kept a preview open while the pointer sat in empty space well
+    // away from any tab.
+    var CT_HOVER_ZONE = '#auto-hide-overlay, .auto-hide-strip-tab';
+    var ctInZone = false;
+
+    function ctZoneUpdate(target) {
+      var inZone = !!(target && target.closest && target.closest(CT_HOVER_ZONE));
+      // Only on a transition.  `startDismissal` restarts its timer each call,
+      // so running it on every mousemove would keep pushing the close back and
+      // the preview would hang about for as long as the pointer kept moving.
+      if (inZone === ctInZone) { return; }
+      ctInZone = inZone;
+      if (inZone) {
+        `cancelDismissal`();
+      } else {
+        `cancelHoverPreview`();
+        `startDismissal`();
+      }
+    }
+
+    // `mouseover` alone fires only when the pointer crosses into a different
+    // element, so a move that stays within one element is never re-judged.
+    // `mousemove` carries the same topmost target and covers the rest.
+    document.addEventListener('mouseover', function (ev) { ctZoneUpdate(ev.target); }, true);
+    document.addEventListener('mousemove', function (ev) { ctZoneUpdate(ev.target); }, true);
+
+    // Pointer off the window entirely: no further events are coming, so close
+    // rather than leave the preview stranded.
+    document.addEventListener('mouseout', function (ev) {
+      if (ev.relatedTarget === null) {
+        ctInZone = false;
+        `cancelHoverPreview`();
+        `startDismissal`();
+      }
+    }, true);
+  """.}
+
 proc setupMouseLeaveDismissal*() =
-  ## Cancel auto-hide whenever the mouse is inside the overlay OR either
-  ## side strip.  Moving between the strip tabs and the overlay content
-  ## must not trigger a close — all three elements form one logical zone.
+  ## Cancel auto-hide whenever the mouse is inside the overlay OR any strip.
+  ## Moving between the strip tabs and the overlay content must not trigger a
+  ## close — they form one logical zone.
   let overlayEl = document.getElementById(cstring"auto-hide-overlay")
   if not overlayEl.isNil:
     attachHoverZone(overlayEl)
 
-  let stripLeft = document.getElementById(cstring"auto-hide-strip-left")
-  if not stripLeft.isNil:
-    attachHoverZone(stripLeft)
-
-  let stripRight = document.getElementById(cstring"auto-hide-strip-right")
-  if not stripRight.isNil:
-    attachHoverZone(stripRight)
+  # The strips themselves are deliberately NOT hover zones.  Each one spans the
+  # whole side of the window, so holding the preview open for the entire strip
+  # kept it up while the pointer rested in empty space far from any tab.
+  # `setupZoneTracking` scopes the zone to the tabs instead, and covers the
+  # bottom strip too — which has no stable element to bind a listener to.
+  setupZoneTracking()
 
 # ---------------------------------------------------------------------------
 # Full overlay setup

--- a/src/frontend/ui/layout.nim
+++ b/src/frontend/ui/layout.nim
@@ -226,15 +226,6 @@ proc createContextMenuFromOptions(
     actions: actions
   )
 
-proc pinActiveContentItem(layout: js, stack: js, edge: AutoHideEdge) =
-  ## Pin the currently active tab in `stack` to the given auto-hide edge.
-  ## Uses `getActiveContentItem` to find what to detach.
-  let activeItem = stack.getActiveContentItem()
-  if activeItem.isNil or activeItem.isUndefined:
-    cwarn "auto_hide: no active content item in stack"
-    return
-  pinPanel(cast[GoldenLayout](layout), cast[GoldenContentItem](activeItem), edge)
-
 proc injectPinButton(tabElement: JsObject, onPin: proc()) =
   ## Insert a pin button to the left of the GL close button inside a tab element.
   ## Clicking it calls `onPin`, which sends the panel to the auto-hide sidebar.
@@ -287,9 +278,6 @@ proc setupDropdownDismissListeners() =
         { container: '.vcs-branch-picker',
           open: '.vcs-branch-current-open',
           trigger: '.vcs-branch-current-open' },
-        { container: '.layout-buttons-container',
-          open: '.layout-buttons-container.active',
-          trigger: '.layout-buttons-container.active' },
         { container: '.session-tab-bar',
           open: '.session-tab-bar.overflow-open',
           trigger: '.session-tab-bar.overflow-open .session-tab-overflow' },
@@ -342,6 +330,10 @@ proc setupSelectedPanelOutline() =
   ## the panel are one continuous outline, so the joins are exact by
   ## construction rather than by alignment.
   ##
+  ## A connector is only drawn where there is room for one.  Against the panel's
+  ## own edge there is none, and forcing one in is what used to flare the curve
+  ## past the panel into the window corner and double the path back on itself.
+  ##
   ## The path is rebuilt from measured geometry, so it follows any tab width,
   ## any radius and any panel size.  Stroke colour and width come from the
   ## stylesheet (`.ct-selected-outline`), keeping them on design tokens.
@@ -355,7 +347,7 @@ proc setupSelectedPanelOutline() =
       // corner for all four drew a square outline over a rounded panel.
       function buildPath(w, h, tabX0, tabX1, tabTop, panelTop, panelBottom,
                          tabTL, tabTR, panelTL, panelTR, panelBR, panelBL,
-                         connR, inset, tabIsFirst) {
+                         connR, inset, tabIsFirst, tabIsLast) {
         // Inset by half the stroke so the line sits INSIDE the shape: SVG
         // centres a stroke on its path.
         var l = inset, r = w - inset, b = panelBottom - inset, t = tabTop + inset;
@@ -368,10 +360,20 @@ proc setupSelectedPanelOutline() =
         d.push('M', x0 + tabTL, t);
         d.push('L', x1 - tabTR, t);
         d.push('A', tabTR, tabTR, 0, 0, 1, x1, t + tabTR);
-        d.push('L', x1, pt - connR);
-        d.push('A', connR, connR, 0, 0, 0, x1 + connR, pt);
-        d.push('L', r - panelTR, pt);
-        d.push('A', panelTR, panelTR, 0, 0, 1, r, pt + panelTR);
+
+        // The right connector needs room between the tab's edge and the panel's
+        // corner.  A last tab is flush against that edge and has none, so the
+        // path runs straight down the edge the two share.  The clamp is the
+        // guard: without it the curve reaches past r and the path doubles back.
+        var cRight = tabIsLast ? 0 : Math.max(0, Math.min(connR, r - panelTR - x1));
+        if (cRight > 0.01) {
+          d.push('L', x1, pt - cRight);
+          d.push('A', cRight, cRight, 0, 0, 0, x1 + cRight, pt);
+          d.push('L', r - panelTR, pt);
+          d.push('A', panelTR, panelTR, 0, 0, 1, r, pt + panelTR);
+        } else {
+          d.push('L', r, pt);
+        }
         d.push('L', r, b - panelBR);
         d.push('A', panelBR, panelBR, 0, 0, 1, r - panelBR, b);
         d.push('L', l + panelBL, b);
@@ -384,13 +386,30 @@ proc setupSelectedPanelOutline() =
         } else {
           d.push('L', l, pt + panelTL);
           d.push('A', panelTL, panelTL, 0, 0, 1, l + panelTL, pt);
-          d.push('L', x0 - connR, pt);
-          d.push('A', connR, connR, 0, 0, 0, x0, pt - connR);
+          var cLeft = Math.max(0, Math.min(connR, x0 - panelTL - l));
+          if (cLeft > 0.01) {
+            d.push('L', x0 - cLeft, pt);
+            d.push('A', cLeft, cLeft, 0, 0, 0, x0, pt - cLeft);
+          } else {
+            d.push('L', x0, pt);
+          }
           d.push('L', x0, t + tabTL);
         }
         d.push('A', tabTL, tabTL, 0, 0, 1, x0 + tabTL, t);
         d.push('Z');
         return d.join(' ');
+      }
+
+      // The one connector radius, in pixels.  It rides on the stroked path's
+      // `border-top-left-radius` (see golden_layout.styl) because that resolves
+      // to pixels, where a custom property would come back as its raw `em`.
+      function connectorRadius() {
+        var probe = document.querySelector('.ct-selected-outline path, .ct-docked-outline path');
+        if (probe !== null) {
+          var v = parseFloat(window.getComputedStyle(probe).borderTopLeftRadius);
+          if (isFinite(v) && v > 0) { return v; }
+        }
+        return 6;
       }
 
       function radiusOf(el, pseudo, prop) {
@@ -406,6 +425,15 @@ proc setupSelectedPanelOutline() =
       }
 
       function update() {
+        // A selected docked panel outlines itself in CSS (it is a plain
+        // rectangle, with no tab or connectors to trace).  GL keeps its own
+        // `.lm_focused` while that is so, and drawing this outline as well
+        // would put two selection cues on screen at once.
+        if (document.querySelector('.auto-hide-docked.ct-docked-focused') !== null) {
+          clearOutlines(null); updateDockedOutline(); return;
+        }
+        removeDockedOutline();
+
         var stack = document.querySelector('.lm_stack:has(> .lm_header.lm_focused)');
         if (stack === null) { clearOutlines(null); return; }
 
@@ -444,9 +472,261 @@ proc setupSelectedPanelOutline() =
           radiusOf(items, null, 'borderTopRightRadius'),
           radiusOf(items, null, 'borderBottomRightRadius'),
           radiusOf(items, null, 'borderBottomLeftRadius'),
-          radiusOf(tab, '::before', 'borderBottomRightRadius') || 10,
+          connectorRadius(),
           strokeWidth / 2,
-          tab.parentElement !== null && tab.parentElement.firstElementChild === tab));
+          tab.parentElement !== null && tab.parentElement.firstElementChild === tab,
+          tab.parentElement !== null && tab.parentElement.lastElementChild === tab));
+      }
+
+      // ---------------------------------------------------------------------
+      // The same outline, for a docked auto-hide panel.
+      //
+      // A docked panel is the GoldenLayout case turned on its side: the strip
+      // tab plays the part of the GL tab and juts out of the panel's edge, so
+      // the line has to run around the tab and not stop at the panel.  Same
+      // shape, same concave connectors, same tokens — only the axis differs.
+      // ---------------------------------------------------------------------
+      var DOCKED_OUTLINE_CLASS = 'ct-docked-outline';
+
+      function radii(el) {
+        var cs = window.getComputedStyle(el);
+        var f = function (v) { var n = parseFloat(v); return isFinite(n) ? n : 0; };
+        return { tl: f(cs.borderTopLeftRadius), tr: f(cs.borderTopRightRadius),
+                 br: f(cs.borderBottomRightRadius), bl: f(cs.borderBottomLeftRadius) };
+      }
+
+      function removeDockedOutline() {
+        // Document-wide: an outline left behind by an earlier build may still be
+        // parked on the body rather than in `#root-container`.
+        var old = document.querySelectorAll('.' + DOCKED_OUTLINE_CLASS);
+        for (var i = 0; i < old.length; i++) { old[i].remove(); }
+      }
+
+      // The panel alone: a plain rounded rectangle.  Used for the bottom edge,
+      // whose tabs live in the status bar rather than in a strip beside it, and
+      // whenever the tab that opened the panel cannot be found.
+      function dockedPanelOnlyPath(p, rr, inset) {
+        var l = p.left + inset, r = p.right - inset, t = p.top + inset, b = p.bottom - inset;
+        return ['M', l + rr.tl, t,
+                'L', r - rr.tr, t, 'A', rr.tr, rr.tr, 0, 0, 1, r, t + rr.tr,
+                'L', r, b - rr.br, 'A', rr.br, rr.br, 0, 0, 1, r - rr.br, b,
+                'L', l + rr.bl, b, 'A', rr.bl, rr.bl, 0, 0, 1, l, b - rr.bl,
+                'L', l, t + rr.tl, 'A', rr.tl, rr.tl, 0, 0, 1, l + rr.tl, t, 'Z'].join(' ');
+      }
+
+      // Panel plus the strip tab that juts out of one side of it.
+      //
+      // `side` is the side the tab is on: 'left' for the left strip, 'right'
+      // for the right one.  The traversal is written for the left strip and
+      // mirrored horizontally for the right, so the shape is described once.
+      //
+      // A tab flush with the panel's top or bottom has no room for a connector
+      // on that end — the curve would reach past the panel and the path would
+      // double back on itself.  There the tab and the panel share one straight
+      // edge instead, which is what the GL outline does for a first tab.
+      function dockedWithTabPath(p, tb, rr, tr_, inset, side) {
+        var mirror = (side === 'right');
+        var px = function (x) { return mirror ? (p.left + p.right) - x : x; };
+        var sgn = mirror ? -1 : 1;
+        var CV = mirror ? 0 : 1;   // convex corner sweep
+        var CC = mirror ? 1 : 0;   // concave connector sweep
+
+        var L  = (mirror ? p.right : p.left)  + sgn * inset;   // panel inner edge
+        var R  = (mirror ? p.left  : p.right) - sgn * inset;   // panel outer edge
+        var T  = p.top + inset, B = p.bottom - inset;
+        var TO = (mirror ? tb.right : tb.left) + sgn * inset;  // tab outer edge
+        var TI = (mirror ? tb.left  : tb.right);               // tab inner edge
+        var tT = tb.top + inset, tB = tb.bottom - inset;
+
+        // Panel corners, and the two tab corners on its outer side.
+        var pTL = mirror ? rr.tr : rr.tl, pTR = mirror ? rr.tl : rr.tr;
+        var pBR = mirror ? rr.bl : rr.br, pBL = mirror ? rr.br : rr.bl;
+        var tTL = mirror ? tr_.tr : tr_.tl, tBL = mirror ? tr_.br : tr_.bl;
+
+        // The connector spans the gap between the tab's edge and the panel's,
+        // so that gap is its radius; it is clamped again at each end by the
+        // room actually left there.
+        // One radius for every connector, clamped by the room actually there:
+        // along the panel's edge (so the curve cannot run off its end) and
+        // across the tab's edge (so it lands on the flat, not on its corner).
+        var CONN = connectorRadius();
+        var tabRoom = Math.abs(L - TO) - Math.max(tTL, tBL);
+        var flushTop = (tT - T) < 1.5;
+        var flushBot = (B - tB) < 1.5;
+        var cT = flushTop ? 0 : Math.max(0, Math.min(CONN, tT - T, tabRoom));
+        var cB = flushBot ? 0 : Math.max(0, Math.min(CONN, B - tB, tabRoom));
+
+        var d = [];
+        // Top edge — from the tab's outer corner when the two share it.
+        if (flushTop) {
+          d.push('M', px(TO + sgn * tTL), T);
+        } else {
+          d.push('M', px(L + sgn * pTL), T);
+        }
+        d.push('L', px(R - sgn * pTR), T);
+        d.push('A', pTR, pTR, 0, 0, CV, px(R), T + pTR);
+        d.push('L', px(R), B - pBR);
+        d.push('A', pBR, pBR, 0, 0, CV, px(R - sgn * pBR), B);
+
+        // Bottom edge, then up the left-hand profile.
+        if (flushBot) {
+          d.push('L', px(TO + sgn * tBL), B);
+          d.push('A', tBL, tBL, 0, 0, CV, px(TO), B - tBL);
+        } else {
+          d.push('L', px(L + sgn * pBL), B);
+          d.push('A', pBL, pBL, 0, 0, CV, px(L), B - pBL);
+          d.push('L', px(L), tB + cB);
+          if (cB > 0.01) { d.push('A', cB, cB, 0, 0, CC, px(L - sgn * cB), tB); }
+          else { d.push('L', px(L), tB); }
+          d.push('L', px(TO + sgn * tBL), tB);
+          d.push('A', tBL, tBL, 0, 0, CV, px(TO), tB - tBL);
+        }
+
+        // Up the tab's outer edge.
+        d.push('L', px(TO), (flushTop ? T : tT) + tTL);
+        d.push('A', tTL, tTL, 0, 0, CV, px(TO + sgn * tTL), (flushTop ? T : tT));
+
+        if (!flushTop) {
+          d.push('L', px(L - sgn * cT), tT);
+          if (cT > 0.01) { d.push('A', cT, cT, 0, 0, CC, px(L), tT - cT); }
+          else { d.push('L', px(L), tT); }
+          d.push('L', px(L), T + pTL);
+          d.push('A', pTL, pTL, 0, 0, CV, px(L + sgn * pTL), T);
+        }
+        d.push('Z');
+        return d.join(' ');
+      }
+
+      // The bottom edge: the panel sits above its tab rather than beside it, and
+      // the tabs live in the status bar (`#auto-hide-bottom-strip`) instead of a
+      // strip alongside.  Same shape, same connectors, turned a quarter turn.
+      function dockedWithTabPathBottom(p, tb, rr, tr_, inset) {
+        var L = p.left + inset, R = p.right - inset;
+        var T = p.top + inset, B = p.bottom - inset;
+        var tL = tb.left + inset, tR = tb.right - inset, tB = tb.bottom - inset;
+
+        // Same radius as everywhere else, clamped by the room along the panel's
+        // bottom edge and by the height of the tab's own side edge.
+        var CONN = connectorRadius();
+        var tabRoom = (tB - B) - Math.max(tr_.bl, tr_.br);
+        var cL = Math.max(0, Math.min(CONN, tL - L, tabRoom));
+        var cR = Math.max(0, Math.min(CONN, R - tR, tabRoom));
+
+        var d = [];
+        d.push('M', L + rr.tl, T);
+        d.push('L', R - rr.tr, T);
+        d.push('A', rr.tr, rr.tr, 0, 0, 1, R, T + rr.tr);
+        d.push('L', R, B - rr.br);
+        d.push('A', rr.br, rr.br, 0, 0, 1, R - rr.br, B);
+        // Leftward along the panel's bottom, then down and around the tab.
+        d.push('L', tR + cR, B);
+        if (cR > 0.01) { d.push('A', cR, cR, 0, 0, 0, tR, B + cR); }
+        else { d.push('L', tR, B); }
+        d.push('L', tR, tB - tr_.br);
+        d.push('A', tr_.br, tr_.br, 0, 0, 1, tR - tr_.br, tB);
+        d.push('L', tL + tr_.bl, tB);
+        d.push('A', tr_.bl, tr_.bl, 0, 0, 1, tL, tB - tr_.bl);
+        d.push('L', tL, B + cL);
+        if (cL > 0.01) { d.push('A', cL, cL, 0, 0, 0, tL - cL, B); }
+        else { d.push('L', tL, B); }
+        // And on along the panel's bottom to close.
+        d.push('L', L + rr.bl, B);
+        d.push('A', rr.bl, rr.bl, 0, 0, 1, L, B - rr.bl);
+        d.push('L', L, T + rr.tl);
+        d.push('A', rr.tl, rr.tl, 0, 0, 1, L + rr.tl, T);
+        d.push('Z');
+        return d.join(' ');
+      }
+
+      function updateDockedOutline() {
+        removeDockedOutline();
+        var panel = document.querySelector('.auto-hide-docked.docked-open.ct-docked-focused');
+        if (panel === null) { return; }
+
+        var pr = panel.getBoundingClientRect();
+        if (pr.width < 1 || pr.height < 1) { return; }
+
+        // Trim the resize grip off the panel's edge.
+        //
+        // It is the divider between this panel and whatever it is docked
+        // against — GoldenLayout's own `.lm_splitter` in all but name — but it
+        // lives INSIDE the docked container, so the container's rect covers it
+        // and the outline was drawn around the gap as though it were part of
+        // the panel.  A GL panel's outline stops at its own edge and leaves the
+        // splitter beside it alone; this one now does the same.
+        var p = { left: pr.left, top: pr.top, right: pr.right, bottom: pr.bottom };
+        var grip = panel.querySelector('.auto-hide-docked-resize-handle');
+        if (grip !== null) {
+          var g = grip.getBoundingClientRect();
+          if (g.width > 0 && g.height > 0) {
+            if (g.width < g.height) {
+              // Upright grip: it hugs the left or the right edge.
+              if (Math.abs(g.right - p.right) < 1) { p.right = g.left; }
+              else if (Math.abs(g.left - p.left) < 1) { p.left = g.right; }
+            } else {
+              // Lying flat: the top or the bottom edge.
+              if (Math.abs(g.top - p.top) < 1) { p.top = g.bottom; }
+              else if (Math.abs(g.bottom - p.bottom) < 1) { p.bottom = g.top; }
+            }
+          }
+        }
+
+        var side = panel.id.indexOf('right') !== -1 ? 'right'
+                 : panel.id.indexOf('bottom') !== -1 ? 'bottom' : 'left';
+
+        var svg = document.createElementNS(SVG_NS, 'svg');
+        svg.setAttribute('class', DOCKED_OUTLINE_CLASS);
+        var path = document.createElementNS(SVG_NS, 'path');
+        svg.appendChild(path);
+        // Into `#root-container`, NOT the body.  That element is
+        // `position: fixed; z-index: 0`, so it opens a stacking context, and the
+        // hover overlay lives inside it: parked on the body this outline would
+        // be compared against root-container's own 0 and win every time,
+        // painting across a hovered panel however high the overlay's z-index
+        // was set.  Inside, the two are ordered against each other and the
+        // overlay covers the outline where they meet.  `position: fixed` still
+        // resolves against the viewport here (no transformed ancestor), so the
+        // viewport coordinates below stay correct.
+        var host = document.getElementById('root-container') || document.body;
+        host.appendChild(svg);
+
+        var w = window.innerWidth, h = window.innerHeight;
+        svg.setAttribute('viewBox', '0 0 ' + w + ' ' + h);
+        svg.setAttribute('width', w);
+        svg.setAttribute('height', h);
+
+        var strokeWidth = parseFloat(window.getComputedStyle(path).strokeWidth) || 1;
+        var inset = strokeWidth / 2;
+        var rr = radii(panel);
+
+        // The bottom strip is the status bar, and is named differently from the
+        // two side strips.
+        var stripSel = side === 'bottom' ? '#auto-hide-bottom-strip'
+                                         : '#auto-hide-strip-' + side;
+
+        // Find the tab by the docked panel's own title, not by `.active`.  That
+        // class marks a tab whose panel is docked *or* being previewed in the
+        // hover overlay, so while hovering two tabs carry it and picking the
+        // first drew this border around whichever tab the pointer was over.
+        // The border is for the docked panel alone.
+        var wanted = panel.getAttribute('data-ct-docked-title');
+        var tab = null;
+        var candidates = document.querySelectorAll(stripSel + ' .auto-hide-strip-tab');
+        for (var ti = 0; ti < candidates.length; ti++) {
+          if (candidates[ti].textContent.trim() === wanted) { tab = candidates[ti]; break; }
+        }
+        if (tab === null) {
+          path.setAttribute('d', dockedPanelOnlyPath(p, rr, inset));
+          return;
+        }
+        var tb = tab.getBoundingClientRect();
+        if (tb.width < 1 || tb.height < 1) {
+          path.setAttribute('d', dockedPanelOnlyPath(p, rr, inset));
+          return;
+        }
+        path.setAttribute('d', side === 'bottom'
+          ? dockedWithTabPathBottom(p, tb, rr, radii(tab), inset)
+          : dockedWithTabPath(p, tb, rr, radii(tab), inset, side));
       }
 
       var pending = false;
@@ -465,6 +745,15 @@ proc setupSelectedPanelOutline() =
         attributes: true, attributeFilter: ['class'], subtree: true, childList: true
       });
       window.addEventListener('resize', schedule);
+
+      // Dragging a docked panel's resize grip changes its width through inline
+      // style, which the class-filtered observer above never sees.
+      if (typeof ResizeObserver !== 'undefined') {
+        var ro = new ResizeObserver(schedule);
+        var docks = document.querySelectorAll('.auto-hide-docked');
+        for (var di = 0; di < docks.length; di++) { ro.observe(docks[di]); }
+      }
+
       schedule();
     })();
   """.}
@@ -481,15 +770,41 @@ proc setupClickToFocusListeners() =
   ## (it blurs the previously focused item and emits its focus event); setting the
   ## class here would leave the two disagreeing.
   ##
+  ## A docked auto-hide panel counts as a panel here too.  It lives outside the
+  ## GoldenLayout tree, so GL has no way to focus it and no way to know it was
+  ## clicked; `ct-docked-focused` is the equivalent, and the outline builder
+  ## stands down while it is set so exactly one panel is ever outlined.
+  ##
   ## Listens in the capture phase and never calls `preventDefault`, so the click
   ## still reaches whatever was clicked — this only runs alongside it.
   {.emit: """
+    function ctClearDockedFocus(except) {
+      var docked = document.querySelectorAll('.auto-hide-docked.ct-docked-focused');
+      for (var i = 0; i < docked.length; i++) {
+        if (docked[i] !== except) { docked[i].classList.remove('ct-docked-focused'); }
+      }
+    }
+
     document.addEventListener('mousedown', function (ev) {
       var target = ev.target;
       if (!target || !target.closest) return;
 
+      var docked = target.closest('.auto-hide-docked');
+      if (docked !== null) {
+        ctClearDockedFocus(docked);
+        // A docked panel that is not open is a zero-size container; only an
+        // open one can be the selected panel.
+        if (docked.classList.contains('docked-open')) {
+          docked.classList.add('ct-docked-focused');
+        }
+        return;
+      }
+
       var stack = target.closest('.lm_stack');
       if (stack === null) return;
+
+      // Clicking back into the layout hands the selection to GoldenLayout.
+      ctClearDockedFocus(null);
 
       // Header clicks are GoldenLayout's own business: tabs, the close and pin
       // buttons and the stack menu all live there and already focus correctly.
@@ -634,7 +949,6 @@ proc createLayoutDropdown(layout: js, stackCreatedEvent: Event): kdom.Element =
     pinActiveContentItem(layout, stackCreatedEvent.toJs.target, AutoHideEdge.Left)
   appendDropdownItem(cstring"Pin to Right"):
     pinActiveContentItem(layout, stackCreatedEvent.toJs.target, AutoHideEdge.Right)
-
 proc closeLayoutTab*(data: Data, content: Content, id: int) =
   if not data.ui.componentMapping[content].hasKey(id):
     raise newException(Exception, "There is not any component with the given id.")
@@ -927,38 +1241,34 @@ proc initLayout*(initialLayout: GoldenLayoutResolvedConfig,
     proc() = (cdebug "layout: component unbinded")
   )
 
-  # Create nested buttons in header
+  # The header used to also carry a `.layout-buttons-container` dropdown
+  # (close all / maximise / pin to an edge).  It was removed: every one of those
+  # actions is on the tab's right-click menu (`addPanelTransferContextMenu`), so
+  # the button was a second way to reach the same commands and cost a permanent
+  # 1.7em of header width per stack.
   layout.on(cstring"stackCreated") do (ev: Event):
-    let newElement = kdom.document.createElement("div")
-    let hiddenDropdown = createLayoutDropdown(layout, ev)
-    newElement.classList.add("layout-buttons-container")
-    newElement.setAttribute("tabindex", "0")
-    newElement.onclick = proc(e: Event) {.nimcall.} =
-      let currentElement = cast[kdom.Element](e.toJs.currentTarget)
-      let element = cast[kdom.Element](currentElement.children[0])
+    # Hand back GoldenLayout's `tabControlOffset` (10px by default).
+    #
+    # GL decides how many tabs fit by comparing their total width against
+    # `header - controls - tabControlOffset`, and that offset exists to reserve
+    # room for the header controls it draws itself.  We delete those controls
+    # (below) and the tab strip is a full-width flex row, so the tabs overrun
+    # that budget by exactly the offset and GL banishes every tab after the
+    # first into `.lm_tabdropdown_list` — a list whose only trigger lives in the
+    # controls we just removed.  Nesting two panels then looks like the second
+    # one vanished.  Zero the offset and the arithmetic comes out even.
+    #
+    # Set per stack rather than in the layout config: a config can arrive from
+    # the saved-layout database, a fixture or a default, and GL's own resolver
+    # fills the field back in with 10 wherever it is missing.
+    ev.toJs.target.header[cstring"_tabControlOffset"] = 0.toJs
 
-      if element.classList.contains("hidden"):
-        element.classList.remove("hidden")
-        currentElement.classList.add("active")
-      else:
-        element.classList.add("hidden")
-        currentElement.classList.remove("active")
-
-      cast[kdom.Element](e.target).focus()
-
-    newElement.onblur = proc(e: Event) {.nimcall.} =
-      let currentElement = cast[kdom.Element](e.toJs.currentTarget)
-      e.toJs.target.children[0].classList.add("hidden")
-      currentElement.classList.remove("active")
-
+    # Strip GoldenLayout's own stack-header controls.  Left alone, GL paints its
+    # close/popout/maximise glyphs into the header.
     let container = ev.toJs.target.element.childNodes[0].childNodes[1]
-    let tabContainer = ev.toJs.target.element.childNodes[0].childNodes[0]
 
     while cast[kdom.Element](container).childNodes.len() > 0:
       container.removeChild(container.childNodes[0])
-
-    newElement.appendChild(hiddenDropdown)
-    tabContainer.appendChild(newElement)
 
   data.ui.layout = layout
   data.ui.layoutConfig = cast[GoldenLayoutConfigClass](window.toJs.LayoutConfig)

--- a/src/frontend/ui/layout.nim
+++ b/src/frontend/ui/layout.nim
@@ -226,6 +226,15 @@ proc createContextMenuFromOptions(
     actions: actions
   )
 
+proc pinActiveContentItem(layout: js, stack: js, edge: AutoHideEdge) =
+  ## Pin the currently active tab in `stack` to the given auto-hide edge.
+  ## Uses `getActiveContentItem` to find what to detach.
+  let activeItem = stack.getActiveContentItem()
+  if activeItem.isNil or activeItem.isUndefined:
+    cwarn "auto_hide: no active content item in stack"
+    return
+  pinPanel(cast[GoldenLayout](layout), cast[GoldenContentItem](activeItem), edge)
+
 proc injectPinButton(tabElement: JsObject, onPin: proc()) =
   ## Insert a pin button to the left of the GL close button inside a tab element.
   ## Clicking it calls `onPin`, which sends the panel to the auto-hide sidebar.

--- a/src/frontend/viewmodel/views/isonim_request_panel_view.nim
+++ b/src/frontend/viewmodel/views/isonim_request_panel_view.nim
@@ -279,6 +279,12 @@ proc appendRenderedChild(r: MockRenderer; host, child: MockNode) =
   ## helper of the same name so ``renderFilterPicker`` can stay generic.
   r.appendChild(host, child)
 
+proc setInnerHtml(r: MockRenderer; node: MockNode; html: string) =
+  ## Set the inner HTML of a mock node.  ``renderFilterPicker`` uses this to
+  ## inject the chevron SVG.  In the mock renderer this is a no-op: tests do
+  ## not inspect the chevron SVG content.
+  discard
+
 # Web-renderer picker helpers forward-declared here (before renderFilterPicker)
 # so that generic instantiation for WebRenderer finds setInnerHtml /
 # appendRenderedChild. Mirrors the VCS view's pattern exactly.

--- a/src/frontend/viewmodel/views/isonim_vcs_view.nim
+++ b/src/frontend/viewmodel/views/isonim_vcs_view.nim
@@ -267,6 +267,12 @@ proc attachScrollSentinel(r: MockRenderer; sentinel: MockNode;
 proc appendRenderedChild(r: MockRenderer; host, child: MockNode) =
   r.appendChild(host, child)
 
+proc setInnerHtml(r: MockRenderer; node: MockNode; html: string) =
+  ## Set the inner HTML of a mock node.  ``renderBranchPicker`` uses this to
+  ## inject the chevron SVG.  In the mock renderer this is a no-op: tests do
+  ## not inspect the chevron SVG content.
+  discard
+
 when defined(js):
   proc attachScrollSentinel(r: WebRenderer; sentinel: isonim_dom.Element;
                             callbacks: VCSCallbacks) =

--- a/src/tests/gui/tests/auto-hide/auto-hide-panes.spec.ts
+++ b/src/tests/gui/tests/auto-hide/auto-hide-panes.spec.ts
@@ -32,8 +32,10 @@
  *                                  since a6151510e, and the per-tab buttons
  *                                  that replaced it were deleted in 1af471302)
  *   #auto-hide-backdrop          — click-to-dismiss backdrop behind overlay
- *   .layout-buttons-container    — GL stack header dropdown toggle
- *   .layout-dropdown-node        — individual item inside the dropdown
+ *   .context-menu-item           — a row in that menu; the pin/close/maximise
+ *                                  commands moved here when the stack-header
+ *                                  .layout-buttons-container dropdown was
+ *                                  removed as a duplicate affordance
  *
  * No mocks: a real JavaScript recording opened by the real Electron app.
  * The strip/overlay DOM is built by `layout.nim` the same way for every
@@ -78,12 +80,17 @@ const WAIT_TIMEOUT_MS = 15000;
 // ---------------------------------------------------------------------------
 
 /**
- * Open the dropdown menu on the first visible GL stack header and click
- * the menu item whose text matches `itemText` (e.g. "Pin to Bottom").
+ * Right-click the active tab of the first visible GL stack and click the
+ * context-menu item whose text matches `itemText` (e.g. "Pin to Bottom").
  *
- * The dropdown is a `.layout-buttons-container` div rendered in each
- * stack header. Clicking it toggles a child `.layout-dropdown` between
- * hidden and visible. Menu items are `.layout-dropdown-node` elements.
+ * The stack-header `.layout-buttons-container` dropdown this helper used to
+ * drive was removed — every action it carried is on the tab's right-click
+ * menu (`addPanelTransferContextMenu` in `ui/layout.nim`), which is now the
+ * only way to reach them.  That menu renders into `#context-menu-container`
+ * as `.context-menu-item` rows.
+ *
+ * Note the label change that came with the move: the dropdown's "Close all"
+ * is "Close" on the context menu.
  *
  * Returns the title text of the active tab in the stack that was acted
  * upon, so tests can assert which panel was pinned.
@@ -100,24 +107,18 @@ async function clickDropdownItem(
   await expect(stack).toBeVisible({ timeout: 10_000 });
 
   // The active tab label lives inside .lm_tab.lm_active .lm_title
-  const activeTitle = await stack
-    .locator(".lm_tab.lm_active .lm_title")
-    .first()
-    .textContent();
+  const activeTab = stack.locator(".lm_tab.lm_active").first();
+  const activeTitle = await activeTab.locator(".lm_title").first().textContent();
 
-  // Click the dropdown toggle (the container div in the stack header).
-  const toggle = stack.locator(".layout-buttons-container").first();
-  await toggle.click();
+  // Open the tab's context menu.  The handler calls preventDefault, so the
+  // browser's own menu never appears.
+  await activeTab.click({ button: "right" });
 
-  // Wait for the dropdown to become visible (hidden class removed).
-  const dropdown = stack.locator(".layout-dropdown").first();
-  await expect(dropdown).not.toHaveClass(/hidden/, { timeout: WAIT_TIMEOUT_MS });
+  const menu = ctPage.locator("#context-menu-container");
+  await expect(menu).toBeVisible({ timeout: WAIT_TIMEOUT_MS });
 
-  // Wait for the desired menu item to be visible so the DOM is populated.
-  const menuItem = dropdown.locator(".layout-dropdown-node", {
-    hasText: itemText,
-  });
-  await expect(menuItem).toBeVisible({ timeout: WAIT_TIMEOUT_MS });
+  const menuItem = menu.locator(".context-menu-item", { hasText: itemText });
+  await expect(menuItem.first()).toBeVisible({ timeout: WAIT_TIMEOUT_MS });
 
   const layoutUpdatedPromise = ctPage.evaluate(() => {
     return new Promise<void>((resolve) => {
@@ -125,26 +126,19 @@ async function clickDropdownItem(
     });
   });
 
-  // Click via page.evaluate() to avoid the blur race condition: the
-  // dropdown's onblur handler closes the menu before Playwright's
-  // click() can land. Using the DOM API fires the click synchronously.
-  // We scope the search to the correct stack (by index) since all
-  // stacks have identical menu items.
-  await ctPage.evaluate(
-    ({ text, idx }) => {
-      const stacks = document.querySelectorAll(".lm_stack");
-      const stack = stacks[idx];
-      if (!stack) return;
-      const items = stack.querySelectorAll(".layout-dropdown-node");
-      for (const item of items) {
-        if (item.textContent?.trim() === text) {
-          (item as HTMLElement).click();
-          return;
-        }
+  // Click via the DOM API: the menu closes itself on any document click, so
+  // a synthetic click is steadier than routing one through the page.
+  await ctPage.evaluate((text) => {
+    const items = document.querySelectorAll(
+      "#context-menu-container .context-menu-item",
+    );
+    for (const item of items) {
+      if (item.textContent?.trim() === text) {
+        (item as HTMLElement).click();
+        return;
       }
-    },
-    { text: itemText, idx: stackIndex },
-  );
+    }
+  }, itemText);
 
   // Wait for the deterministic layoutUpdated signal before returning
   await layoutUpdatedPromise;

--- a/src/tests/gui/tests/visual-audit/comprehensive-v2.spec.ts
+++ b/src/tests/gui/tests/visual-audit/comprehensive-v2.spec.ts
@@ -332,26 +332,24 @@ async function pinToEdge(
     .first()
     .textContent();
 
-  const toggle = stack.locator(".layout-buttons-container").first();
-  await toggle.click();
+  // The stack-header dropdown was removed; these commands live on the tab's
+  // right-click menu now (`addPanelTransferContextMenu` in `ui/layout.nim`).
+  await stack.locator(".lm_tab.lm_active").first().click({ button: "right" });
 
-  const dropdown = stack.locator(".layout-dropdown").first();
-  await expect(dropdown).not.toHaveClass(/hidden/, { timeout: 5_000 });
+  const menu = page.locator("#context-menu-container");
+  await expect(menu).toBeVisible({ timeout: 5_000 });
 
-  await page.evaluate(
-    ({ text, idx }) => {
-      const stacks = document.querySelectorAll(".lm_stack");
-      const s = stacks[idx];
-      if (!s) return;
-      for (const item of s.querySelectorAll(".layout-dropdown-node")) {
-        if (item.textContent?.trim() === text) {
-          (item as HTMLElement).click();
-          return;
-        }
+  await page.evaluate((text) => {
+    const items = document.querySelectorAll(
+      "#context-menu-container .context-menu-item",
+    );
+    for (const item of items) {
+      if (item.textContent?.trim() === text) {
+        (item as HTMLElement).click();
+        return;
       }
-    },
-    { text: `Pin to ${edge}`, idx: stackIndex },
-  );
+    }
+  }, `Pin to ${edge}`);
 
   await wait(1500);
   return (activeTitle ?? "").trim();

--- a/src/tests/gui/tests/visual-audit/final-fixes.spec.ts
+++ b/src/tests/gui/tests/visual-audit/final-fixes.spec.ts
@@ -342,19 +342,19 @@ test.describe("Visual Review — All Components", () => {
     });
 
     if (pinned !== "ok") {
-      console.warn(`Pin FILESYSTEM failed: ${pinned}, using dropdown fallback`);
-      // Fallback: use dropdown menu to pin the active tab.
+      console.warn(`Pin FILESYSTEM failed: ${pinned}, using context-menu fallback`);
+      // Fallback: pin the active tab from its right-click menu.  The
+      // stack-header dropdown that used to serve this was removed.
       const stacks = ctPage.locator(".lm_stack");
       const stack = stacks.first();
       if (await stack.isVisible({ timeout: 3_000 }).catch(() => false)) {
-        const toggle = stack.locator(".layout-buttons-container").first();
-        await toggle.click();
+        await stack.locator(".lm_tab.lm_active").first().click({ button: "right" });
         await wait(300);
         await ctPage.evaluate(() => {
-          const stacks = document.querySelectorAll(".lm_stack");
-          const s = stacks[0];
-          if (!s) return;
-          for (const item of s.querySelectorAll(".layout-dropdown-node")) {
+          const items = document.querySelectorAll(
+            "#context-menu-container .context-menu-item",
+          );
+          for (const item of items) {
             if (item.textContent?.trim() === "Pin to Left") {
               (item as HTMLElement).click();
               return;

--- a/src/tests/gui/tests/visual-audit/strip-layout-verify.spec.ts
+++ b/src/tests/gui/tests/visual-audit/strip-layout-verify.spec.ts
@@ -21,7 +21,9 @@ import {
 const DIR = "/tmp/strip-layout-verify";
 const wait = (ms: number) => new Promise(r => setTimeout(r, ms));
 
-// Helper: pin via JS (avoids dropdown blur race)
+// Helper: pin the stack's active tab via its right-click context menu.
+// The stack-header dropdown that used to carry these commands was removed;
+// `addPanelTransferContextMenu` in `ui/layout.nim` is now the only route.
 async function pinToEdge(
   page: import("@playwright/test").Page,
   edge: string,
@@ -29,23 +31,19 @@ async function pinToEdge(
 ) {
   const stacks = page.locator(".lm_stack");
   const stack = stacks.nth(stackIndex);
-  const toggle = stack.locator(".layout-buttons-container").first();
-  await toggle.click();
+  await stack.locator(".lm_tab.lm_active").first().click({ button: "right" });
   await wait(300);
-  await page.evaluate(
-    ([e, idx]) => {
-      const stacks = document.querySelectorAll(".lm_stack");
-      const s = stacks[Number(idx)];
-      if (!s) return;
-      for (const item of s.querySelectorAll(".layout-dropdown-node")) {
-        if (item.textContent?.trim() === `Pin to ${e}`) {
-          (item as HTMLElement).click();
-          return;
-        }
+  await page.evaluate((e) => {
+    const items = document.querySelectorAll(
+      "#context-menu-container .context-menu-item",
+    );
+    for (const item of items) {
+      if (item.textContent?.trim() === `Pin to ${e}`) {
+        (item as HTMLElement).click();
+        return;
       }
-    },
-    [edge, String(stackIndex)],
-  );
+    }
+  }, edge);
   await wait(1500);
 }
 


### PR DESCRIPTION
Third round of UI design improvements, following #646.

Supersedes #656, which was closed on 28 Aug — this branch carries all of its
commits plus a round of work on auto-hide panels, so the earlier PR's
"stylesheets only" description no longer described it.

Every change was measured in the running app over CDP rather than eyeballed,
and each commit body carries the reasoning in full.

## Auto-hide panels (new in this round)

A panel docked to an edge had no way to show it was the one being worked in —
the selected-panel border stopped at the GoldenLayout tree. It now carries the
same line, built the same way: one stroked path around the tab and the panel
together, from the same tokens, on all three edges. Docking selects the panel
and GL's outline stands down, so exactly one panel is ever outlined.

Fixing that surfaced several things that were wrong the moment panels could be
nested at all:

- **Nesting was broken.** GoldenLayout reserves room for header controls this
  app deletes (`tabControlOffset`), so the tabs overran its fit budget by
  exactly that offset and every tab after the first was banished to an overflow
  list whose only trigger had been removed with them. Nesting two panels looked
  like the second one vanished.
- **Tabs are separated with the flex container's `gap`, not margins.** GL
  charges the *active* tab's margin to every tab when it totals the strip, so
  any margin pushed the sum over; zeroing the active tab's margin to dodge that
  left it with no gap to its neighbour.
- **The connector is traced at its painted radius.** The curve is a box-shadow
  with a negative spread, which shrinks its corner, so the stroke had been
  following a 10px arc around a 6px curve.
- **The border no longer encloses the resize grip.** That grip is the splitter
  between a docked panel and what it abuts, but it lives inside the container,
  so the border took in the gap as though it were panel.
- **Side docked panels paint on the panel surface.** They were transparent and
  showed the window through; the bottom one always had this.
- **The stack-header dropdown is gone.** Every command on it is on the tab's
  right-click menu, and it cost 1.7em of header width per stack.

Hover dismissal is now tracked by delegation on the document. The bottom strip
is rebuilt whenever the status bar re-renders, so a listener bound to it was
dropped and leaving a status-bar tab never closed the preview. The zone is the
tabs themselves rather than the strips, which span the whole window.

## Stylesheets (carried over from #656)

Welcome screen typography and layout, input and VCS border weights, the panel
scrollbar, the tab close icon, and the event-log filter trigger. Seven `.styl`
files, no logic.

## Not done

**The four GUI specs in this PR are updated but have not been run.** They were
changed to drive the tab's right-click menu after the header dropdown was
removed; running them needs a full build, which I did not do. Worth a CI run
before merge.
