### PR TITLE
ci: resolve the six IsoNim-family siblings from the workspace lock

### DIFF
--- a/.github/actions/setup-isonim-siblings/action.yml
+++ b/.github/actions/setup-isonim-siblings/action.yml
@@ -81,10 +81,11 @@ runs:
         # revision for a moving branch tip — a real loss of reproducibility,
         # and invisible, because CI would go on passing.
         #
-        # The five pinned entries are the ones the lock genuinely cannot
-        # answer: they are not members of codetracer's project in
-        # `metacraft-labs/metacraft-manifests`, so the lock has nothing to say
-        # about them and a bare entry fails the step outright:
+        # ALL NINE ARE BARE, and that is new. Five of them — isonim,
+        # isonim-tui, isonim-gpui, nim-termctl, nim-pty — carried `=dev` until
+        # metacraft-manifests@8ddec34f, because they were not members of
+        # codetracer's project there, so the lock had nothing to say about them
+        # and a bare entry failed the step outright:
         #
         #   The workspace lock for codetracer@<sha> pins no revision for these
         #   sibling(s): isonim isonim-tui isonim-gpui nim-termctl nim-pty
@@ -94,18 +95,23 @@ runs:
         # ct-test gates — because they all reach this action through
         # `Setup dev env`.
         #
-        # THE PROPER FIX is to declare these five in codetracer's project
-        # manifest so the lock pins them too, and then delete the `=dev` from
-        # all five. It is a change in `metacraft-manifests` and CI stays red
-        # until it lands and a new lock publishes, which is the only reason it
-        # is not done here. Until then these five, and ONLY these five, are
-        # unpinned.
+        # TWO changes were needed, and only the first had been made. The
+        # project declaration (3c625e7) covered isonim and runquota; the other
+        # four stayed undeclared, and — the part that made the first look
+        # ineffective — declaring a repo does not put it in a lock.
+        # `publish-workspace-lock.yml` re-anchors each mainline commit's lock
+        # from its PARENT, copying the repo SET verbatim, so the 99-repo
+        # lineage in flight simply never grew the new members. The lock for dev
+        # HEAD 79275598, published after that declaration, still pinned none of
+        # them. metacraft-manifests@8ddec34f declares the remaining four AND
+        # seeds that lock with all six, so the carry propagates them from here
+        # on.
         siblings: |
-          isonim=dev
-          isonim-tui=dev
-          isonim-gpui=dev
-          nim-termctl=dev
-          nim-pty=dev
+          isonim
+          isonim-tui
+          isonim-gpui
+          nim-termctl
+          nim-pty
           nim-everywhere
           nim-acp
           nim-agent-harbor

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -4722,7 +4722,10 @@ jobs:
             nim-stackable-hooks=dev
             codetracer-visual-replay=dev
             codetracer-native-backend=dev
-            runquota=dev
+            # Bare since metacraft-manifests@8ddec34f: runquota is a member of
+            # codetracer's project there and the lock pins it, so the revision
+            # comes from the lock rather than from whatever `dev` points at.
+            runquota
 
       - name: Stage codetracer-trace-format into libs/
         # The nix flake build below overrides the codetracer-trace-format input
@@ -5416,7 +5419,15 @@ jobs:
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           trusted-public-keys: ${{ vars.ATTIC_TRUSTED_PUBLIC_KEY }}
           siblings: |
-            isonim=dev
+            # `isonim` and `runquota` are BARE since metacraft-manifests@8ddec34f
+            # declared both in codetracer's project and seeded the dev-HEAD lock
+            # with them: their revision now comes from the per-commit workspace
+            # lock instead of whatever `dev` pointed at when the job ran. The
+            # remaining `=dev` entries below are the lock-outage tourniquet that
+            # ci/test/sibling-provisioning-test.sh caps and is converting; every
+            # one of them names a repo the lock ALREADY pins, so they are
+            # convertible the same way whenever that work is picked up.
+            isonim
             nim-everywhere=dev
             nim-acp=dev
             nim-agent-harbor=dev
@@ -5432,7 +5443,7 @@ jobs:
             codetracer-native-recorder=dev
             codetracer-native-test-programs=dev
             codetracer-visual-replay-fixtures=dev
-            runquota=dev
+            runquota
 
       - name: Run visual replay regression gate
         env:

--- a/.github/workflows/launcher-recorder-e2e.yml
+++ b/.github/workflows/launcher-recorder-e2e.yml
@@ -460,7 +460,7 @@ jobs:
         # fixture check two steps below passed.  The workspace was just three
         # repos where the build needs eleven.
         #
