### PR TITLE
docs(dev): correct prose that names things the tree does not contain

### DIFF
--- a/ci/lib/test-lane-files.sh
+++ b/ci/lib/test-lane-files.sh
@@ -346,16 +346,26 @@ test_lane_files() {
 		;;
 
 	host-instantiations)
-		# NOT test files. The platform facade's two host instantiations —
-		# production modules — compiled on the backend they actually ship on.
+		# NOT test files. Production modules of the platform facade, compiled
+		# on the backend they actually ship on. Four are echoed at the bottom
+		# of this arm; read that list, not a count written here.
 		#
-		# WHY THIS LANE EXISTS, and it is not a hypothetical. Both of these
-		# modules are `{.error.}` on the C backend by design, so `vm-unit`
-		# cannot see them; and neither is imported by any suite in `vm-unit-js`,
-		# because the whole point of `platform/web_platform.nim` is that it
-		# reaches no browser API and can therefore be tested without these.
-		# The result was a hole exactly the shape of these two files: NOTHING
-		# IN CI COMPILED THEM AT ALL.
+		# WHY THIS LANE EXISTS, and it is not a hypothetical. The argument is
+		# about the two host INSTANTIATIONS — `desktop_electron.nim` and
+		# `web_browser.nim`. Both are `{.error.}` on the C backend by design,
+		# so `vm-unit` cannot see them; and neither is imported by any suite in
+		# `vm-unit-js`, because the whole point of
+		# `platform/web_platform.nim` is that it reaches no browser API and can
+		# therefore be tested without these. The result was a hole exactly the
+		# shape of those two files: NOTHING IN CI COMPILED THEM AT ALL.
+		#
+		# The other two in the list are here for their own reasons, not this
+		# one. `platform_host.nim` is here for its Electron arm (spelled out
+		# below). `opfs_volume.nim` is the web instantiation's OPFS volume: it
+		# is also `{.error.}` on C, but unlike the two above it IS driven by a
+		# suite — `test_opfs_volume.nim`, added to `vm-unit-js` against a fake
+		# `navigator.storage` — so for it this lane is a second compile rather
+		# than the only one.
 		#
 		# It was not theoretical for long. `web_browser.nim` reached `dev` at
 		# ed9d6021 with a doc comment after the closing paren of an object

--- a/ci/test/identity-token-mutation.sh
+++ b/ci/test/identity-token-mutation.sh
@@ -6,13 +6,27 @@
 # `src/frontend/viewmodel/identity/token.nim` decides whether a signed identity
 # token is accepted, which band of its life it is in, and whether a subject is
 # revoked. A suite that reports ten green cases over it is worth exactly what
-# the evidence says it is, so this file supplies the evidence: one mutation per
+# the evidence says it is, so this file supplies the evidence: a mutation per
 # assertion family, each verified to redden THE CASE WRITTEN FOR IT.
 #
 # A mutation caught by some other case is a MISS, not a kill. Every arm below
 # names the case it expects to go red, and several additionally name the cases
 # that must stay GREEN — because an arm that reddens everything proves only
 # that the suite noticed a change, not that the assertion in question can fail.
+#
+# WHAT THIS FILE DOES NOT DO, and the PASSED line now says so too: it never
+# reads the suites' case NAMES. The arms are a hand-written list, each matched
+# against one name, so "every declared arm killed the case it names" is the only
+# universal this gate can support. A case that no arm targets is simply absent
+# from the run, and several cases in the three suites are in that position today.
+#
+# The one thing that IS pinned is the case COUNT: each control arm requires
+# exactly `active_cases` `[OK]` lines, so adding a case makes the control arm
+# MISS until someone bumps that number. That is a prompt, not a guard — bumping
+# the counter is enough to go green again, and nothing requires the new case to
+# acquire an arm. Closing the gap properly would mean enumerating the suites'
+# `test "..."` names here and failing on any without a corresponding arm, which
+# is not implemented.
 #
 # ## The arm that justifies the JS lane
 #
@@ -572,4 +586,12 @@ if [ "${misses}" -gt 0 ]; then
 	echo "RESULT: FAILED — ${misses} arm(s) did not kill on their own case"
 	exit 1
 fi
-echo "RESULT: OK — every assertion family in the identity layer (${MODULE}, ${MODULE2}, ${MODULE3}) has a mutation that reddens it"
+echo "RESULT: OK — ${arms} mutation arm(s) over the identity layer (${MODULE}, ${MODULE2}, ${MODULE3}); each reddened the case it names"
+echo "  SCOPE, because this line used to claim more than it checks: this is NOT"
+echo '  "every assertion family has a mutation". The arms are a hand-written list'
+echo "  and nothing here reads the suites' case names, so a case that no arm"
+echo "  targets is invisible to this gate — and several are in that position."
+echo "  The control arms do pin the case COUNT, so a NEW case makes them miss"
+echo "  until the counter is bumped; bumping it is enough, no arm is required."
+echo '  Diff the arms against the suites test "..." names by hand before'
+echo "  reading this line as coverage."

