### PR TITLE
docs(cloud): correct prose that describes checks and mechanisms that changed

### DIFF
--- a/.github/workflows/deploy-web-codetracer.yml
+++ b/.github/workflows/deploy-web-codetracer.yml
@@ -10,8 +10,16 @@ name: Deploy ide.codetracer.com
 # NAMES (2026-08-29): the hosted CodeTracer web product's domain is
 # https://ide.codetracer.com. An earlier plan put it on `web.codetracer.com` and
 # a later note here described `web.` as a separate authenticated application that
-# had to keep working; both are superseded — `ide.` is the product's one domain,
-# and `web.codetracer.com` is not a name this repo targets any more. Unchanged by
+# had to keep working; both are superseded — `ide.` is the product's PRIMARY
+# domain, and `web.codetracer.com` is not a name this repo targets any more.
+#
+# `ide.` is NOT the only host this deployment serves, and reading this header as
+# if it were is how the verify step came to check two hosts while the deployment
+# declared three. The authoritative list is the descriptor's `origin` plus every
+# `languageOrigins[].origin` — see `CT_WEB_LANGUAGE_ORIGINS` below, which today
+# adds `noirstudio.dev` and `www.noirstudio.dev`. Anything that enumerates hosts
+# (a cache purge, a reachability check) must derive them from that variable and
+# not from this paragraph. Unchanged by
 # that decision: the Cloudflare Pages PROJECT is still named `web-codetracer`,
 # this workflow file is still `deploy-web-codetracer.yml`, and the preview host is
 # still `web-codetracer.pages.dev` — those are infrastructure identifiers, not the
@@ -81,8 +89,10 @@ name: Deploy ide.codetracer.com
 #
 # ONE ENVIRONMENT / ONE PROJECT
 #   The `web-codetracer` Pages project's PRODUCTION branch is `cloud`. Merging
-#   to `cloud` publishes a production deployment served on ide.codetracer.com
-#   (and web-codetracer.pages.dev).
+#   to `cloud` publishes a production deployment served on ide.codetracer.com,
+#   on web-codetracer.pages.dev, and on every host in CT_WEB_LANGUAGE_ORIGINS
+#   (currently noirstudio.dev and www.noirstudio.dev) — one bundle, several
+#   hostnames, each with its own Cloudflare cache.
 #   (Cloudflare decides production-vs-preview by comparing the deployed branch
 #   to the project's configured production branch — see metacraft-labs/web-site
 #   DEPLOY.md.) Create the project once with wrangler before the first run; this

--- a/ci/test/js-bundle-name-uniqueness.sh
+++ b/ci/test/js-bundle-name-uniqueness.sh
@@ -146,7 +146,10 @@ if [ "${failed}" -ne 0 ]; then
 	echo "${failed} failure(s).  A duplicated name means one definition silently" >&2
 	echo "replaced another and its callers now run the wrong body.  If this" >&2
 	echo "started after a build change, check for '--hotCodeReloading' being" >&2
-	echo "re-enabled on a JS bundle in repro.nim." >&2
+	echo "re-enabled on a JS bundle. TWO places set it, and repro.nim is only" >&2
+	echo "one of them: repro.nim's hotCodeReloadingOnValue, and the justfile's" >&2
+	echo "build-ui-js / build-ui-js-hmr recipes, which pass" >&2
+	echo "--hotCodeReloading:on while compiling src/frontend/ui_js.nim." >&2
 	exit 1
 fi
 

--- a/ci/test/noir-template-toolchain.sh
+++ b/ci/test/noir-template-toolchain.sh
@@ -431,12 +431,16 @@ else
 fi
 
 provenance="$(grep '^provenance ' "${cache}/control-report.txt" | sed 's/^provenance //')"
+# The string must name the compiler that PRODUCED the shipped number, which is
+# the wasm module this page runs — not `nargo`, whose answer for this template
+# differs. Asserting "nargo info" here is what kept the wrong provenance in
+# place while certifying nothing about the number.
 case "${provenance}" in
-*"nargo info"*)
-	ck ok "the shipped counts carry their provenance: ${provenance}"
+*"compiler this page runs"*)
+	ck ok "the shipped counts name the compiler that produced them: ${provenance}"
 	;;
 *)
