### PR TITLE
fix(ci): redact credentials that live in a git config KEY NAME

### DIFF
--- a/.github/actions/dump-git-fetch-env/action.yml
+++ b/.github/actions/dump-git-fetch-env/action.yml
@@ -90,7 +90,26 @@ runs:
         keys="$(git config --list --show-origin --name-only 2>/dev/null \
           | grep -iE 'http\.|url\.|credential')"
         if [ -n "${keys}" ]; then
-          printf '%s\n' "${keys}" | sed 's/^/  /'
+          # REDACT CREDENTIALS THAT LIVE IN THE KEY NAME ITSELF.
+          #
+          # This block deliberately prints names and never values, on the
+          # reasoning that a name cannot carry a secret. That reasoning stops
+          # holding the moment anyone authenticates git the way nix's fetcher
+          # actually honours it. Measured on nix 2.25: the fetcher respects
+          # `url.<...>.insteadOf` from the user's git config and IGNORES
+          # `http.<...>.extraHeader` -- so the only rewrite that can
+          # authenticate a `builtins.fetchGit` is
+          #
+          #     url."https://x-access-token:<TOKEN>@github.com/".insteadOf
+          #
+          # which puts the token INSIDE the key name, where this loop would
+          # print it in full. Strip any `user:pass@` from the names so that
+          # adopting that fix cannot silently turn this diagnostic into the
+          # leak. Done here rather than at the call site because the next
+          # person to add a `--name-only` dump will copy this block.
+          printf '%s\n' "${keys}" \
+            | sed -E 's#://[^/@[:space:]]*:[^/@[:space:]]*@#://<redacted>@#g' \
+            | sed 's/^/  /'
         else
           echo "  (none — git has no http./url./credential keys from any file)"
         fi


### PR DESCRIPTION
`dump-git-fetch-env` lists every `http.*`/`url.*`/`credential` key with `--name-only`, on the stated reasoning that *a name cannot carry a secret*. That has one hole, and it opens exactly when the fetch failure this action diagnoses gets fixed.

Measured on nix 2.25 against uncached public repos:

- nix's git fetcher **does** honour `url.<...>.insteadOf` (a fake-hostname rewrite was applied and the fetch succeeded);
- nix's git fetcher **ignores** `http.<...>.extraHeader` — a deliberately malformed `AUTHORIZATION` header fails plain `git ls-remote` on the same host while `builtins.fetchGit` reaches GitHub and lists refs anyway. Reproduced on two repos.

So `http.extraHeader` — what `actions/checkout` uses — **cannot** authenticate a `builtins.fetchGit`, and the only rewrite that can is `url."https://x-access-token:<TOKEN>@github.com/".insteadOf`, which puts the token **inside the key name**. Adopting that fix would make this loop print the credential in full, on every job that provisions Nix, while the surrounding comment still said names are safe.

Log masking is not a defence, and the file already says why: it redacts only values it was told about, and a credential written by a runner image or setup action was never registered as a secret.

This strips `user:pass@` userinfo before printing. Verified on a sample with a token-bearing `insteadOf`, an `extraheader`, and a credential-free `insteadOf` — the token becomes `<redacted>`, the other two are untouched.

No probe behaviour changes; the step still ends `exit 0`.

---

Also running this as a PR on purpose: `push` runs on `dev` share one concurrency group, and GitHub evicts the *pending* run whenever a newer push lands, so probes F/G (added in 79275598) have not executed once in ~6 consecutive `dev` runs. A PR gets its own group, so `lint-nix` here should finally report what `POST /<repo>/git-upload-pack` returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)