### PR TITLE
ci(mode roundtrip): wire the edit-toolbar gate, and repair the three assertions that kept it from ever passing

### DIFF
--- a/.github/workflows/deploy-web-codetracer.yml
+++ b/.github/workflows/deploy-web-codetracer.yml
@@ -807,6 +807,58 @@ jobs:
             direnv exec "$(pwd)" bash ci/test/editor-resize-follows-pane.sh
           '
 
+      - name: Prove the EDIT-MODE TOOLBAR survives the mode round trip
+        # THE GATE FOR THE TOPBAR ITSELF, and it is being wired rather than
+        # written: `ci/test/noir-mode-roundtrip.sh` has existed, complete, with
+        # a control arm and a mutation arm, and no workflow has ever called it.
+        # It was recorded in `ci/test/shell-gate-coverage.known-dark.txt` under
+        # "WIRED TO A `just` RECIPE THAT NO WORKFLOW CALLS" — and that file's
+        # own rule says an UNWIRED gate "lands wired or it does not land", so
+        # the entry should never have been written. Its line is deleted in this
+        # commit and the RECORDED-DARK-CEILING comes down with it.
+        #
+        # WHY IT BELONGS IN *THIS* JOB rather than in `codetracer.yml`. The
+        # gate's preconditions refuse a tree with no Noir compiler and no
+        # replay engine — it exits 2 rather than measuring a Run that could
+        # never reach a replay. This is the only job that has both, already
+        # assembled at `studio-bundle/`, which is exactly why the four browser
+        # gates above run here too. So it was never BLOCKED; the step was
+        # simply not written.
+        #
+        # WHAT IT ASSERTS THAT THE FOUR ABOVE DO NOT. Every one of them loads
+        # the page in ONE mode. This gate's subject is the TRANSITION: it reads
+        # `data-topbar-surface` and `data-button-count` off the panel root at
+        # every leg, presses the real Run button, asserts the topbar became
+        # `debugger-controls` with Build GONE, presses the real Stop button,
+        # and asserts the topbar came back to `edit-commands` with Build and
+        # Run on it — three round trips, because per Mode-Transitions.md §6 the
+        # failure mode is a slot that is right once and empty afterwards.
+        #
+        # A VIEW-MODEL TEST WOULD HAVE PASSED THROUGHOUT. The toolbar's model
+        # is 1103 lines and tested on two backends, and for most of its life it
+        # was imported by nothing outside its own suites — a correct capability
+        # nothing reached. What separates the two is a DOM in a real browser on
+        # a BUILT bundle, which is what this runs.
+        #
+        # TWO OF ITS ASSERTIONS COULD NOT PASS UNTIL THIS COMMIT, and being
+        # dark is why nobody knew. FILES asked for `#filesystemComponent-0`,
+        # an id the IsoNim view has never emitted, so the pane read `absent`;
+        # VCS asserted `> 0` commit rows against a template that is not a git
+        # repository and never becomes one. Both are corrected in the probe and
+        # the shell here, and both were verified against the DEPLOYED bundle
+        # before this step was added — FILES now reads 12 rows and VCS reads a
+        # painted `no-repo` body.
+        #
+        # Same refusal rule as the steps above: no replay engine, no session,
+        # no Debug mode — it exits 2 and says the case went unmeasured rather
+        # than reporting zero failures over an empty list.
+        run: |
+          set -euo pipefail
+          nix develop .#ci --command bash -c '
+            export CT_WEB_BUNDLE_DIR="$(pwd)/studio-bundle"
+            direnv exec "$(pwd)" bash ci/test/noir-mode-roundtrip.sh
+          '
+
       - name: Upload what the pre-publish browser saw and reported
         # BOTH FORMS. This step shipped sixteen PNGs and no JSON, which made a
         # DOM failure undiagnosable by construction: the run-control check

--- a/ci/test/noir-mode-roundtrip.sh
+++ b/ci/test/noir-mode-roundtrip.sh
@@ -434,6 +434,7 @@ while [ "${trip}" -le "${trips}" ]; do
 	# run recorded rather than against a number someone expected.
 	b_files="$(num "$(leg "${control}" "trip-${trip}-edit" '.filesEntries')")"
 	b_vcs="$(num "$(leg "${control}" "trip-${trip}-edit" '.vcsEntries')")"
