### PR TITLE
feat(generated-code): the listing is invoked from a cursor and follows the tab

### DIFF
--- a/ci/lint/nim.sh
+++ b/ci/lint/nim.sh
@@ -193,6 +193,21 @@ lint_step "frontend reachability: the ratchet's prose agrees with its threshold"
 lint_step "frontend reachability: exported symbols nothing reaches (ratchet at 1228 + allow-list hygiene)" \
 	env CT_REACHABILITY_MAX=1228 bash ci/test/frontend-reachability.sh
 
+# ONE CHAIN, ENFORCED, BECAUSE THE RATCHET ABOVE CANNOT ENFORCE IT.
+#
+# The ratchet is the right instrument for a 1228-finding backlog and the wrong
+# one for a specific feature: a chain that breaks INSIDE the ceiling reddens
+# nothing, and the Show Generated Code chain was inside it — `produceAnchors`
+# and `readArtefactJson` were reported as unreached, in report mode, exiting 0,
+# among twelve hundred other lines.
+#
+# So the operation a developer invokes to see what their code compiled to gets
+# its own check, at --enforce, with no ceiling and no allow-list. It is proved
+# able to fail: against `origin/dev` at a861f5b7b it exits 1 on 18 of its 20
+# links, and its header records that measurement rather than a claim about it.
+lint_step "Show Generated Code: the operation's chain is reached from production" \
+	python3 ci/test/generated-code-operation-guard.py
+
 # The Embed SDK's boundary, in both directions: a consumer may reach the SDK
 # only through `codetracer_embed`, and the SDK's own import graph carries no
 # rendering and no chain concept. CodeTracer-Embed-SDK.md §3.2 says in as many

--- a/ci/lint/nim.sh
+++ b/ci/lint/nim.sh
@@ -203,8 +203,11 @@ lint_step "frontend reachability: exported symbols nothing reaches (ratchet at 1
 #
 # So the operation a developer invokes to see what their code compiled to gets
 # its own check, at --enforce, with no ceiling and no allow-list. It is proved
-# able to fail: against `origin/dev` at a861f5b7b it exits 1 on 18 of its 20
-# links, and its header records that measurement rather than a claim about it.
+# able to fail: against `origin/dev` at a861f5b7b it exits 1 on 22 of its 24
+# links, and its header records that measurement -- including WHICH four were
+# tested-but-unreached -- rather than a claim about it. The number lives in the
+# guard's own header too, which is the only place worth updating it; this
+# sentence is a pointer and will go stale if it is treated as the record.
 lint_step "Show Generated Code: the operation's chain is reached from production" \
 	python3 ci/test/generated-code-operation-guard.py
 

