### PR TITLE
ci: run the DAP flow workflows on dev, the branch this repo merges into

### DIFF
--- a/.github/workflows/beam-flow.yml
+++ b/.github/workflows/beam-flow.yml
@@ -20,7 +20,10 @@ on:
       - 'scripts/resolve-sibling-rev.sh'
       - '.github/workflows/beam-flow.yml'
   push:
-    branches: [main]
+    # This repo's mainline is `dev` (`stable` is the release branch). The
+    # filter previously named `main`, a branch this repo does not have, so
+    # no mainline push ever triggered this workflow.
+    branches: [dev, stable]
     paths:
       - 'src/db-backend/**'
       - 'libs/ct-dap-client/**'

--- a/.github/workflows/mcr-dap-flow.yml
+++ b/.github/workflows/mcr-dap-flow.yml
@@ -24,7 +24,10 @@ on:
       - 'justfile'
       - '.github/workflows/mcr-dap-flow.yml'
   push:
-    branches: [main]
+    # This repo's mainline is `dev` (`stable` is the release branch). The
+    # filter previously named `main`, a branch this repo does not have, so
+    # no mainline push ever triggered this workflow.
+    branches: [dev, stable]
     paths:
       - 'src/db-backend/**'
       - 'libs/ct-dap-client/**'


### PR DESCRIPTION
## Problem

`beam-flow.yml` and `mcr-dap-flow.yml` filtered their `push:` trigger on `main` — a branch this repository does not have. Every merge lands on `dev`, so the filter matched nothing and neither cross-repo DAP flow check ever ran on a mainline push. They ran on pull requests only, which left the merged state of `dev` unverified.

## Change

| File | Trigger | Before | After |
|---|---|---|---|
| `.github/workflows/beam-flow.yml` | `push.branches` | `[main]` | `[dev, stable]` |
| `.github/workflows/mcr-dap-flow.yml` | `push.branches` | `[main]` | `[dev, stable]` |

`main` is dropped because it does not exist here; `stable` is the release branch. The `paths:` lists and the `pull_request:` triggers are untouched, so the set of changes that can trigger these workflows is unchanged — only the branch they fire on is corrected.

`deploy-web-codetracer.yml` is deliberately left alone: it targets the real `cloud` branch and is a deliberately scoped deploy.

## Validation

`actionlint` was run over both files before and after the change. The findings are byte-identical (2 expression, 8 runner-label, 26 shellcheck — all pre-existing and inside `run:` scripts), so no new issue is introduced and the YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4JgdPtUJfzSSa61DA7Xkz