--- a/ci/test/renderer-host-reach-budget.sh
+++ b/ci/test/renderer-host-reach-budget.sh
@@ -104,12 +104,15 @@ count_in() {
 #               is absent on web). A facade arm for these would promise what a
 #               tab cannot do.
 #
-# THE THREE KINDS ARE REPORTED SEPARATELY, ON PURPOSE. Sixteen of the nineteen
-# reaches below are in `webexcluded` modules. That is NOT the same fact as
-# sixteen having been migrated, and a single shrinking total would let the two
-# read alike — the exclusion removed them from one CONFIGURATION, it did not
-# remove a single call. Step 3 checks the guards actually exist, so the
-# classification is enforced rather than asserted.
+# THE THREE KINDS ARE REPORTED SEPARATELY, ON PURPOSE. Most of the reaches
+# budgeted below sit in `webexcluded` modules; run this gate and read its
+# RESULT line for the split, which is computed from `budget_for` rather than
+# restated here — a hardcoded total is exactly what goes stale the next time a
+# budget moves, and the one that used to stand here did. "In a module a web
+# build cannot compile" is NOT the same fact as "migrated", and a single
+# shrinking total would let the two read alike: the exclusion removed them from
+# one CONFIGURATION, it did not remove a single call. Step 3 checks the guards
+# actually exist, so the classification is enforced rather than asserted.
 # ---------------------------------------------------------------------------
 budget_for() {
 	case "$1" in

--- a/justfile
+++ b/justfile
@@ -2554,19 +2554,32 @@ test-vm: test-vm-native test-vm-js
 # nothing compiles.
 #
 # ---------------------------------------------------------------------------
-# DEFERRED, AND SAY SO: NONE OF THE 13 RECIPES BELOW IS IN A PIPELINE YET.
+# DEFERRED, AND SAY SO: ALL BUT ONE OF THE 13 RECIPES NAMED BELOW ARE IN NO
+# PIPELINE YET.
 # ---------------------------------------------------------------------------
-# "Picked up by its lane" is NOT the same as "runs in CI", and for these
-# thirteen the second is currently false.  No workflow, no entry in
-# ci/verdict/required-jobs.txt, and no aggregate recipe invokes any of them —
-# 76 of the 220 files the lane library resolves are in lanes no pipeline runs
-# (`test_lane_all_files | wc -l` for the 220; the reachable 144 are the lanes
-# behind `just test-vm`, `test-cli-record`, `test-ct-trace-units`,
+# "Picked up by its lane" is NOT the same as "runs in CI", and for twelve of
+# the thirteen the second is currently false: no workflow, no entry in
+# ci/verdict/required-jobs.txt, and no aggregate recipe invokes them.  The one
+# exception is `test-lane-coverage` — `ci/lint/nim.sh` runs its script
+# (`ci/test/test-lane-coverage.sh`) as part of the `lint-nim` job, and
+# `lint-nim` IS listed in ci/verdict/required-jobs.txt.  That is repeated in
+# the promotable list further down; both statements are meant to agree.
+#
+# For HOW MUCH of the tree the deferral leaves dark, count it rather than
+# trusting a number written here — the figures that used to stand in this
+# paragraph (76 dark of 220 resolved, 144 reachable) were all stale against
+# the very command they cited.  Run:
+#
+#   source ci/lib/test-lane-files.sh && test_lane_all_files | wc -l
+#
+# for every file the lane library resolves.  The reachable share is whatever
+# the lanes behind `just test-vm`, `test-cli-record`, `test-ct-trace-units`,
 # `test-mcr-enrichment-units`, `test-m16-release-gate`, `test-ct-providers`,
 # `test-visual-replay-gate`, `test-vm-recorder-gated` and
-# `test-no-sidecar-manifests`).  A reader who assumed otherwise would be repeating this
-# campaign's own mistake one level up, so it is written down here rather than
-# left to be discovered.
+# `test-no-sidecar-manifests` resolve to; the rest are in lanes no pipeline
+# runs.  A reader who assumed otherwise would be repeating this campaign's own
+# mistake one level up, so it is written down here rather than left to be
+# discovered.
 #
 # WHY it is deferred: six of these lanes are red for reasons that are not
 # theirs to fix, and wiring a red lane into a required job breaks every build

--- a/justfile
+++ b/justfile
@@ -1477,18 +1477,25 @@ test-rust-flow-nightly:
   ../../scripts/with-rust-nightly cargo nextest run --no-capture test_rust_flow
   echo "Rust nightly flow test passed!"
 
-# Test with all supported Rust versions
+# Rust flow tests — STABLE ONLY, despite the `-all` name.
+#
+# Unlike `test-nim-flow-all` above, which really does invoke all three of its
+# per-version recipes, this invokes only `test-rust-flow-stable`.
+# `test-rust-flow` (ambient toolchain) and `test-rust-flow-nightly` exist and
+# are not run here; why they were left out is not recorded anywhere I could
+# find, so do not read this as a statement that they are unsupported.
 test-rust-flow-all:
   #!/usr/bin/env bash
   set -e
   echo "========================================"
-  echo "Testing Rust flow with supported versions"
+  echo "Testing Rust flow with Rust stable only"
   echo "========================================"
   echo ""
   just test-rust-flow-stable
   echo ""
   echo "========================================"
-  echo "All Rust flow tests passed!"
+  echo "Rust stable flow test passed!"
+  echo "(test-rust-flow and test-rust-flow-nightly were NOT run)"
   echo "========================================"
 
 # ====
@@ -2842,8 +2849,10 @@ test-host-instantiations:
 #
 # NEEDS isonim's `build/tailwind-styles.json`: `ui_js.nim` reaches
 # `isonim/dsl/tailwind`, which `staticRead`s it at compile time, and a missing
-# file is an uncatchable Nim error minutes in. `just build-tailwind` generates
-# it; CI seeds a `{}` placeholder in `.github/actions/setup-isonim-siblings`.
+# file is an uncatchable Nim error minutes in. `just vm-test-prereqs` generates
+# it (it runs `scripts/build-tailwind.sh`; there is no `build-tailwind`
+# recipe); CI seeds a `{}` placeholder in
+# `.github/actions/setup-isonim-siblings`.
 test-renderer-browser:
   #!/usr/bin/env bash
   set -euo pipefail

--- a/scripts/require-siblings.sh
+++ b/scripts/require-siblings.sh
@@ -206,13 +206,13 @@ sibling_remote_org="${CODETRACER_SIBLING_REMOTE_ORG:-https://github.com/metacraf
 # for a lane that means to assert a complete workspace.
 # -----------------------------------------------------------------------------
 required_siblings=(
-	'isonim|src/isonim.nim|ISONIM_SRC|the reactive UI framework the whole renderer is written against (223 `import isonim/...` sites); also the source `build-tailwind.sh` extracts utility classes from'
+	'isonim|src/isonim.nim|ISONIM_SRC|the reactive UI framework the whole renderer is written against — hundreds of `import isonim/...` sites across the frontend; count them with: grep -rl "import isonim/" --include=*.nim src | wc -l . Also the source `build-tailwind.sh` extracts utility classes from'
 	'nim-agents|src/nim_agents.nim||`import nim_agents` in src/frontend/viewmodel/agent_service.nim and the agentic-session UI'
 	"nim-agent-harbor|src/nim_agent_harbor.nim||the session/worktree backend nim_agents is written against; passed unconditionally by src/Tuprules.tup:79"
 	"nim-acp|src||the Agent Client Protocol bindings src/Tuprules.tup:78 puts on the Nim search path"
 	"nim-everywhere|src||the patched Nim 2.x distribution src/Tuprules.tup:77 puts on the Nim search path"
 	'codetracer-trace-format-nim|src/codetracer_ct_print_lib.nim|CODETRACER_TRACE_FORMAT_NIM_SRC|`ct print` (src/ct/cli/print_trace.nim) imports codetracer_trace_writer/* and codetracer_ct_print_lib'
-	'codetracer-trace-format|codetracer_trace_types/Cargo.toml||five `path = "../../../codetracer-trace-format/..."` dependencies in src/db-backend/Cargo.toml; cargo cannot even parse the manifest without them'
+	'codetracer-trace-format|codetracer_trace_types/Cargo.toml||every `path = "../../../codetracer-trace-format/..."` dependency in src/db-backend/Cargo.toml resolves through it (grep -c that path in the manifest for how many); cargo cannot even parse the manifest without them'
 	'codetracer-native-recorder|ct_emulator/src/ct_emulator/emulator_wasm_api.nim|CT_CODETRACER_NATIVE_RECORDER_SIBLING|src/db-backend/build.rs compiles the Nim MCR emulator from ct_emulator/ and links it as lib${CT_MCR_EMULATOR_LINK_NAME}.so; without it the db-backend link fails with 81 undefined `mcr*` symbols'
 	# Override column deliberately empty -- see the RUNQUOTA_SRC discussion in
 	# the tier notes above. Accepting the env var here would green this check on

--- a/scripts/sibling-pins.sh
+++ b/scripts/sibling-pins.sh
@@ -60,12 +60,18 @@
 #
 # ## What this does NOT buy
 #
-# Input determinism, not bit-identical output. `ci/deploy/noir-wasm.pin`
-# records the measured reason: building one revision twice from two different
-# checkout DIRECTORIES gave 15862494 vs 15862541 bytes, because rustc embeds
-# source paths and the length of the build directory reaches the artifact.
-# Pinning inputs does not touch that and does not claim to. What it buys is
-# that the QUESTION "what should this commit produce?" now has an answer.
+# Input determinism, not bit-identical output. The reason is rustc: it embeds
+# source paths, so the LENGTH OF THE BUILD DIRECTORY reaches the artifact, and
+# one revision built twice from two different checkout directories produces two
+# different byte counts. Pinning inputs does not touch that and does not claim
+# to. What it buys is that the QUESTION "what should this commit produce?" now
+# has an answer.
+#
+# This used to cite `ci/deploy/noir-wasm.pin` for the measured byte counts.
+# There is no such file on this branch — it belongs to the Noir Studio wasm
+# deploy work, which has not landed here — so the figures cannot be checked
+# from this checkout and are not repeated. The mechanism above is the part
+# this script depends on, and it does not need a number.
 #
 # AND IT DOES NOT COVER THE TOOLCHAIN. `SIBLINGS` below is a list of three
 # REPOSITORIES. The compilers that read them are not in it, and a PASS here is

--- a/src/ct/utilities/language_detection.nim
+++ b/src/ct/utilities/language_detection.nim
@@ -154,8 +154,9 @@ proc detectLangFromPath*(path: string, isWasm: bool): Lang =
   ## The explicit return is required **regardless of which value is ordinal
   ## zero**.  A proc whose correctness depends on the enum's declaration order
   ## is not correct; it is merely lucky, and the luck is invisible at the call
-  ## site.  `lang_detection_test.nim` asserts the returned value directly so a
-  ## future reordering of `Lang` cannot quietly reintroduce the defect.
+  ## site.  `src/tests/cli/lang_enum_contract_test.nim` asserts the returned
+  ## value directly so a future reordering of `Lang` cannot quietly reintroduce
+  ## the defect.
   let ext = path.splitFile.ext
   if ext.len <= 1:
     return LangUnknown

--- a/src/ct_test/release_gate.nim
+++ b/src/ct_test/release_gate.nim
@@ -903,9 +903,12 @@ const
     #   * the hand-written JS ordinal map in `src/frontend/trace_metadata.nim`.
     #
     # A copy that falls behind does not fail loudly — it decodes an integer as a
-    # different language.  That has already happened here: `src/tui/src/lang.rs`
-    # stopped at `Solana` (37 of 40) and `libs/ct-dap-client` diverged from
-    # ordinal 6 onwards, both silently.  `lang_enum_contract_test` is what pins
+    # different language.  That has already happened here, and the examples are
+    # HISTORY, not the current tree: the TUI once kept its own copy in
+    # `src/tui/src/lang.rs`, which had stopped short at `Solana` and was missing
+    # everything after it — the file is gone, deleted in 84a8b633 when the TUI
+    # was pointed at `libs/ct-lang` — and `libs/ct-dap-client` diverged from
+    # ordinal 6 onwards.  Both were silent.  `lang_enum_contract_test` is what pins
     # the three copies together, and it fails rather than silently comparing
     # nothing if it cannot locate either list.
     #

--- a/src/db-backend/src/task.rs
+++ b/src/db-backend/src/task.rs
@@ -49,11 +49,13 @@ pub struct CtLoadLocalsResponseBody {
 /// The wire spellings of [`FlowMode`], in variant order.
 ///
 /// These strings are the cross-language contract for `ct/load-flow`.
-/// `src/common/common_types/codetracer_features/flow.nim` declares the
-/// identical list next to its own `FlowMode`, and
-/// `tests/flow_mode_wire_test.rs` reads that file and fails if the two ever
-/// disagree — the drift this constant exists to prevent was silent for as
-/// long as the wire form was an ordinal.
+/// `src/common/flow_mode_wire.nim` declares the identical list as
+/// `FlowModeWireNames` (the engine `FlowMode` it spells lives in
+/// `src/common/common_types/codetracer_features/flow.nim`), and
+/// `tests/flow_mode_wire_test.rs` reads that file — plus
+/// `viewmodels/flow_vm.nim` for the view-granularity enum — and fails if
+/// the vocabularies ever disagree; the drift this constant exists to
+/// prevent was silent for as long as the wire form was an ordinal.
 pub const FLOW_MODE_WIRE_NAMES: &[&str] = &["call", "diff"];
 
 /// Flow mode for the flow preloader.
@@ -158,7 +160,7 @@ impl<'de> Deserialize<'de> for FlowMode {
     }
 }
 
-/// args for `ct/load-locals`
+/// args for `ct/load-flow`
 #[derive(Serialize, Deserialize, Debug, PartialEq, Default, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
@@ -2675,10 +2677,16 @@ pub struct GoToTicksArguments {
     ///
     /// Nothing reads it: `Handler::goto_ticks` uses only `ticks`, and
     /// the sibling `ct/timeline-seek` path already passes
-    /// `thread_id: 0` (`dap_server.rs:2144`). It is kept rather than
-    /// deleted because the Python API's `trace.goto_ticks` still sends
-    /// it, and silently rejecting a field a client supplies is the
-    /// habit this file is trying to break.
+    /// `thread_id: 0`. It is kept rather than deleted because live
+    /// senders still put it on the wire: the Python bridge in
+    /// `backend-manager` synthesizes `{"threadId": 1, "ticks": …}`
+    /// when it relays a `ct/py-navigate` `goto_ticks` (see
+    /// `BackendManager`'s py-navigate arm — the Python client itself
+    /// only sends `tracePath`/`method`/`ticks`), and the wasm-testing
+    /// harnesses (`wasm-testing/replay-test.js`,
+    /// `wasm-testing/node-host/probe_reverse_step_in.mjs`) send
+    /// `threadId: 1` directly. Silently rejecting a field a client
+    /// supplies is the habit this file is trying to break.
     #[serde(default)]
     pub thread_id: i64,
     pub ticks: i64,

--- a/src/db-backend/src/task.rs
+++ b/src/db-backend/src/task.rs
@@ -2683,10 +2683,10 @@ pub struct GoToTicksArguments {
     /// when it relays a `ct/py-navigate` `goto_ticks` (see
     /// `BackendManager`'s py-navigate arm — the Python client itself
     /// only sends `tracePath`/`method`/`ticks`), and the wasm-testing
-    /// harnesses (`wasm-testing/replay-test.js`,
-    /// `wasm-testing/node-host/probe_reverse_step_in.mjs`) send
-    /// `threadId: 1` directly. Silently rejecting a field a client
-    /// supplies is the habit this file is trying to break.
+    /// harnesses under `src/db-backend/wasm-testing/` — `replay-test.js`
+    /// and `node-host/probe_reverse_step_in.mjs` — send `threadId: 1`
+    /// directly. Silently rejecting a field a client supplies is the
+    /// habit this file is trying to break.
     #[serde(default)]
     pub thread_id: i64,
     pub ticks: i64,

--- a/src/db-backend/tests/cow_namespace_crossread_test.rs
+++ b/src/db-backend/tests/cow_namespace_crossread_test.rs
@@ -168,16 +168,20 @@ fn reads_nim_bulk_built_cow_image() {
 
 /// M4 — emit a CoW namespace image written by the **Rust** writer
 /// ([`CowNamespaceWriter`]) plus its `(key, descriptor-hex)` manifest, into the
-/// shared fixtures dir. The Nim test `test_cow_btree.nim::"rust-written CoW
-/// image reads back through loadCowBTree"` reads it back, proving the Rust
-/// writer's on-disk page format is byte-compatible with the Nim reader — the
-/// reverse direction of `rust_reader_round_trips_nim_cow_image`, closing the
-/// bidirectional wire-format loop the M5/M6 Rust replay-time write path depends
-/// on.
+/// shared fixtures dir, for a Nim-side cross-read to consume.
 ///
-/// This is a generator, not an assertion test: it writes the fixture, then
-/// re-reads it through the Rust reader as a self-check. The Nim consumer test
-/// skips cleanly when the fixture is absent.
+/// This is a generator, not a cross-language assertion. The only thing asserted
+/// below is that the **Rust** reader round-trips the **Rust** writer's image.
+///
+/// NOT CLOSED: no Nim consumer of this fixture exists in the tree — no `*.nim`
+/// file reads a `.cowbt` at all (`git grep -l cowbt -- '*.nim'` is empty).
+/// Until one does, the reverse direction of `rust_reader_round_trips_nim_cow_image`
+/// is unproven: the Rust writer's on-disk page format has never been read back
+/// by Nim's `loadCowBTree`, so the bidirectional wire-format compatibility the
+/// M5/M6 Rust replay-time write path wants is not established here or anywhere
+/// else. The missing consumer would load `cow_btree_rust_typea.cowbt` with
+/// `cltTypeA` and check every `(key, descriptor-hex)` line of the `.manifest`
+/// written beside it.
 #[test]
 fn gen_rust_written_cow_fixture_for_nim() {
     let dir = fixture_dir();
@@ -214,7 +218,8 @@ fn gen_rust_written_cow_fixture_for_nim() {
     assert_eq!(r.lookup(21).expect("lookup 21"), &0xDEAD_BEEFu64.to_le_bytes());
 
     eprintln!(
-        "OK: wrote Rust-written CoW fixture ({} keys) to {} for the Nim cross-read",
+        "OK: wrote Rust-written CoW fixture ({} keys) to {} \
+         (Rust-reader self-check only — no Nim consumer reads it yet)",
         N,
         image_path.display()
     );

--- a/src/frontend/tests/nimLanguage.test.mjs
+++ b/src/frontend/tests/nimLanguage.test.mjs
@@ -4,8 +4,8 @@
  * These tests verify that the Nim tokenizer correctly tokenizes
  * various Nim language constructs.
  *
- * Run with: node --experimental-vm-modules nimLanguage.test.js
- * Or use a test runner like Mocha/Jest
+ * Run with: node src/frontend/tests/nimLanguage.test.mjs (from the repo root).
+ * `just test-frontend-js` runs it in that lane; it needs no node flags.
  */
 
 import { nimConf, nimLanguage } from '../languages/nimLanguage.js';

--- a/src/frontend/ui/search_results.nim
+++ b/src/frontend/ui/search_results.nim
@@ -406,8 +406,15 @@ method register*(self: SearchResultsComponent, api: MediatorWithSubscribers) =
 # import this module directly (cycle: ``ui_imports`` → ``renderer`` →
 # ``search_service`` → ``search_results`` → ``ui_imports``), so it
 # declares ``syncSearchResults*Hook`` proc variables and we install the
-# concrete implementations at module-init time here.  The hooks are
-# called from ``onSearchResultsUpdated`` in ``search_service.nim``.
+# concrete implementations at module-init time here.
+#
+# TWO of the three are called: ``onSearchResultsUpdated`` in
+# ``search_service.nim`` invokes the append-batch and set-query hooks.
+# ``syncSearchResultsClearHook`` is declared there and assigned below but
+# has NO call site anywhere in the tree — installing it currently wires
+# nothing up. Either give the service a path that clears the VM, or drop
+# the variable; do not read the assignment below as evidence that clearing
+# happens.
 # ---------------------------------------------------------------------------
 
 syncSearchResultsAppendBatchHook = syncSearchResultsAppendBatch

--- a/src/frontend/viewmodel/app/isonim_app.nim
+++ b/src/frontend/viewmodel/app/isonim_app.nim
@@ -21,8 +21,7 @@
 ##     code is identical — it does not know whether it reads from the
 ##     primary or mirror signals.
 ##
-## Usage:
-##   # In ui_js.nim configureMiddleware, after creating activeSessionVM:
+## Usage (illustrative — nothing in the tree calls this today):
 ##   import viewmodel/app/isonim_app
 ##   mountIsoNimApp(activeSessionVM)
 
@@ -115,15 +114,21 @@ proc createIsoNimApp*(session: SessionViewModel): IsoNimApp =
   )
 
 # ---------------------------------------------------------------------------
-# Top-level mount proc — called from ui_js.nim
+# Top-level mount proc — currently uncalled
 # ---------------------------------------------------------------------------
 
 proc mountIsoNimApp*(session: SessionViewModel): IsoNimApp =
   ## Mount the IsoNim application into the `#isonim-app` container.
   ##
-  ## This is the main entry point called from ui_js.nim. It creates the
+  ## This is the entry point for the standalone shell. It creates the
   ## full IsoNim app with all panels, or returns nil if the container div
   ## is not present in the HTML.
+  ##
+  ## It has no call site in the tree. `ui_js.nim` imports this module but
+  ## deliberately does not mount the shell — mounting it there would build
+  ## a second DOM tree in `#isonim-app` on top of the per-panel mounts
+  ## (`calltrace.nim`, `state.nim`, `event_log.nim`, …) that GoldenLayout
+  ## already drives. See the comment next to that decision in `ui_js.nim`.
   ##
   ## The standalone shell is mounted only by callers that opt into this entry
   ## point. The regular application mounts IsoNim views directly into

--- a/src/frontend/viewmodel/backend/dap_dialect.md
+++ b/src/frontend/viewmodel/backend/dap_dialect.md
@@ -112,8 +112,9 @@ which halves have been seen. A dropped request was the whole reason this cost a
 day to find.
 
 **Status: fixed.** `dap_server.rs::browser_setup_from_vfs_when_ready`. Tests:
-`dap_server.rs` `mod browser_handshake` (6 cases, both orders end-to-end through
-a real `setup_from_vfs`), run with
+`dap_server.rs` `mod browser_handshake` (both orders end-to-end through a real
+`setup_from_vfs`; the cases are the `#[test]` fns in that module — run them
+rather than counting from here), run with
 `cargo test --features browser-transport --lib browser_handshake`.
 
 ---
@@ -152,7 +153,7 @@ it — for the VFS only.
 | # | command | trap | consequence |
 | --- | --- | --- | --- |
 | D1 | `ct/load-locals` | `origin_query.rs:260` | **the State pane cannot work at all** |
-| D2 | any step reaching a **trace boundary** | `task.rs:1960` | reverse stepping dies at the ends of the trace |
+| D2 | any step reaching a **trace boundary** | `task.rs::Notification::new` | reverse stepping dies at the ends of the trace |
 | D3 | `ct/originChain` | `origin_query.rs:260`/`:266` | Value-Origin-Tracking's query surface |
 | D4 | `disconnect` | `dap_server.rs:2613` | **every session teardown** |
 
@@ -168,12 +169,12 @@ because it is easy to get wrong:
 
 The guard at `dap_handler.rs:978` is `trace_kind == TraceKind::Materialized`,
 which the browser path *always* satisfies (`dap_server.rs:1589-1590`, inside
-`setup_from_vfs`). It is **not** reached via `HistoryResult::new` (`task.rs:1416`),
+`setup_from_vfs`). It is **not** reached via `HistoryResult::new` (`task.rs`),
 which has the same hazardous body but is dead code — zero callers in the crate —
 nor via `db.rs:2519`, which is `load_history`, a different command.
 
 **D2** is `dap_handler.rs:2096` choosing `"beginning"`/`"end"`, then `:2097`
-calling `send_notification` -> `Notification::new` (`task.rs:1960`). The blast
+calling `send_notification` -> `Notification::new` (`task.rs`). The blast
 radius is wider than stepping: `send_notification` has 13 call sites in
 `dap_handler.rs`, including `"No breakpoints were hit!"` (`:3734`) and
 `"can't jump to line"` (`:3829`). Reverse stepping **mid-trace works** — the e2e
@@ -195,7 +196,7 @@ exits and `thread::sleep` (`:2613`) traps at
 in normal use the adapter *masks* D4. The engine defect is real regardless, and
 any consumer that awaits a `disconnect` response hangs.
 
-`Stop::new` (`task.rs:1347`) shares the pattern and is live (called from
+`Stop::new` (`task.rs`) shares the pattern and is live (called from
 `dap_handler.rs:4337`, `event_db.rs:595`). `Instant::now()` — equally unsupported
 — appears at `emulator_origin.rs:283`, `omniscient_origin.rs:319`,
 `recreator_origin.rs:233`/`:345`.
@@ -256,7 +257,8 @@ but the string is linked either way.
       "flowMode": modeStr,      # $mode -> "fmCall"
     }
 
-The engine wants `CtLoadFlowArguments` (`src/db-backend/src/task.rs:58-64`):
+The engine wants `CtLoadFlowArguments` (`src/db-backend/src/task.rs`), which at
+the time of this write-up read:
 
     #[derive(Serialize, Deserialize, Debug, PartialEq, Default, Clone, JsonSchema)]
     #[serde(rename_all = "camelCase")]
@@ -267,14 +269,19 @@ The engine wants `CtLoadFlowArguments` (`src/db-backend/src/task.rs:58-64`):
 
 Three separate disagreements:
 
-1. **`flowMode` encoding.** Rust's `FlowMode` (`task.rs:49-56`) derives
-   `Deserialize_repr` with `#[repr(u8)]` — it accepts a JSON **number only**. The
-   string `"fmCall"` fails with *invalid type: string, expected variant index*.
+1. **`flowMode` encoding.** Rust's `FlowMode` (`task.rs`) derived
+   `Deserialize_repr` with `#[repr(u8)]` — it accepted a JSON **number only**.
+   The string `"fmCall"` failed with *invalid type: string, expected variant
+   index*.
 2. **`location` is required**, not `Option`. No `#[serde(default)]` at container
    or field level.
 3. **`rrTicks` is at the wrong level.** The struct does not declare it; the real
-   tick lives *inside* `Location` (`task.rs:400`). There is no
-   `deny_unknown_fields` here, so the top-level `rrTicks` is silently discarded.
+   tick lives *inside* `Location` (`task.rs`). At the time there was no
+   `deny_unknown_fields` on this struct, so the top-level `rrTicks` was silently
+   discarded. That is no longer true: b6f39ca7 added
+   `#[serde(deny_unknown_fields)]` to `CtLoadFlowArguments`, so a stray
+   top-level `rrTicks` is now a hard deserialisation error rather than a silent
+   drop — see the Status below, where the sender stopped sending it.
 
 **The vocabularies also differ in size:** Rust `FlowMode` is `Call | Diff`;
 Nim's (`flow_vm.nim:50-54`) is `fmCall | fmLine | fmFunction`. Two of Nim's three

--- a/src/frontend/viewmodel/identity/webcrypto_verifier.nim
+++ b/src/frontend/viewmodel/identity/webcrypto_verifier.nim
@@ -9,14 +9,19 @@
 ##
 ## The obvious way to ship a browser crypto binding is to write it, assert it
 ## appears in the bundle, and hope. That is the shape this campaign keeps
-## calling a vacuous pass. It is avoidable here because **`vm-unit-js` runs
-## under Node, and Node's `globalThis.crypto.subtle` implements Ed25519 with
-## the same API a browser exposes** — measured on the toolchain's Node 22:
-## a generated key exports 32 raw bytes, a signature is 64, verification of a
-## good signature is `true` and of a one-bit-flipped signature is `false`.
+## calling a vacuous pass. It is avoidable here because **Node's
+## `globalThis.crypto.subtle` implements Ed25519 with the same API a browser
+## exposes**, so this code can be run for real rather than inspected.
 ##
-## So `test_webcrypto_verifier.nim` generates a real key pair, signs a real
-## container, and verifies it through this exact code. The JS lane runs real
+## It is *not* a `vm-unit-js` suite that does this: `crypto.subtle.verify`
+## resolves on V8's microtask queue, which `drainPlatformCallbacks` does not
+## drain. The gate is `ci/test/identity-webcrypto.sh`, which compiles
+## `ci/test/identity_webcrypto_probe.nim` against this module and runs it
+## under Node. The probe generates a real Ed25519 key pair, signs a real
+## container, and verifies it through this exact code — a good signature
+## verifies, a one-bit-flipped signature and a one-bit-flipped message do not,
+## and unusable key material comes back as an error rather than a bad-signature
+## verdict. It is wired into `just test-identity`. The JS lane runs real
 ## Ed25519; the C lane runs the refusal below. Both are the shipped path for
 ## their backend.
 ##

--- a/src/frontend/viewmodel/viewmodels/flow_layout.nim
+++ b/src/frontend/viewmodel/viewmodels/flow_layout.nim
@@ -484,9 +484,11 @@ func sourceIndentLevel*(text: string; tabSize: int = 4): int =
   ## rendered `.cigr` indent-guide elements in the line's view overlay — a
   ## measurement of the editor's DOM, available to no other renderer.
   ##
-  ## **That proc had no call site.** It was declared at `ui/flow.nim:212`,
-  ## defined at 4358, and never invoked from anywhere in the tree; `FlowLine`'s
-  ## matching `indentationsCount` field was never read either. So the spec's
+  ## **That proc had no call site.** It was forward-declared, defined, and
+  ## invoked from nowhere in the tree; `FlowLine`'s matching
+  ## `indentationsCount` field (`types.nim`) was never read either, and still
+  ## is not. The proc itself is gone now — `ui/flow.nim` carries a tombstone
+  ## comment where it stood, next to `createFlowViewZone`. So the spec's
   ## third positioning rule was, on the desktop, computed by nothing — which is
   ## also why replacing it here cannot change what the desktop draws.
   ##

--- a/src/frontend/viewmodel/viewmodels/no_source_vm.nim
+++ b/src/frontend/viewmodel/viewmodels/no_source_vm.nim
@@ -126,6 +126,17 @@ proc jumpBack*(vm: NoSourceVM) =
   ## safe to call from the view's click handler regardless of the
   ## current state — the view simply hides the button when there is
   ## no history.
+  ##
+  ## KNOWN DEFECT — THE REQUEST IS ACCEPTED AND THE TARGET IS DISCARDED.
+  ## ``ct/history-jump`` deserialises its arguments as the engine's
+  ## ``Location``, which is ``#[serde(default)]`` at the container level and
+  ## has no ``deny_unknown_fields``.  ``{previousPath, action}`` shares none
+  ## of ``Location``'s field names, so every field defaults: the engine gets
+  ## a zeroed ``Location`` and ``location_jump`` uses only ``rr_ticks``,
+  ## which means it jumps to step 0 and answers success.  Nothing here
+  ## reaches the previous path.  ``task.rs``'s ``Location`` doc comment
+  ## records the same mismatch from the engine side and names this literal.
+  ## ``origin_chain_vm.onSeekToHop`` has the identical bug.
   let history = vm.history.val
   if not history.hasHistory:
     return

--- a/src/frontend/viewmodel/viewmodels/origin_chain_vm.nim
+++ b/src/frontend/viewmodel/viewmodels/origin_chain_vm.nim
@@ -213,8 +213,24 @@ proc onSeekToHop*(vm: OriginChainVM; hop: OriginHop) =
     return
   if vm.store.isNil or vm.store.backend.isNil:
     return
-  # Fallback: forward the seek as a history-jump request so the
-  # existing backend dispatcher (`ct/history-jump`) handles it.
+  # Fallback: forward the seek as a `ct/history-jump` request.
+  #
+  # KNOWN DEFECT — THE DISPATCHER RUNS AND THE SEEK TARGET IS DISCARDED.
+  # This used to say the existing dispatcher "handles it". It does not.
+  # `ct/history-jump` deserialises its arguments as the engine's `Location`
+  # (`dap_server.rs` dispatch -> `dap_handler.rs`'s `Handler::history_jump`),
+  # and `Location` carries `#[serde(default)]` at the container level. The
+  # object below is a DIFFERENT SHAPE: `path`/`line`/`rrTicks` are nested
+  # under `location`, and `expression`/`stepId` are not `Location` fields at
+  # all. Nothing binds, so the engine constructs a fully zeroed `Location`
+  # and `location_jump` reads only `rr_ticks` — it jumps to step 0, the start
+  # of the trace, and reports success. `task.rs`'s `Location` doc comment
+  # records this same mismatch from the engine side and names this literal.
+  #
+  # Closing it means either flattening this payload into `Location`'s own
+  # fields or giving `ct/history-jump` an argument type of its own. Neither
+  # has been done; until then the host bridge above is the only path that
+  # actually seeks.
   let args = %*{
     "expression": hop.targetExpr,
     "location": %*{


### PR DESCRIPTION
A prose sweep of `dev`, in the pattern confirmed repeatedly in these repos: when a check, constant or mechanism changes, the assertion gets corrected and the sentence describing it does not. Every claim was verified against the thing it describes — the real source, a tree-wide caller grep, the cited command actually run — never against another comment.

### Citations to things that do not exist
- `language_detection.nim` credited a `lang_detection_test.nim` for asserting `detectLangFromPath`'s return value. No such file. The test that does make that assertion is `src/tests/cli/lang_enum_contract_test.nim`, so the citation is re-pointed rather than deleted — the coverage is real.
- `webcrypto_verifier.nim` credited a `test_webcrypto_verifier.nim` under the heading "This is exercised, not merely written". No such file either; the coverage is real via `ci/test/identity-webcrypto.sh`, wired at `justfile:2993`. Also re-pointed.
- `cow_namespace_crossread_test.rs`'s M4 generator claimed a Nim test read its fixture back, "closing the bidirectional wire-format loop the M5/M6 Rust replay-time write path depends on". There is no such consumer — no `*.nim` file reads a `.cowbt` at all. **The loop is open.** The comment now says so and gives the shape of the missing test instead of claiming a guarantee nothing provides, and its green line no longer announces a cross-read that never happens.
- `release_gate.nim`'s ordinal-drift example cites `src/tui/src/lang.rs`, deleted in `84a8b633`.

### Procs described as called, with no callers
`isonim_app.nim` said two procs are "called from ui_js.nim" — zero call sites tree-wide, and `ui_js.nim` says the opposite ("The standalone isonim_app shell remains disabled here"). `search_results.nim` claimed three hooks are called from `onSearchResultsUpdated`; `syncSearchResultsClearHook` is declared, assigned, and never called.

### Numbers stale next to the command that refutes them
`justfile:2555` said "76 of the 220 files (`test_lane_all_files | wc -l` for the 220)". Running it gives **274**. The reach budget said "sixteen of the nineteen"; `budget_for()` sums to 20. `require-siblings.sh` said five trace-format deps (7) and 223 import sites (532 lines across 226 files). Rather than writing fresh numbers that will rot the same way, these now name the command that computes them.

### Green paths and instructions that do not work
`just build-tailwind` does not exist (the step is `vm-test-prereqs`). `test-rust-flow-all` prints "All Rust flow tests passed!" while running only the stable arm — why the other two are skipped is recorded nowhere, and the comment now says that rather than inventing a reason. The identity mutation gate's `RESULT: OK` claimed every assertion family has an arm that reddens it; it never quantified over families.

### A real defect found behind reassuring prose
Two viewmodels documented `ct/history-jump` as handled by "the existing backend dispatcher". It parses `Location`, which is `#[serde(default)]`; neither payload shares a field name with it, so every field defaults and `location_jump` runs on a zeroed `Location` — **a jump to step 0 that returns success**. Marked as a known defect in both viewmodels; no behaviour change here, since the fix is to flatten the payloads or give the command its own argument type.

`dap_dialect.md`'s `task.rs` line citations had all drifted; the numbers are dropped in favour of symbol names, which do not rot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)