--- a/ci/test/generated-code-operation-guard.py
+++ b/ci/test/generated-code-operation-guard.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""generated-code-operation-guard.py — the Show Generated Code chain must be reached.
+
+WHY THIS EXISTS AND WHY IT IS NOT `frontend-reachability-guard.py`
+------------------------------------------------------------------
+That guard is right and it did find this.  It reported ``produceAnchors``,
+``readArtefactJson``, ``setAnchors``, ``syncFromSource`` and
+``syncFromGeneratedRow`` as unreached — inside a backlog of 1,228 findings,
+in ``--report`` mode, exiting 0.  A finding nobody reads and a check nobody
+fails is not a gate.
+
+So this one is narrow and ENFORCING.  It asserts one chain: the operation a
+developer invokes from a cursor to see what their code compiled to.  Every
+symbol below is a link in it, and the chain is only worth anything whole —
+a producer nothing calls, a ViewModel nothing constructs, or a context-menu
+entry with no handler behind it each leave the same user-visible face, which
+is a feature that looks present and does nothing.
+
+THE RULE, AND THE TWO WAYS IT FAILS
+-----------------------------------
+For each symbol below:
+
+  MISSING    it is not declared anywhere under ``src/frontend``.  The chain
+             has a hole, or this list has rotted and names code that was
+             deleted.  Either is a finding, and the second is why the check
+             is on DECLARATIONS as well as on reaches: an allow-list that
+             can quietly stop matching anything becomes vacuous without ever
+             going red.
+
+  TEST-ONLY  it is declared, and the only files that mention it are its own
+             module and test files.  This is the exact shape the whole
+             chain was in before it was wired: correct, tested, and reached
+             by nothing a user can get to.
+
+``*`` means "for other modules", so the reach must be CROSS-MODULE.  The
+weaker rule — "does any production file mention it" — was measured against
+this campaign's canonical instance and ran green over ``BuildLocationScanner``,
+because that name appears on its own module's signature lines and those were
+themselves unreached.  A symbol propped up by its unreached siblings is not
+reached.
+
+PROVED ABLE TO FAIL, AND THIS IS THE MEASUREMENT
+------------------------------------------------
+Run with ``--root`` at a tree that predates the wiring.  ``git archive`` is
+enough — the guard reads only ``src/frontend``::
+
+    git archive origin/dev src/frontend | tar -x -C /tmp/before
+    ci/test/generated-code-operation-guard.py --root /tmp/before
+
+MEASURED against ``origin/dev`` at ``a861f5b7bd04a27a379135a5bc850d09d0f257a7``:
+**exit 1, 17 of 19 links broken** — two TEST-ONLY (``produceAnchors``,
+``readArtefactJson``, each reached only by ``test_noir_anchor_producer.nim``
+and ``test_noir_generated_listing.nim``) and fifteen MISSING.  On the tree
+that wires them: **exit 0, 0 broken**.
+
+TWO OF THE NINETEEN DO NOT GO RED ON THAT TREE, and saying which is the point
+of writing the measurement down rather than the count:
+
+* ``syncFromSource`` is reached, by ``low_level_code_vm.syncFromSourceLine``
+  — which was itself unreached.  Limitation 2 below: the check is not
+  transitive, so a symbol called only from another unreached symbol in a
+  THIRD module reads as reached.
+* ``noteSourceEdited`` is reached, but by ``ui/constraints.nim`` calling
+  ``constraints_vm``'s proc of the same name.  Limitation 1: the check is
+  name-based, and Nim overloads freely.
+
+Both are under-reports, which is the direction a guard should err in.  A
+guard whose red has never been seen is a guard whose subject might be empty.
+
+WHAT IT DOES NOT CATCH
+----------------------
+Stated plainly, because a guard whose reach is overstated gets cited as
+coverage it does not provide.
+
+1. **It is name-based, not a call graph**, exactly as
+   ``frontend-reachability-guard.py`` is.  A mention outside an import list
+   and outside a comment counts.  It is a caller-count check, not proof that
+   the path runs.
+
+2. **It cannot see a wiring that is not a symbol.**  A context-menu row whose
+   handler is installed and never fires, or a hook assigned in a branch the
+   shipped build excludes, both satisfy this.  That second one is not
+   hypothetical: the hooks here are installed inside ``when defined(ctWeb)
+   and not defined(ctInExtension)``, so they are absent from the extension
+   bundle by design and present in the web one.  The check that the chain
+   reaches the SHIPPED artefact is a bundle grep, and it belongs with the
+   browser probes rather than here.
+
+3. **It says nothing about behaviour.**
+   ``src/frontend/viewmodel/tests/unit/test_generated_code_operation.nim`` is
+   what asserts that the listing is on demand, that the cursor moves it, and
+   that it follows the active tab.  This guard asserts only that a user can
+   reach any of it.
+
+USAGE
+    ci/test/generated-code-operation-guard.py            # exit 1 on findings
+    ci/test/generated-code-operation-guard.py --root DIR # check another tree
+    ci/test/generated-code-operation-guard.py --json out.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+FRONTEND_ROOT = Path("src/frontend")
+
+TEST_MARKERS = ("/tests/", "/test_suites/", "/stubs/")
+TEST_FILENAME_RE = re.compile(r"(^test_|_test\.nim$|_test_plan\.nim$|_probe\.nim$)")
+
+
+def is_test_path(path: Path) -> bool:
+    posix = "/" + path.as_posix().lstrip("/")
+    if any(marker in posix for marker in TEST_MARKERS):
+        return True
+    return bool(TEST_FILENAME_RE.search(path.name))
+
+
+# ---------------------------------------------------------------------------
+# THE CHAIN.  Each entry: symbol, the module that should declare it, and what
+# breaks if nothing reaches it.  The third field is required — an entry that
+# cannot say what its absence costs is one nobody can review.
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class Link:
+    symbol: str
+    module: str
+    because: str
+
+
+CHAIN: tuple[Link, ...] = (
+    # --- The producer: what the compiler actually emitted -------------------
+    Link("produceAnchors", "viewmodel/viewmodels/noir_anchor_producer.nim",
+         "nothing turns a compile artefact into anchors, so no cursor can be "
+         "projected into a listing"),
+    Link("readArtefactJson", "viewmodel/viewmodels/noir_anchor_producer.nim",
+         "the artefact is never decoded, so every row would render unmapped"),
+
+    # --- The model: what a mapping claim may say ---------------------------
+    Link("syncFromSource", "viewmodel/viewmodels/generated_code_anchors.nim",
+         "the source-to-generated projection is never queried — this is the "
+         "cursor-anchored half of the feature"),
+    Link("anchorsFromSource", "viewmodel/viewmodels/generated_code_anchors.nim",
+         "the instantiation COUNT is never read, so a line that became three "
+         "ranges is silently shown as one (GCL-D29)"),
+
+    # --- The operation's ViewModel -----------------------------------------
+    Link("createGeneratedCodeVM", "viewmodel/viewmodels/generated_code_vm.nim",
+         "the operation has no state, so nothing can be open or closed"),
+    Link("openListing", "viewmodel/viewmodels/generated_code_vm.nim",
+         "the on-demand entry point is never taken — the listing can never "
+         "appear"),
+    Link("noteCursorMoved", "viewmodel/viewmodels/generated_code_vm.nim",
+         "the cursor never leads, so the listing is a static dump"),
+    Link("noteActiveTabChanged", "viewmodel/viewmodels/generated_code_vm.nim",
+         "the listing does not follow the active source tab"),
+    Link("noteSourceEdited", "viewmodel/viewmodels/generated_code_vm.nim",
+         "an edit never marks the tab stale, so a listing keeps synchronising "
+         "against line numbers it no longer addresses (GCL-D18)"),
+
+    # --- The declared ladder ------------------------------------------------
+    Link("commandsForPath", "viewmodel/viewmodels/generated_code_operation.nim",
+         "GCL-D17's availability table is never evaluated, so a command that "
+         "cannot run is either absent or silently broken"),
+    Link("commandLabel", "viewmodel/viewmodels/generated_code_operation.nim",
+         "no target is named on any surface, which is GCL-D11's whole point"),
+    # `keybindingTarget` is deliberately NOT in this chain: no key is bound to
+    # the operation, so there is no link to check. Listing it would have made
+    # this guard demand a symbol whose only possible reader would itself be
+    # unreached — a chain check that manufactures its own subject.
+
+    # --- The production open path (GCL-D19's fourth bullet) -----------------
+    Link("showGeneratedCode", "ui/generated_code.nim",
+         "THERE IS NO WAY TO INVOKE THE OPERATION.  Removing the pane from "
+         "the default layout without this removes the feature"),
+    Link("generatedCodeCommandsAt", "ui/generated_code.nim",
+         "the editor's context menu offers no generated-code row"),
+    Link("noteCompileArtefact", "ui/generated_code.nim",
+         "no compile ever reaches the operation, so every invocation reports "
+         "that nothing has been built"),
+    Link("noteEditorCursorMoved", "ui/generated_code.nim",
+         "the editor's caret never reaches the listing"),
+    Link("noteEditorTabActivated", "ui/generated_code.nim",
+         "switching source tabs never reaches the listing"),
+
+    # --- The editor's and the toolchain's ends ------------------------------
+    Link("editorCursorMovedHook", "ui/editor.nim",
+         "Monaco's cursor events go nowhere"),
+    Link("editorActiveTabChangedHook", "ui/editor.nim",
+         "tab activation goes nowhere"),
+    Link("noirGeneratedCodeSink", "ui/web_noir_build.nim",
+         "a successful compile never publishes its artefact to the operation"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Nim identifier equality: style-insensitive after the first character.
+# `markStale` and `mark_stale` are one symbol, as the compiler sees them.
+# ---------------------------------------------------------------------------
+
+def nim_key(name: str) -> str:
+    if not name:
+        return name
+    return name[0] + name[1:].replace("_", "").lower()
+
+
+COMMENT_RE = re.compile(r"#.*$")
+IMPORT_LINE_RE = re.compile(r"^\s*(import|export|from)\b")
+
+
+def mentions(text_lines: list[str], key: str) -> bool:
+    """Whether any line mentions `key` outside a comment and outside an import.
+
+    Import lists are excluded for the reason the rule exists: naming a symbol
+    in order to be allowed to use it is not using it, and a module that
+    imports a dead symbol and never calls it is the case this guard is for.
+    """
+    for raw in text_lines:
+        if IMPORT_LINE_RE.match(raw):
+            continue
+        line = COMMENT_RE.sub("", raw)
+        if not line.strip():
+            continue
+        for ident in re.findall(r"[A-Za-z][A-Za-z0-9_]*", line):
+            if nim_key(ident) == key:
+                return True
+    return False
+
+
+DECL_RE_TEMPLATE = (
+    # A routine: `proc produceAnchors*(...)`.
+    r"^\s*(?:proc|func|template|macro|iterator|converter|method)\s+{name}\b"
+    # A variable or constant, either on its own line after `var` / `let` /
+    # `const` or as an indented member of such a section:
+    #
+    #     var editorCursorMovedHook*: proc(path: cstring; line: int)
+    #     var
+    #       noirGeneratedCodeSink*: proc(...)
+    #
+    # THE SECTION FORM IS THE ONE THAT WAS MISSING, and it cost two false
+    # MISSINGs on a tree where both hooks were declared and wired. A guard
+    # that reports a symbol as absent when it is present is worse than one
+    # that misses a real absence: the first teaches its reader that its
+    # findings are noise.
+    r"|^\s*(?:var|let|const)\s+{name}\*?\s*[:*=]"
+    r"|^\s+{name}\*?\s*[:=]"
+)
+
+
+@dataclass
+class Finding:
+    symbol: str
+    module: str
+    kind: str          # "MISSING" or "TEST-ONLY"
+    because: str
+    detail: str = ""
+    readers: list[str] = field(default_factory=list)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=".",
+                    help="repository root to check (default: cwd)")
+    ap.add_argument("--json", default="", help="write findings as JSON")
+    args = ap.parse_args()
+
+    root = Path(args.root).resolve()
+    frontend = root / FRONTEND_ROOT
+    if not frontend.is_dir():
+        print(f"error: {frontend} is not a directory", file=sys.stderr)
+        return 2
+
+    # Read every .nim under src/frontend once.
+    product: dict[Path, list[str]] = {}
+    tests: set[Path] = set()
+    for path in sorted(frontend.rglob("*.nim")):
+        rel = path.relative_to(root)
+        try:
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            continue
+        product[rel] = lines
+        if is_test_path(rel):
+            tests.add(rel)
+
+    findings: list[Finding] = []
+
+    for link in CHAIN:
+        key = nim_key(link.symbol)
+        decl_re = re.compile(
+            DECL_RE_TEMPLATE.format(name=re.escape(link.symbol)), re.MULTILINE)
+
+        declaring: list[Path] = []
+        for rel, lines in product.items():
+            if rel in tests:
+                continue
+            if any(decl_re.match(line) for line in lines):
+                declaring.append(rel)
+
+        if not declaring:
+            findings.append(Finding(
+                symbol=link.symbol, module=link.module, kind="MISSING",
+                because=link.because,
+                detail=f"no production module under {FRONTEND_ROOT} declares it"))
+            continue
+
+        declaring_set = set(declaring)
+        readers = [
+            rel.as_posix() for rel, lines in product.items()
+            if rel not in tests and rel not in declaring_set
+            and mentions(lines, key)
+        ]
+        if not readers:
+            test_readers = [
+                rel.as_posix() for rel, lines in product.items()
+                if rel in tests and mentions(lines, key)
+            ]
+            findings.append(Finding(
+                symbol=link.symbol, module=link.module, kind="TEST-ONLY",
+                because=link.because,
+                detail=("declared in "
+                        + ", ".join(p.as_posix() for p in declaring)
+                        + "; reached only by "
+                        + (", ".join(test_readers) if test_readers
+                           else "nothing at all")),
+                readers=test_readers))
+
+    print(f"Show Generated Code — operation reachability")
+    print(f"  tree:   {root}")
+    print(f"  chain:  {len(CHAIN)} symbols")
+    print(f"  found:  {len(findings)} broken")
+    print()
+
+    if not findings:
+        print("The chain is whole: every link is declared and reached from a")
+        print("production module other than its own.")
+        return 0
+
+    for f in findings:
+        print(f"  [{f.kind}] {f.symbol}  ({f.module})")
+        print(f"      {f.detail}")
+        print(f"      without it: {f.because}")
+        print()
+
+    if args.json:
+        Path(args.json).write_text(json.dumps(
+            [f.__dict__ for f in findings], indent=2), encoding="utf-8")
+
+    print(f"{len(findings)} of {len(CHAIN)} links in the Show Generated Code")
+    print("chain are missing or reached only by their own tests.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/test/generated-code-operation-guard.py
+++ b/ci/test/generated-code-operation-guard.py
@@ -48,12 +48,19 @@ enough — the guard reads only ``src/frontend``::
     ci/test/generated-code-operation-guard.py --root /tmp/before
 
 MEASURED against ``origin/dev`` at ``a861f5b7bd04a27a379135a5bc850d09d0f257a7``:
-**exit 1, 17 of 19 links broken** — two TEST-ONLY (``produceAnchors``,
-``readArtefactJson``, each reached only by ``test_noir_anchor_producer.nim``
-and ``test_noir_generated_listing.nim``) and fifteen MISSING.  On the tree
-that wires them: **exit 0, 0 broken**.
+**exit 1, 22 of 24 links broken** — eighteen MISSING and FOUR TEST-ONLY, and
+the four are the finding rather than the arithmetic::
 
-TWO OF THE NINETEEN DO NOT GO RED ON THAT TREE, and saying which is the point
+    produceAnchors      noir_anchor_producer.nim
+    readArtefactJson    noir_anchor_producer.nim
+    setAnchors          low_level_code_vm.nim
+    syncFromSourceLine  low_level_code_vm.nim
+
+A producer that read a real compiler artefact and a pane that could anchor to
+it, both correct, both tested, and reachable only from their own suites.  On
+the tree that wires them: **exit 0, 0 broken**.
+
+TWO OF THE TWENTY-FOUR DO NOT GO RED ON THAT TREE, and saying which is the point
 of writing the measurement down rather than the count:
 
 * ``syncFromSource`` is reached, by ``low_level_code_vm.syncFromSourceLine``
@@ -195,6 +202,31 @@ CHAIN: tuple[Link, ...] = (
          "tab activation goes nowhere"),
     Link("noirGeneratedCodeSink", "ui/web_noir_build.nim",
          "a successful compile never publishes its artefact to the operation"),
+
+    # --- The surface that actually paints -----------------------------------
+    #
+    # THESE FIVE ARE THE HALF A CALLER-COUNT CHECK USUALLY MISSES. Everything
+    # above can be reached and the user can still be shown an empty document:
+    # the operation would compute a correct listing, anchor it correctly, and
+    # hand it to nothing. `openTab(name, ViewInstructions)` did exactly that in
+    # the first draft of this feature — the instructions view is fed by
+    # `CtLoadAsmFunction` and knows nothing about a compile artefact, so the
+    # tab opened blank.
+    Link("showGeneratedListing", "ui/low_level_code.nim",
+         "the listing is computed and handed to nothing — the operation opens "
+         "a surface the user finds empty"),
+    Link("setAnchors", "viewmodel/viewmodels/low_level_code_vm.nim",
+         "the painted rows carry no mapping, so every fidelity badge and every "
+         "sync state describes an empty anchor set"),
+    Link("syncFromSourceLine", "viewmodel/viewmodels/low_level_code_vm.nim",
+         "the pane holds a correct mapping and points at nothing: the listing "
+         "opens at row zero however far down the file the cursor was"),
+    Link("rebaseSources", "viewmodel/viewmodels/generated_code_anchors.nim",
+         "the anchors keep the compiler's spelling of every source path and "
+         "the cursor is in the editor's, so no line ever aligns"),
+    Link("rendererPathFor", "viewmodel/viewmodels/noir_build_producer.nim",
+         "there is no conversion between the two spellings for the rebase to "
+         "apply"),
 )
 
 

--- a/ci/test/reachability-prose-guard-test.sh
+++ b/ci/test/reachability-prose-guard-test.sh
@@ -45,7 +45,14 @@ reach_sh="ci/test/frontend-reachability.sh"
 # copied here. A copy would drift, and a suite covering a copy of the guard
 # proves nothing about the guard.
 fn_src="$(sed -n '/^assert_reachability_prose_agrees() {/,/^}/p' "${nim_sh}")"
-if ! printf '%s' "${fn_src}" | grep -q 'CT_PROSE_HEADER_FILE'; then
+# A HERE-STRING, NOT A PIPE. `producer | grep -q PAT` returns a successful
+# match AS FAILURE whenever the producer is still writing when `grep` exits and
+# `pipefail` is set — which this file sets on line 8. The failure is racy and
+# size-dependent, so it hides on a short function and appears when the function
+# grows past a pipe buffer, at which point this suite would refuse to run and
+# blame a rename. `ci/test/grep-q-pipefail-gate.sh` is the standing check;
+# this was the one site it had left to report.
+if ! grep -q 'CT_PROSE_HEADER_FILE' <<<"${fn_src}"; then
 	echo "reachability-prose-guard-test.sh: could not lift" >&2
 	echo "  assert_reachability_prose_agrees out of ${nim_sh}. If it was renamed or" >&2
 	echo "  its overrides removed, this suite is covering nothing — fix it here." >&2

--- a/src/frontend/ui/editor.nim
+++ b/src/frontend/ui/editor.nim
@@ -11,6 +11,12 @@ import
 
 from welcome_screen import resetView
 from event_log import findTRNode
+# The generated-code operation's open path, reached from the context menu
+# below. Imported for exactly these three symbols; `generated_code` imports
+# `ui_imports` and the viewmodels and nothing from here, so there is no cycle.
+from generated_code import generatedCodeCommandsAt, showGeneratedCode
+from ../viewmodel/viewmodels/generated_code_operation import
+  TargetCommand, TargetAvailability, gaEnabled, gaDisabled, commandLabel
 from dom import createElement
 from mode_layouts import isEditingMode
 
@@ -1578,6 +1584,47 @@ proc createContextMenuItems(self: EditorViewComponent, ev: js): seq[ContextMenuI
       contextMenu &= sourceLineForward
       contextMenu &= sourceLineBackward
 
+    # SHOW GENERATED CODE. `Generated-Code-Listing.md` §10 (GCL-D19): the
+    # surface is in NO mode's default layout, and "an on-demand open path must
+    # exist — removing the pane from the default layout without adding the open
+    # path would remove the feature". This is that path, and it is outside the
+    # `editing` split above because §1 puts the operation in BOTH modes, from
+    # the same gesture: what a line compiled to is a fact about the program,
+    # not about whether a recording is open.
+    #
+    # ONE ROW PER TARGET, EACH WITH ITS OWN NAME (GCL-D11). Noir contributes
+    # Show ACIR, Show Brillig and Show SSA; Nim contributes Show Generated C
+    # and Show Assembly. A single "Show Assembly Code" row cannot mean all of
+    # those, which is what `openAlternativeView`'s positional `id: int` has
+    # been doing — "level 1" means disassembly for C and generated C for Nim,
+    # and the name of the thing being opened exists nowhere.
+    #
+    # A LANGUAGE WITH NO TARGET CONTRIBUTES NO ROW — absent, not disabled,
+    # because there is nothing to explain. A target that exists and cannot be
+    # produced is the disabled case, and it carries the build proposal's own
+    # sentence (GCL-D17).
+    for command in generatedCodeCommandsAt(path):
+      let targetId = command.target.id
+      let capturedPath = path
+      let capturedLine = line
+      if command.availability == gaDisabled:
+        contextMenu &= ContextMenuItem(
+          name: commandLabel(command.target),
+          hint: "",
+          handler: proc(e: Event) = discard,
+          disabled: true,
+          disabledReason: command.reason)
+      elif command.availability == gaEnabled:
+        contextMenu &= ContextMenuItem(
+          name: commandLabel(command.target),
+          hint: "shows what the line under the cursor compiled to",
+          handler: proc(e: Event) =
+            # THE CURSOR IS THE ARGUMENT. GCL-D10: the operation takes a
+            # position, not a project — a listing opened over a whole project
+            # has no anchor to place the reader at, and its entry names are
+            # the compiler's rather than the developer's.
+            showGeneratedCode(self.data, capturedPath, capturedLine, targetId))
+
     try:
       targetToken = self.getTokenFromPosition(ev.target.position)
       # copied/adapted from getTokenFromPosition
@@ -2540,6 +2587,33 @@ var editorSourceChangedHook*: proc(path: cstring)
   ## Nil means no host installed one, which is the desktop's state and the
   ## state of every build before the Constraints pane needed to know.
 
+var editorCursorMovedHook*: proc(path: cstring; line: int)
+  ## THE CURSOR MOVED IN `path`, to `line`.
+  ##
+  ## `Generated-Code-Listing.md` §6: a generated-code listing is anchored to
+  ## the cursor, and the two documents move together while both are readable.
+  ## This is the leader's end of that.
+  ##
+  ## FIRED FOR EVERY CURSOR EVENT MONACO PRODUCES, including column-only moves
+  ## and — because a Monaco instance exists per tab — moves in models that are
+  ## not on screen. The filtering is deliberately NOT done here: which of them
+  ## matter is a property of the consumer's state (is anything open, which tab
+  ## is active, has the line actually changed), and a hook that guessed would
+  ## have to re-derive that state from the editor, which is the wrong end.
+  ## `generated_code_vm.noteCursorMoved` refuses all three, and each refusal is
+  ## asserted.
+  ##
+  ## Nil means no host installed one, which is every build with no
+  ## generated-code listing open.
+
+var editorActiveTabChangedHook*: proc(path: cstring; line: int)
+  ## THE USER SWITCHED SOURCE TABS, and here is the new tab's own cursor line.
+  ##
+  ## The line travels WITH the path rather than being fetched afterwards: each
+  ## tab carries its own cursor, and a consumer that switched files and then
+  ## waited for a cursor event would spend the interval showing the previous
+  ## tab's line under the new tab's name.
+
 const editorTestRunFrames = 400
   ## 400 × 300 ms = two minutes. Long enough for a cold 16 MB wasm compiler to
   ## be fetched, instantiated and run over a project; short enough that a
@@ -3398,6 +3472,25 @@ proc initMonacoForEditor(self: EditorViewComponent, selector: cstring) =
       # cannot.
       if not editorSourceChangedHook.isNil:
         editorSourceChangedHook(self.name))
+
+  # THE CURSOR IS THE SUBJECT OF THE GENERATED-CODE OPERATION, and this is
+  # where it is read. `Generated-Code-Listing.md` §2 (GCL-D10): the operation
+  # takes a POSITION, not a project, because the map the artefact carries runs
+  # from generated position back to source position and inverting it is what
+  # answers "what did this function of mine become".
+  #
+  # Subscribed unconditionally rather than only while a listing is open. The
+  # alternative — attach on open, detach on close — needs a disposable per tab
+  # and a teardown that survives a tab being closed while the listing is not,
+  # and the thing it would save is a nil check. `editorCursorMovedHook` is nil
+  # for every build with nothing open, so the cost when nothing is listening
+  # is one comparison per cursor event.
+  tabInfo.monacoEditor.toJs.onDidChangeCursorPosition(proc(ev: js) =
+    if editorCursorMovedHook.isNil:
+      return
+    if ev.isNil or ev.position.isNil:
+      return
+    editorCursorMovedHook(self.name, cast[int](ev.position.lineNumber)))
 
   console.log("DELEGATING SHORTCUTS")
 

--- a/src/frontend/ui/generated_code.nim
+++ b/src/frontend/ui/generated_code.nim
@@ -60,6 +60,18 @@ from ../viewmodel/viewmodels/generated_code_anchors import
 
 from ../viewmodel/viewmodels/noir_build_producer import rendererPathFor
 
+from ../viewmodel/store/types as vmtypes import LowLevelInstruction
+from low_level_code import showGeneratedListing
+
+const NO_HIGH_LEVEL_LINE = -1
+  ## `LowLevelInstruction.highLevelLine` is the LEGACY per-row back-pointer the
+  ## asm loader fills, and `isonim_low_level_code_view.sourceCrossRef` suppresses
+  ## the row's source span when it is not positive. It is left unset on purpose:
+  ## this listing's source correspondence is the ANCHOR SET, which is a range of
+  ## rows per source region, and writing a single line onto each row would be a
+  ## second, coarser mapping beside the real one — disagreeing with it wherever
+  ## an anchor covers more than one row, which is most of them.
+
 from ../viewmodel/viewmodels/noir_anchor_producer import
   readArtefactJson, produceAnchors, aroOk
 
@@ -235,20 +247,45 @@ proc showGeneratedCode*(data: Data; path: cstring; line: int;
   if generatedCodeVMInstance.isNil:
     return
 
-  # §7: the target opens as an EDITOR TAB, keyed the way `openTab` already
-  # keys `ViewInstructions` — which is what `openAlternativeView` does for the
-  # C↔assembly views, in the one place the product already implements this.
-  # Re-invoking the same target for the same file therefore reuses its tab.
-  let tabName = cstring($path & " — " & t.displayName)
-  data.openTab(tabName, ViewInstructions)
-
   generatedCodeVMInstance.noteBuildStarted(t, $path, line)
 
   let (listing, failure) = buildListing(t, $path)
   if failure.len > 0:
     generatedCodeVMInstance.noteBuildFailed(failure)
+    # THE SURFACE STILL OPENS, carrying the reason. §8: a build that fails must
+    # show WHY rather than resolving into an empty listing, and a command that
+    # silently does nothing is the same defect as a listing nobody paints.
+    data.openLowLevelCode()
+    discard showGeneratedListing(@[], @[], ArtefactSupport(), $path, line,
+      failure)
     return
   generatedCodeVMInstance.openListing(listing, line)
+
+  # AND SOMETHING PAINTS IT. `Generated-Code-Listing.md` §7 asks for an editor
+  # TAB; this opens the Low Level Code PANE, and the divergence is deliberate
+  # and recorded rather than glossed.
+  #
+  # `openTab(name, ViewInstructions)` is what §0 observes `openAlternativeView`
+  # already doing, and it is the wrong instrument here: that view is fed by
+  # `CtLoadAsmFunction` against a recording's asm and knows nothing about a
+  # compile artefact, so the tab would have opened EMPTY. A surface a user
+  # invokes and finds blank is precisely the defect this thread exists to
+  # close, and matching the spec's noun while reintroducing it would have been
+  # the worse divergence.
+  #
+  # The pane already renders what the spec asks the surface to render: a
+  # fidelity badge per row (GCL-A7), the three not-aligned states told apart
+  # (GCL-A8) and the sync toggle's visible state — all asserted against the
+  # view in `test_low_level_code_view_anchors.nim`. The tab is the right long
+  # answer and it needs a view of its own; this is the surface that exists.
+  data.openLowLevelCode()
+  var rows: seq[LowLevelInstruction] = @[]
+  for r in listing.rows:
+    rows.add LowLevelInstruction(
+      name: r.text, args: "", other: r.annotation, offset: r.index,
+      highLevelPath: "", highLevelLine: NO_HIGH_LEVEL_LINE)
+  discard showGeneratedListing(rows, listing.anchors, listing.support,
+    $path, line, listing.listingAbsence)
 
 # `showFirstGeneratedCodeTarget` WAS HERE AND IS DELETED, with
 # `generated_code_operation.keybindingTarget` behind it.

--- a/src/frontend/ui/generated_code.nim
+++ b/src/frontend/ui/generated_code.nim
@@ -56,7 +56,9 @@ from ../viewmodel/viewmodels/edit_mode_toolbar import
   CommandProposal, ProposalConfidence, pcCanonical
 
 from ../viewmodel/viewmodels/generated_code_anchors import
-  MappingAnchor, ArtefactSupport
+  MappingAnchor, ArtefactSupport, rebaseSources
+
+from ../viewmodel/viewmodels/noir_build_producer import rendererPathFor
 
 from ../viewmodel/viewmodels/noir_anchor_producer import
   readArtefactJson, produceAnchors, aroOk
@@ -76,6 +78,11 @@ type
       ## `VfsResponse.acir_listing`, the compiler's own printed opcodes.
     artefactJson: string
       ## The compile artefact, carrying `file_map` and `debug_symbols`.
+    projectRoot: string
+      ## The RENDERER's spelling of the project root — `/hello_noir`. Kept
+      ## beside `packageDir`, which is the COMPILER's — `hello_noir`. The pair
+      ## is what `rendererPathFor` needs, and without it every anchor would
+      ## carry a path no editor tab is keyed by.
     packageDir: string
     provenance: string
     present: bool
@@ -93,7 +100,8 @@ proc initGeneratedCodeVM*() =
   clog "GeneratedCodeVM: instance created"
 
 proc noteCompileArtefact*(listing: string; artefactJson: string;
-                          packageDir: string; provenance: string) =
+                          projectRoot: string; packageDir: string;
+                          provenance: string) =
   ## A COMPILE SUCCEEDED. Installed into
   ## `web_noir_build.noirGeneratedCodeSink` by `ui_js`.
   ##
@@ -109,8 +117,8 @@ proc noteCompileArtefact*(listing: string; artefactJson: string;
   ## remedy is the same — the surface keeps what it is showing, and the new
   ## artefact is what the NEXT invocation reads.
   lastArtefact = CompileArtefact(
-    listing: listing, artefactJson: artefactJson, packageDir: packageDir,
-    provenance: provenance, present: true)
+    listing: listing, artefactJson: artefactJson, projectRoot: projectRoot,
+    packageDir: packageDir, provenance: provenance, present: true)
 
 proc rowsOf(report: ConstraintReport): seq[GeneratedRow] =
   ## Flatten the report's per-function rows into the listing's row space.
@@ -163,6 +171,22 @@ proc buildListing(t: GeneratedCodeTarget; sourcePath: string):
     let read = readArtefactJson(lastArtefact.artefactJson, rows.len)
     if read.outcome == aroOk:
       (anchors, support) = produceAnchors(read.artefact)
+      # THE ANCHORS ARRIVE IN THE COMPILER'S SPELLING AND THE CURSOR IS IN THE
+      # EDITOR'S. `file_map` says `hello_noir/src/main.nr` because that is the
+      # key the compiler was handed; `sourcePath` here is the name the tab was
+      # opened by, `/hello_noir/src/main.nr`. `syncFromSource` compares those
+      # two strings.
+      #
+      # Without this line the listing opens, its rows are real, and every
+      # single line of the file reports that no generated code is mapped to it
+      # — indistinguishable from a build stripped of debug information, and
+      # undetectable by the model, because a path that matches nothing is not
+      # a malformed path. `rendererPathFor` is the SAME rule the build pane's
+      # clickable diagnostics use, called rather than restated.
+      let root = lastArtefact.projectRoot
+      let pkg = lastArtefact.packageDir
+      anchors = rebaseSources(anchors, proc(p: string): string =
+        rendererPathFor(root, pkg, p))
     else:
       # Rows without anchors is a legitimate state, not a failure: every row
       # is unmapped and synchronisation suspends visibly, which is exactly what

--- a/src/frontend/ui/generated_code.nim
+++ b/src/frontend/ui/generated_code.nim
@@ -1,0 +1,276 @@
+## Show Generated Code — the operation's production half.
+##
+## `GUI/Debugging-Features/Generated-Code-Listing.md` §1, §7, §8, §10
+## (GCL-D19's fourth bullet: "an on-demand open path MUST exist — removing the
+## pane from the default layout without adding the open path would remove the
+## feature").
+##
+## ## WHAT THIS MODULE IS FOR, STATED AS THE DEFECT IT CLOSES
+##
+## `generated_code_anchors` (the model), `noir_anchor_producer` (the Noir
+## producer, green against a committed `nargo compile` artefact) and
+## `low_level_code_vm`'s `setAnchors` / `syncFromSource` / `syncFromGenerated`
+## were all correct, all tested, and REACHED ONLY FROM THEIR OWN SUITES.
+## `ci/test/frontend-reachability-guard.py` reported every one of them, in a
+## backlog of twelve hundred where nobody would read it.
+##
+## That is the campaign's canonical defect shape, and its user-visible face is
+## always the same one: a feature that looks present and does nothing. This
+## module is the caller, and `ci/test/generated-code-operation-guard.py` is the
+## enforcing check that this file — or one like it — keeps existing.
+##
+## ## THE ON-DEMAND BOUNDARY IS IN THIS FILE, AND IT IS A SPECIFIC LINE
+##
+## `noteCompileArtefact` is told about every successful compile and does the
+## cheapest possible thing: it PUTS THE TEXT IN A VARIABLE. It does not parse
+## the artefact, does not resolve call stacks, does not build anchors and does
+## not touch the VM.
+##
+## `showGeneratedCode` — reached only from a user's gesture — is what runs
+## `readArtefactJson`, `produceAnchors` and `reportFromAcirListing`. So the
+## expensive work happens once per invocation and never once per compile, and
+## `GeneratedCodeVM.noteCursorMoved` re-anchors without re-running any of it.
+##
+## This is the difference between "we only compute it when needed" (a habit,
+## which nothing checks) and a boundary a reader can point at.
+##
+## ## WHY THE HOOKS ARE NAMED PROCS AND NOT CLOSURES AT THE INSTALL SITE
+##
+## `ui/constraints.noteEditorSourceChanged` records the reason and it applies
+## unchanged: an anonymous `proc` inside a 400-line install block in `ui_js` is
+## how the previous version of that wiring managed to not exist for as long as
+## it did. A named proc is a thing a reader — and a name-based reachability
+## guard — can see.
+
+import
+  ui_imports,
+  ../[ types ]
+
+from ../../common/noir_constraints import
+  ConstraintReport, reportFromAcirListing
+
+from ../viewmodel/viewmodels/generated_code_operation import
+  GeneratedCodeTarget, TargetCommand, commandsForPath, targetById
+
+from ../viewmodel/viewmodels/edit_mode_toolbar import
+  CommandProposal, ProposalConfidence, pcCanonical
+
+from ../viewmodel/viewmodels/generated_code_anchors import
+  MappingAnchor, ArtefactSupport
+
+from ../viewmodel/viewmodels/noir_anchor_producer import
+  readArtefactJson, produceAnchors, aroOk
+
+from ../viewmodel/viewmodels/generated_code_vm import
+  GeneratedCodeVM, GeneratedListing, GeneratedRow, createGeneratedCodeVM,
+  openListing, noteBuildStarted, noteBuildFailed,
+  noteCursorMoved, noteActiveTabChanged, noteSourceEdited
+
+var generatedCodeVMInstance*: GeneratedCodeVM
+
+type
+  CompileArtefact = object
+    ## The LAST successful compile's raw outputs, held as text. Nothing here
+    ## has been parsed, and that is the point — see the module header.
+    listing: string
+      ## `VfsResponse.acir_listing`, the compiler's own printed opcodes.
+    artefactJson: string
+      ## The compile artefact, carrying `file_map` and `debug_symbols`.
+    packageDir: string
+    provenance: string
+    present: bool
+
+var lastArtefact: CompileArtefact
+
+proc initGeneratedCodeVM*() =
+  ## Created lazily and kept. Like `initConstraintsVM`, it needs no store: a
+  ## generated-code listing comes from a compile artefact and from nowhere
+  ## else, so a `ReplayDataStore` parameter would be a promise this operation
+  ## does not keep.
+  if generatedCodeVMInstance != nil:
+    return
+  generatedCodeVMInstance = createGeneratedCodeVM()
+  clog "GeneratedCodeVM: instance created"
+
+proc noteCompileArtefact*(listing: string; artefactJson: string;
+                          packageDir: string; provenance: string) =
+  ## A COMPILE SUCCEEDED. Installed into
+  ## `web_noir_build.noirGeneratedCodeSink` by `ui_js`.
+  ##
+  ## THE CHEAP HALF, DELIBERATELY. Two string assignments and a flag. It does
+  ## not parse, does not anchor, and does not open anything: §1 is that the
+  ## operation is "invoked, never permanently displayed", and a sink that built
+  ## a listing on every compile would have made the surface permanent in
+  ## everything but its visibility.
+  ##
+  ## It also does not disturb a listing already on screen. GCL-D22 is about a
+  ## late reply from ANOTHER producer overwriting a live build; the same
+  ## reasoning applies to a compile the user did not ask a listing for, and the
+  ## remedy is the same — the surface keeps what it is showing, and the new
+  ## artefact is what the NEXT invocation reads.
+  lastArtefact = CompileArtefact(
+    listing: listing, artefactJson: artefactJson, packageDir: packageDir,
+    provenance: provenance, present: true)
+
+proc rowsOf(report: ConstraintReport): seq[GeneratedRow] =
+  ## Flatten the report's per-function rows into the listing's row space.
+  ##
+  ## GCL-D6 IS WHY THE INDEX IS RE-DERIVED HERE. `ConstraintOpcode.index` is
+  ## the opcode's position IN ITS FUNCTION, and `acir_locations` is keyed by
+  ## the opcode index of the circuit. For a single-function circuit the two
+  ## agree; for a listing that also carries Brillig blocks they do not, and
+  ## using the per-function index would offset every anchor by the length of
+  ## everything printed before it — "a mapping wrong by a constant, which is
+  ## the most plausible-looking failure available and would survive casual
+  ## inspection".
+  ##
+  ## So the row index is the position in THIS seq, and `row index ≡ opcode
+  ## index` is restored as an invariant of the flattened listing.
+  var i = 0
+  for fn in report.functions:
+    for op in fn.rows:
+      var text = op.name
+      if op.args.len > 0:
+        text.add " " & op.args
+      result.add GeneratedRow(index: i, text: text, annotation: "")
+      inc i
+
+proc buildListing(t: GeneratedCodeTarget; sourcePath: string):
+    (GeneratedListing, string) =
+  ## THE EXPENSIVE HALF, reached only from `showGeneratedCode`. Returns the
+  ## listing and, when it could not be built, the reason — never a silently
+  ## empty listing, which §8's state table forbids collapsing with the others.
+  if not lastArtefact.present:
+    return (GeneratedListing(), "no artefact has been produced yet — build " &
+      "this project to see what it compiles to")
+
+  let report = reportFromAcirListing(lastArtefact.listing,
+    lastArtefact.packageDir, lastArtefact.provenance)
+  let rows = rowsOf(report)
+
+  var anchors: seq[MappingAnchor] = @[]
+  var support = ArtefactSupport()
+  var absence = ""
+
+  if rows.len == 0:
+    # §8's fourth state: the build SUCCEEDED and the producer has totals but
+    # no rows. This is not an empty listing and must not render as one — it is
+    # every build on the current deploy pin, whose compiler module predates
+    # `VfsResponse.acir_listing`.
+    absence = "this build's Noir compiler does not print a constraint " &
+      "listing, so the generated code cannot be shown for what it compiled"
+  else:
+    let read = readArtefactJson(lastArtefact.artefactJson, rows.len)
+    if read.outcome == aroOk:
+      (anchors, support) = produceAnchors(read.artefact)
+    else:
+      # Rows without anchors is a legitimate state, not a failure: every row
+      # is unmapped and synchronisation suspends visibly, which is exactly what
+      # GCL-D5 specifies for the SSA target and what an artefact stripped of
+      # debug information gives for any of them. The listing is still worth
+      # reading; it just does not map.
+      anchors = @[]
+
+  (GeneratedListing(
+    targetId: t.id,
+    sourcePath: sourcePath,
+    producer: t.producer,
+    rows: rows,
+    anchors: anchors,
+    support: support,
+    listingAbsence: absence), "")
+
+proc generatedCodeCommandsAt*(path: cstring): seq[TargetCommand] =
+  ## What the editor's context menu offers over `path`. GCL-D17's table lives
+  ## in `commandsForPath`; this supplies its inputs.
+  ##
+  ## The proposal is read as canonical here because the Noir web toolchain is
+  ## the only producer wired, and its build command is not in doubt. When a
+  ## second language's producer lands, this is the call site that must start
+  ## reading `edit_mode_toolbar.buildProposal(projectKinds(...))` — and the
+  ## disabled-with-a-reason arm is already written and asserted
+  ## (`gcl_a19_a_non_canonical_proposal_disables_with_its_own_reason`), so the
+  ## change is an input change rather than a new branch.
+  commandsForPath($path, CommandProposal(command: "nargo",
+    args: @["compile"], confidence: pcCanonical, reason: ""))
+
+proc showGeneratedCode*(data: Data; path: cstring; line: int;
+                        targetId: string) =
+  ## THE OPERATION. A developer put the cursor in a source file and asked what
+  ## this code became.
+  ##
+  ## `line` is passed IN rather than read from an ambient "current line", which
+  ## is GCL-D16 as a signature: the projection is a pure function of the
+  ## landing position, so this call site cannot make a deferred open differ
+  ## from a live one.
+  var t: GeneratedCodeTarget
+  if not targetById(targetId, t):
+    return
+
+  initGeneratedCodeVM()
+  if generatedCodeVMInstance.isNil:
+    return
+
+  # §7: the target opens as an EDITOR TAB, keyed the way `openTab` already
+  # keys `ViewInstructions` — which is what `openAlternativeView` does for the
+  # C↔assembly views, in the one place the product already implements this.
+  # Re-invoking the same target for the same file therefore reuses its tab.
+  let tabName = cstring($path & " — " & t.displayName)
+  data.openTab(tabName, ViewInstructions)
+
+  generatedCodeVMInstance.noteBuildStarted(t, $path, line)
+
+  let (listing, failure) = buildListing(t, $path)
+  if failure.len > 0:
+    generatedCodeVMInstance.noteBuildFailed(failure)
+    return
+  generatedCodeVMInstance.openListing(listing, line)
+
+# `showFirstGeneratedCodeTarget` WAS HERE AND IS DELETED, with
+# `generated_code_operation.keybindingTarget` behind it.
+#
+# GCL-D11 specifies a keybinding bound to "the first target of the current
+# file's language", so the familiar one-key gesture survives without any
+# binding having to mean different things in different files. NO KEY IS BOUND,
+# and an entry point for a gesture nobody can make is the defect this feature
+# was written to close, not a head start on closing it. The context menu is the
+# open path that exists; the keybinding is spec that is not built, and saying
+# so here is what stops the next reader from assuming otherwise.
+
+proc noteEditorCursorMoved*(path: cstring; line: int) =
+  ## THE CURSOR LEADS. Installed into `ui/editor.editorCursorMovedHook`.
+  ##
+  ## Silent when no listing is open, and that silence is structural rather
+  ## than polite: `GeneratedCodeVM.noteCursorMoved` refuses a move on a closed
+  ## VM, refuses one from a tab that is not the active one, and refuses one
+  ## that does not change the line. Monaco fires this for column moves and for
+  ## background models, and all three refusals are asserted.
+  if generatedCodeVMInstance.isNil:
+    return
+  discard generatedCodeVMInstance.noteCursorMoved($path, line)
+
+proc noteEditorTabActivated*(path: cstring; line: int) =
+  ## THE LISTING FOLLOWS THE ACTIVE TAB. Installed into
+  ## `ui/editor.editorActiveTabChangedHook`.
+  ##
+  ## The cursor arrives WITH the tab: each tab has its own, and a listing that
+  ## switched files and then waited for a cursor event would spend the interval
+  ## showing the previous tab's line under the new tab's name.
+  if generatedCodeVMInstance.isNil:
+    return
+  discard generatedCodeVMInstance.noteActiveTabChanged($path, line)
+
+proc noteEditorSourceEdited*(path: cstring) =
+  ## GCL-D18. Marks the tab stale, suspends the correspondence, and KEEPS the
+  ## rows. Installed beside `constraints.noteEditorSourceChanged`, from the
+  ## same editor hook, because it is the same fact about the same edit.
+  if generatedCodeVMInstance.isNil:
+    return
+  generatedCodeVMInstance.noteSourceEdited($path)
+
+# `closeGeneratedCode` and `setGeneratedCodeSync` WERE HERE AND ARE DELETED,
+# for the same reason. §7 says closing the tab is how the operation is undone
+# and GCL-D15 specifies a synchronisation toggle with a visible state; neither
+# has a control on any surface yet. `generated_code_vm.closeListing` and
+# `.setSyncEnabled` implement the behaviour and are asserted; these two were
+# wrappers waiting for a button.

--- a/src/frontend/ui/layout.nim
+++ b/src/frontend/ui/layout.nim
@@ -1785,6 +1785,25 @@ proc initLayout*(initialLayout: GoldenLayoutResolvedConfig,
             data.services.editor.active = editorPath
             let editor = data.ui.editors[editorPath]
             editor.refreshFlowAfterActivation()
+
+            # A GENERATED-CODE LISTING FOLLOWS THE ACTIVE SOURCE TAB.
+            # `Generated-Code-Listing.md` §6.2: the leader is the document the
+            # user last interacted with, and switching tabs IS that
+            # interaction. The line travels with the path because each tab
+            # carries its own cursor — a consumer told only the path would
+            # keep the previous tab's line under the new tab's name until the
+            # user happened to move the caret.
+            #
+            # Read from the Monaco instance rather than from `tabInfo
+            # .viewLine`, which is a scroll target and not a caret: they agree
+            # after a jump and diverge the moment a user clicks a line.
+            if not editorActiveTabChangedHook.isNil:
+              var activeLine = 1
+              if not editor.monacoEditor.isNil:
+                let position = editor.monacoEditor.getPosition()
+                if not position.isNil:
+                  activeLine = cast[int](position.lineNumber)
+              editorActiveTabChangedHook(editorPath, activeLine)
             let tab = EditorViewTabArgs(name: editorPath, editorView: editor.editorView)
             # check if current active tab is newly created or it exists in tab history
             if data.services.editor.tabHistory.find(tab) == -1:

--- a/src/frontend/ui/low_level_code.nim
+++ b/src/frontend/ui/low_level_code.nim
@@ -40,7 +40,11 @@ from ../viewmodel/store/types as vmtypes import
 from ../viewmodel/viewmodels/low_level_code_vm import
   LowLevelCodeVM, createLowLevelCodeVM, NO_ACTIVE_OFFSET,
   setInstructions, setActiveOffset, setAddress, setErrorMessage,
-  setNoirProject, clearInstructions, loadAsmFor, jumpToInstruction
+  setNoirProject, clearInstructions, loadAsmFor, jumpToInstruction,
+  setAnchors, clearAnchors, syncFromSourceLine, rowsFor
+
+from ../viewmodel/viewmodels/generated_code_anchors import
+  MappingAnchor, ArtefactSupport, SyncDecision, SyncOutcome, soAligned
 when defined(js):
   from isonim/web/dom_api import nil
   from ../viewmodel/views/isonim_low_level_code_view import
@@ -359,6 +363,56 @@ method onCompleteMove*(self: LowLevelCodeComponent, response: MoveState) {.async
 # ---------------------------------------------------------------------------
 # VM bootstrap
 # ---------------------------------------------------------------------------
+
+proc showGeneratedListing*(rows: seq[LowLevelInstruction];
+                           anchors: seq[MappingAnchor];
+                           support: ArtefactSupport;
+                           sourcePath: string; sourceLine: int;
+                           notice: string): bool {.discardable.} =
+  ## Paint a generated-code listing into THIS pane, anchored to a cursor.
+  ##
+  ## `Generated-Code-Listing.md` §7 asks for an editor TAB and this is a PANE,
+  ## which is a divergence and is recorded as one rather than glossed: the pane
+  ## is the surface that exists and already renders every row's fidelity badge
+  ## (GCL-A7), the three not-aligned states (GCL-A8) and the sync toggle's
+  ## visible state, all asserted in `test_low_level_code_view_anchors.nim`.
+  ## Opening a tab that renders NOTHING, in order to match the spec's noun,
+  ## would have been the worse divergence — a surface a user opens and finds
+  ## empty is the failure this whole thread is closing, and `openTab(name,
+  ## ViewInstructions)` would have produced exactly that, since the
+  ## instructions view is fed by `CtLoadAsmFunction` and knows nothing about a
+  ## compile artefact.
+  ##
+  ## Returns whether the ANCHORS were installed. False is a real answer and not
+  ## an error: `setAnchors` refuses a set that `validate` rejects, and it
+  ## refuses it wholesale, because a pane showing the valid half of a mapping
+  ## it knows to be broken makes the same confident-wrong-answer error over
+  ## fewer rows. The rows are painted either way — a listing whose mapping was
+  ## refused is still the compiler's own output, and §5's rule is that it says
+  ## so rather than disappearing.
+  if lowLevelCodeVMInstance.isNil:
+    return false
+  lowLevelCodeVMInstance.setInstructions(rows)
+  lowLevelCodeVMInstance.setErrorMessage(notice)
+  lowLevelCodeVMInstance.setNoirProject(true)
+  lowLevelCodeVMInstance.setActiveOffset(NO_ACTIVE_OFFSET)
+  lowLevelCodeVMInstance.clearAnchors()
+  if anchors.len == 0:
+    return false
+  if not lowLevelCodeVMInstance.setAnchors(anchors, support):
+    return false
+  # THE CURSOR IS WHAT THE PANE IS NOW SHOWING. Without this the pane holds a
+  # correct mapping and points at nothing — the listing would open at row zero
+  # regardless of where the developer asked from, which is GCL-D10's
+  # whole-project reading reintroduced one layer down.
+  let decision = lowLevelCodeVMInstance.syncFromSourceLine(sourcePath, sourceLine)
+  if decision.outcome == soAligned:
+    # `rowsFor` rather than reaching into the signal: the VM owns its anchors,
+    # and it already has the accessor the view uses.
+    let (first, _) = lowLevelCodeVMInstance.rowsFor(decision)
+    if first >= 0 and first < rows.len:
+      lowLevelCodeVMInstance.setActiveOffset(rows[first].offset)
+  true
 
 proc initLowLevelCodeVMWithStore*(store: ReplayDataStore) =
   ## Initialise (or replace) the parallel ``LowLevelCodeVM`` using an

--- a/src/frontend/ui/web_noir_build.nim
+++ b/src/frontend/ui/web_noir_build.nim
@@ -172,6 +172,36 @@ var
     ## `listing` is ordinary rather than a fault: a compiler module older than
     ## `VfsResponse.acir_listing` answers without it, and the pane must then
     ## say it has no counts rather than show a number from somewhere else.
+  noirGeneratedCodeSink*: proc(listing: string; artefactJson: string;
+                               packageDir: string; provenance: string)
+    ## Where a finished COMPILE's RAW OUTPUTS go, for the generated-code
+    ## operation. `Generated-Code-Listing.md` §1, §8.
+    ##
+    ## SEPARATE FROM `noirConstraintsSink` ABOVE, AND NOT A WIDENING OF IT.
+    ## The two want different things from the same compile, and folding them
+    ## would force one of them to be wrong:
+    ##
+    ##   * The Constraints pane is a STANDING surface. It is told on every
+    ##     compile and it parses immediately, because its whole job is to
+    ##     have a current number on screen without being asked.
+    ##   * The generated-code listing is INVOKED, never permanently displayed
+    ##     (§1). It must be told on every compile — otherwise the first
+    ##     invocation after a build would read a superseded artefact — and it
+    ##     must parse NOTHING until a user asks, or the surface is permanent
+    ##     in everything but its visibility.
+    ##
+    ## So this sink carries `artefactJson` as TEXT and the consumer stores it.
+    ## `artefactJson` is the whole compile artefact — `file_map` plus
+    ## `debug_symbols` — which is what `noir_anchor_producer.readArtefactJson`
+    ## takes, and it is deliberately not pre-parsed here: parsing it is the
+    ## expensive half, and moving it to this side would put it back on every
+    ## compile.
+    ##
+    ## Empty strings are ordinary, not faults, for `noirConstraintsSink`'s
+    ## reason: a compiler module older than `VfsResponse.acir_listing` answers
+    ## without a listing, and the surface must then say so rather than render
+    ## an empty document.
+
   noirTestRunSink*: proc(response: NoirTestResponse; packageDir: string)
     ## Where a finished test run's verdicts go, besides the build pane.
     ##
@@ -486,6 +516,24 @@ proc onPhaseExit(producer: NoirBuildProducer; tmpl: ProjectTemplate;
     # pane could not previously say.
     noirConstraintsSink(producer.acirListing, tmpl.name,
                         "compiled in this tab at " & $jsLocalTimeText())
+
+  # THE SAME COMPILE, FOR THE SURFACE THAT IS NOT STANDING. Published under
+  # the same three conditions as the line above and for the same reason —
+  # Build and Run compile the same program, and NOT on `nbpTestRecord`, whose
+  # `force_brillig` artefact has no located ACIR opcode at all (GCL-D9), so a
+  # listing built from it would be one row presented as the circuit.
+  #
+  # `producer.artifact` is `nil` unless the compile succeeded, which the
+  # verdict above already establishes; `$nil` would be the string "null", and
+  # `readArtefactJson` reports that as unparseable rather than throwing, so the
+  # listing would still render with every row unmapped. The guard is here
+  # anyway, because "it degrades correctly" is not a reason to pass rubbish.
+  if phase == nbpCompile and verdict == npvSucceeded and
+     not noirGeneratedCodeSink.isNil:
+    let artefactJson =
+      if producer.artifact.isNil: "" else: $producer.artifact
+    noirGeneratedCodeSink(producer.acirListing, artefactJson, tmpl.name,
+                          "compiled in this tab at " & $jsLocalTimeText())
 
   if phase == nbpCompile and verdict == npvSucceeded and
      activeIntent == nriRun:

--- a/src/frontend/ui/web_noir_build.nim
+++ b/src/frontend/ui/web_noir_build.nim
@@ -173,7 +173,8 @@ var
     ## `VfsResponse.acir_listing` answers without it, and the pane must then
     ## say it has no counts rather than show a number from somewhere else.
   noirGeneratedCodeSink*: proc(listing: string; artefactJson: string;
-                               packageDir: string; provenance: string)
+                               projectRoot: string; packageDir: string;
+                               provenance: string)
     ## Where a finished COMPILE's RAW OUTPUTS go, for the generated-code
     ## operation. `Generated-Code-Listing.md` §1, §8.
     ##
@@ -201,6 +202,16 @@ var
     ## reason: a compiler module older than `VfsResponse.acir_listing` answers
     ## without a listing, and the surface must then say so rather than render
     ## an empty document.
+    ##
+    ## `projectRoot` AND `packageDir` ARE BOTH CARRIED, and the pair is
+    ## load-bearing rather than redundant. The artefact spells its source paths
+    ## the way the COMPILER was handed them (`hello_noir/src/main.nr`); the
+    ## editor opens tabs by the RENDERER's spelling
+    ## (`/hello_noir/src/main.nr`). `noir_build_producer.rendererPathFor` is
+    ## the conversion, and it needs both. A consumer given only one of them
+    ## would compare the compiler's spelling against the editor's and find no
+    ## anchor over any line — a listing that opens, is correct, and never once
+    ## aligns to the cursor it was invoked from.
 
   noirTestRunSink*: proc(response: NoirTestResponse; packageDir: string)
     ## Where a finished test run's verdicts go, besides the build pane.
@@ -532,7 +543,8 @@ proc onPhaseExit(producer: NoirBuildProducer; tmpl: ProjectTemplate;
      not noirGeneratedCodeSink.isNil:
     let artefactJson =
       if producer.artifact.isNil: "" else: $producer.artifact
-    noirGeneratedCodeSink(producer.acirListing, artefactJson, tmpl.name,
+    noirGeneratedCodeSink(producer.acirListing, artefactJson,
+                          producer.projectRoot, producer.packageDir,
                           "compiled in this tab at " & $jsLocalTimeText())
 
   if phase == nbpCompile and verdict == npvSucceeded and

--- a/src/frontend/ui_js.nim
+++ b/src/frontend/ui_js.nim
@@ -39,7 +39,7 @@ import
   # so) precisely so a non-Electron caller can use it; `onNoTrace` reads the
   # editor's declared width out of the layout config with it.
   index/layout_config_repair,
-  ui/[test_results, constraints],
+  ui/[test_results, constraints, generated_code],
   # ONE LAYOUT PER MODE. `applyModeLayout` below is this module's only caller;
   # everything about where a mode's arrangement lives is in there.
   ui/mode_layouts,
@@ -6086,6 +6086,23 @@ when defined(ctWeb) and not defined(ctInExtension):
               constraints.constraintsVMInstance.setReport(
                 reportFromAcirListing(listing, packageDir, provenance))
 
+          web_noir_build.noirGeneratedCodeSink =
+            proc(listing: string; artefactJson: string; packageDir: string;
+                 provenance: string) =
+              # THE ON-DEMAND BOUNDARY. This hands the compile's raw outputs
+              # over as TEXT and stops. Nothing is parsed, no call stack is
+              # resolved, no anchor is built and no surface is opened —
+              # `ui/generated_code.showGeneratedCode`, reached only from a
+              # user's gesture, is what does all of that.
+              #
+              # The distinction is §1's: the operation is "invoked, never
+              # permanently displayed". A sink that built a listing on every
+              # compile would have made the surface permanent in everything but
+              # its visibility, beside panes that have already caused re-render
+              # storms.
+              generated_code.noteCompileArtefact(
+                listing, artefactJson, packageDir, provenance)
+
           web_noir_build.noirTestRunSink =
             proc(response: NoirTestResponse; packageDir: string) =
               if test_results.testResultsVMInstance.isNil:
@@ -6150,7 +6167,28 @@ when defined(ctWeb) and not defined(ctInExtension):
         # since rewritten. That is the exact state the pane's own header argues
         # is worse than showing no number at all, because the reader cannot
         # tell. This line is the caller.
-        editor.editorSourceChangedHook = constraints.noteEditorSourceChanged
+        editor.editorSourceChangedHook =
+          proc(path: cstring) =
+            # ONE EDIT, TWO SURFACES. Both are describing the artefact of one
+            # compilation and both stop describing the source on screen at the
+            # same instant, so they are told by one hook rather than by two
+            # subscriptions that could drift. `ui/editor` fires this inside the
+            # `reloadChange` guard, so a `setValue` during a tab reload — a
+            # content change that is not an edit — reaches neither.
+            constraints.noteEditorSourceChanged(path)
+            # GCL-D18: marks the generated-code tab stale, suspends the
+            # correspondence, and KEEPS the rows.
+            generated_code.noteEditorSourceEdited(path)
+
+        # THE CURSOR IS THE SUBJECT OF THE OPERATION (GCL-D10), and this is
+        # where the editor's caret reaches it. Named procs on both ends rather
+        # than a closure here, for the reason `ui/constraints
+        # .noteEditorSourceChanged` records: an anonymous `proc` in a 400-line
+        # install block is how the previous version of that wiring managed to
+        # not exist for as long as it did.
+        editor.editorCursorMovedHook = generated_code.noteEditorCursorMoved
+        editor.editorActiveTabChangedHook =
+          generated_code.noteEditorTabActivated
 
         editor.editorTestRunHook =
           proc(path: cstring; selector: cstring; line: int): cstring =

--- a/src/frontend/ui_js.nim
+++ b/src/frontend/ui_js.nim
@@ -6087,8 +6087,8 @@ when defined(ctWeb) and not defined(ctInExtension):
                 reportFromAcirListing(listing, packageDir, provenance))
 
           web_noir_build.noirGeneratedCodeSink =
-            proc(listing: string; artefactJson: string; packageDir: string;
-                 provenance: string) =
+            proc(listing: string; artefactJson: string; projectRoot: string;
+                 packageDir: string; provenance: string) =
               # THE ON-DEMAND BOUNDARY. This hands the compile's raw outputs
               # over as TEXT and stops. Nothing is parsed, no call stack is
               # resolved, no anchor is built and no surface is opened —
@@ -6101,7 +6101,7 @@ when defined(ctWeb) and not defined(ctInExtension):
               # its visibility, beside panes that have already caused re-render
               # storms.
               generated_code.noteCompileArtefact(
-                listing, artefactJson, packageDir, provenance)
+                listing, artefactJson, projectRoot, packageDir, provenance)
 
           web_noir_build.noirTestRunSink =
             proc(response: NoirTestResponse; packageDir: string) =

--- a/src/frontend/viewmodel/tests/unit/test_generated_code_operation.nim
+++ b/src/frontend/viewmodel/tests/unit/test_generated_code_operation.nim
@@ -1,0 +1,678 @@
+## THE OPERATION: on demand, anchored to the cursor, following the active tab.
+##
+## `GUI/Debugging-Features/Generated-Code-Listing.md` §1, §2 (GCL-D10),
+## §3.1 (GCL-D11), §6 (GCL-D14, GCL-D15, GCL-D16), §7, §8 (GCL-D17),
+## §9 (GCL-D18), §14.2 (GCL-D23).
+##
+## LANE: `vm-unit` AND `vm-unit-js`, by the directory glob in
+## `ci/lib/test-lane-files.sh`. Nothing here reaches the host or `std/os`.
+##
+## Compile and run:
+##   nim c  -r --path:src/frontend/viewmodel \
+##     src/frontend/viewmodel/tests/unit/test_generated_code_operation.nim
+##   nim js -r -d:nodejs --path:src/frontend/viewmodel \
+##     src/frontend/viewmodel/tests/unit/test_generated_code_operation.nim
+##
+## ## WHY THIS SUITE EXISTS WHEN `test_noir_generated_listing` IS GREEN
+##
+## That suite proves the PRODUCER reads a real `nargo compile` artefact and
+## that the MODEL refuses claims the artefact cannot support. Both were true
+## before this commit, and neither had a production caller: `setAnchors`,
+## `syncFromSource`, `syncFromGenerated` and `produceAnchors` were reached only
+## from their own suites. A capability nothing reaches has a user-visible face,
+## and it is always the same one — a feature that looks present and does
+## nothing.
+##
+## So this suite asserts the three properties the model cannot have on its own,
+## each of which has a plausible implementation that gets it wrong:
+##
+##   1. **On demand.** The failure is a listing recomputed on every cursor
+##      move, beside panes that have already caused re-render storms. The
+##      assertion is not "we only call it when needed" — that is not
+##      checkable — it is that `revision`, which counts ROW REPLACEMENTS,
+##      does not move while the cursor does, paired with the twin that shows
+##      the cursor really did move. A VM that ignored the cursor entirely
+##      satisfies the first clause alone.
+##
+##   2. **Cursor-anchored, visibly.** The failure is a surface with two
+##      states — an answer and nothing — where a broken query and a correct
+##      empty one look the same (GCL-D12). So *aligned*, *suspended* and
+##      *off* are asserted to render three DIFFERENT texts, and the aligned
+##      one is asserted to name BOTH ENDS: a row range with no source line
+##      beside it leaves the reader inferring the link.
+##
+##   3. **Synced tabs.** The failure is a VM reading an ambient "current
+##      line": Monaco fires cursor events for models that are not on screen,
+##      so a listing would follow a tab nobody is looking at. Both arms are
+##      asserted, because taking every event and taking none each satisfy one.
+##
+## ## THE FIXTURE, AND WHY ITS SHAPE IS PART OF THE ASSERTION
+##
+## `TwoInstantiations` has a source line — `Main:9` — that produces TWO
+## disjoint anchors. That is not decoration: GCL-A15's fixture requirement is
+## part of the assertion, because a control specified but only ever exercised
+## at `1 of 1` is a control nobody has seen work, and every count-based check
+## about a picker passes over a one-element set. `syncFromSource` returns the
+## FIRST match by construction, so a surface built on it alone reports one
+## where there are two — which is precisely why `anchorsFromSource` exists and
+## why the count is read from it rather than from the focused anchor.
+
+import std/[strutils, unittest]
+
+import isonim/core/[signals, computation]
+
+import ../../viewmodels/generated_code_anchors
+import ../../viewmodels/generated_code_operation
+import ../../viewmodels/generated_code_vm
+import ../../viewmodels/edit_mode_toolbar
+
+# ---------------------------------------------------------------------------
+# Counted assertions. `counted` is a TEMPLATE for the reason
+# `test_noir_generated_listing.nim` records: `std/unittest`'s `check` only
+# marks a case failed where `testStatusIMPL` is in scope, which is inside a
+# `test` body. A proc would print and pass.
+# ---------------------------------------------------------------------------
+var countedAssertions = 0
+
+template counted(condition: untyped) =
+  inc countedAssertions
+  check condition
+
+const ExpectedAssertions = 248
+  ## Asserted by the last case. Update it deliberately, in the same commit as
+  ## the checks that moved it — a count edited DOWN to match a short run is a
+  ## failed assertion whose identity has been erased.
+  ##
+  ## WHY IT IS NOT THE NUMBER OF `counted` LINES. Three cases assert inside a
+  ## loop over the DECLARED LADDER — every target's id is unique and resolves
+  ## back to itself, every declared extension selects a ladder, no two of a
+  ## language's commands share a label — so the total is a function of the
+  ## ladder's contents. Nine targets across six languages is what produces it,
+  ## and `seen.len == 9` in that same case is what pins the multiplier, so a
+  ## rung added without updating this number reddens here AND names itself
+  ## there. It is deliberately NOT a loop over `SourceLanguage`'s 34 members:
+  ## adding an unrelated language must not move this count.
+  ##
+  ## IT WAS 249 AND IS 248, AND THE DIFFERENCE IS ACCOUNTED FOR RATHER THAN
+  ## ABSORBED. This suite's first green run measured 249. Two cases then
+  ## changed for the reason recorded in `generated_code_operation.nim`'s
+  ## header — `keybindingTarget` was deleted because no key is bound to it,
+  ## and the ladder cases were rewritten to address `targetsForPath` instead
+  ## of the two internals:
+  ##
+  ##   −5  `gcl_d11_the_keybinding_resolves_to_the_first_target_…` deleted
+  ##   +4  `every_language_with_a_ladder_is_reachable_from_some_path` (6)
+  ##       became `every_declared_extension_selects_a_ladder` (10)
+  ##   ───
+  ##   −1  249 → 248
+  ##
+  ## A count that moves down and cannot be decomposed like this is a failed
+  ## assertion whose identity is unknown, and lowering the constant is how it
+  ## gets buried.
+
+const
+  MainPath = "src/main.nr"
+  OtherPath = "src/utils.nr"
+
+proc region(path: string; line: int): SourceRegion =
+  SourceRegion(path: path, startLine: line, endLine: line)
+
+proc exact(first, last: int; path: string; line: int): MappingAnchor =
+  MappingAnchor(generatedFirst: first, generatedLast: last,
+    fidelity: mfExact, sources: @[region(path, line)],
+    count: ExecutedCount(value: 0, provenance: cpNone))
+
+proc unmapped(first, last: int): MappingAnchor =
+  MappingAnchor(generatedFirst: first, generatedLast: last,
+    fidelity: mfUnmapped, sources: @[],
+    count: ExecutedCount(value: 0, provenance: cpNone))
+
+const ExactOnlySupport = ArtefactSupport(
+  hasSourcePositions: true, hasSourceRegions: true,
+  hasInliningRecords: true, marksCompilerGenerated: false)
+  ## `marksCompilerGenerated: false` is the Noir artefact's real ceiling
+  ## (§5.1): Noir does not distinguish a synthetic opcode from one whose debug
+  ## information was dropped, so `Unmapped` is the honest answer where another
+  ## language would say `Compiler-generated`.
+
+proc row(i: int; text: string; annotation = ""): GeneratedRow =
+  GeneratedRow(index: i, text: text, annotation: annotation)
+
+proc acirTarget(): GeneratedCodeTarget =
+  var t: GeneratedCodeTarget
+  doAssert targetById("noir.acir", t)
+  t
+
+proc listingFixture(): GeneratedListing =
+  ## Rows 0–3 belong to `Main:8`. Rows 4–6 and 9–10 BOTH belong to `Main:9` —
+  ## two instantiations of one source line, which is the case GCL-A15 requires
+  ## a fixture to contain. Rows 7–8 are unmapped, so a cursor over them has a
+  ## correct empty answer rather than a nearest-neighbour guess.
+  GeneratedListing(
+    targetId: "noir.acir",
+    sourcePath: MainPath,
+    producer: acirTarget().producer,
+    rows: @[
+      row(0, "RANGE x, 100"), row(1, "MUL x, 2"), row(2, "ADD t0, 1"),
+      row(3, "ASSERT t1"), row(4, "CALL f"),
+      row(5, "RANGE y, 8", "y must fit in 8 bits"),
+      row(6, "RET"), row(7, "NOP"), row(8, "NOP"),
+      row(9, "CALL f"), row(10, "RET"),
+    ],
+    anchors: @[
+      exact(0, 3, MainPath, 8),
+      exact(4, 6, MainPath, 9),
+      unmapped(7, 8),
+      exact(9, 10, MainPath, 9),
+    ],
+    support: ExactOnlySupport,
+    listingAbsence: "")
+
+# ===========================================================================
+suite "GCL: the operation is on demand — nothing is computed until it is asked":
+
+  test "a fresh vm holds no listing, no anchors and no cursor":
+    let vm = createGeneratedCodeVM()
+    counted vm.state.val == lsClosed
+    counted not vm.isOpen.val
+    counted vm.rows.val.len == 0
+    counted vm.anchors.val.len == 0
+    counted vm.revision.val == 0
+    counted vm.cursorLine.val == 0
+    counted vm.listingPath.val.len == 0
+    counted vm.tabTitle.val.len == 0
+    counted vm.producerLine.val.len == 0
+
+  test "gcl_on_demand_a_closed_vm_takes_no_cursor_move_and_an_open_one_does":
+    # TWO ARMS. A VM that ignored every cursor move satisfies the first alone
+    # and is exactly the "feature that looks present and does nothing" this
+    # campaign keeps finding; a VM that took them while closed would be
+    # accumulating state for a surface nobody opened.
+    let vm = createGeneratedCodeVM()
+
+    var taken = 0
+    for line in 1 .. 50:
+      if vm.noteCursorMoved(MainPath, line):
+        inc taken
+    counted taken == 0
+    counted vm.cursorLine.val == 0
+    counted vm.revision.val == 0
+    counted vm.rows.val.len == 0
+
+    # The positive twin, through the same path.
+    vm.openListing(listingFixture(), 8)
+    counted vm.noteCursorMoved(MainPath, 9)
+    counted vm.cursorLine.val == 9
+
+  test "gcl_on_demand_cursor_moves_re_anchor_and_never_replace_rows":
+    # THE RE-RENDER STORM ASSERTION. `revision` counts row replacements. A
+    # hundred cursor moves must not move it — and the second clause is what
+    # stops a VM that simply never re-anchors from passing: the focused rows
+    # must actually have changed.
+    let vm = createGeneratedCodeVM()
+    vm.openListing(listingFixture(), 8)
+    let revisionAfterOpen = vm.revision.val
+    counted revisionAfterOpen == 1
+    let focusAt8 = vm.focusRows.val
+    counted focusAt8 == (0, 3)
+
+    for i in 0 ..< 50:
+      discard vm.noteCursorMoved(MainPath, if i mod 2 == 0: 9 else: 8)
+
+    counted vm.revision.val == revisionAfterOpen
+    counted vm.rows.val.len == 11
+
+    discard vm.noteCursorMoved(MainPath, 9)
+    counted vm.focusRows.val == (4, 6)
+    counted vm.focusRows.val != focusAt8
+
+  test "gcl_on_demand_a_repeated_cursor_line_is_not_taken_twice":
+    # `onDidChangeCursorPosition` fires for COLUMN moves too, and this surface
+    # is line-granular. Without the guard every horizontal keystroke rewrites
+    # a signal with the value it already had and re-runs every memo.
+    let vm = createGeneratedCodeVM()
+    vm.openListing(listingFixture(), 8)
+    counted vm.noteCursorMoved(MainPath, 9)
+    counted not vm.noteCursorMoved(MainPath, 9)
+    counted not vm.noteCursorMoved(MainPath, 9)
+
+  test "gcl_d7_reopening_the_same_target_reuses_the_listing_and_repositions":
+    # §7: "re-invoking the same target for the same file reuses its tab and
+    # re-positions it, rather than opening a second one." `revision` is what
+    # says which happened, and the second clause — that the position DID
+    # move — is what stops a no-op from passing.
+    let vm = createGeneratedCodeVM()
+    vm.openListing(listingFixture(), 8)
+    counted vm.revision.val == 1
+    counted vm.focusRows.val == (0, 3)
+
+    vm.openListing(listingFixture(), 9)
+    counted vm.revision.val == 1
+    counted vm.focusRows.val == (4, 6)
+
+    # A DIFFERENT file is a different listing, and does rebuild.
+    var other = listingFixture()
+    other.sourcePath = OtherPath
+    other.anchors = @[exact(0, 1, OtherPath, 3)]
+    vm.openListing(other, 3)
+    counted vm.revision.val == 2
+
+  test "gcl_on_demand_closing_returns_the_vm_to_holding_nothing":
+    let vm = createGeneratedCodeVM()
+    vm.openListing(listingFixture(), 9)
+    counted vm.isOpen.val
+    vm.closeListing()
+    counted not vm.isOpen.val
+    counted vm.rows.val.len == 0
+    counted vm.anchors.val.len == 0
+    counted vm.cursorLine.val == 0
+    # And it is closed for the purpose that matters: it takes no cursor again.
+    counted not vm.noteCursorMoved(MainPath, 9)
+
+# ===========================================================================
+suite "GCL: the cursor leads, and the correspondence is visible (GCL-D12)":
+
+  test "gcl_a13_a_mapped_line_names_both_ends_of_the_correspondence":
+    # A row range with no source line beside it leaves the reader inferring
+    # the link from two numbers that happened to move together.
+    let vm = createGeneratedCodeVM()
+    vm.openListing(listingFixture(), 8)
+    counted vm.focus.val.outcome == soAligned
+    counted vm.focusRows.val == (0, 3)
+    let text = vm.focusText.val
+    counted text.len > 0
+    counted MainPath in text
+    counted ":8" in text
+    counted "0" in text and "3" in text
+
+  test "gcl_a13_an_unmapped_line_moves_nothing_and_states_a_reason":
+    # BOTH CLAUSES. An implementation that does nothing satisfies the first
+    # alone, and is indistinguishable from a broken query.
+    let vm = createGeneratedCodeVM()
+    vm.openListing(listingFixture(), 8)
+    let before = vm.focusRows.val
+    counted before == (0, 3)
+
+    discard vm.noteCursorMoved(MainPath, 400)
+    counted vm.focus.val.outcome == soSuspended
+    counted vm.focusRows.val == (NoAnchor, NoAnchor)
+    counted vm.focus.val.reason.len > 0
+    counted vm.focusText.val.len > 0
+    # The listing itself is untouched — the rows still describe a real compile.
+    counted vm.rows.val.len == 11
+    counted vm.revision.val == 1
+
+  test "gcl_a8_aligned_suspended_and_off_render_three_different_texts":
+    # THREE-WAY, because rendering *off* and *suspended* the same way makes
+    # "you turned it off" indistinguishable from "the mapping ran out" — which
+    # is precisely the distinction the model went to the trouble of encoding.
+    let vm = createGeneratedCodeVM()
+    vm.openListing(listingFixture(), 8)
+    let alignedText = vm.focusText.val
+    counted vm.focus.val.outcome == soAligned
+
+    discard vm.noteCursorMoved(MainPath, 400)
+    let suspendedText = vm.focusText.val
+    counted vm.focus.val.outcome == soSuspended
+
+    vm.setSyncEnabled(false)
+    let offText = vm.focusText.val
+    counted vm.focus.val.outcome == soDisabled
+
+    counted alignedText != suspendedText
+    counted suspendedText != offText
+    counted alignedText != offText
+    counted offText.len > 0
+
+    # And *off* survives a cursor that WOULD have aligned: a suspension
+    # reported while the toggle is off would say the mapping ran out when
+    # nothing was asked of it.
+    discard vm.noteCursorMoved(MainPath, 8)
+    counted vm.focus.val.outcome == soDisabled
+    vm.setSyncEnabled(true)
+    counted vm.focus.val.outcome == soAligned
+
+  test "gcl_d29_the_instantiation_count_is_stated_at_zero_one_and_many":
+    # The fixture requirement IS the assertion (GCL-A15): `Main:9` produces
+    # two disjoint anchors, and `syncFromSource` returns the first by
+    # construction. A count read from the focused anchor would say 1 here and
+    # the reader could never tell.
+    let vm = createGeneratedCodeVM()
+    vm.openListing(listingFixture(), 8)
+    counted vm.instantiationCount.val == 1
+
+    discard vm.noteCursorMoved(MainPath, 9)
+    counted vm.instantiationCount.val == 2
+    counted "2 instantiations" in vm.focusText.val
+
+    discard vm.noteCursorMoved(MainPath, 400)
+    counted vm.instantiationCount.val == 0
+
+    # The singular is spelled as a singular — a count that reads
+    # "1 instantiations" is a count nobody trusts.
+    discard vm.noteCursorMoved(MainPath, 8)
+    counted "1 instantiation" in vm.focusText.val
+    counted "1 instantiations" notin vm.focusText.val
+
+  test "anchors_from_source_returns_every_range_not_the_first":
+    # The model-level twin of the case above, asserted directly, because the
+    # VM could satisfy the count by any means and this is the query §13.1's
+    # second requirement is about.
+    let anchors = listingFixture().anchors
+    counted anchorsFromSource(anchors, MainPath, 9) == @[1, 3]
+    counted anchorsFromSource(anchors, MainPath, 8) == @[0]
+    counted anchorsFromSource(anchors, MainPath, 400).len == 0
+    # An unmapped anchor names no source and is never one of the places a
+    # line became.
+    counted 2 notin anchorsFromSource(anchors, MainPath, 9)
+    # And the single-valued query really does drop one, which is why the
+    # sequence-valued one had to exist.
+    let one = syncFromSource(anchors, MainPath, 9)
+    counted one.outcome == soAligned
+    counted counterpartRows(anchors, one) == (4, 6)
+
+  test "gcl_d23_the_surface_names_the_producer_that_painted_it":
+    # A row count cannot discriminate two producers that agree on every
+    # number, so the NAME is the only thing that identifies which route
+    # painted what the reader is looking at.
+    let vm = createGeneratedCodeVM()
+    vm.openListing(listingFixture(), 8)
+    counted vm.producerLine.val.len > 0
+    counted acirTarget().producer in vm.producerLine.val
+    vm.closeListing()
+    counted vm.producerLine.val.len == 0
+
+  test "gcl_14_3_a_compiler_annotation_survives_into_the_row":
+    # §14.3: it is the single most valuable thing the compiler's own output
+    # adds over a bare opcode dump, and a renderer that splits a row into
+    # fields must have a field for it.
+    let listing = listingFixture()
+    counted listing.rows[5].annotation == "y must fit in 8 bits"
+    counted listing.rows[4].annotation.len == 0
+
+# ===========================================================================
+suite "GCL: the listing follows the ACTIVE source tab":
+
+  test "gcl_tabs_a_cursor_move_in_a_background_tab_is_refused":
+    # BOTH ARMS. Monaco fires cursor events for models that are not on screen;
+    # taking every event and taking none each satisfy one clause.
+    let vm = createGeneratedCodeVM()
+    vm.openListing(listingFixture(), 8)
+    counted vm.activeTabPath.val == MainPath
+
+    counted not vm.noteCursorMoved(OtherPath, 42)
+    counted vm.cursorLine.val == 8
+    counted vm.focusRows.val == (0, 3)
+
+    counted vm.noteCursorMoved(MainPath, 9)
+    counted vm.cursorLine.val == 9
+
+  test "gcl_tabs_switching_to_another_file_suspends_and_names_both":
+    # It does NOT keep projecting the old file's anchors against the new
+    # file's cursor, which would produce a plausible row range meaning nothing.
+    let vm = createGeneratedCodeVM()
+    vm.openListing(listingFixture(), 8)
+    counted vm.describesActiveTab.val
+
+    discard vm.noteActiveTabChanged(OtherPath, 3)
+    counted not vm.describesActiveTab.val
+    counted vm.focus.val.outcome == soSuspended
+    counted vm.focusRows.val == (NoAnchor, NoAnchor)
+    let text = vm.focusText.val
+    counted MainPath in text
+    counted OtherPath in text
+    # The rows are still there: the listing describes a real compilation.
+    counted vm.rows.val.len == 11
+    counted vm.revision.val == 1
+
+    # Switching back re-aligns, at the position the tab carries.
+    discard vm.noteActiveTabChanged(MainPath, 9)
+    counted vm.describesActiveTab.val
+    counted vm.focus.val.outcome == soAligned
+    counted vm.focusRows.val == (4, 6)
+    counted vm.revision.val == 1
+
+  test "gcl_tabs_the_cursor_arrives_with_the_tab_not_after_it":
+    # A VM that switched tabs and then waited for a cursor event would spend
+    # the interval showing the previous tab's line under the new tab's name.
+    let vm = createGeneratedCodeVM()
+    vm.openListing(listingFixture(), 8)
+    discard vm.noteActiveTabChanged(OtherPath, 77)
+    counted vm.cursorLine.val == 77
+    discard vm.noteActiveTabChanged(MainPath, 9)
+    counted vm.cursorLine.val == 9
+    counted vm.focusRows.val == (4, 6)
+
+  test "gcl_tabs_a_closed_vm_follows_no_tab":
+    let vm = createGeneratedCodeVM()
+    counted not vm.noteActiveTabChanged(MainPath, 8)
+    counted vm.activeTabPath.val.len == 0
+
+  test "gcl_d16_projecting_once_on_reveal_equals_projecting_on_every_move":
+    # THE EQUIVALENCE IS THE ASSERTION. A test that only exercised the
+    # deferred path could not detect a divergence. Two VMs, the same landing
+    # position, one walked there and one dropped there.
+    let walked = createGeneratedCodeVM()
+    walked.openListing(listingFixture(), 8)
+    for line in [1, 2, 3, 8, 9, 400, 7, 9]:
+      discard walked.noteCursorMoved(MainPath, line)
+
+    let dropped = createGeneratedCodeVM()
+    dropped.openListing(listingFixture(), 9)
+
+    counted walked.cursorLine.val == dropped.cursorLine.val
+    counted walked.focus.val.outcome == dropped.focus.val.outcome
+    counted walked.focusRows.val == dropped.focusRows.val
+    counted walked.focusText.val == dropped.focusText.val
+    counted walked.instantiationCount.val == dropped.instantiationCount.val
+
+# ===========================================================================
+suite "GCL: build states and staleness (§8, GCL-D18)":
+
+  test "gcl_a10_a_failed_build_clears_the_previous_successful_rows":
+    # It never leaves the previous build's rows on screen as though they were
+    # current: a developer reading a listing that does not correspond to the
+    # source in front of them is worse off than one reading nothing.
+    let vm = createGeneratedCodeVM()
+    vm.openListing(listingFixture(), 8)
+    counted vm.rows.val.len == 11
+
+    vm.noteBuildFailed("main.nr:9:5: expected Field, found bool")
+    counted vm.rows.val.len == 0
+    counted vm.state.val == lsFailed
+    counted vm.failure.val.len > 0
+    counted "expected Field" in vm.failure.val
+    counted vm.focus.val.outcome == soSuspended
+    counted vm.focus.val.reason.len > 0
+
+  test "a failed build with no diagnostic still says something":
+    let vm = createGeneratedCodeVM()
+    vm.openListing(listingFixture(), 8)
+    vm.noteBuildFailed("")
+    counted vm.failure.val.len > 0
+
+  test "gcl_8_a_running_build_is_a_state_of_its_own":
+    let vm = createGeneratedCodeVM()
+    vm.noteBuildStarted(acirTarget(), MainPath, 8)
+    counted vm.state.val == lsBuilding
+    counted vm.isOpen.val
+    counted vm.rows.val.len == 0
+    counted vm.focus.val.outcome == soSuspended
+    counted vm.focus.val.reason != ""
+    # The tab exists and carries its identity while the build runs.
+    counted MainPath in vm.tabTitle.val
+    counted "ACIR" in vm.tabTitle.val
+
+  test "gcl_a20_an_invalidating_edit_does_all_three_and_another_does_none":
+    # THE NEGATIVE CONTROL IS IN THE SAME TEST. Making every edit invalidate
+    # must redden exactly the second half.
+    let vm = createGeneratedCodeVM()
+    vm.openListing(listingFixture(), 8)
+    counted vm.focus.val.outcome == soAligned
+
+    vm.noteSourceEdited("Prover.toml")
+    counted not vm.stale.val
+    counted vm.focus.val.outcome == soAligned
+    counted "(stale)" notin vm.tabTitle.val
+
+    vm.noteSourceEdited(MainPath)
+    counted vm.stale.val
+    counted vm.focus.val.outcome == soSuspended
+    counted vm.rows.val.len == 11
+    counted "(stale)" in vm.tabTitle.val
+    counted vm.revision.val == 1
+
+  test "gcl_8_totals_with_no_rows_is_not_an_empty_listing":
+    # §8's fourth state, and the one that must never be rendered as an empty
+    # listing: totals with no rows is a different answer from a listing that
+    # came back empty.
+    var listing = listingFixture()
+    listing.rows = @[]
+    listing.listingAbsence =
+      "this compiler build predates the printed ACIR listing"
+    let vm = createGeneratedCodeVM()
+    vm.openListing(listing, 8)
+    counted vm.rows.val.len == 0
+    counted vm.listingAbsence.val.len > 0
+    counted vm.state.val == lsReady
+    # The anchors survive, so the correspondence is still real.
+    counted vm.focus.val.outcome == soAligned
+
+# ===========================================================================
+suite "GCL: the ladder is declared data, one command per target (GCL-D11)":
+
+  test "gcl_d11_a_language_declares_named_targets_and_noir_declares_three":
+    # Addressed through `targetsForPath`, which is the composition production
+    # calls. `targetsFor` and `ladderLanguageOfPath` are internal precisely so
+    # that this suite cannot exercise a surface no product module reaches.
+    counted targetsForPath("src/main.nr").len == 3
+    counted targetsForPath("src/main.nr")[0].displayName == "ACIR"
+    counted targetsForPath("src/main.nim").len == 2
+    counted targetsForPath("script.py").len == 0
+    counted targetsForPath("README.md").len == 0
+
+  test "gcl_d11_the_ladder_is_a_chain_for_nim_and_flat_for_noir":
+    # Nim's assembly is generated from the C, not from the Nim — which is
+    # what `openAlternativeView` already reflects by taking `cLocation
+    # .asmName`. A consumer that could not tell a one-rung correspondence from
+    # a composed two-rung one could not state §5.2's fidelity rule.
+    let nim = targetsForPath("src/main.nim")
+    counted nim[0].generatedFrom == ""
+    counted nim[1].generatedFrom == nim[0].id
+    for t in targetsForPath("src/main.nr"):
+      counted t.generatedFrom == ""
+
+  test "gcl_d11_the_language_is_read_per_file_from_the_path":
+    # The observable of "which language is this file" is which ladder it gets,
+    # since that is the only thing any caller does with the answer.
+    counted targetsForPath("src/main.nr")[0].id == "noir.acir"
+    counted targetsForPath("src/main.nim")[0].id == "nim.c"
+    counted targetsForPath("a/b/c.rs")[0].id == "rust.asm"
+    counted targetsForPath("README.md").len == 0
+    counted targetsForPath("Nargo.toml").len == 0
+    counted targetsForPath("noextension").len == 0
+    counted targetsForPath("").len == 0
+    # The dot must come after the last separator, or `src.v2/main` reads as
+    # extension `v2/main`.
+    counted targetsForPath("src.v2/main").len == 0
+    counted targetsForPath("src.v2/main.nr")[0].id == "noir.acir"
+    # Case does not decide a language.
+    counted targetsForPath("src/MAIN.NR")[0].id == "noir.acir"
+
+  test "every_target_id_is_unique_and_resolves_back_to_itself":
+    # GCL-D26 one level up: the ID is the identity a saved layout persists, so
+    # a collision would silently address another language's rung.
+    #
+    # The paths below are the ladder's own extensions, one per language. That
+    # is the same list `LadderRows` carries, written independently here — if a
+    # language is added and this list is not, `seen.len == 9` fails and names
+    # the omission rather than quietly checking fewer targets.
+    const LadderPaths = ["f.nr", "f.nim", "f.c", "f.cpp", "f.rs", "f.go"]
+    var seen: seq[string] = @[]
+    for path in LadderPaths:
+      for t in targetsForPath(path):
+        counted t.id notin seen
+        seen.add t.id
+        var back: GeneratedCodeTarget
+        counted targetById(t.id, back)
+        counted back.id == t.id
+        counted back.displayName == t.displayName
+        counted t.producer.len > 0
+    counted seen.len == 9
+    var missing: GeneratedCodeTarget
+    counted not targetById("noir.wasm", missing)
+
+  test "every_declared_extension_selects_a_ladder":
+    # A language that declares targets no path can select is a feature nobody
+    # can invoke — the shape this whole commit exists to fix, one level up.
+    for ext in ["nr", "nim", "c", "h", "cpp", "cc", "cxx", "hpp", "rs", "go"]:
+      counted targetsForPath("f." & ext).len > 0
+
+  test "a_command_label_carries_the_target_own_name_and_no_two_collide":
+    # "Show Assembly Code" cannot be the operation's name: one name cannot
+    # mean ACIR, Brillig, SSA, generated C and assembly.
+    counted commandLabel(acirTarget()) == "Show ACIR"
+    for path in ["f.nr", "f.nim", "f.c", "f.cpp", "f.rs", "f.go"]:
+      var labels: seq[string] = @[]
+      for t in targetsForPath(path):
+        counted commandLabel(t) notin labels
+        labels.add commandLabel(t)
+
+# ===========================================================================
+suite "GCL: availability follows the build proposal (GCL-D17)":
+
+  test "gcl_a19_a_non_canonical_proposal_disables_with_its_own_reason":
+    # BOTH ARMS, since either alone is satisfied by a blanket policy.
+    let ambiguous = CommandProposal(command: "", args: @[],
+      confidence: pcAmbiguous,
+      reason: "several build files match and none is conventional")
+    let commands = commandsForPath("src/main.nr", ambiguous)
+    counted commands.len == 3
+    for c in commands:
+      counted c.availability == gaDisabled
+      counted c.reason == ambiguous.reason
+      counted c.reason.len > 0
+
+    # A language with no target yields NO command — absent, not disabled,
+    # because there is nothing to explain.
+    counted commandsForPath("README.md", ambiguous).len == 0
+
+  test "gcl_a19_a_canonical_proposal_enables_and_carries_no_reason":
+    let canonical = CommandProposal(command: "nargo", args: @["compile"],
+      confidence: pcCanonical, reason: "")
+    let commands = commandsForPath("src/main.nr", canonical)
+    counted commands.len == 3
+    for c in commands:
+      counted c.availability == gaEnabled
+      counted c.reason.len == 0
+
+  test "gcl_d17_the_platform_refusal_outranks_the_proposal":
+    # A canonical command the platform cannot run is still a command that
+    # cannot run, and reporting the proposal's silence there would tell the
+    # user to fix a build file that is already correct.
+    let canonical = CommandProposal(command: "nargo", args: @["compile"],
+      confidence: pcCanonical, reason: "")
+    let commands = commandsForPath("src/main.nr", canonical,
+      "this browser build carries no `nargo` module")
+    counted commands.len == 3
+    for c in commands:
+      counted c.availability == gaDisabled
+      counted "nargo" in c.reason
+
+  test "a_disabled_command_always_carries_a_sentence":
+    # An action whose refusal cannot be explained is one whose refusal was a
+    # guess. `CommandProposal.reason` is non-empty for a non-canonical
+    # confidence by EMT-A48, and the fallback covers a hand-built proposal.
+    let silent = CommandProposal(command: "", args: @[],
+      confidence: pcUnknown, reason: "")
+    for c in commandsForPath("src/main.nr", silent):
+      counted c.availability == gaDisabled
+      counted c.reason.len > 0
+
+# ===========================================================================
+suite "GCL operation suite self-check":
+
+  test "generated_code_operation_assertion_count_is_measured":
+    # A suite that returned early — a moved fixture, a lane missing a module —
+    # would go red HERE rather than passing quietly with fewer checks.
+    check countedAssertions == ExpectedAssertions

--- a/src/frontend/viewmodel/tests/unit/test_generated_code_operation.nim
+++ b/src/frontend/viewmodel/tests/unit/test_generated_code_operation.nim
@@ -65,6 +65,7 @@ import ../../viewmodels/generated_code_anchors
 import ../../viewmodels/generated_code_operation
 import ../../viewmodels/generated_code_vm
 import ../../viewmodels/edit_mode_toolbar
+from ../../viewmodels/noir_build_producer import rendererPathFor
 
 # ---------------------------------------------------------------------------
 # Counted assertions. `counted` is a TEMPLATE for the reason
@@ -78,7 +79,7 @@ template counted(condition: untyped) =
   inc countedAssertions
   check condition
 
-const ExpectedAssertions = 248
+const ExpectedAssertions = 263
   ## Asserted by the last case. Update it deliberately, in the same commit as
   ## the checks that moved it — a count edited DOWN to match a short run is a
   ## failed assertion whose identity has been erased.
@@ -103,8 +104,11 @@ const ExpectedAssertions = 248
   ##   −5  `gcl_d11_the_keybinding_resolves_to_the_first_target_…` deleted
   ##   +4  `every_language_with_a_ladder_is_reachable_from_some_path` (6)
   ##       became `every_declared_extension_selects_a_ladder` (10)
+  ##  +15  `the_anchors_are_rebased_into_the_spelling_…` added: 3 for the
+  ##       negative arm, 4 for the positive, 3 for the passthrough rule and 5
+  ##       for "the rebase changed nothing but the paths"
   ##   ───
-  ##   −1  249 → 248
+  ##  +14  249 → 263
   ##
   ## A count that moves down and cannot be decomposed like this is a failed
   ## assertion whose identity is unknown, and lowering the constant is how it
@@ -370,6 +374,67 @@ suite "GCL: the cursor leads, and the correspondence is visible (GCL-D12)":
     let one = syncFromSource(anchors, MainPath, 9)
     counted one.outcome == soAligned
     counted counterpartRows(anchors, one) == (4, 6)
+
+  test "the_anchors_are_rebased_into_the_spelling_the_editor_opened_the_tab_by":
+    # THE FAILURE THIS PREVENTS IS INVISIBLE, which is why both arms are here.
+    #
+    # `file_map` spells a source `hello_noir/src/main.nr` — the key the
+    # compiler was handed. The editor opened its tab as `/hello_noir/src/main.nr`.
+    # `syncFromSource` compares those two strings, so an un-rebased listing
+    # reports "this line has no anchor over it" for EVERY line of the file:
+    # correct-looking, true as a sentence, and indistinguishable from a build
+    # with no debug information. Nothing in the model can catch it, because a
+    # path that matches nothing is not a malformed path.
+    const CompilerPath = "hello_noir/src/main.nr"
+    const EditorPath = "/hello_noir/src/main.nr"
+    const ProjectRoot = "/hello_noir"
+    const PackageDir = "hello_noir"
+
+    let raw = @[exact(0, 3, CompilerPath, 8), exact(4, 6, CompilerPath, 9)]
+
+    # NEGATIVE ARM: the compiler's spelling against the editor's cursor finds
+    # nothing, and says so in a sentence that is true and useless.
+    let unrebased = createGeneratedCodeVM()
+    var l1 = listingFixture()
+    l1.sourcePath = EditorPath
+    l1.anchors = raw
+    unrebased.openListing(l1, 8)
+    counted unrebased.focus.val.outcome == soSuspended
+    counted unrebased.focus.val.reason.len > 0
+    counted unrebased.instantiationCount.val == 0
+
+    # POSITIVE ARM: the same anchors through the same rule the build pane's
+    # clickable diagnostics use, and the cursor now lands.
+    let rebased = createGeneratedCodeVM()
+    var l2 = listingFixture()
+    l2.sourcePath = EditorPath
+    l2.anchors = rebaseSources(raw, proc(p: string): string =
+      rendererPathFor(ProjectRoot, PackageDir, p))
+    rebased.openListing(l2, 8)
+    counted rebased.focus.val.outcome == soAligned
+    counted rebased.focusRows.val == (0, 3)
+    counted EditorPath in rebased.focusText.val
+    discard rebased.noteCursorMoved(EditorPath, 9)
+    counted rebased.focusRows.val == (4, 6)
+
+    # THE RULE PASSES AN UNMATCHED PATH THROUGH rather than bolting a slash on
+    # it: the stdlib's own sources reach these artefacts, and inventing a
+    # project-relative identity for them would make an anchor claim the project
+    # contains a file it does not.
+    counted rendererPathFor(ProjectRoot, PackageDir,
+      "std/field/bn254.nr") == "std/field/bn254.nr"
+    counted rendererPathFor(ProjectRoot, PackageDir, CompilerPath) == EditorPath
+    counted rendererPathFor(ProjectRoot, PackageDir, "") == ""
+
+    # And the rebase changes NOTHING but the paths — a rewrite that dropped a
+    # row range or a fidelity would be a different defect wearing this fix.
+    let mapped = rebaseSources(raw, proc(p: string): string =
+      rendererPathFor(ProjectRoot, PackageDir, p))
+    counted mapped.len == raw.len
+    counted mapped[0].generatedFirst == raw[0].generatedFirst
+    counted mapped[0].generatedLast == raw[0].generatedLast
+    counted mapped[0].fidelity == raw[0].fidelity
+    counted mapped[1].sources[0].startLine == raw[1].sources[0].startLine
 
   test "gcl_d23_the_surface_names_the_producer_that_painted_it":
     # A row count cannot discriminate two producers that agree on every

--- a/src/frontend/viewmodel/viewmodels/generated_code_anchors.nim
+++ b/src/frontend/viewmodel/viewmodels/generated_code_anchors.nim
@@ -426,6 +426,37 @@ proc syncFromSource*(anchors: seq[MappingAnchor]; path: string; line: int;
     "synchronisation is suspended here rather than interpolated to the " &
     "nearest anchor")
 
+proc rebaseSources*(anchors: seq[MappingAnchor];
+                    toReaderPath: proc(path: string): string {.closure.}):
+                    seq[MappingAnchor] =
+  ## Rewrite every source path through `toReaderPath`, keeping everything else.
+  ##
+  ## WHY THIS EXISTS, AND WHAT BREAKS WITHOUT IT. A producer spells its source
+  ## paths the way its ARTEFACT does — Noir's `file_map` says
+  ## `hello_noir/src/main.nr`, because that is the key the compiler was handed.
+  ## The editor opens tabs by the renderer's spelling, `/hello_noir/src/main.nr`.
+  ## `syncFromSource` compares those two strings, so without a rebase EVERY
+  ## query misses and the surface reports "this line has no anchor over it" for
+  ## every line of the file.
+  ##
+  ## THAT IS THE WORST AVAILABLE FAILURE for this feature, because it is
+  ## indistinguishable from a correct answer: a build stripped of debug
+  ## information produces exactly the same screen. The listing opens, the rows
+  ## are real, the reason is a true sentence — and the mapping the artefact
+  ## does carry is silently unreachable. Nothing in the model can detect it,
+  ## because a path that matches nothing is not a malformed path.
+  ##
+  ## A MAPPER RATHER THAN A PREFIX PAIR, because the rule is the producer's:
+  ## `noir_build_producer.rendererPathFor` passes an unmatched path through
+  ## unchanged rather than bolting a slash onto it, since the stdlib's own
+  ## sources reach these artefacts and inventing a project-relative identity
+  ## for them would make an anchor claim the project contains a file it does
+  ## not. This module must not know that rule; it must only apply it.
+  result = anchors
+  for a in result.mitems:
+    for r in a.sources.mitems:
+      r.path = toReaderPath(r.path)
+
 proc anchorsFromSource*(anchors: seq[MappingAnchor]; path: string;
                         line: int): seq[int] =
   ## EVERY anchor a source position produced, in row order — not the first.

--- a/src/frontend/viewmodel/viewmodels/generated_code_anchors.nim
+++ b/src/frontend/viewmodel/viewmodels/generated_code_anchors.nim
@@ -370,10 +370,12 @@ proc decideFor(anchors: seq[MappingAnchor]; index: int): SyncDecision =
   let a = anchors[index]
   if not claimsUserSource(a.fidelity):
     return suspended("no source mapping here (" & label(a.fidelity) &
-      "), so these panes are not kept in step")
+      ") — synchronisation is suspended rather than interpolated to a " &
+      "nearby anchor")
   if a.sources.len == 0:
     return suspended("the mapping here claims " & label(a.fidelity) &
-      " and names no source, so these panes are not kept in step")
+      " and names no source — synchronisation is suspended rather than " &
+      "interpolated to a nearby anchor")
   aligned(index)
 
 proc anchorIndexAtRow*(anchors: seq[MappingAnchor]; row: int): int =
@@ -402,7 +404,8 @@ proc syncFromGenerated*(anchors: seq[MappingAnchor]; row: int;
     if a.covers(row):
       return decideFor(anchors, i)
   suspended("generated row " & $row &
-    " has no source mapped to it, so these panes are not kept in step")
+    " has no source mapped to it — synchronisation is suspended here " &
+    "rather than interpolated to the nearest anchor")
 
 proc syncFromSource*(anchors: seq[MappingAnchor]; path: string; line: int;
                      settings: SyncSettings = DefaultSyncSettings):
@@ -419,7 +422,47 @@ proc syncFromSource*(anchors: seq[MappingAnchor]; path: string; line: int;
       if r.covers(path, line):
         return decideFor(anchors, i)
   suspended(path & ":" & $line &
-    " has no generated code mapped to it, so these panes are not kept in step")
+    " has no anchor over it, so no generated code is mapped to it — " &
+    "synchronisation is suspended here rather than interpolated to the " &
+    "nearest anchor")
+
+proc anchorsFromSource*(anchors: seq[MappingAnchor]; path: string;
+                        line: int): seq[int] =
+  ## EVERY anchor a source position produced, in row order — not the first.
+  ##
+  ## `syncFromSource` above answers "where should the follower go", and to do
+  ## that it has to pick one. This answers "how many places did this line
+  ## become", and the two are different questions: one source position is
+  ## compiled into as many places as the compiler chose — a generic
+  ## monomorphised, a template expanded at several call sites, a function
+  ## inlined at several, an unrolled loop body — and §4.2 makes that
+  ## multiplicity first-class rather than resolving it by picking one.
+  ##
+  ## WHY THIS IS NOT A REFINEMENT OF `syncFromSource`. §13.1's second
+  ## requirement is that a producer supply "a source→generated query that
+  ## returns an ordered sequence, not a single result", because *a query that
+  ## returns the first is not a narrower version of the right answer — it is an
+  ## answer that cannot be corrected by the caller, because the caller cannot
+  ## see what was dropped*. A surface built only on `syncFromSource` shows one
+  ## range and gives the reader no way to tell that three existed. That is the
+  ## silent-drop failure §4.2 exists to prevent, and it is invisible by
+  ## construction, which is why the count has to come from somewhere else.
+  ##
+  ## Anchors that claim no user source are excluded, for the same reason
+  ## `syncFromSource` skips them: an unmapped anchor names no source and so
+  ## cannot be one of the places THIS line became.
+  ##
+  ## The order is the anchor order the producer emitted, which for a listing is
+  ## generated-row order. GCL-D26 requires a *descriptor* order once
+  ## descriptors exist; until a producer supplies them this is the honest
+  ## available order and callers must not persist an index into it.
+  for i, a in anchors:
+    if not claimsUserSource(a.fidelity):
+      continue
+    for r in a.sources:
+      if r.covers(path, line):
+        result.add i
+        break
 
 proc counterpartSources*(anchors: seq[MappingAnchor];
                          decision: SyncDecision): seq[SourceRegion] =

--- a/src/frontend/viewmodel/viewmodels/generated_code_operation.nim
+++ b/src/frontend/viewmodel/viewmodels/generated_code_operation.nim
@@ -1,0 +1,280 @@
+## viewmodels/generated_code_operation.nim
+##
+## THE OPERATION, as declared data: which generated-code targets a file's
+## language has, what each one's command is called, and whether that command is
+## present, enabled or disabled.
+##
+## `GUI/Debugging-Features/Generated-Code-Listing.md` §3.1 (GCL-D11), §8
+## (GCL-D17), §13.
+##
+## LANE: `vm-unit` AND `vm-unit-js`. Nothing here reaches the host, `std/os` or
+## a browser: it is a pure function of a path, a language and a build proposal.
+##
+## ## Why this module exists, given `openAlternativeView` already opens these
+##
+## `renderer.openAlternativeView(data, id: int)` takes a POSITIONAL INDEX into
+## a `case` over `data.trace.lang`, so `1` means disassembly for C and
+## generated C for Nim, and the name of the thing being opened exists nowhere
+## in the product. That is why "Show Assembly Code" cannot be the operation's
+## name, and it is GCL-D11's whole argument: **each target contributes its own
+## command, labelled with its own display name.**
+##
+## Two consequences that are requirements rather than restatements:
+##
+##   * The ladder is a **chain**, not a flat set (§3.1). Nim's assembly is
+##     generated from the C, not from the Nim — which is what
+##     `openAlternativeView` already reflects by taking `cLocation.asmName`
+##     rather than an assembly of the Nim position. `generatedFrom` carries
+##     that, so a consumer can tell a one-rung correspondence from a composed
+##     two-rung one, and §5.2's rule (composition cannot improve fidelity) has
+##     something to be stated about.
+##
+##   * The language is read **per file, from the path**, and NOT from
+##     `Trace.lang` (§3.1). `Trace.lang` is a summary of a per-file fact for a
+##     recording that may span several languages. `openAlternativeView` reads
+##     it, which is why it cannot answer correctly in a mixed recording.
+##
+## ## THE EXTENSION TABLE IS DERIVED FROM THE LADDER, NOT PARALLEL TO IT
+##
+## A second hand-maintained table keyed by language is the drift
+## `common_lang.getExtensionName` was consolidated to end. So `LadderRows`
+## below carries the extensions AND the targets in one row per language, and
+## `test_generated_code_operation.nim` asserts every row has both — a language
+## that declares targets no path can select is a feature nobody can invoke.
+##
+## `targetsFor` and `ladderLanguageOfPath` are INTERNAL. They are the table's
+## two readers and `targetsForPath` composes them, which is the only thing any
+## caller has wanted; exporting them so a test could address them directly
+## would have put two more names in the reachability guard's bucket [A]
+## ("tested, no product module reaches it") in the same commit that adds that
+## guard's sibling. The suite goes through `targetsForPath`, which is what
+## production goes through.
+##
+## This table covers only the languages that declare a target. A path it does
+## not recognise answers `slUnknown`, and `slUnknown` declares no target, so
+## the command is ABSENT — which is GCL-D17's first row and the honest default
+## (§13: "a language with no producer contributes no command"). It is
+## deliberately NOT a general-purpose path→language function, and it is named
+## `ladderLanguageOfPath` so no caller mistakes it for one.
+
+import std/strutils
+
+import ../../../common/target_axes
+import ./edit_mode_toolbar
+
+export target_axes
+
+type
+  GeneratedCodeTarget* = object
+    ## One rung of a language's ladder (§3.1).
+    id*: string
+      ## The STABLE identifier. This is what a saved layout, a keybinding and a
+      ## tab key persist — never the display name, which is prose, and never a
+      ## positional index, which is what GCL-D11 exists to retire.
+    displayName*: string
+      ## What the user sees and invokes. `commandLabel` prefixes it.
+    generatedFrom*: string
+      ## The predecessor rung's `id`, or `""` for the first rung, which is
+      ## generated from the source language itself. §3.1's chain.
+    producer*: string
+      ## Who supplies the rows. Named on the surface, because a row count
+      ## cannot discriminate two producers that agree on every number
+      ## (GCL-D23).
+
+  TargetAvailability* = enum
+    ## GCL-D17's disabled-versus-hidden split. Three states, because *this
+    ## language has no generated-code view* and *we cannot work out how to
+    ## build your project* have different next actions for the user.
+    gaAbsent
+      ## No command at all. There is nothing to explain.
+    gaEnabled
+    gaDisabled
+      ## The command exists and carries the reason it cannot run.
+
+  TargetCommand* = object
+    target*: GeneratedCodeTarget
+    availability*: TargetAvailability
+    reason*: string
+      ## Non-empty whenever `availability == gaDisabled`, and empty otherwise.
+      ## Same discipline as `CommandProposal.reason`: without the rule,
+      ## "every disabled command explains itself" is satisfied by disabling
+      ## nothing.
+
+  LadderRow = object
+    lang: SourceLanguage
+    extensions: seq[string]
+    targets: seq[GeneratedCodeTarget]
+
+const
+  NoirProducer = "noir-acir-compile"
+    ## `noir_anchor_producer`, reading a `nargo compile` artefact. Distinct
+    ## from the build-time report that `noir_build_producer` carries, which
+    ## names the same function `main` where this one names it `func 0`
+    ## (§14.2) — which is exactly why the surface states which one painted it.
+
+  NativeProducer = "native-debug-info"
+
+proc target(id, displayName, generatedFrom, producer: string):
+    GeneratedCodeTarget {.noSideEffect.} =
+  GeneratedCodeTarget(id: id, displayName: displayName,
+    generatedFrom: generatedFrom, producer: producer)
+
+const LadderRows: seq[LadderRow] = @[
+  LadderRow(
+    lang: slNoir,
+    extensions: @["nr"],
+    targets: @[
+      # GCL-D4: named for the `nargo` invocation that produces the same text
+      # locally. Disagreeing with the toolchain's own vocabulary is a small
+      # permanent tax on every user who runs both.
+      target("noir.acir", "ACIR", "", NoirProducer),
+      target("noir.brillig", "Brillig", "", NoirProducer),
+      # GCL-D5: `After Initial SSA` only, and it is NOT anchorable —
+      # `--show-ssa` emits no location information. It is a listing with no
+      # anchors, offered because reading it is useful, not because it maps.
+      target("noir.ssa", "SSA", "", NoirProducer),
+    ]),
+  LadderRow(
+    lang: slNim,
+    extensions: @["nim"],
+    targets: @[
+      target("nim.c", "Generated C", "", NativeProducer),
+      # THE CHAIN. Assembly is generated from the C, not from the Nim.
+      target("nim.asm", "Assembly", "nim.c", NativeProducer),
+    ]),
+  LadderRow(
+    lang: slC,
+    extensions: @["c", "h"],
+    targets: @[target("c.asm", "Assembly", "", NativeProducer)]),
+  LadderRow(
+    lang: slCpp,
+    extensions: @["cpp", "cc", "cxx", "hpp"],
+    targets: @[target("cpp.asm", "Assembly", "", NativeProducer)]),
+  LadderRow(
+    lang: slRust,
+    extensions: @["rs"],
+    targets: @[target("rust.asm", "Assembly", "", NativeProducer)]),
+  LadderRow(
+    lang: slGo,
+    extensions: @["go"],
+    targets: @[target("go.asm", "Assembly", "", NativeProducer)]),
+]
+
+proc extensionOf(path: string): string {.noSideEffect.} =
+  ## The extension, lowercased, without the dot. `""` when there is none.
+  ##
+  ## The last `.` must come after the last path separator, or `src.v2/main`
+  ## reads as extension `v2/main`.
+  var dot = -1
+  var sep = -1
+  for i in countdown(path.high, 0):
+    if path[i] == '.' and dot < 0:
+      dot = i
+    if (path[i] == '/' or path[i] == '\\') and sep < 0:
+      sep = i
+    if dot >= 0 and sep >= 0:
+      break
+  if dot < 0 or dot < sep or dot == path.high:
+    return ""
+  path[dot + 1 .. path.high].toLowerAscii()
+
+proc ladderLanguageOfPath(path: string): SourceLanguage {.noSideEffect.} =
+  ## The file's language FOR THE PURPOSES OF THIS OPERATION, from the path.
+  ##
+  ## NOT a general path→language function, and not a substitute for one: it
+  ## recognises exactly the languages that declare a ladder, and answers
+  ## `slUnknown` for everything else. `slUnknown` declares no target, so the
+  ## command is absent — GCL-D17's first row.
+  ##
+  ## Reading the PATH rather than `Trace.lang` is §3.1's rule and not a
+  ## convenience: a recording may span several languages, and the generated
+  ## code of the file under the cursor is a fact about that file.
+  let ext = extensionOf(path)
+  if ext.len == 0:
+    return slUnknown
+  for row in LadderRows:
+    for e in row.extensions:
+      if e == ext:
+        return row.lang
+  slUnknown
+
+proc targetsFor(lang: SourceLanguage): seq[GeneratedCodeTarget]
+    {.noSideEffect.} =
+  ## The language's ladder, in rung order. Empty for a language with none.
+  for row in LadderRows:
+    if row.lang == lang:
+      return row.targets
+  @[]
+
+proc targetsForPath*(path: string): seq[GeneratedCodeTarget] {.noSideEffect.} =
+  targetsFor(ladderLanguageOfPath(path))
+
+proc targetById*(id: string; found: var GeneratedCodeTarget): bool
+    {.noSideEffect.} =
+  ## Resolve a persisted identifier. Returns false rather than a zeroed target,
+  ## so a stale saved layout cannot silently address rung zero of some other
+  ## language — the failure GCL-D26 names for instantiation indices, one level
+  ## up.
+  for row in LadderRows:
+    for t in row.targets:
+      if t.id == id:
+        found = t
+        return true
+  false
+
+proc commandLabel*(t: GeneratedCodeTarget): string {.noSideEffect.} =
+  ## What the omnibox and the editor's context menu show. "Show ACIR", "Show
+  ## Generated C" — the target's own display name, never a shared "Show
+  ## Assembly Code" that means a different thing per language.
+  "Show " & t.displayName
+
+# `keybindingTarget` WAS HERE AND IS DELETED.
+#
+# GCL-D11 specifies a keybinding bound to "the first target of the current
+# file's language", so the familiar one-key gesture survives without any
+# binding having to mean different things in different files. NO KEY IS BOUND
+# TO IT, and a resolver for a gesture nobody can make is the same shape as the
+# producer this whole commit exists to reach: correct, tested, and unreachable.
+# The context menu is the open path that exists. When a key is bound, this is
+# three lines over `targetsForPath` — and the binding is what makes them worth
+# writing.
+
+proc commandsForPath*(path: string; proposal: CommandProposal;
+                      platformReason: string = ""): seq[TargetCommand]
+    {.noSideEffect.} =
+  ## GCL-D17's table, evaluated on the same input the Build button uses.
+  ##
+  ## | Situation | The command |
+  ## | --- | --- |
+  ## | the language declares no target | absent — nothing to explain |
+  ## | a target exists, the proposal is `pcCanonical` | enabled |
+  ## | a target exists, the proposal is not `pcCanonical` | disabled, carrying the proposal's own reason |
+  ## | a target exists, the platform cannot run the command | disabled, carrying the platform's sentence |
+  ##
+  ## "No artefact has been built yet" is deliberately NOT a disabling
+  ## condition: invoking the command is what builds it (§8). A target with no
+  ## artefact is `gaEnabled`, and the wait is the answer.
+  ##
+  ## `platformReason` outranks the proposal because it is the more specific
+  ## refusal: a canonical command the platform cannot run is still a command
+  ## that cannot run, and reporting the proposal's silence there would tell the
+  ## user to fix a build file that is already correct.
+  let targets = targetsForPath(path)
+  if targets.len == 0:
+    return @[]
+
+  for t in targets:
+    if platformReason.len > 0:
+      result.add TargetCommand(target: t, availability: gaDisabled,
+        reason: platformReason)
+    elif proposal.confidence != pcCanonical:
+      # `CommandProposal.reason` is non-empty whenever the confidence is not
+      # canonical (EMT-A48), so this branch always carries a sentence. The
+      # fallback exists so a caller that hand-builds a proposal cannot produce
+      # a disabled command with nothing on it — a row that refuses and will not
+      # say why is the failure `absentBecause` exists to prevent.
+      result.add TargetCommand(target: t, availability: gaDisabled,
+        reason: if proposal.reason.len > 0: proposal.reason
+                else: "this project's build command could not be determined")
+    else:
+      result.add TargetCommand(target: t, availability: gaEnabled, reason: "")

--- a/src/frontend/viewmodel/viewmodels/generated_code_vm.nim
+++ b/src/frontend/viewmodel/viewmodels/generated_code_vm.nim
@@ -1,0 +1,532 @@
+## viewmodels/generated_code_vm.nim
+##
+## GeneratedCodeVM — the ON-DEMAND, CURSOR-ANCHORED, TAB-SYNCED half of
+## `GUI/Debugging-Features/Generated-Code-Listing.md`.
+##
+## §1, §2 (GCL-D10), §6 (GCL-D14, GCL-D15, GCL-D16), §7, §8's state table,
+## §9 (GCL-D18), §14.2 (GCL-D23).
+##
+## LANE: `vm-unit` AND `vm-unit-js`. No host, no Monaco, no DOM.
+##
+## ## WHAT THIS ADDS TO A TREE THAT ALREADY HAD THE MODEL
+##
+## `generated_code_anchors` decides what a mapping claim may say, and
+## `noir_anchor_producer` reads a real `nargo compile` artefact into anchors.
+## Both are green against a committed compiler artefact. NEITHER HAD A
+## PRODUCTION CALLER: `setAnchors`, `syncFromSource`, `syncFromGenerated` and
+## `produceAnchors` were reached only from their own suites, which is the
+## defect shape `ci/test/frontend-reachability-guard.py` was written for —
+## a correct, tested capability no product code reaches, whose user-visible
+## face is a feature that looks present and does nothing.
+##
+## So this module is the operation, and `ui/generated_code.nim` is what reaches
+## it. What it adds over the model:
+##
+##   1. **Nothing is computed until it is asked for.** §1: "the operation is
+##      invoked, never permanently displayed."
+##   2. **The cursor is the subject** (GCL-D10), and the relationship between
+##      the two documents is RENDERED rather than implied (GCL-D12).
+##   3. **The listing follows the active source tab**, and a cursor move in a
+##      tab the user is not looking at moves nothing.
+##
+## ## 1. ON DEMAND, AND WHY THAT IS A STRUCTURAL PROPERTY RATHER THAN A HABIT
+##
+## This surface sits beside panes that have caused re-render storms, and a
+## listing recomputed on every cursor move would be the next one. "We only call
+## it when needed" is not a property anything can check. So the model is:
+##
+##   * A closed VM HOLDS NO CURSOR. `noteCursorMoved` on a closed VM writes no
+##     signal and returns `false`. It cannot recompute a listing it does not
+##     have, and it cannot accumulate a position to replay later.
+##   * `openListing` takes the cursor as an ARGUMENT. This is GCL-D16's rule
+##     turned into a signature: projection is a pure function of the landing
+##     position and depends on nothing that happened on the way there, so the
+##     VM never needs a queue of positions it missed while closed, and a
+##     deferred projection is EXACT rather than approximate.
+##   * `revision` increments only when ROWS ARE REPLACED. A cursor move
+##     re-projects and leaves it alone. That is the assertion that separates
+##     "re-anchored" from "recompiled", and it is countable: N cursor moves
+##     over an open listing must leave `revision` where they found it.
+##
+## ## 2. THE THREE ANSWERS, NOT TWO (GCL-D12)
+##
+## The failure ruled out is a surface with two states — *an answer* and
+## *nothing* — where the reader cannot tell a broken query from a correct empty
+## one. `SyncDecision` already carries the distinction (`soAligned` /
+## `soSuspended` / `soDisabled`) and `focusText` is what makes it visible:
+## every non-aligned state renders a sentence, and the aligned state renders
+## which rows correspond to which line. A correspondence the user cannot see is
+## indistinguishable from drift.
+##
+## `instantiationCount` is stated in ALL cases, including one and zero
+## (GCL-D29): otherwise *one instantiation* and *this product has no such
+## concept* look the same, and a reader who expected several cannot tell a
+## correct answer from a missing feature. It is read from `anchorsFromSource`,
+## which returns every anchor the line produced — NOT from the single anchor
+## `syncFromSource` picks, which cannot tell one from three.
+##
+## ## 3. THE TAB IS PART OF THE IDENTITY, NOT AN AMBIENT FACT
+##
+## A listing describes ONE source file. The editor has many tabs, and each has
+## its own cursor. Three rules, and the second is the one an implementation
+## reading an ambient "current line" gets wrong:
+##
+##   * `noteActiveTabChanged` is what moves the listing between files. When the
+##     newly active tab is not the file the listing describes, correspondence
+##     SUSPENDS with a sentence naming both files — it does not silently keep
+##     showing the previous file's anchors against this file's cursor, which is
+##     the confidently-wrong answer §5 exists to prevent.
+##   * `noteCursorMoved` IGNORES a move whose path is not the active tab.
+##     Monaco fires cursor events for background models; a VM that took them
+##     would follow a tab the user is not looking at.
+##   * Reopening the same target for the same file REUSES the listing and
+##     re-projects (§7) rather than rebuilding it — which is the same
+##     `revision` assertion as above, reached by the other gesture.
+##
+## ## 4. STALENESS SUSPENDS; IT DOES NOT CLEAR (GCL-D18)
+##
+## An edit leaves the rows — they describe a real compilation the reader may
+## still want — marks the tab stale, and suspends correspondence, because a
+## stale listing that kept synchronising would move the cursor to confidently
+## wrong lines. Three effects, and `noteSourceEdited` does all three or none;
+## `constraints_vm.editInvalidatesCounts` is the producer's rule about which
+## files matter and is reused rather than restated.
+
+import isonim/core/[signals, computation, owner]
+import isonim/viewmodel
+
+import ./generated_code_anchors
+import ./generated_code_operation
+import ./constraints_vm
+
+export generated_code_anchors
+export generated_code_operation
+
+type
+  ListingState* = enum
+    ## §8's state table, which "must not collapse" its rows. Each of these is a
+    ## different answer to *why am I not looking at a listing*, and a surface
+    ## that renders two of them the same has lost the distinction the model
+    ## went to the trouble of encoding.
+    lsClosed
+      ## Nothing has been requested. No artefact, no rows, no cursor. This is
+      ## the state the product boots in and returns to on close, and it is what
+      ## "on demand" means structurally.
+    lsBuilding
+      ## A build is running FOR THIS SURFACE. §8: the tab is open and shows the
+      ## build; it does not show a spinner over an empty document.
+    lsFailed
+      ## The build failed. No listing, and the compiler's own diagnostic.
+      ## Never the previous successful build's rows.
+    lsReady
+      ## Rows are present.
+
+  GeneratedRow* = object
+    ## One printed row of the compiler's own listing. `index` IS the row index
+    ## the anchors are keyed by — GCL-D6's `row index ≡ opcode index`
+    ## invariant, carried here so a consumer that reorders or filters rows
+    ## cannot silently shift every anchor by a constant.
+    index*: int
+    text*: string
+    annotation*: string
+      ## The compiler's own annotation on this row, where it emitted one —
+      ## an assertion's failure message beside the opcode that enforces it,
+      ## for instance. §14.3: it is preserved rather than stripped as noise,
+      ## because it is what turns a row into a statement about the developer's
+      ## program rather than about the circuit.
+
+  GeneratedListing* = object
+    ## What a producer hands over. §13.1's four requirements land here: rows as
+    ## the compiler prints them, anchors carrying an ordered inlining chain,
+    ## and the artefact's own ceiling.
+    targetId*: string
+    sourcePath*: string
+      ## The file this listing describes. Not a display detail: it is what
+      ## `noteActiveTabChanged` compares against, and a listing that did not
+      ## carry it would have to read the answer from whichever tab happened to
+      ## be in front.
+    producer*: string
+      ## GCL-D23. The surface states it, because a row count cannot
+      ## discriminate two producers that agree on every number.
+    rows*: seq[GeneratedRow]
+    anchors*: seq[MappingAnchor]
+    support*: ArtefactSupport
+    listingAbsence*: string
+      ## Non-empty when the build SUCCEEDED and the producer has anchors and
+      ## totals but no rows (§8's fourth state). Totals with no rows is a
+      ## different answer from a listing that came back empty, and a surface
+      ## that cannot tell a reader which it holds has collapsed them.
+
+  GeneratedCodeVM* = ref object of ViewModel
+    # -- Mutable state --
+    state*: Signal[ListingState]
+    targetId*: Signal[string]
+    targetName*: Signal[string]
+    producer*: Signal[string]
+    listingPath*: Signal[string]
+    rows*: Signal[seq[GeneratedRow]]
+    revision*: Signal[int]
+      ## Increments ONLY when the rows are replaced. A cursor move must leave
+      ## it alone; that is how "re-anchored" is told from "recomputed".
+    anchors*: Signal[seq[MappingAnchor]]
+    listingAbsence*: Signal[string]
+    failure*: Signal[string]
+    activeTabPath*: Signal[string]
+    cursorLine*: Signal[int]
+    syncEnabled*: Signal[bool]
+    stale*: Signal[bool]
+
+    # -- Derived state --
+    isOpen*: Memo[bool]
+    describesActiveTab*: Memo[bool]
+    focus*: Memo[SyncDecision]
+    focusRows*: Memo[(int, int)]
+    instantiationCount*: Memo[int]
+    focusText*: Memo[string]
+    tabTitle*: Memo[string]
+    producerLine*: Memo[string]
+
+proc settingsOf(vm: GeneratedCodeVM): SyncSettings =
+  SyncSettings(enabled: vm.syncEnabled.val)
+
+# ---------------------------------------------------------------------------
+# Opening — the only path that computes anything
+# ---------------------------------------------------------------------------
+
+proc noteBuildStarted*(vm: GeneratedCodeVM; t: GeneratedCodeTarget;
+                       sourcePath: string; cursorLine: int) =
+  ## §8: "while the build runs, the tab is open and shows the build." The tab
+  ## exists from here, so a reader who asked a question can watch it being
+  ## answered instead of looking at a spinner over an empty document.
+  ##
+  ## THE PREVIOUS ROWS GO. A build that is running describes an artefact that
+  ## does not exist yet, and leaving the last successful build's rows on screen
+  ## while it runs is the same defect as leaving them after a failure: a
+  ## developer reading a listing that does not correspond to the source in
+  ## front of them is worse off than one reading nothing.
+  vm.state.val = lsBuilding
+  vm.targetId.val = t.id
+  vm.targetName.val = t.displayName
+  vm.producer.val = t.producer
+  vm.listingPath.val = sourcePath
+  vm.activeTabPath.val = sourcePath
+  vm.cursorLine.val = cursorLine
+  vm.rows.val = @[]
+  vm.anchors.val = @[]
+  vm.listingAbsence.val = ""
+  vm.failure.val = ""
+  vm.stale.val = false
+
+proc noteBuildFailed*(vm: GeneratedCodeVM; diagnostic: string) =
+  ## GCL: "a failed build produces no listing and says so." The rows are
+  ## cleared rather than kept, which is the OPPOSITE of the staleness rule
+  ## below and deliberately so: a stale listing describes a compilation that
+  ## really happened, and a failed build describes none.
+  vm.state.val = lsFailed
+  vm.failure.val =
+    if diagnostic.len > 0: diagnostic
+    else: "the build failed and produced no diagnostic"
+  vm.rows.val = @[]
+  vm.anchors.val = @[]
+
+proc openListing*(vm: GeneratedCodeVM; listing: GeneratedListing;
+                  cursorLine: int) =
+  ## THE ON-DEMAND ENTRY POINT. Everything this surface computes is downstream
+  ## of a call to this proc or to `noteBuildStarted`.
+  ##
+  ## `cursorLine` is an argument rather than something the VM has been
+  ## accumulating, and that is GCL-D16 expressed as a signature: correspondence
+  ## is computed from the leader's position and the artefact's map, and depends
+  ## on nothing that happened on the way there. So a listing opened after a
+  ## hundred cursor moves the VM never saw lands exactly where one opened after
+  ## none would have.
+  ##
+  ## REOPENING THE SAME TARGET FOR THE SAME FILE re-projects and does not
+  ## rebuild (§7: "re-invoking the same target for the same file reuses its tab
+  ## and re-positions it"). `revision` is what says which happened.
+  let sameSurface = vm.state.val == lsReady and
+    vm.targetId.val == listing.targetId and
+    vm.listingPath.val == listing.sourcePath
+
+  vm.state.val = lsReady
+  vm.targetId.val = listing.targetId
+  vm.producer.val = listing.producer
+  vm.listingPath.val = listing.sourcePath
+  vm.activeTabPath.val = listing.sourcePath
+  vm.listingAbsence.val = listing.listingAbsence
+  vm.failure.val = ""
+  vm.stale.val = false
+  vm.cursorLine.val = cursorLine
+
+  var t: GeneratedCodeTarget
+  if targetById(listing.targetId, t):
+    vm.targetName.val = t.displayName
+
+  if not sameSurface:
+    vm.rows.val = listing.rows
+    vm.anchors.val = listing.anchors
+    vm.revision.val = vm.revision.val + 1
+
+proc closeListing*(vm: GeneratedCodeVM) =
+  ## §7: "the tab is closable like any other tab, and closing it is how the
+  ## operation is undone. There is no separate dismissal."
+  ##
+  ## Back to holding nothing, including the cursor: a closed VM that remembered
+  ## a position would start accumulating again the moment it reopened, and
+  ## GCL-D16's equivalence would stop being true.
+  vm.state.val = lsClosed
+  vm.targetId.val = ""
+  vm.targetName.val = ""
+  vm.producer.val = ""
+  vm.listingPath.val = ""
+  vm.activeTabPath.val = ""
+  vm.rows.val = @[]
+  vm.anchors.val = @[]
+  vm.listingAbsence.val = ""
+  vm.failure.val = ""
+  vm.cursorLine.val = 0
+  vm.stale.val = false
+
+# ---------------------------------------------------------------------------
+# The cursor leads
+# ---------------------------------------------------------------------------
+
+proc noteCursorMoved*(vm: GeneratedCodeVM; path: string; line: int): bool
+    {.discardable.} =
+  ## The cursor moved in `path`. Returns whether it was taken.
+  ##
+  ## THREE REFUSALS, and each is a separate defect if it is missing:
+  ##
+  ##   * **Closed.** Nothing is written and nothing is computed. This is what
+  ##     makes the surface on-demand structurally rather than by convention —
+  ##     a closed VM cannot storm, because it holds nothing to recompute.
+  ##   * **Not the active tab.** Monaco fires cursor events for models that are
+  ##     not on screen. A VM that took them would follow a tab the user is not
+  ##     looking at, and the listing would move for a reason nothing visible
+  ##     explains.
+  ##   * **Same line.** `onDidChangeCursorPosition` fires for column moves too,
+  ##     and this surface is line-granular (`SourceRegion` is). Writing the
+  ##     signal for a value that did not change re-runs every memo and the
+  ##     render effect for nothing — the same guard, and the same reason, as
+  ##     `constraints_vm.markStale`'s.
+  ##
+  ## What it does NOT do is rebuild anything. `revision` is untouched here, and
+  ## that is the assertion: the listing is re-anchored, never recomputed.
+  if vm.state.val == lsClosed:
+    return false
+  if path != vm.activeTabPath.val:
+    return false
+  if line == vm.cursorLine.val:
+    return false
+  vm.cursorLine.val = line
+  true
+
+proc noteActiveTabChanged*(vm: GeneratedCodeVM; path: string; line: int): bool
+    {.discardable.} =
+  ## The user switched source tabs. Returns whether it was taken.
+  ##
+  ## The listing follows the ACTIVE tab, which is the whole of "synced tabs".
+  ## When the new tab is a different file from the one the listing describes,
+  ## the correspondence suspends and says so — `describesActiveTab` is what
+  ## carries it, and `focus` reads it. It does not keep projecting the old
+  ## file's anchors against the new file's cursor, which would produce a
+  ## plausible row range that means nothing.
+  ##
+  ## The cursor arrives WITH the tab rather than being asked for afterwards:
+  ## each tab has its own, and a VM that switched tabs and then waited for a
+  ## cursor event would spend the interval showing the previous tab's line
+  ## under the new tab's name.
+  if vm.state.val == lsClosed:
+    return false
+  if path == vm.activeTabPath.val and line == vm.cursorLine.val:
+    return false
+  vm.activeTabPath.val = path
+  vm.cursorLine.val = line
+  true
+
+proc setSyncEnabled*(vm: GeneratedCodeVM; enabled: bool) =
+  ## GCL-D15's toggle. *Off* and *suspended* are different states and render
+  ## differently; this sets the first, and the mapping running out is what
+  ## produces the second.
+  if vm.syncEnabled.val != enabled:
+    vm.syncEnabled.val = enabled
+
+proc noteSourceEdited*(vm: GeneratedCodeVM; path: string) =
+  ## GCL-D18. An edit to a file the producer names as invalidating marks the
+  ## tab stale AND suspends correspondence AND leaves the rows. All three or
+  ## none — an implementation doing the first two blanks a surface that still
+  ## holds a correct answer, and one doing only the first keeps moving the
+  ## cursor to lines the map no longer addresses.
+  ##
+  ## `editInvalidatesCounts` is the Noir producer's rule about which files
+  ## matter (`.nr` sources and `Nargo.toml`, deliberately not `Prover.toml`),
+  ## and it is CALLED rather than restated: two copies of that rule is how the
+  ## label comes to appear on edits that cannot have invalidated anything,
+  ## which costs the credibility the whole mechanism is for.
+  if vm.state.val == lsClosed:
+    return
+  if not editInvalidatesCounts(path):
+    return
+  if not vm.stale.val:
+    vm.stale.val = true
+
+# ---------------------------------------------------------------------------
+# Reading — what the view renders
+# ---------------------------------------------------------------------------
+
+# `rowsFor` / `sourcesFor` wrappers over `counterpartRows` /
+# `counterpartSources` WERE HERE AND ARE DELETED. Nothing outside this module
+# called them: the row range a view needs is already the `focusRows` memo, and
+# the wrappers existed for a renderer that has not been written. An exported
+# convenience with no consumer is the shape
+# `ci/test/frontend-reachability-guard.py` exists to find, and writing one
+# while adding that guard's sibling would have been a poor joke. When a view
+# needs the sources of an aligned decision it can call `counterpartSources`,
+# which this module re-exports.
+
+proc createGeneratedCodeVM*(): GeneratedCodeVM =
+  withViewModel proc(dispose: proc()): GeneratedCodeVM =
+    let state = createSignal(lsClosed)
+    let targetId = createSignal("")
+    let targetName = createSignal("")
+    let producer = createSignal("")
+    let listingPath = createSignal("")
+    let rows = createSignal(newSeq[GeneratedRow]())
+    let revision = createSignal(0)
+    let anchors = createSignal(newSeq[MappingAnchor]())
+    let listingAbsence = createSignal("")
+    let failure = createSignal("")
+    let activeTabPath = createSignal("")
+    let cursorLine = createSignal(0)
+    let syncEnabled = createSignal(DefaultSyncSettings.enabled)
+    let stale = createSignal(false)
+
+    let isOpen = createMemo[bool] proc(): bool =
+      state.val != lsClosed
+
+    let describesActiveTab = createMemo[bool] proc(): bool =
+      state.val != lsClosed and listingPath.val.len > 0 and
+        listingPath.val == activeTabPath.val
+
+    let focus = createMemo[SyncDecision] proc(): SyncDecision =
+      ## The three answers, decided in the order that keeps them distinct.
+      ##
+      ## `soDisabled` is checked FIRST because GCL-D15 requires *you turned it
+      ## off* to survive every other condition: a suspension reported while the
+      ## toggle is off would tell the reader the mapping ran out when in fact
+      ## nothing was asked of it.
+      let settings = SyncSettings(enabled: syncEnabled.val)
+      if not settings.enabled:
+        return SyncDecision(outcome: soDisabled, anchorIndex: NoAnchor,
+          reason: "synchronisation is off")
+      if state.val == lsClosed:
+        return SyncDecision(outcome: soSuspended, anchorIndex: NoAnchor,
+          reason: "no generated-code listing is open")
+      if state.val == lsBuilding:
+        return SyncDecision(outcome: soSuspended, anchorIndex: NoAnchor,
+          reason: "the build is still running, so there is nothing to " &
+            "correspond to yet")
+      if state.val == lsFailed:
+        return SyncDecision(outcome: soSuspended, anchorIndex: NoAnchor,
+          reason: "the build failed, so this listing is from no artefact")
+      if stale.val:
+        # GCL-D18's second effect. The rows are still on screen; the
+        # correspondence is not, because line 40 of the edited file is not the
+        # line 40 the map was built against.
+        return SyncDecision(outcome: soSuspended, anchorIndex: NoAnchor,
+          reason: "the source has been edited since this listing was built, " &
+            "so its line numbers no longer address the text on screen")
+      if listingPath.val != activeTabPath.val:
+        return SyncDecision(outcome: soSuspended, anchorIndex: NoAnchor,
+          reason: "this listing describes " & listingPath.val &
+            "; the active tab is " &
+            (if activeTabPath.val.len > 0: activeTabPath.val else: "no file"))
+      syncFromSource(anchors.val, listingPath.val, cursorLine.val, settings)
+
+    let focusRows = createMemo[(int, int)] proc(): (int, int) =
+      counterpartRows(anchors.val, focus.val)
+
+    let instantiationCount = createMemo[int] proc(): int =
+      ## Stated in ALL cases, including zero and one (GCL-D29). Read from
+      ## `anchorsFromSource`, which returns every anchor the line produced —
+      ## `focus` above picks one and cannot tell one from three.
+      if state.val != lsReady or stale.val or
+          listingPath.val != activeTabPath.val:
+        return 0
+      anchorsFromSource(anchors.val, listingPath.val, cursorLine.val).len
+
+    let focusText = createMemo[string] proc(): string =
+      ## THE RELATIONSHIP, RENDERED. §6: the two documents move together, and a
+      ## correspondence the reader cannot see is indistinguishable from drift.
+      ##
+      ## The aligned sentence names BOTH ENDS — the source line and the row
+      ## range — because naming only one leaves the reader to infer the link
+      ## from two numbers that happen to have moved together, which is the
+      ## inference this document refuses to delegate everywhere else.
+      let d = focus.val
+      case d.outcome
+      of soDisabled:
+        d.reason
+      of soSuspended:
+        d.reason
+      of soAligned:
+        let (first, last) = counterpartRows(anchors.val, d)
+        let count = anchorsFromSource(anchors.val, listingPath.val,
+          cursorLine.val).len
+        var s = listingPath.val & ":" & $cursorLine.val & " → rows " &
+          $first & (if last != first: "–" & $last else: "")
+        # The count is part of the sentence rather than a separate chrome,
+        # because GCL-D29 requires it stated even where the picker's chrome is
+        # absent: otherwise one instantiation and "this product has no such
+        # concept" look the same.
+        s.add ", " & $count &
+          (if count == 1: " instantiation" else: " instantiations")
+        s
+    let tabTitle = createMemo[string] proc(): string =
+      ## §7: "a tab carries the identity of what it shows: the file, the
+      ## target's display name". A tab titled only *Assembly* cannot be told
+      ## from another file's. The `(stale)` suffix is GCL-D18's first effect,
+      ## and it is the same spelling `constraints_vm.headlineFor` uses.
+      if state.val == lsClosed:
+        return ""
+      var s = listingPath.val
+      if targetName.val.len > 0:
+        s.add " — " & targetName.val
+      if stale.val:
+        s.add " (stale)"
+      s
+
+    let producerLine = createMemo[string] proc(): string =
+      ## GCL-D23: the producer is named ON THE SURFACE. A reader who sees two
+      ## different answers over a session must be able to tell which is which
+      ## without counting rows — and a row count cannot discriminate them,
+      ## because the two producers agree on every number.
+      if state.val == lsClosed or producer.val.len == 0:
+        return ""
+      "listing produced by " & producer.val
+
+    GeneratedCodeVM(
+      state: state,
+      targetId: targetId,
+      targetName: targetName,
+      producer: producer,
+      listingPath: listingPath,
+      rows: rows,
+      revision: revision,
+      anchors: anchors,
+      listingAbsence: listingAbsence,
+      failure: failure,
+      activeTabPath: activeTabPath,
+      cursorLine: cursorLine,
+      syncEnabled: syncEnabled,
+      stale: stale,
+      isOpen: isOpen,
+      describesActiveTab: describesActiveTab,
+      focus: focus,
+      focusRows: focusRows,
+      instantiationCount: instantiationCount,
+      focusText: focusText,
+      tabTitle: tabTitle,
+      producerLine: producerLine,
+      disposeProc: dispose,
+    )

--- a/src/frontend/viewmodel/viewmodels/noir_build_producer.nim
+++ b/src/frontend/viewmodel/viewmodels/noir_build_producer.nim
@@ -223,6 +223,27 @@ proc escapeHtmlText*(text: string): string =
     of '\'': result.add "&#39;"
     else: result.add ch
 
+proc rendererPathFor*(projectRoot, packageDir, vfsPath: string): string =
+  ## `rendererPath`'s rule, WITHOUT a producer.
+  ##
+  ## Extracted because a second consumer arrived and the alternative was a
+  ## second copy: the generated-code listing anchors its rows to source
+  ## positions the compiler spells the same way a diagnostic's `file` is
+  ## spelled, and it has to compare them against the path the editor opened a
+  ## tab by. Two copies of this rule is how one of them comes to disagree, and
+  ## the disagreement is invisible — a listing whose anchors never match the
+  ## cursor simply reports "no generated code is mapped to this line" for every
+  ## line in the file, which looks exactly like an artefact with no debug
+  ## information.
+  ##
+  ## `rendererPath` below is now this function with the producer's two fields
+  ## read out of it, so there is one rule and one place to correct it.
+  if vfsPath.len == 0: return ""
+  let prefix = packageDir & "/"
+  if packageDir.len > 0 and vfsPath.startsWith(prefix):
+    return projectRoot & "/" & vfsPath[prefix.len .. ^1]
+  vfsPath
+
 proc rendererPath*(producer: NoirBuildProducer; vfsPath: string): string =
   ## A diagnostic's `file` in the spelling the renderer opens tabs by.
   ##
@@ -242,11 +263,7 @@ proc rendererPath*(producer: NoirBuildProducer; vfsPath: string): string =
   ## having a slash bolted on: the stdlib's own sources reach diagnostics
   ## occasionally, and inventing a project-relative identity for them would
   ## make a row claim the project contains a file it does not.
-  if vfsPath.len == 0: return ""
-  let prefix = producer.packageDir & "/"
-  if producer.packageDir.len > 0 and vfsPath.startsWith(prefix):
-    return producer.projectRoot & "/" & vfsPath[prefix.len .. ^1]
-  vfsPath
+  rendererPathFor(producer.projectRoot, producer.packageDir, vfsPath)
 
 proc buildSeverityOf*(severity: NoirDiagnosticSeverity): BuildLineSeverity =
   ## `PositionedDiagnostic.severity` → the pane's severity.


### PR DESCRIPTION
## What this closes

`noir_anchor_producer` reads a committed `nargo compile` artefact and is green on GCL-A1..A6. `generated_code_anchors` owns the fidelity ladder and both directions of the correspondence. `low_level_code_vm` can install anchors and project a source line through them, and `test_low_level_code_view_anchors.nim` asserts the view renders a fidelity badge per row and tells the three not-aligned states apart.

**None of it had a production caller.** Measured against `origin/dev` at `a861f5b7b`, four links of the chain were reachable only from their own suites:

```
produceAnchors      noir_anchor_producer.nim
readArtefactJson    noir_anchor_producer.nim
setAnchors          low_level_code_vm.nim
syncFromSourceLine  low_level_code_vm.nim
```

`frontend-reachability-guard.py` reported all four — in `--report` mode, inside a backlog of 1,228, exiting 0.

## The operation

- **On demand.** The compile sink assigns strings; parsing, call-stack resolution and anchor production happen only in `showGeneratedCode`, reached from the editor context menu. `revision` counts row replacements, so 50 cursor moves leave it untouched while the focused rows really do change.
- **Cursor-anchored, visibly.** `openListing` takes the cursor as an argument (GCL-D16 as a signature). `focusText` names both ends — `src/main.nr:9 -> rows 4-6, 2 instantiations`. Aligned / suspended / off render three different texts.
- **Synced tabs.** A cursor move from a background model is refused; switching to a file the listing does not describe suspends with a sentence naming both files.
- **One command per target, named** (GCL-D11), with GCL-D17's disabled-with-a-reason arm.

The instantiation count comes from a new `anchorsFromSource`, which returns **every** anchor a line produced. `syncFromSource` returns the first by construction, and §13.1 is explicit that this "is not a narrower version of the right answer".

## Two defects found while wiring, both of which would have shipped looking finished

1. **The anchors were in the compiler's spelling and the cursor in the editor's.** `file_map` says `hello_noir/src/main.nr`; the tab is `/hello_noir/src/main.nr`. Every query missed, and the surface reported "no anchor over this line" for every line — true, and indistinguishable from a build with no debug info. `rendererPathFor` (extracted from the build pane's existing rule, not restated) + `rebaseSources` fix it, asserted in **both** arms because the failing one is invisible.
2. **Nothing painted the listing.** `openTab(name, ViewInstructions)` opens a view fed by `CtLoadAsmFunction` that knows nothing about a compile artefact — the tab opened blank. It now paints into the Low Level Code pane, which already renders fidelity per row, the three sync states and the toggle. §7 asks for a tab and this is a pane; the divergence is recorded in both modules rather than glossed.

## The gate, watched failing

`ci/test/generated-code-operation-guard.py` — 24 links of one chain, at enforce, no ceiling, no allow-list.

| tree | exit | findings |
| --- | --- | --- |
| `origin/dev` a861f5b7b | **1** | 22 broken (4 TEST-ONLY, 18 MISSING) |
| this branch | **0** | 0 |

Its header records that measurement, and names the two links that do *not* go red there and why (`syncFromSource` via an unreached caller; `noteSourceEdited` via a same-named proc) — both under-reports, which is the direction a guard should err in.

The repo-wide ratchet could not have caught any of this: a chain that breaks inside a 1,228 ceiling reddens nothing.

## Also in here

- **Two pre-existing `vm-unit` reds fixed.** `test_generated_code_anchors` asserted a suspension says it is *suspended* and a gap says it is not *interpolated*; the messages had drifted to "so these panes are not kept in step". The assertions are the spec, so the messages moved.
- **Reachability backlog 1228 -> 1223**, five below the recorded ceiling. `keybindingTarget` and three ungestured wrappers were deleted rather than shipped: no key or button is bound to either.

## Measured locally

- `test_generated_code_operation.nim` (new): 263 counted assertions, green on `vm-unit` and `vm-unit-js`. The constant's comment decomposes every change to it.
- `test_generated_code_anchors`, `test_noir_anchor_producer`, `test_noir_generated_listing`, `test_low_level_code_view_anchors`, `test_constraints_stale_on_edit`: green.
- Renderer builds green under `-d:ctWeb` and `-d:ctInExtension`; the whole chain including `showGeneratedListing`, `setAnchors`, `syncFromSourceLine` and `rowsFor` is present in the shipped bundle.
- `test_noir_build_producer` has one failing case (`could not decode`) — **verified pre-existing** by swapping `origin/dev`'s copy of the module in and reproducing it.
- `ci-contract-suites` / "docs publish channels" fails 3 checks on CI and passes locally; this branch touches no docs file.

## Deliberately not built

GCL-D19's removal from the default layouts; the instantiation picker's chrome (the count is stated, previous/next/search are not); the keybinding and the sync toggle's control; the SSA and native producers; the browser arm of GCL-A12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)