-	ck fail "the shipped counts carry no provenance naming nargo info ('${provenance}') — a count a user cannot judge"
+	ck fail "the shipped counts do not name the compiler that produced them ('${provenance}') — a count a user cannot judge, or one attributed to a compiler that returns a different number"
 	;;
 esac
 echo

--- a/ci/test/noir-template-toolchain.sh
+++ b/ci/test/noir-template-toolchain.sh
@@ -15,8 +15,11 @@
 #      it twice. A citation of an absent check is worse than no citation: it
 #      reads, in review, exactly like a check.
 #   3. (new) `noirTemplateNargoInfoJson` — the constraint counts the
-#      Constraints pane shows on the web, produced by `nargo info --json` at
-#      build time because a browser has no `nargo`.
+#      Constraints pane shows on the web. They are carried in `nargo info
+#      --json`'s SHAPE, but this gate no longer checks them with `nargo`: the
+#      ACIR total is compared against the wasm module the deploy ships, which
+#      is the only compiler whose answer a visitor can see. The unconstrained
+#      counts are compared against nothing.
 #
 # This gate is all three, plus the one that matters most for NS9:
 #
@@ -53,9 +56,11 @@
 #     reddens the selector-set equality alone — `nargo` then runs 4 tests and
 #     the parser still reports 5, which is precisely the drift claim 4 is
 #     about. The compile and info checks stay green.
-#   * arm I (perturb one opcode count in the shipped constant): reddens the
-#     `nargo info` equality alone. Everything the toolchain says is unchanged;
-#     what changed is the bundle's claim about it.
+#   * arm I (perturb the shipped ACIR total): reddens the engine-equality check
+#     alone — the comparison against the wasm module's own count, NOT a `nargo
+#     info` comparison; there is no longer one. Everything the toolchain says is
+#     unchanged; what changed is the bundle's claim about it. Perturbing an
+#     UNCONSTRAINED count instead reddens nothing, because nothing compares it.
 #   * arm B (break the Noir syntax in `main.nr`): reddens the compile check
 #     first, and the gate says so rather than reporting five confusing
 #     downstream failures.
@@ -74,7 +79,11 @@
 #
 # Usage:  bash ci/test/noir-template-toolchain.sh
 # Env:    CT_NIM_CACHE_ROOT       nim cache root (default /tmp/ct-nim-cache)
-#         CT_NOIR_WASM_COMPILER   noir_wasm.wasm, for arm V (optional)
+#         CT_NOIR_WASM_COMPILER   noir_wasm.wasm (optional). Gates BOTH arm V's
+#                                 verdict diff and the control arm's ACIR
+#                                 comparison — the check that decides whether
+#                                 the pane's number is right. Without it the
+#                                 shipped count is not checked at all.
 
 set -uo pipefail
 
@@ -476,8 +485,8 @@ fi
 echo
 
 # ---------------------------------------------------------------------------
-echo "Arm I: MUTATION — the shipped constraint counts drift from the producer"
-echo "    Expect the INFO equality RED, everything else green."
+echo "Arm I: MUTATION — the shipped ACIR total drifts from the shipping engine"
+echo "    Expect the ENGINE ACIR equality RED, everything else green."
 # ---------------------------------------------------------------------------
 # THE PERTURBATION IS DERIVED FROM THE SHIPPED VALUE, NOT WRITTEN HERE.
 #

--- a/ci/test/web-renderer-mounts.sh
+++ b/ci/test/web-renderer-mounts.sh
@@ -809,14 +809,17 @@ PY2
 
 # Arm N — THE CONSTRAINT COUNTS THE BUNDLE SHIPS ARE WRONG.
 #
-# The web build cannot run `nargo`: there is no subprocess in a tab, the wasm
-# compiler exports no `info` operation, and the only compile a tracer host asks
-# for sets `force_brillig`, so even decoding its artifact would answer about an
-# all-unconstrained build. The counts therefore travel with the sources they
-# describe, produced by `nargo info --json` at build time
-# (`platform/noir_template.noirTemplateNargoInfoJson`), and
-# `ci/test/noir-template-toolchain.sh` re-runs the producer on every CI run and
-# fails on drift.
+# The web build cannot run `nargo` — there is no subprocess in a tab, and the
+# wasm module has no `info` export — so the counts travel with the sources they
+# describe (`platform/noir_template.noirTemplateNargoInfoJson`). That is a
+# packaging choice, not an impossibility: the ACIR total CAN be computed in the
+# browser over the existing ABI, and `ci/test/noir-template-acir-count.mjs`
+# does exactly that. See that constant's docstring before concluding the number
+# is expensive to produce.
+#
+# `ci/test/noir-template-toolchain.sh` is what checks it, in the web-deploy
+# lane only (`deploy-web-codetracer.yml`) — NOT on every CI run — and it
+# compares the ACIR total alone.
 #
 # THIS arm is the other half of that: it perturbs the shipped constant and
 # requires the PANE to disagree. Without it, arm R's opcode-count check