-        # SIX OF THE EIGHT ARE ADDED HERE, BARE, and bare is not a shortcut: the
+        # ALL EIGHT ARE ADDED HERE, BARE, and bare is not a shortcut: the
         # workspace lock published for this commit pins every one of them, so
         # `clone-siblings` resolves each through NEED_LOCK=1 exactly as it does
         # the planner's three.  `codetracer-trace-format-nim` is repeated from
@@ -470,28 +470,30 @@ jobs:
         # per BLOCK, and a block naming one half only is the defect it names).
         # The repeat costs one extra clone of an already-pinned revision.
         #
-        # THE REMAINING TWO ARE NOT IN THIS REPO'S GIFT.  `isonim` and
-        # `runquota` are absent from the `codetracer` project in
-        # metacraft-labs/metacraft-manifests, so the lock has no revision for
-        # them and a bare entry would fail this step outright with
+        # THE LAST TWO WERE NOT IN THIS REPO'S GIFT UNTIL NOW.  `isonim` and
+        # `runquota` were absent from the `codetracer` project in
+        # metacraft-labs/metacraft-manifests, so the lock had no revision for
+        # them and a bare entry failed this step outright with
         #
         #   The workspace lock for codetracer@<sha> pins no revision for these
         #   sibling(s): isonim runquota
         #
         # -- verified against the published lock for d05e45f97e449c03, which
-        # names 96 repos and neither of those.  The two escape hatches are both
-        # closed on purpose and must stay closed: a `<name>=<ref>` entry is
-        # refused by the planner's own guard above (revisions come from the
-        # lock), and it would also push this repo past the shrink-only
-        # branch-tip ceiling in ci/test/sibling-provisioning-test.sh.
+        # names 96 repos and neither of those.  Both escape hatches were closed
+        # on purpose and stay closed: a `<name>=<ref>` entry is refused by the
+        # planner's own guard above (revisions come from the lock), and it would
+        # also push this repo past the shrink-only branch-tip ceiling in
+        # ci/test/sibling-provisioning-test.sh.
         #
-        # So this gate cannot go green from this repository alone.  The remedy
-        # is to declare `isonim` and `runquota` in codetracer's project manifest
-        # and publish a new lock -- `repro workspace lock --trigger-repo=
-        # codetracer` in a workspace whose `.repro/manifests` is a real git
-        # checkout -- and then add the two names to the block below.
-        # ci/test/launcher-recorder-e2e-workflow-test.sh holds that gap as a
-        # named, shrink-only exception so it cannot be forgotten or widened.
+        # metacraft-manifests@8ddec34f closed the gap at its source: it declares
+        # both repos in codetracer's project AND seeds the lock for dev HEAD
+        # 79275598 with them.  The second half mattered on its own -- an earlier
+        # commit there had already declared them, with no effect, because
+        # `publish-workspace-lock.yml` re-anchors each lock from its PARENT and
+        # copies the repo SET verbatim, so a newly declared repo never enters
+        # the lineage on its own.  With the lock seeded, the carry propagates
+        # both forward and the two names below resolve like every other bare
+        # entry.
         uses: metacraft-labs/metacraft-github-actions/setup-dev-env@dev
         with:
           env-flavor: nix
@@ -510,6 +512,8 @@ jobs:
             codetracer-trace-format
             codetracer-trace-format-nim
             codetracer-native-recorder
+            isonim
+            runquota
 
       - name: Check the workspace has the shape the driver expects
         # Cheap, and it turns the one class of failure a local rehearsal cannot

--- a/ci/test/build-once-workspace-test.sh
+++ b/ci/test/build-once-workspace-test.sh
@@ -95,23 +95,23 @@ readonly PREFLIGHT="$REPO_ROOT/scripts/require-siblings.sh"
 # real gap, so closing one forces its deletion; adding one is a deliberate,
 # reviewed act. There is no ceiling and no wildcard: an unlisted gap fails.
 #
-# Both entries below are the SAME cause, and it is not in this repository.
+# CLOSED, 2026-09-03: the `launcher-recorder-e2e` pair that used to head this
+# list is gone, and the shrink-only rule above is what forced its deletion.
 # `clone-siblings` resolves a bare entry from the workspace lock published for
 # the commit under test, and the `codetracer` project in
-# metacraft-labs/metacraft-manifests does not declare `isonim` or `runquota` --
-# the lock for d05e45f97e449c03 names 96 repos and neither of those. A bare
-# entry for either fails `Setup dev env` outright with "the workspace lock for
-# codetracer@<sha> pins no revision for these sibling(s)". The two ways to
-# spell around that are both closed on purpose: `launcher-recorder-e2e.yml`'s
-# planner refuses any `<name>=<ref>` entry, and a new branch-tip pin would
-# break the shrink-only ceiling in ci/test/sibling-provisioning-test.sh.
+# metacraft-labs/metacraft-manifests declared neither `isonim` nor `runquota`,
+# so a bare entry for either failed `Setup dev env` outright with "the
+# workspace lock for codetracer@<sha> pins no revision for these sibling(s)".
 #
