### PR TITLE
ci: route windows-installer-build to eph-win-x64-release

### DIFF
--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -2451,7 +2451,7 @@ jobs:
     # outage cannot turn PR runs red. This job is NOT in push-tag's `needs`, so
     # while GARM is down it can hang/fail without ever blocking a release —
     # create-release simply skips the (absent) win artifact (see below).
-    runs-on: eph-win-x64  # CIP-5: DIY-Windows (env.ps1) -> eph-win-x64
+    runs-on: eph-win-x64-release  # CIP-5: DIY-Windows (env.ps1) -> eph-win-x64-release (dedicated release scale set)
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       # See the eph-win-x64 note at the top of this file: actions/checkout needs


### PR DESCRIPTION
Routes the release NSIS installer build (`windows-installer-build`) off the saturated shared `eph-win-x64` pool onto the dedicated `eph-win-x64-release` scale set, for faster release iteration.

Scope: one line. Only `windows-installer-build` (the release-gated `if: github.ref == 'refs/heads/main'` job) is changed. All PR/CI Windows jobs — `windows-bootstrap-smoke`, `origin-dap-windows`, `origin-dap-windows-nightly`, `windows-named-pipe-tests`, `windows-rust-components`, `windows-headless-test` — stay on `eph-win-x64` so the 2-slot release lane cannot bottleneck CI. `windows-installer-publish` is a Linux (R2 upload) job and is untouched.

Note: target base is `dev` (the source-of-truth integration branch for `codetracer.yml`); there is no `main` branch in the repo — `main` is the intended release ref the job is gated to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)