@@ -1680,10 +1683,12 @@ print(len(boxes), len(bad), len(zero))
 		ck fail "arm R: ${1:-0} run control(s) measured, ${2:-?} overlapping the breakpoint marker and ${3:-?} with no width — a control a click cannot reach, or one that steals the breakpoint's"
 	fi
 
-	# CONSTRAINTS SHOWS A MEASURED NUMBER. 17 is `nargo info --json`'s answer
-	# for this template; `ci/test/noir-template-toolchain.sh` re-runs the
-	# producer and fails if the bundle's copy has drifted from it, so the
-	# number written here is pinned by a measurement rather than by taste.
+	# CONSTRAINTS SHOWS A MEASURED NUMBER. 17 is the ACIR total the SHIPPING
+	# wasm compiler computes for this template — NOT the flake `nargo`'s answer,
+	# which differs for these same sources; that disagreement is why the gate
+	# was moved onto the shipping engine. `ci/test/noir-template-toolchain.sh`
+	# recompiles with that module and fails if the bundle's copy has drifted, so
+	# the number written here is pinned by a measurement rather than by taste.
 	r_constraints="$(python3 -c '
 import json, sys
 rows = json.load(open(sys.argv[1]))["dom"].get("constraintRows") or []

--- a/ci/test/web-renderer-mounts.sh
+++ b/ci/test/web-renderer-mounts.sh
@@ -1704,11 +1704,11 @@ print(" ".join(r["name"] + "=" + r["count"] + "(" + r["kind"] + ")" for r in row
 	esac
 	r_prov="$(jsonraw route dom.constraintProvenance)"
 	case "${r_prov}" in
-	*"nargo info"*)
-		ck ok "arm R: the counts carry their provenance, so a reader can judge them: ${r_prov}"
+	*"compiler this page runs"*)
+		ck ok "arm R: the counts name the compiler that produced them, so a reader can judge them: ${r_prov}"
 		;;
 	*)
-		ck fail "arm R: the constraint counts carry no provenance (${r_prov}) — a number a user cannot judge"
+		ck fail "arm R: the constraint counts do not name the compiler that produced them (${r_prov}) — a number a user cannot judge"
 		;;
 	esac
 

--- a/docs/preserved-branch-triage-2026-09.md
+++ b/docs/preserved-branch-triage-2026-09.md
@@ -76,9 +76,15 @@ After that landing, `scripts/sibling-pins.sh` on `cloud` is a strict superset
 of the twin's version — a line-level diff shows **0 lines present only in the
 twin** — and `ci/test/sibling-pins-test.sh` is byte-identical between them.
 
-**`fix/sibling-pin-assert` must still be kept.** `origin/dev` and `origin/main`
-do **not** carry either file, so the branch-tip-instead-of-commit defect
-remains open on `dev`. Delete it only once an equivalent guard is on `dev`.
+**`fix/sibling-pin-assert` is no longer the sole carrier for `dev`.** This
+section previously said `origin/dev` did not carry either file. It does, and
+did when that sentence was written: `git ls-tree -r origin/dev` lists both
+`scripts/sibling-pins.sh` and `ci/test/sibling-pins-test.sh`, and both are
+byte-identical to `cloud`'s copies. `origin/main` genuinely carries neither.
+
+So the guard is on `dev` and the defect is closed there; what is still open is
+`main`. Keep or delete the branch on that basis, not on the one this paragraph
+used to give.
 
 ## Why this mattered
 

--- a/src/frontend/ui/web_entry_surface.nim
+++ b/src/frontend/ui/web_entry_surface.nim
@@ -648,8 +648,12 @@ proc templateConstraintReport*(tmpl: ProjectTemplate): ConstraintReport =
   ## `parseNargoInfoJson` the desktop uses on live `nargo info` output — one
   ## parser, one shape, two sources. The counts are a pure function of sources
   ## that are themselves a compile-time constant, and