-# REMEDY, and it is a change in another repository: declare `isonim` and
-# `runquota` in codetracer's project manifest, publish a lock
-# (`repro workspace lock --trigger-repo=codetracer`, in a workspace whose
-# `.repro/manifests` is a real git checkout -- where it is a plain directory
-# the lock is generated and then silently dropped), then add the two names to
-# the `siblings:` block in launcher-recorder-e2e.yml and delete these lines.
+# The remedy was in another repository and took TWO steps, not one. Declaring
+# the repos was necessary and by itself did nothing observable:
+# `publish-workspace-lock.yml` re-anchors each mainline lock from its PARENT
+# and copies the repo SET verbatim, so a repo declared after a lineage started
+# never enters it -- the lock published for dev HEAD 79275598, after the
+# declaration landed, still named neither. metacraft-manifests@8ddec34f did
+# both: it completed the declaration and seeded that lock with the six repos
+# the IsoNim provisioning needs. The two names are now in
+# launcher-recorder-e2e.yml's `siblings:` block, bare, like the other six.
 #
 # THE OTHER TWO JOBS ARE A DIFFERENT CASE and are recorded as FOUND, not as
 # accepted. This suite's first run reported them, they are static facts about
@@ -122,10 +122,6 @@ readonly PREFLIGHT="$REPO_ROOT/scripts/require-siblings.sh"
 # listed rather than fixed because fixing them means editing jobs this change
 # cannot exercise; each line says what is missing and what would close it.
 KNOWN_GAPS=(
-	# The lock cannot answer for these two -- see the paragraph above.
-	"launcher-recorder-e2e.yml|launcher-recorder-e2e|isonim"
-	"launcher-recorder-e2e.yml|launcher-recorder-e2e|runquota"
-
 	# viewmodel-tests provisions the IsoNim family through
 	# .github/actions/setup-isonim-siblings and adds codetracer-trace-format-nim,
 	# codetracer-js-recorder and runquota as clone-repo steps -- but not

--- a/ci/verdict/workspace-lock-freshness.sh
+++ b/ci/verdict/workspace-lock-freshness.sh
@@ -13,8 +13,8 @@
 # `siblings:` entries now name their refs explicitly so it cannot happen again.
 #
 # But that coupling was also the ONLY thing anyone was watching. Removing it
-# fixes the pipeline and silences the alarm in the same stroke, and the
-# underlying condition is not small:
+# fixes the pipeline and silences the alarm in the same stroke, and at the time
+# this was written the underlying condition was not small:
 #
 #   Nothing has been committed to metacraft-labs/metacraft-manifests, for ANY
 #   repo, since 2026-08-02 (`b3b0ac6 Publish 1 workspace lock entry`).
@@ -23,13 +23,42 @@
 # A stall means no reproducible snapshot of the workspace exists for any commit
 # in that window — a fact about the whole workspace, not about CI.
 #
-# The failure is quieter than "the tooling broke". `repro`'s post-commit hook
-# still WRITES the lock, into a workspace-local checkout of the manifests repo,
-# and logs `ok wrote <path>` and exits 0. It is the commit-and-push that stopped:
-# the files sit untracked in that checkout. On 2026-08-13 a developer's checkout
-# held twenty untracked codetracer locks, including one for the exact commit CI
-# was reporting as unlocked. The tooling's success message was true and useless
-# — the artefact existed on one disk and nowhere else.
+# THAT OUTAGE IS OVER, and the sentence above is left standing only because the
+# rest of this comment is a record of why the alarm exists. Measured 2026-09-03:
+# the manifests repo has taken 609 commits since 2026-08-02, and since
+# 2026-08-27 the publisher has been the `metacraft-ci` account rather than a
+# developer's hook — 26 commits on 08-30, 23 on 09-02, 43 on 09-03. What closed
+# it is `.github/workflows/publish-workspace-lock.yml`: a push to a locked
+# mainline re-anchors the previous HEAD's lock onto the new one, server-side.
+# Publication is automatic and prolific. An alarm that fires here today is
+# reporting something else, and should not be read as this outage returning.
+#
+# TWO STALE EXPLANATIONS TO NOT REACH FOR, both checked on 2026-09-03:
+#
+#   * "The post-commit hook refuses while sibling worktrees are dirty." That
+#     refusal is REAL and reproducible locally — `repro` declines with "NO lock
+#     written: dirty sibling(s): ..." — but it is a DIFFERENT CODE PATH and does
+#     not operate here. The CI publisher is two steps, mint-a-token and call
+#     `publish-workspace-lock@dev`; it checks out no sibling and runs `git
+#     status` on nothing, because it copies lock metadata rather than resolving
+#     a workspace. A dirty local worktree cannot stall CI publication.
+#
+#   * "The lock was written but never pushed." That was the 2026-08-13 story —
+#     `repro`'s post-commit hook WROTE the lock into a workspace-local checkout,
+#     logged `ok wrote <path>` and exited 0, while the commit-and-push never
+#     happened, so twenty untracked codetracer locks sat on one developer's
+#     disk. True then; not the mechanism now, because the publisher is no longer
+#     a developer's disk.
+#
+# THE LIVE FAILURE MODE IS NEITHER, and it is silent: the re-anchor copies the
+# previous lock's repo SET verbatim, so a repository newly declared in a
+# project manifest NEVER enters a lineage already in flight. A lock keeps
+# publishing, on time, for every commit — and simply does not mention the new
+# repo. Nothing is red. `isonim` and `runquota` sat in exactly that state:
+# declared, and absent from every lock published afterwards, until the lineage
+# head was seeded by hand (metacraft-manifests@8ddec34f). A freshness alarm
+# cannot see this, because the lock is fresh. It is the lock's CONTENTS that
+# were stale.
 #
 # So this job exists to say that out loud, on every run, in its own name.
 #


### PR DESCRIPTION
Unblocks `ci-verdict` **step 5** (`sibling-provisioning-test.sh`), which has been failing on every run and taking steps 6-14 with it — including step 14, the verdict itself. The gate built to distinguish "tests failed" from "tests never ran" has never reached the step that says which.

Paired with metacraft-labs/metacraft-manifests@8ddec34f. **Both halves are required**; either alone changes nothing observable.

## The gap, and why the obvious fix had already been tried and failed

`clone-siblings` resolves a bare `siblings:` entry from the per-commit workspace lock. Six repos the IsoNim provisioning needs were not in codetracer's project in `metacraft-manifests`, so the lock could not answer for them and a bare entry failed `Setup dev env` outright. The workaround was `=dev` — a branch-tip pin, which `sibling-provisioning-test.sh` counts against a shrink-only ceiling. The guard therefore forbade the only workaround for a gap the manifest created.

An earlier manifests commit had **already declared** `isonim` and `runquota`, and nothing changed. That is the part worth recording, because it looked like the fix had landed:

> **Declaring a repo does not put it in a lock.** `publish-workspace-lock.yml` re-anchors each mainline commit's lock from its *parent*, copying the repo **set** verbatim. A repo declared after a lineage began never enters it. The lock published for `dev` HEAD `79275598` *after* that declaration still named neither repo.

`metacraft-manifests@8ddec34f` does both halves: it declares the four still-missing repos (`isonim-tui`, `isonim-gpui`, `nim-termctl`, `nim-pty`) and **seeds the `79275598` lock** with all six. The re-anchor carry propagates them from there.

## Scope correction

The gap is **six** repos, not two, and the `=dev` overrides are **eight** entries, not two. Fixing only `isonim`+`runquota` would have left four overrides with no lock to resolve from and `sibling-provisioning-test.sh` failing on exactly the assertion it fails on now.

## Revisions

Each is the repo's `dev` tip as of 2026-09-03 — precisely what the `=dev` overrides already resolved to at that moment. Pinning **freezes the revision CI was already building against** rather than choosing a different one: the change is reproducibility, not content.

## Verified locally (bash 5.2 + GNU sed, CI-equivalent layout)

| suite | before | after |
|---|---|---|
| `ci/test/sibling-provisioning-test.sh` | 2 of 26 failed | **all 26 passed** |
| `ci/test/build-once-workspace-test.sh` | 4/4, 10 gaps | **4/4, 8 gaps** |

The pass is **not vacuous**: both runs report identical populations — 95 sibling entries across 16 blocks, 9 entries in `setup-isonim-siblings`, the same expected IsoNim set, the same 26 assertions. Only the two failing assertions flipped.

Branch-tip entries go **67 → 59** against `BRANCH_TIP_CEILING=59`. The ceiling is **left at 59, not lowered** — 59 entries genuinely remain, so lowering it would be false. That `67-8=59` lands exactly on the ceiling is not a coincidence.

`ci-verdict` steps 2-9 and 11 all pass locally under a CI-equivalent environment (step 10 fails only here, identically on pristine `dev`: its fake GitHub API will not start under this sandbox).

## Not verified

**Whether `ci-verdict` reaches step 14 in CI.** It `needs:` 27 jobs including the Windows lanes, which queue ~15h, so the observation is 12-18h out. This PR is the run that produces it; it is not inferred here.

## Follow-up, not done here

All 59 remaining branch-tip entries name repos the published lock **already pins**. They are convertible by deleting `=dev` alone, with no manifests change. That is the next decrement of the ceiling.