### PR TITLE
ci: run the AppImage cross-distro job on eph-linux-x64

### DIFF
--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -3970,12 +3970,15 @@ jobs:
   # don't need FUSE in the runner.  See
   # scripts/test-appimage-cross-distro.sh.
   appimage-cross-distro:
-    # Self-hosted on the nested-Docker class: this job's core is a 5-distro
-    # Docker matrix (scripts/test-appimage-cross-distro.sh pulls
-    # ubuntu/debian/fedora/arch images and runs the AppImage inside each), and
-    # eph-linux-x64-nested is the Incus class that exposes an in-guest Docker
-    # daemon (security.nesting + fuse-overlayfs). aws-cli comes from nixpkgs.
-    runs-on: eph-linux-x64-nested
+    # Self-hosted: this job's core is a 5-distro Docker matrix
+    # (scripts/test-appimage-cross-distro.sh pulls ubuntu/debian/fedora/arch
+    # images and runs the AppImage inside each), so it needs an in-guest Docker
+    # daemon. Every `eph-linux-x64` container now provides one: the runner-image
+    # consolidation folded the retired nested golden's capability into the single
+    # `vmh-linux-runner` image (security.nesting + nested KVM + docker/fuse3
+    # baked), so nested Docker is no longer a separate class. aws-cli comes from
+    # nixpkgs.
+    runs-on: eph-linux-x64
     needs:
       - appimage-build
     strategy:


### PR DESCRIPTION
`appimage-cross-distro` needs an in-guest Docker daemon (it pulls ubuntu/debian/fedora/arch images and runs the AppImage inside each), which used to mean targeting a separate runner class.

That class no longer carries any extra capability: the Linux runner-image consolidation bakes Docker, qemu/KVM and fuse3 into the single image and enables nesting for every `eph-linux-x64` container. `eph-linux-x64-nested` is now a transitional alias resolving to the same container.

Moving the job to `eph-linux-x64` lets that alias be retired, which frees its reserved slots back into the shared pool.

No behaviour change expected — same container, larger pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4JgdPtUJfzSSa61DA7Xkz