-  ## `ci/test/noir-template-toolchain.sh` re-runs `nargo info` and fails on any
-  ## drift, so this is a measurement that travels rather than a cached answer.
+  ## `ci/test/noir-template-toolchain.sh` recompiles the template with the wasm
+  ## module the deploy ships and fails if the ACIR total has drifted from it —
+  ## so the headline number is a measurement that travels rather than a cached
+  ## answer. The unconstrained counts are NOT covered by that comparison; see
+  ## `noirTemplateNargoInfoJson`'s docstring for what the gate does and does not
+  ## establish.
   if not tmpl.hasFiles:
     return absentReport("No project is open.")
   parseNargoInfoJson(noirTemplateNargoInfoJson,

--- a/src/frontend/viewmodel/platform/noir_template.nim
+++ b/src/frontend/viewmodel/platform/noir_template.nim
@@ -370,7 +370,19 @@ const noirTemplateNargoInfoJson* = """{"programs":[{"package_name":"hello_noir",
   ## whatever `wasm_worker_browser.js` dispatches. Read them there.
 
 const noirTemplateConstraintProvenance* =
-  "nargo info --json, run against this template at build time"
+  "measured at build time by the Noir compiler this page runs"
   ## Shown in the pane. A count with no provenance is a count a user cannot
   ## judge: "17" means one thing measured a second ago and another thing
   ## shipped in a bundle, and the pane must not make them look alike.
+  ##
+  ## THIS SAID "nargo info --json, run against this template at build time"
+  ## and that named the wrong compiler. The shipped ACIR total is the WASM
+  ## module's answer; the flake's `nargo` returns a different number for these
+  ## same sources, so a developer who ran the named command got a figure the
+  ## pane never shows and had no way to tell which was wrong. The string now
+  ## names the compiler whose answer the visitor is actually looking at.
+  ##
+  ## `ci/test/noir-template-toolchain.sh` checks this string. It used to assert
+  ## only that it contained "nargo info" — a check that certified the wrong
+  ## provenance and pinned it in place. It now asserts the string names the
+  ## shipping engine, so the two move together.

--- a/src/frontend/viewmodel/platform/noir_template.nim
+++ b/src/frontend/viewmodel/platform/noir_template.nim
@@ -299,7 +299,12 @@ proc fileContent*(tmpl: ProjectTemplate; path: string): string =
 # ---------------------------------------------------------------------------
 
 const noirTemplateNargoInfoJson* = """{"programs":[{"package_name":"hello_noir","functions":[{"name":"main","opcodes":17}],"unconstrained_functions":[{"name":"directive_invert","opcodes":9},{"name":"directive_integer_quotient","opcodes":8}]}]}"""
-  ## The bundled template's `nargo info --json`, verbatim.
+  ## The bundled template's constraint counts, in `nargo info --json`'s shape
+  ## so one parser serves both hosts. It is no longer one command's verbatim
+  ## output: the ACIR total is maintained against the wasm compiler the browser
+  ## runs (which is not the flake's `nargo` — the two disagree on this
+  ## template), while the unconstrained counts still carry `nargo info`'s
+  ## figures. See the drift section below for which half a gate checks.
   ##
   ## ## Why a constant is the honest representation, and not a cached answer
   ##
@@ -310,12 +315,22 @@ const noirTemplateNargoInfoJson* = """{"programs":[{"package_name":"hello_noir",
   ## function of a constant is a constant, so carrying the answer is the same
   ## kind of claim as carrying the files.
   ##
-  ## What would make it dishonest is drift, and what prevents it is
-  ## `ci/test/noir-template-toolchain.sh`: it writes this template to a
-  ## temporary directory, runs `nargo info --json` against it, and fails if the
-  ## bytes differ. So editing `main.nr` without re-measuring fails a gate
-  ## instead of shipping a number that is quietly wrong — the same gate that
-  ## checks the crate compiles and its five tests pass.
+  ## What would make it dishonest is drift, and what partly prevents it is
+  ## `ci/test/noir-template-toolchain.sh`. Be exact about how much it covers,
+  ## because it is less than this whole constant:
+  ##
+  ## * The **ACIR total** — the sum of `programs[].functions[].opcodes`, `17`
+  ##   here — is compiled from this template by the shipping wasm module and
+  ##   compared as an integer. That comparison is the one that decides whether
+  ##   the pane's headline number is right.
+  ## * The **unconstrained counts** (`directive_invert`, `directive_integer_quotient`)
+  ##   are compared against nothing. Editing them, or editing `main.nr` in a way
+  ##   that only moves them, passes the gate.
+  ##
+  ## It does not diff these bytes and it does not run `nargo info` — see that
+  ## script's own note at the ACIR comparison ("Only the ACIR total is
+  ## compared"). The gate that checks the crate compiles and its five tests pass
+  ## is the same script, in its other arms.
   ##
   ## THIS NAMED `test_noir_template_constraints.nim` UNTIL 09-02, AND NO SUCH
   ## FILE HAS EVER EXISTED. The description was accurate and the filename was
@@ -334,18 +349,25 @@ const noirTemplateNargoInfoJson* = """{"programs":[{"package_name":"hello_noir",
   ##
   ## ## And why the web needs it at all
   ##
-  ## `nargo` is not in a browser, and the wasm compiler has no `info`
-  ## operation: `compile_vfs.rs` exports `nv_compile_vfs` and `nv_test_vfs` and
-  ## nothing else, the worker dispatches `compile`, `test` and `trace`, and the
-  ## only compile a tracer host asks for sets `force_brillig: true` — so even
-  ## decoding its artifact would answer about an all-unconstrained build rather
-  ## than the circuit. Producing this number in a tab needs a new wasm export
-  ## and a new worker branch; until then the answer travels with the sources it
-  ## is an answer about.
+  ## `nargo` is not in a browser and the wasm module has no `info` export, so
+  ## the number cannot be *asked for* by that name. It can still be COMPUTED:
+  ## `ci/test/noir-template-acir-count.mjs` gets exactly this ACIR total from
+  ## the shipping module over the existing ABI, and `web_noir_build.nim` already
+  ## issues a program-mode (`nbmProgram`) compile through the worker from a tab.
   ##
-  ## THE SAME SENTENCE WAS TRUE OF `nargo test` AND IS NOT ANY MORE, which is
-  ## why the list above is spelled out rather than left as "exactly two". A
-  ## count goes stale silently; a list names what it is missing.
+  ## SO THE REASON THIS IS A CONSTANT IS NOT THAT COMPUTING IT IS BLOCKED.
+  ## Nothing new has to be exported and no worker branch has to be added. The
+  ## reason is rule 5's: a constant costs no storage, needs no network, and is
+  ## already correct on first paint, whereas computing it would make the pane
+  ## wait for a compile to display a property of files that cannot change.
+  ##
+  ## THIS PARAGRAPH HAS BEEN WRONG TWICE. It once said the same of `nargo test`;
+  ## it then said producing the count "needs a new wasm export and a new worker
+  ## branch", which told a reader that work was expensive when it was nearly
+  ## free. Do not restate the module's exports or the worker's subcommand list
+  ## here — both have grown since each was last written down. The exports are
+  ## whatever `ci/test/noir-wasm-worker/worker.mjs` binds; the subcommands are
+  ## whatever `wasm_worker_browser.js` dispatches. Read them there.
 
 const noirTemplateConstraintProvenance* =
   "nargo info --json, run against this template at build time"

--- a/src/frontend/viewmodel/tests/unit/test_noir_wasm_delivery.nim
+++ b/src/frontend/viewmodel/tests/unit/test_noir_wasm_delivery.nim
@@ -101,10 +101,13 @@ suite "the Noir wasm registry follows the delivery (NS3)":
       noirToolchainCommand, @["compile"]).kind == wrResolved
 
   test "a full delivery declares exactly the three subcommands the worker routes":
-    # `wasm_worker_browser.js` routes `compile` -> `compileVfs`,
-    # `test` -> `testVfs` and `trace` -> `traceArtifact`, and nothing else.
-    # Declaring a fourth would produce a run that reaches the worker and dies
-    # there.
+    # Three is the NARGO module's share of the worker's routing: `compile` ->
+    # `compileVfs`, `test` -> `testVfs`, `trace` -> `traceArtifact`. The file
+    # routes more than that — `transpile` belongs to the avm-transpiler module,
+    # and session subcommands are dispatched before the one-shot chain — so the
+    # number here is about this delivery, not about the worker. Declaring a
+    # fourth subcommand for THIS module would produce a run that reaches the
+    # worker and dies there.
     let registry = noirWasmRegistry(bothModules())
     counted registry.modules.len == 1
 

--- a/src/frontend/viewmodel/viewmodels/constraints_vm.nim
+++ b/src/frontend/viewmodel/viewmodels/constraints_vm.nim
@@ -13,10 +13,20 @@
 ## The counts describe a set of sources. The moment a visitor edits one they
 ## describe a project that no longer exists, and an unlabelled stale number is
 ## worse than no number because it is indistinguishable from a current one.
-## `markStale` is therefore called from the editor's change hook, and the view
-## says so. On a host that cannot recompute — a browser, today — being stale is
-## permanent until the sources are restored, and the pane says that too rather
-## than showing a spinner nothing will ever resolve.
+## `markStale` is the flag for that, and it is wired as far as the view: it sets
+## `report.stale` without discarding the counts, and the `headline` memo runs
+## `headlineFor`, which appends " (stale)".
+##
+## NOTHING CALLS IT. `markStale` occurs three times in the whole tree — its
+## definition, one re-export in `ui/constraints.nim`, and this sentence. It has
+## no call site, so the editor's change hook does not reach it and a visitor who
+## edits a source still sees an unlabelled count: exactly the state the
+## paragraph above calls worse than no number. What is missing is not the
+## mechanism but the one call that decides when to use it.
+##
+## On a host that cannot recompute — a browser, today — being stale would be
+## permanent until the sources are restored, which is why the pane is built to
+## say so rather than show a spinner nothing will ever resolve.
 
 import isonim/core/[signals, computation, owner]
 import isonim/viewmodel


### PR DESCRIPTION
A prose sweep of `cloud`, in the pattern already confirmed seven times in these repos: when a check, constant or mechanism changes, the assertion gets corrected and the sentence describing it does not. Every claim here was verified against the thing it describes — the real source, a tree-wide caller grep, a resolved ref — never against another comment.

**Three sentences said work was blocked or expensive when it was not.** `noir_template.nim` said producing the template's opcode count in a browser "needs a new wasm export and a new worker branch". It needs neither: `ci/test/noir-template-acir-count.mjs` already computes exactly that total from the shipping module over the existing ABI, and `web_noir_build.nim` already issues a program-mode compile through the worker. The same paragraph's "exports `nv_compile_vfs` and `nv_test_vfs` and nothing else" and "the only compile a tracer host asks for sets `force_brillig: true`" were both false too. That paragraph carried its own warning that it had gone stale once before, over `nargo test`; it then went stale again in the same shape, so it no longer restates the export or subcommand lists and points at the files that define them.

**Six places described a `nargo info` comparison that was removed** for being against the wrong compiler. The gate compares the ACIR total as an integer against the wasm module; it does not run `nargo info`, does not diff bytes, and does not check the unconstrained counts at all — perturbing one reddens no arm. The gate's own comment beside the comparison already said so; the prose around it did not.

**A user-visible string attributed the count to the wrong compiler**, and two gates asserted only that it contained "nargo info" — certifying a claim about provenance while establishing nothing about the number, and pinning the wrong attribution in place. String and both gates are corrected together.

**A keep/delete verdict rested on a false premise:** the triage doc said `origin/dev` carries neither sibling-pins file. It carries both, byte-identical to cloud's copies. Only `main` lacks them, so the verdict is restated on the premise that survives.

**A deploy header said "`ide.` is the product's one domain"** while the same workflow declares `noirstudio.dev` and `www.noirstudio.dev`. Reading that header as exhaustive is how the verify step came to check two hosts while the deployment declared three — the defect that step was repaired for.

**One correction is load-bearing and left a real gap visible rather than hidden:** `constraints_vm.nim` said `markStale` "is therefore called from the editor's change hook". It has no call site — three occurrences tree-wide, being its definition, one re-export, and that sentence. The pane therefore never labels a stale count, which is the exact state the paragraph above it calls worse than no number. The comment now says that plainly instead of describing an intention as behaviour.

All source changes are comments, docstrings and message text, except the provenance string and the two gate assertions that check it, which move together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)