### PR TITLE
ci: declare the web deploy exempt from the mainline-filter guard

### DIFF
--- a/.github/workflows/deploy-web-codetracer.yml
+++ b/.github/workflows/deploy-web-codetracer.yml
@@ -127,6 +127,13 @@ name: Deploy ide.codetracer.com
 #   workflow does not create it.
 # ---------------------------------------------------------------------------
 
+# ci-mainline-exempt: deploys ide.codetracer.com; `cloud` is the deploy branch and a mainline push must not reach production
+#
+# The filter below names `cloud` and no mainline branch. That is deliberate, not
+# the "filter omits the mainline" defect: this workflow publishes to production,
+# so a push to `dev` must NOT trigger it. The marker above declares that to the
+# shared branch-filter guard.
+
 on:
   push:
     branches: [cloud]


### PR DESCRIPTION
Follow-up to #711.

A shared guard (metacraft-github-actions #14) fails CI when a workflow's `branches:` filter does not name the repo's mainline. `deploy-web-codetracer.yml` triggers on `push: branches: [cloud]` and that is **correct** — it publishes to production, so a push to `dev` must not reach it. To the guard, though, a correct scoped deploy is indistinguishable from the defect, so the file declares itself.

## Change

Comment only. Added above the `on:` block:

    # ci-mainline-exempt: deploys ide.codetracer.com; `cloud` is the deploy branch and a mainline push must not reach production

plus a short note explaining why the narrow filter is deliberate.

**The `on:` block is unchanged** — still `push: branches: [cloud]` and `workflow_dispatch:`. There is no trigger effect whatsoever.

One deviation from the suggested wording: the reason says **`ide.codetracer.com`**, not `web.codetracer.com`. This file's own header states that `web.codetracer.com` "is not a name this repo targets any more" and that `ide.` is the product's primary domain — the workflow is even named `Deploy ide.codetracer.com`. The `web-codetracer` spelling survives only as the Cloudflare Pages project and this filename. The marker prefix is exactly as specified; only the human-readable reason is corrected to match reality.

## Validation

`actionlint` before and after: findings byte-identical (1 runner-label, 18 shellcheck — all pre-existing), so the YAML still parses and nothing new is flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4JgdPtUJfzSSa61DA7Xkz