+	b_vcsbody="$(leg "${control}" "trip-${trip}-edit" '.vcsBody')"
 	b_tests="$(num "$(leg "${control}" "trip-${trip}-edit" '.testsEntries')")"
 	p_files="$(num "$(leg "${control}" "edit-initial" '.filesEntries')")"
 	m_present="$(jq -r --argjson t "${trip}" \
@@ -515,8 +516,26 @@ while [ "${trip}" -le "${trips}" ]; do
 	ck "$([ "${p_files}" -gt 0 ] && [ "${b_files}" -ge "${p_files}" ] &&
 		echo ok || echo no)" \
 		"trip ${trip}: and FILES still lists its files after Stop (${b_files} entries; ${p_files} before the Run) — the pane came back with its tree, not merely mounted"
-	ck "$([ "${b_vcs}" -gt 0 ] && echo ok || echo no)" \
-		"trip ${trip}: and VCS still lists its commits after Stop (${b_vcs} rows)"
+	# VCS IS ASKED FOR A BODY, NOT FOR COMMITS, and the difference is the
+	# difference between an assertion this gate can satisfy and one it cannot.
+	#
+	# The subject here is a TEMPLATE unpacked into a VFS. It is not a git
+	# repository and never becomes one, so the pane's correct answer is the
+	# `.vcs-no-repo` empty state and `.vcs-commit` is zero in every healthy web
+	# build — permanently. `[ "${b_vcs}" -gt 0 ]` was therefore unsatisfiable
+	# by any product, which is one of the two reasons this gate has never run
+	# green; the other was FILES' stale `#filesystemComponent-0`.
+	#
+	# Weakening is exactly what must not happen here, so the assertion is not
+	# dropped but RE-AIMED at the reported defect. That report was "the VCS
+	# panel becomes EMPTY after Stop", and an emptied host is distinguishable
+	# from a rendered no-repo state: the latter painted a body. `no-body` and
+	# `absent` are the failures; `no-repo` and `commits` are both a pane that
+	# came back. The row count is still printed, so a fixture WITH history
+	# still says how much it listed.
+	ck "$([ "${b_vcsbody}" = "no-repo" ] || [ "${b_vcsbody}" = "commits" ] &&
+		echo ok || echo no)" \
+		"trip ${trip}: and VCS still paints a body after Stop (${b_vcsbody}, ${b_vcs} commit rows) — the pane came back, not merely its container"
 	ck "$([ "${b_tests}" -gt 0 ] && echo ok || echo no)" \
 		"trip ${trip}: and TESTS still lists its tests after Stop (${b_tests} rows)"
 	ck "$([ "${m_present}" = true ] && echo ok || echo no)" \
@@ -640,8 +659,23 @@ ck "$([ "${a_back}" = false ] && echo ok || echo no)" \
 # ---------------------------------------------------------------------------
 echo
 echo "${checks} check(s), ${failures} failure(s)"
-# 8 baseline + 14 per trip + 3 menu-bar gesture + 1 page-errors + 4 arm
-expect_count $((8 + 14 * trips + 3 + 1 + 4))
+# 8 baseline + 18 per trip + 3 menu-bar gesture + 1 page-errors + 4 arm
+#
+# EIGHTEEN, NOT FOURTEEN, and the four that were missing are the reason to say
+# so here. The per-trip block grew by the three sidebar-pane assertions (FILES,
+# VCS, TESTS) and the "the user's edit is STILL THERE" marker check, and this
+# arithmetic was never updated — so the gate's own tally guard failed every run
+# with "34 assertion(s) ran, 30 were written", at any value of `trips`. It was
+# never noticed because no workflow called this gate; it is called now, from
+# `deploy-web-codetracer.yml`, so the number has to be true.
+#
+# CORRECTED UPWARD, TO MATCH THE CODE. The count is a statement about how many
+# `ck` calls the script contains — `grep -c '^\tck '` over the loop body is 18
+# and over everything outside it is 16 — so the tally was the thing that was
+# wrong, not the assertions. Editing the guard DOWN to meet a short tally is
+# the failure this guard exists to catch, and it would have cemented the four
+# checks' silence rather than reporting it.
+expect_count $((8 + 18 * trips + 3 + 1 + 4))
 if [ "${failures}" -eq 0 ]; then
 	echo "RESULT: OK — Run enters the debugger, Stop comes back, ${trips} times, and the edit survives"
 	exit 0

--- a/ci/test/noir_mode_roundtrip_probe.mjs
+++ b/ci/test/noir_mode_roundtrip_probe.mjs
@@ -181,7 +181,23 @@ const snapshotScript = () => {
   // above zero means the view mounted AND rendered, which is the pair that came
   // apart: the mount latch survived a container the layout swap destroyed, so
   // the view never re-mounted into the fresh, empty host.
-  const filesEntries = paneRowCount('#filesystemComponent-0', 'a.jstree-anchor');
+  //
+  // FILES IS MATCHED BY PREFIX, and the exact id is why this gate could never
+  // have passed. `viewmodel/views/isonim_filesystem_view.nim:442` emits
+  // `id = "filesystemComponent"` with NO `-0`; only the legacy Karax path used
+  // `filesystemComponent-{id}` (`ui/filesystem.nim:511-512` tries the keyed id
+  // and then falls back to the bare one). This probe asked for
+  // `#filesystemComponent-0`, got no host, and reported `filesEntries:
+  // 'absent'` — which `noir-mode-roundtrip.sh`'s `num()` turns into -1 and
+  // every `-gt 0` comparison then fails. Measured on the deployed build: the
+  // host is `#filesystemComponent`, it carries `data-ct-isonim-mounted="1"`,
+  // and it holds 12 `a.jstree-anchor` rows. The pane was never the problem.
+  //
+  // `[id^="filesystemComponent"]` is the form `jump_follow_probe.mjs:262` and
+  // `noir_demo_path_probe.mjs:221` already use, and `pane_children_probe.mjs`
+  // records having made exactly this correction — so this file was the last
+  // one holding the stale id.
+  const filesEntries = paneRowCount('[id^="filesystemComponent"]', 'a.jstree-anchor');
   const testsEntries = paneRowCount('#testResultsComponent-0',
     '.test-results-row, .isonim-test-row, li');
   let vcsEntries = paneRowCount('#vcsComponent-0', '.vcs-commit, .isonim-vcs-commit, li');
@@ -190,6 +206,29 @@ const snapshotScript = () => {
     // pane's own mount helper tries both, so the probe must too.
     vcsEntries = paneRowCount('#vCSComponent-0', '.vcs-commit, .isonim-vcs-commit, li');
   }
+
+  // WHETHER VCS PAINTED A BODY AT ALL, which is a different question from how
+  // many commits it lists and is the one this gate can actually ask.
+  //
+  // The web fixture is a template unpacked into a VFS; it is NOT a git
+  // repository, so the pane's correct and permanent answer is the
+  // `.vcs-no-repo` empty state — zero `.vcs-commit` rows, forever. The
+  // assertion `vcsEntries > 0` therefore could not be satisfied by any healthy
+  // web build, which is the second reason this gate has never been green.
+  //
+  // The reported defect was "the VCS panel becomes EMPTY after Stop", and an
+  // emptied host and a rendered no-repo state are distinguishable: the latter
+  // has a body. So the subject here is the body, and the commit count stays
+  // beside it for the case where a fixture does have history.
+  const vcsBody = (() => {
+    const host = document.querySelector('#vcsComponent-0')
+      || document.querySelector('#vCSComponent-0');
+    if (!host) return 'absent';
+    const rendered = host.querySelector('.vcs-container, .vcs-panel-body');
+    if (!rendered) return 'no-body';
+    if (host.querySelector('.vcs-no-repo')) return 'no-repo';
+    return 'commits';
+  })();
 
   // The mark `ui/isonim_panel_mount.nim` writes onto a container it has mounted
   // a view into. Recorded so a failure can distinguish "the view never mounted"
@@ -228,8 +267,9 @@ const snapshotScript = () => {
     // never collapsed into a single "the sidebar is populated" boolean.
     filesEntries,
     vcsEntries,
+    vcsBody,
     testsEntries,
-    filesMounted: paneMounted('#filesystemComponent-0'),
+    filesMounted: paneMounted('[id^="filesystemComponent"]'),
     vcsMounted: paneMounted('#vcsComponent-0'),
     testsMounted: paneMounted('#testResultsComponent-0'),
   };

--- a/ci/test/shell-gate-coverage.known-dark.txt
+++ b/ci/test/shell-gate-coverage.known-dark.txt
@@ -13,7 +13,7 @@
 # where a reviewer sees it; wiring one up means editing it downward, which the
 # both-directions rule already forces in the same commit.
 #
-# RECORDED-DARK-CEILING: 23
+# RECORDED-DARK-CEILING: 21
 #
 # TWO KINDS OF DARK, AND ONLY ONE OF THEM MAY BE ADDED HERE.
 #
@@ -105,10 +105,20 @@
 # =============================================================================
 # WIRED TO A `just` RECIPE THAT NO WORKFLOW CALLS
 # =============================================================================
-# Fifteen: the thirteen the old scan credited to the justfile, plus the two under
-# scripts/ that the old scan could not see at all. Each has a recipe, each recipe
-# is real and probably works when a person types it, and no lane types it. Named
-# with the recipe that is their only caller.
+# Fourteen. It was fifteen — the thirteen the old scan credited to the justfile,
+# plus the two under scripts/ that the old scan could not see at all — and
+# `ci/test/noir-mode-roundtrip.sh` came off the list when it was wired into
+# `deploy-web-codetracer.yml`, which is the only job that assembles the Noir
+# compiler and replay engine its preconditions demand. Each remaining one has a
+# recipe, each recipe is real and probably works when a person types it, and no
+# lane types it. Named with the recipe that is their only caller.
+#
+# NOTE FOR WHOEVER WIRES THE NEXT ONE. `noir-mode-roundtrip.sh` was green only
+# after two of its own assertions were repaired: FILES asked for
+# `#filesystemComponent-0`, an id `viewmodel/views/isonim_filesystem_view.nim`
+# has never emitted, and VCS asserted `> 0` commit rows against a template that
+# is not a git repository. A gate that has never run is not a gate that passes,
+# so budget for fixing it, not merely for calling it.
 
 # `just test-noir-build-mutations` — the mutation arms for the pane below.
 ci/test/noir-build-mutations.sh
@@ -121,9 +131,6 @@ ci/test/noir-build-in-browser.sh
 
 # `just test-noir-replay-in-browser`.
 ci/test/noir-replay-in-browser.sh
-
-# `just test-noir-mode-roundtrip`.
-ci/test/noir-mode-roundtrip.sh
 
 # `just test-noir-edit-persists`.
 ci/test/noir-edit-persists.sh
@@ -222,21 +229,21 @@ ci/test/constraints-listing-browser.sh
 # =============================================================================
 # NOT A GATE, AND NOT AN EXEMPTION EITHER
 # =============================================================================
-
-# A LIBRARY, listed here rather than marked `NOT-A-CI-GATE:` — and the
-# distinction is the point. It resolves a bundle's copy of an asset whose name
-# carries a content digest, and it is dark for one reason only: all five scripts
-# that `source` it are dark (`wasm-worker-session.sh`, `noir-replay-in-browser.sh`,
-# `noir-mode-roundtrip.sh`, `noir-build-in-browser.sh`,
-# `build-error-navigation-in-browser.sh`). Wire any one of them and this lights
-# up on its own — at which point the both-directions rule deletes this line.
 #
-# A `NOT-A-CI-GATE:` marker here would be a landmine for exactly that reason:
-# the guard fails a file that is reachable AND declares it is not a gate, so the
-# marker would have to be removed by whoever wires a consumer, and they would
-# have no reason to expect it. `visual-replay-gate-lib.sh` is the same shape and
-# carries no marker, because its consumer is live.
-ci/lib/published-asset.sh
+# `ci/lib/published-asset.sh` STOOD HERE AND ITS LINE IS GONE, which is this
+# section working exactly as its own entry predicted. The entry read: "it is
+# dark for one reason only: all five scripts that `source` it are dark ...
+# Wire any one of them and this lights up on its own — at which point the
+# both-directions rule deletes this line." `ci/test/noir-mode-roundtrip.sh` was
+# wired in this commit and it `source`s the library at line 77, so the library
+# is reachable and the guard would have failed on a stale entry.
+#
+# The reasoning against a `NOT-A-CI-GATE:` marker is kept, because it is about
+# the next library someone is tempted to list: the guard fails a file that is
+# reachable AND declares it is not a gate, so the marker would have to be
+# removed by whoever wires a consumer, and they would have no reason to expect
+# it. `visual-replay-gate-lib.sh` is the same shape and carries no marker,
+# because its consumer is live.
 
 # --- added 2026-09-04, with M0's browser seekable-container gate -------------
 #


### PR DESCRIPTION
## The reported defect is not present

The edit-mode toolbar was reported as rendering **zero controls** on the web `/noir` build. Measured on the **deployed** bundle — `478d92a4`, the commit `noirstudio.dev/build-id.txt` names — it renders correctly at all three entries:

| entry | surface | `data-button-count` | buttons | marks | page errors |
|---|---|---|---|---|---|
| `/` | `edit-commands` | 2 | `build-image`, `run-image` | 2 | 0 |
| `/noir` | `edit-commands` | 2 | `build-image`, `run-image` | 2 | 0 |
| `/noir/demo` | `edit-commands` | 2 | `build-image`, `run-image` | 2 | 0 |

The panel is inside `#isonim-debug-controls`, `display: flex`, `visibility: visible`, `opacity: 1`, each button 26×26 at a hit-testable point. Two full `Run -> replay -> Stop -> edit` round trips return to `edit-commands` with both buttons each time.

**Of the three candidate defects — does not mount / mounts and renders zero children / renders children that are not visible — it is none of them.** `buttons=2 kinds=1 group=true` is exactly what `editModeToolbar` composes (`result.buttons = @[result.build, result.run]`), and `test_edit_mode_toolbar_view.nim` asserts the same 2.

So this PR changes no product code.

## What is actually broken: the gate over it

`ci/test/noir-mode-roundtrip.sh` is the only check whose subject is this toolbar **on a built bundle in a real browser**. A view-model test cannot see this defect class — the toolbar's 1103-line model was tested on two backends while imported by nothing outside its own suites, which is this campaign's signature failure.

**That gate has never run.** It sat in `shell-gate-coverage.known-dark.txt` under *"WIRED TO A `just` RECIPE THAT NO WORKFLOW CALLS"* — and that file's own rule is that an UNWIRED gate *"lands wired or it does not land"*. It was never blocked: `deploy-web-codetracer.yml` already assembles the Noir compiler and replay engine its preconditions demand, and already runs four sibling browser gates.

Wiring it surfaced three defects, none visible while it was dark:

1. **FILES asked for `#filesystemComponent-0`.** `isonim_filesystem_view.nim:442` emits `id = "filesystemComponent"`, unsuffixed; only the legacy Karax path used the keyed form. The probe found no host, reported `'absent'`, and `num()` turned that into `-1` — so `-gt 0` failed on a pane that was healthy all along (12 rows, `data-ct-isonim-mounted="1"`). Every sibling probe already uses `[id^="filesystemComponent"]`.

2. **VCS asserted `> 0` commit rows.** The subject is a template in a VFS — not a git repository, ever — so the pane's correct answer is its `.vcs-no-repo` state and the count is permanently zero. **Not weakened, re-aimed:** the report was *"the VCS panel becomes EMPTY after Stop"*, and an emptied host and a painted no-repo state are distinguishable. The assertion is now that the pane painted a **body**, row count printed beside it.

3. **`expect_count` was stale by 4 per trip.** The loop holds 18 `ck` calls, not 14 — it grew by the three sidebar assertions and the marker check and the arithmetic never followed. The tally guard failed every run at every `trips` (*"34 ran, 30 were written"*). Corrected **upward to match the code**; editing a guard down to meet a short tally is the failure that guard exists to catch.

## Measured, not asserted

- Repaired gate against a locally built bundle at the CI default of **3 trips: 70 checks, 0 failures**, tally matched. Before the repair: `34 ran, 30 written`, FILES and VCS red.
- **Both repaired assertions still redden** — emptying the FILES tree takes it `12 -> 0`; emptying the VCS host takes it `no-repo -> no-body`.
- `shell-gate-coverage.sh`: **142 reachable** (was 140), 21 dark, 0 unrecorded.
- Wiring this also makes `ci/lib/published-asset.sh` reachable — which its own known-dark entry predicted and asked to be deleted for. Both lines removed; `RECORDED-DARK-CEILING` 23 -> 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
