### PR TITLE
fix(windows): bound bootstrap downloads on inactivity, not just on total time

### DIFF
--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -514,6 +514,19 @@ jobs:
             }
           }
 
+      - name: Validate env.ps1 component decomposition
+        shell: pwsh
+        # Asserts every gated component in env.ps1's dispatch block is
+        # accounted for in the per-component decomposition, and that the
+        # accounting helpers record what they claim. The coverage check is
+        # mechanical (an AST parse of env.ps1) rather than by eye, so a
+        # component added or removed later cannot fall out unnoticed. Hermetic and cheap:
+        # it parses env.ps1 and exercises the helpers against a temp
+        # directory. It installs no toolchain and downloads nothing, so it
+        # belongs in this smoke job rather than behind a real provision.
+        run: |
+          pwsh -File ci/test/bootstrap-decomposition.ps1
+
       - name: Validate toolchain-versions.env
         shell: pwsh
         run: |
@@ -1253,6 +1266,31 @@ jobs:
             codetracer-trace-format=dev
             codetracer-trace-format-nim=dev
             codetracer-native-recorder=dev
+
+      - name: Upload env.ps1 component decomposition
+        # env.ps1 writes a per-component breakdown of the bootstrap -- wall
+        # clock, install size and relocatability class per component, plus the
+        # install-root total -- to `.tmp/windows-diy/`. This runner is
+        # EPHEMERAL: without this step the file is destroyed with the VM and
+        # the measurement may as well not have been taken.
+        #
+        # `if: always()` is the whole point. env.ps1 emits the report from a
+        # `finally`, so a run that dies mid-bootstrap still publishes a partial
+        # table naming the component it died in and what everything before it
+        # cost -- which is the more useful artifact while the lane is red. A
+        # success-only upload would collect the report exactly when it is least
+        # needed.
+        #
+        # `if-no-files-found: ignore` because this also runs when the bootstrap
+        # never got far enough to write anything, and a missing report must not
+        # become a second, misleading failure.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-env-decomposition
+          path: .tmp/windows-diy/windows-env-decomposition.json
+          if-no-files-found: ignore
+          retention-days: 30
 
       - name: Remove WSL bash stub from System32
         # db-backend's build.rs runs ``Command::new("bash") ...

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -527,6 +527,21 @@ jobs:
         run: |
           pwsh -File ci/test/bootstrap-decomposition.ps1
 
+      - name: Validate bootstrap download and native-command bounds
+        shell: pwsh
+        # Asserts that a stalled toolchain download fails fast with a real
+        # error instead of blocking until the job timeout, and likewise for
+        # the native commands the MSYS2 leg shells out to. The checks are
+        # NEGATIVE: each bound is driven against a loopback server or a child
+        # process that genuinely never finishes, because a timeout that has
+        # only run on the happy path has not been tested. Hermetic -- the
+        # server is a loopback socket in a background job, nothing leaves the
+        # machine and no toolchain is installed -- so it belongs in this
+        # smoke job rather than behind a real provision.
+        timeout-minutes: 10
+        run: |
+          pwsh -File ci/test/download-stall-bound.ps1
+
       - name: Validate toolchain-versions.env
         shell: pwsh
         run: |

--- a/.github/workflows/windows-msys2-provision-check.yml
+++ b/.github/workflows/windows-msys2-provision-check.yml
@@ -9,9 +9,9 @@
 #
 # But `codetracer.yml` has no `workflow_dispatch` inputs, so dispatching it
 # starts the widest matrix in this repository, several jobs of which contend
-# for the same two Windows runner slots. That is a poor trade for exercising
-# one component, and on a lane whose known failure mode is a multi-hour hang it
-# is an actively bad one.
+# for the same scarce Windows runners. That is a poor trade for exercising one
+# component, and on a lane whose known failure mode is a long hang it is an
+# actively bad one.
 #
 # `WINDOWS_DIY_ONLY=NIM` reduces the bootstrap to the single phase that reaches
 # `Ensure-Nim` -> `Ensure-TupMsys2BuildPrereqs`, which is exactly the code under

--- a/.github/workflows/windows-msys2-provision-check.yml
+++ b/.github/workflows/windows-msys2-provision-check.yml
@@ -1,0 +1,71 @@
+# A NARROW, MANUALLY-DISPATCHED PROBE OF THE WINDOWS BOOTSTRAP'S MSYS2 LEG.
+#
+# WHY THIS EXISTS RATHER THAN DISPATCHING `codetracer.yml`.
+#
+# The MSYS2 leg of `env.ps1` -- the base-tarball download, its SHA check, the
+# `tar` extraction and the `pacman` install -- is reachable only by actually
+# provisioning, so a change to how those operations are bounded cannot be
+# validated by any amount of local testing. It has to run on `eph-win-x64`.
+#
+# But `codetracer.yml` has no `workflow_dispatch` inputs, so dispatching it
+# starts the widest matrix in this repository, several jobs of which contend
+# for the same two Windows runner slots. That is a poor trade for exercising
+# one component, and on a lane whose known failure mode is a multi-hour hang it
+# is an actively bad one.
+#
+# `WINDOWS_DIY_ONLY=NIM` reduces the bootstrap to the single phase that reaches
+# `Ensure-Nim` -> `Ensure-TupMsys2BuildPrereqs`, which is exactly the code under
+# test and nothing else.
+#
+# THE TIMEOUT IS DELIBERATELY TIGHT. The point of this lane is to find out
+# QUICKLY whether the bounded download fires, succeeds, or is never reached. A
+# generous cap would reintroduce the thing being fixed: a job that tells you
+# nothing for hours. If the bounds work, a stall now surfaces as a real error in
+# minutes, so a run that needs more than 30 is itself the finding.
+#
+# `workflow_dispatch` only: this never triggers on push or pull_request, and it
+# consumes a Windows slot only when somebody asks for it.
+name: Windows MSYS2 provision check
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: windows-msys2-provision-check-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  msys2-provision:
+    runs-on: eph-win-x64
+    timeout-minutes: 30
+    steps:
+      # `actions/checkout` needs a real git on PATH on these guests; without one
+      # it falls back to the REST API. This job does not need submodules, so a
+      # shallow default checkout is enough.
+      - uses: actions/checkout@v4
+
+      # Cheap and hermetic, and it runs the bounds' own tests on a REAL Windows
+      # host rather than only on Linux pwsh. If the negative tests behave
+      # differently here, that matters more than the provisioning result.
+      - name: Validate download and native-command bounds
+        shell: pwsh
+        timeout-minutes: 10
+        run: pwsh -File ci/test/download-stall-bound.ps1
+
+      - name: Provision only the NIM phase (reaches the MSYS2 leg)
+        shell: pwsh
+        timeout-minutes: 15
+        env:
+          WINDOWS_DIY_ONLY: NIM
+          # Keep the failure signal fast and specific. These are well under the
+          # shipped defaults on purpose: this lane is a probe, and a stall here
+          # should be reported in minutes rather than waited out.
+          CODETRACER_DOWNLOAD_STALL_SECONDS: "60"
+          CODETRACER_DOWNLOAD_TIMEOUT_SECONDS: "600"
+          CODETRACER_NATIVE_COMMAND_TIMEOUT_SECONDS: "600"
+        run: |
+          . ./env.ps1
+          Write-Host "NIM phase completed without hanging."

--- a/ci/test/bootstrap-decomposition.ps1
+++ b/ci/test/bootstrap-decomposition.ps1
@@ -1,0 +1,530 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# Gate for the env.ps1 per-component decomposition: a machine-readable
+# per-component table that must cover every gated component in env.ps1's
+# dispatch block, checked mechanically against that dispatch list rather than
+# by eye, so a component added or removed later cannot silently fall out of
+# the decomposition.
+#
+# The mechanical check has two halves, because either alone can pass while
+# the decomposition is wrong:
+#
+#   1. STATIC (AST): every Ensure-* call in env.ps1's gated dispatch block
+#      goes through Invoke-BootstrapStep. This is what stops a newly added
+#      component from being invisible to the report -- a bare `Ensure-Foo`
+#      would install a tool that the decomposition never mentions, and the
+#      omission would be indistinguishable from a component that costs
+#      nothing.
+#
+#   2. BEHAVIOURAL: Invoke-BootstrapStep and Write-BootstrapStepReport
+#      actually record what they claim, against a real filesystem -- skips,
+#      failures, sizes, and the reparse-point exclusion that keeps the
+#      install-root total from double-counting junctions.
+#
+# NO MOCKS. Per the workspace policy on mock objects, this file uses none:
+# the AST half parses the real env.ps1, and the behavioural half runs the
+# real functions from the real toolchain-utils.ps1 against real directories
+# under a temporary root. The only substitution is that the scriptblocks
+# passed to Invoke-BootstrapStep create directories directly instead of
+# downloading a toolchain -- that is the test's own subject matter (what the
+# wrapper does with an arbitrary action), not a stand-in for a collaborator.
+#
+# Runs on Linux/macOS pwsh as well as Windows: nothing here needs a Windows
+# API. The reparse-point case is skipped where the platform cannot create a
+# symlink without elevation, and says so.
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$envPs1Path = Join-Path $repoRoot "env.ps1"
+$utilsPath = Join-Path $repoRoot "non-nix-build/windows/toolchain-utils.ps1"
+
+$script:Failures = 0
+$script:Checks = 0
+
+function Assert-True {
+  param([bool]$Condition, [string]$Message)
+  $script:Checks++
+  if (-not $Condition) {
+    $script:Failures++
+    Write-Host "  FAIL: $Message"
+  } else {
+    Write-Host "  ok:   $Message"
+  }
+}
+
+function Assert-Equal {
+  param($Expected, $Actual, [string]$Message)
+  Assert-True -Condition ($Expected -eq $Actual) -Message "$Message (expected '$Expected', got '$Actual')"
+}
+
+# ---------------------------------------------------------------------------
+# Part 1 - static: the dispatch block routes every component through the
+# accounting wrapper.
+# ---------------------------------------------------------------------------
+
+Write-Host "== dispatch-block coverage (AST of env.ps1)"
+
+if (-not (Test-Path -LiteralPath $envPs1Path -PathType Leaf)) {
+  throw "env.ps1 not found at '$envPs1Path'."
+}
+
+$parseErrors = $null
+$envAst = [System.Management.Automation.Language.Parser]::ParseFile(
+  $envPs1Path, [ref]$null, [ref]$parseErrors)
+if ($parseErrors.Count -gt 0) {
+  $parseErrors | ForEach-Object { Write-Host "  env.ps1: $($_.Message)" }
+  throw "env.ps1 does not parse."
+}
+
+function Get-CommandAsts {
+  param($Ast, [string]$NamePattern)
+  return @($Ast.FindAll({
+    param($node)
+    ($node -is [System.Management.Automation.Language.CommandAst]) -and
+    ($null -ne $node.GetCommandName()) -and
+    ($node.GetCommandName() -like $NamePattern)
+  }, $true))
+}
+
+# The gated dispatch block is the `if ($doSync) { ... }` whose body contains
+# the Invoke-BootstrapStep calls. env.ps1 has more than one `if ($doSync)`
+# -- the other guards Ensure-NodeTooling -- so it is identified by content
+# rather than by position, which also keeps this gate working when the file
+# is edited above it.
+$dispatchBlocks = @($envAst.FindAll({
+  param($node)
+  ($node -is [System.Management.Automation.Language.IfStatementAst]) -and
+  (@(Get-CommandAsts -Ast $node -NamePattern "Invoke-BootstrapStep").Count -gt 0)
+}, $true))
+
+# FindAll returns nested matches too (an outer `if` containing the real one).
+# The dispatch block is the innermost such statement.
+$dispatchBlock = $dispatchBlocks |
+  Sort-Object -Property { $_.Extent.EndOffset - $_.Extent.StartOffset } |
+  Select-Object -First 1
+
+Assert-True -Condition ($null -ne $dispatchBlock) `
+  -Message "env.ps1 contains an `$doSync dispatch block using Invoke-BootstrapStep"
+
+if ($null -eq $dispatchBlock) {
+  Write-Host "FAILED: cannot continue without the dispatch block."
+  exit 1
+}
+
+$stepCalls = @(Get-CommandAsts -Ast $dispatchBlock -NamePattern "Invoke-BootstrapStep")
+$ensureCalls = @(Get-CommandAsts -Ast $dispatchBlock -NamePattern "Ensure-*")
+
+# Every Ensure-* call inside the block must sit inside the extent of some
+# Invoke-BootstrapStep call -- i.e. inside its -Action scriptblock.
+$uncovered = @()
+foreach ($ensure in $ensureCalls) {
+  $covered = $false
+  foreach ($step in $stepCalls) {
+    if ($ensure.Extent.StartOffset -ge $step.Extent.StartOffset -and
+        $ensure.Extent.EndOffset -le $step.Extent.EndOffset) {
+      $covered = $true
+      break
+    }
+  }
+  if (-not $covered) {
+    $uncovered += "$($ensure.GetCommandName()) at line $($ensure.Extent.StartLineNumber)"
+  }
+}
+
+Assert-True -Condition ($uncovered.Count -eq 0) `
+  -Message ("every Ensure-* call in the dispatch block goes through Invoke-BootstrapStep" +
+            $(if ($uncovered.Count -gt 0) { " (uncovered: $($uncovered -join '; '))" } else { "" }))
+
+# A leftover bare `Test-BootstrapStepEnabled` gate in this block means a
+# component is gated but unaccounted: it would run without being timed.
+$rawGates = @(Get-CommandAsts -Ast $dispatchBlock -NamePattern "Test-BootstrapStepEnabled")
+Assert-Equal -Expected 0 -Actual $rawGates.Count `
+  -Message "no bare Test-BootstrapStepEnabled gate remains in the dispatch block"
+
+# Extract the declared -Step and -Relocatability of each call.
+$declared = @()
+foreach ($step in $stepCalls) {
+  $stepName = $null
+  $class = $null
+  for ($i = 0; $i -lt $step.CommandElements.Count; $i++) {
+    $element = $step.CommandElements[$i]
+    if ($element -is [System.Management.Automation.Language.CommandParameterAst]) {
+      $next = if (($i + 1) -lt $step.CommandElements.Count) { $step.CommandElements[$i + 1] } else { $null }
+      $value = $null
+      if ($next -is [System.Management.Automation.Language.StringConstantExpressionAst]) {
+        $value = $next.Value
+      }
+      switch ($element.ParameterName) {
+        "Step" { $stepName = $value }
+        "Relocatability" { $class = $value }
+      }
+    }
+  }
+  $declared += [pscustomobject]@{ step = $stepName; relocatability = $class; line = $step.Extent.StartLineNumber }
+}
+
+$validClasses = @("relocatable", "junction", "installer")
+$badClass = @($declared | Where-Object { $validClasses -notcontains $_.relocatability })
+Assert-True -Condition ($badClass.Count -eq 0) `
+  -Message ("every dispatched component declares a valid relocatability class" +
+            $(if ($badClass.Count -gt 0) { " (bad: $(($badClass | ForEach-Object { "$($_.step)=$($_.relocatability)" }) -join ', '))" } else { "" }))
+
+$missingName = @($declared | Where-Object { [string]::IsNullOrWhiteSpace($_.step) })
+Assert-Equal -Expected 0 -Actual $missingName.Count `
+  -Message "every dispatched component declares a literal -Step name"
+
+$names = @($declared | ForEach-Object { $_.step })
+$duplicates = @($names | Group-Object | Where-Object { $_.Count -gt 1 } | ForEach-Object { $_.Name })
+Assert-True -Condition ($duplicates.Count -eq 0) `
+  -Message ("component names are unique" + $(if ($duplicates.Count -gt 0) { " (duplicated: $($duplicates -join ','))" } else { "" }))
+
+# There are 22 gated components today. Assert the floor rather than equality:
+# adding a component is legitimate and must not break this gate, whereas
+# losing one silently is the failure mode the gate exists for.
+Assert-True -Condition ($stepCalls.Count -ge 22) `
+  -Message "the dispatch block covers at least the 22 known gated components (found $($stepCalls.Count))"
+
+# ...and the NAMES, not just the count. A count floor alone is defeated by the
+# most likely edit of all: one component dropped while another is added, which
+# leaves the total at 22 and the decomposition quietly missing a tool. Pinning
+# the names makes a removal an explicit, reviewable edit to this list rather
+# than an invisible consequence of an unrelated change. Additions still need no
+# edit here -- this is a required SUBSET, not an exact set.
+$requiredComponents = @(
+  "TTD", "NODE", "UV", "GCC", "GNAT", "GO", "LDC", "VLANG", "FPC", "ZSTD",
+  "ZLIB", "LLVM", "CLINGO", "RUST", "JUST", "NEXTEST", "NIM", "CAPNP", "TUP",
+  "NARGO", "DOTNET", "CT_REMOTE"
+)
+$missingComponents = @($requiredComponents | Where-Object { $names -notcontains $_ })
+Assert-True -Condition ($missingComponents.Count -eq 0) `
+  -Message ("every known gated component is still dispatched" +
+            $(if ($missingComponents.Count -gt 0) { " (missing: $($missingComponents -join ','))" } else { "" }))
+
+Write-Host "  components dispatched: $(($names | Sort-Object) -join ', ')"
+
+# ---------------------------------------------------------------------------
+# Part 2 - behavioural: the wrapper and the report record what they claim.
+# ---------------------------------------------------------------------------
+
+Write-Host "== Invoke-BootstrapStep / Write-BootstrapStepReport behaviour"
+
+. $utilsPath
+
+$testRoot = Join-Path ([IO.Path]::GetTempPath()) ("ct-decomp-" + [Guid]::NewGuid().ToString('N'))
+$installRoot = Join-Path $testRoot "install"
+$reportDir = Join-Path $testRoot "report"
+New-Item -ItemType Directory -Force -Path $installRoot | Out-Null
+
+try {
+  Reset-BootstrapStepRecords
+
+  # A component that installs something: 3 files of known size.
+  Invoke-BootstrapStep -Step "ALPHA" -Relocatability relocatable -Root $installRoot -Action {
+    $dir = Join-Path $installRoot "alpha/1.0"
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    foreach ($name in @("a.bin", "b.bin", "c.bin")) {
+      [IO.File]::WriteAllBytes((Join-Path $dir $name), (New-Object byte[] 1000))
+    }
+  }
+
+  # A component disabled by its skip variable.
+  $env:WINDOWS_DIY_SKIP_BETA = "1"
+  try {
+    Invoke-BootstrapStep -Step "BETA" -Relocatability relocatable -Root $installRoot -Action {
+      throw "BETA must not run while WINDOWS_DIY_SKIP_BETA is set."
+    }
+  } finally {
+    Remove-Item Env:\WINDOWS_DIY_SKIP_BETA -ErrorAction SilentlyContinue
+  }
+
+  # A component installed by a vendor installer, declared as such.
+  Invoke-BootstrapStep -Step "GAMMA" -Relocatability installer -Root $installRoot -Action {
+    $dir = Join-Path $installRoot "gamma"
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    [IO.File]::WriteAllBytes((Join-Path $dir "setup.log"), (New-Object byte[] 500))
+  }
+
+  # A component that fails. The wrapper must record the cost and RETHROW --
+  # swallowing it would turn a broken provision into a silently partial one,
+  # which is the exact defect this file guards against.
+  $rethrown = $false
+  try {
+    Invoke-BootstrapStep -Step "DELTA" -Relocatability relocatable -Root $installRoot -Action {
+      $dir = Join-Path $installRoot "delta"
+      New-Item -ItemType Directory -Force -Path $dir | Out-Null
+      throw "simulated DELTA failure"
+    }
+  } catch {
+    $rethrown = ($_.Exception.Message -eq "simulated DELTA failure")
+  }
+  Assert-True -Condition $rethrown -Message "a failing component rethrows rather than being swallowed"
+
+  $records = Get-BootstrapStepRecords
+  Assert-Equal -Expected 4 -Actual $records.Count -Message "one record per dispatched component"
+
+  $alpha = $records | Where-Object { $_.step -eq "ALPHA" }
+  $beta = $records | Where-Object { $_.step -eq "BETA" }
+  $gamma = $records | Where-Object { $_.step -eq "GAMMA" }
+  $delta = $records | Where-Object { $_.step -eq "DELTA" }
+
+  Assert-Equal -Expected "ok" -Actual $alpha.status -Message "ALPHA recorded as ok"
+  Assert-Equal -Expected "skipped" -Actual $beta.status -Message "BETA recorded as skipped"
+  Assert-Equal -Expected "failed" -Actual $delta.status -Message "DELTA recorded as failed"
+  Assert-Equal -Expected "WINDOWS_DIY_SKIP_BETA" -Actual $beta.skip_variable `
+    -Message "the skip variable that disabled BETA is named in the record"
+  Assert-True -Condition ($delta.error -eq "simulated DELTA failure") `
+    -Message "the failure message is recorded"
+  Assert-True -Condition ($alpha.created_dirs -contains "alpha") `
+    -Message "ALPHA's install directory is attributed to it"
+  Assert-True -Condition ($beta.created_dirs.Count -eq 0) `
+    -Message "a skipped component is attributed no install directory"
+
+  $reportPath = Write-BootstrapStepReport -Root $installRoot -OutputDir $reportDir
+  Assert-True -Condition (Test-Path -LiteralPath $reportPath -PathType Leaf) `
+    -Message "the decomposition file is written"
+
+  $report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json
+  Assert-Equal -Expected "codetracer.windows-env-decomposition.v1" -Actual $report.schema `
+    -Message "the report declares its schema"
+  Assert-Equal -Expected 4 -Actual $report.components.Count -Message "the report has a row per component"
+
+  # A run with a skip or a failure is NOT a complete provision, and the
+  # report must say so: a green run must not be green by omission.
+  Assert-Equal -Expected $false -Actual $report.complete `
+    -Message "a run with a skipped and a failed component is reported incomplete"
+  Assert-True -Condition ($report.skipped_steps -contains "BETA") `
+    -Message "the skipped component is named in skipped_steps"
+  Assert-True -Condition ($report.failed_steps -contains "DELTA") `
+    -Message "the failed component is named in failed_steps"
+
+  $alphaRow = $report.components | Where-Object { $_.step -eq "ALPHA" }
+  Assert-Equal -Expected 3000 -Actual $alphaRow.bytes -Message "ALPHA's install size is measured exactly"
+  Assert-Equal -Expected 3 -Actual $alphaRow.files -Message "ALPHA's file count is measured exactly"
+  $gammaRow = $report.components | Where-Object { $_.step -eq "GAMMA" }
+  Assert-Equal -Expected "installer" -Actual $gammaRow.relocatability `
+    -Message "the declared relocatability class survives into the report"
+
+  # The whole-root total.
+  Assert-Equal -Expected 3500 -Actual $report.install_root_bytes `
+    -Message "the install-root total is the sum of everything under the root"
+
+  # A directory nobody created must be reported as unattributed rather than
+  # quietly dropped, or the per-component rows could sum to less than the
+  # root total with no indication why.
+  New-Item -ItemType Directory -Force -Path (Join-Path $installRoot "stray") | Out-Null
+  [IO.File]::WriteAllBytes((Join-Path $installRoot "stray/x.bin"), (New-Object byte[] 250))
+  $report2 = Get-Content -LiteralPath (Write-BootstrapStepReport -Root $installRoot -OutputDir $reportDir) -Raw | ConvertFrom-Json
+  Assert-True -Condition ($report2.unattributed_install_dirs -contains "stray") `
+    -Message "a directory no component created is reported as unattributed"
+
+  # Reparse points must be counted but not followed. Following a junction
+  # that points back inside the install root would double-count it and
+  # inflate the install-root total by a variable amount.
+  $linkPath = Join-Path $installRoot "linked"
+  $linkCreated = $false
+  try {
+    New-Item -ItemType SymbolicLink -Path $linkPath -Target (Join-Path $installRoot "alpha") -ErrorAction Stop | Out-Null
+    $linkCreated = $true
+  } catch {
+    Write-Host "  skip: cannot create a symlink on this platform/privilege level ($($_.Exception.Message))"
+  }
+  if ($linkCreated) {
+    $measured = Measure-DirectorySize -Path $installRoot
+    Assert-Equal -Expected 3750 -Actual $measured.bytes `
+      -Message "a symlink back into the install root is not followed (no double-count)"
+    Assert-True -Condition ($measured.reparse_points -ge 1) `
+      -Message "the reparse point is counted"
+  }
+
+  # WINDOWS_DIY_ONLY: the positive allowlist a satellite repo uses to ask for
+  # a subset of components (codetracer-trace-format wants CAPNP and nothing
+  # else). Expressing that subtractively would silently break the moment a
+  # new component is added, because the new one defaults to ON -- so the
+  # allowlist must EXCLUDE by default, and that is what these two cases pin.
+  Reset-BootstrapStepRecords
+  $env:WINDOWS_DIY_ONLY = "CAPNP"
+  try {
+    Invoke-BootstrapStep -Step "CAPNP" -Relocatability relocatable -Root $installRoot -Action { }
+    Invoke-BootstrapStep -Step "NARGO" -Relocatability relocatable -Root $installRoot -Action {
+      throw "NARGO must not run when WINDOWS_DIY_ONLY does not list it."
+    }
+    $onlyRecords = Get-BootstrapStepRecords
+    $capnpRecord = $onlyRecords | Where-Object { $_.step -eq "CAPNP" }
+    $nargoRecord = $onlyRecords | Where-Object { $_.step -eq "NARGO" }
+    Assert-Equal -Expected "ok" -Actual $capnpRecord.status `
+      -Message "WINDOWS_DIY_ONLY=CAPNP runs the listed component"
+    Assert-Equal -Expected "skipped" -Actual $nargoRecord.status `
+      -Message "WINDOWS_DIY_ONLY=CAPNP skips an unlisted component"
+    Assert-Equal -Expected "not listed in WINDOWS_DIY_ONLY" -Actual $nargoRecord.skip_reason `
+      -Message "the allowlist exclusion records WHY it was skipped, not just that it was"
+  } finally {
+    Remove-Item Env:\WINDOWS_DIY_ONLY -ErrorAction SilentlyContinue
+  }
+
+  # The allowlist is case- and separator-insensitive, because it is written by
+  # hand in workflow YAML.
+  Reset-BootstrapStepRecords
+  $env:WINDOWS_DIY_ONLY = "capnp, rust"
+  try {
+    Invoke-BootstrapStep -Step "RUST" -Relocatability relocatable -Root $installRoot -Action { }
+    $rustRecord = Get-BootstrapStepRecords | Where-Object { $_.step -eq "RUST" }
+    Assert-Equal -Expected "ok" -Actual $rustRecord.status `
+      -Message "the allowlist accepts lowercase, comma-and-space separated names"
+  } finally {
+    Remove-Item Env:\WINDOWS_DIY_ONLY -ErrorAction SilentlyContinue
+  }
+
+  # A skip variable still wins inside an allowlist: the two gates compose,
+  # and neither silently overrides the other.
+  Reset-BootstrapStepRecords
+  $env:WINDOWS_DIY_ONLY = "CAPNP"
+  $env:WINDOWS_DIY_SKIP_CAPNP = "1"
+  try {
+    Invoke-BootstrapStep -Step "CAPNP" -Relocatability relocatable -Root $installRoot -Action {
+      throw "CAPNP must not run while WINDOWS_DIY_SKIP_CAPNP is set."
+    }
+    $bothRecord = Get-BootstrapStepRecords | Where-Object { $_.step -eq "CAPNP" }
+    Assert-Equal -Expected "skipped" -Actual $bothRecord.status `
+      -Message "an explicit skip still applies to a component inside WINDOWS_DIY_ONLY"
+  } finally {
+    Remove-Item Env:\WINDOWS_DIY_ONLY -ErrorAction SilentlyContinue
+    Remove-Item Env:\WINDOWS_DIY_SKIP_CAPNP -ErrorAction SilentlyContinue
+  }
+
+  # THE DISPATCH GATE AND THE ASSERTION GATE MUST AGREE.
+  #
+  # env.ps1 asks whether a component is wanted TWICE: once to dispatch it
+  # (through Invoke-BootstrapStep) and once afterwards to decide whether to
+  # ASSERT the tool is present -- `WINDOWS_DIY_ENSURE_TTD` and
+  # `WINDOWS_DIY_ENSURE_DOTNET` both default to `Test-BootstrapStepEnabled`.
+  # If only the first consultation honoured WINDOWS_DIY_ONLY, then
+  # `WINDOWS_DIY_ONLY=CAPNP` would skip Ensure-Ttd and then throw
+  # "Microsoft Time Travel Debugging is not available" a few hundred lines
+  # later -- the run failing on the absence of something it was told not to
+  # install. These cases pin the two gates to the same answer.
+  Reset-BootstrapStepRecords
+  $env:WINDOWS_DIY_ONLY = "CAPNP"
+  try {
+    Assert-True -Condition (Test-BootstrapAllowlistActive) `
+      -Message "WINDOWS_DIY_ONLY is reported as an active allowlist"
+    Assert-Equal -Expected $false -Actual (Test-BootstrapStepEnabled "TTD") `
+      -Message "Test-BootstrapStepEnabled agrees the dispatch skipped TTD under WINDOWS_DIY_ONLY=CAPNP"
+    Assert-Equal -Expected $false -Actual (Test-BootstrapStepEnabled "DOTNET") `
+      -Message "Test-BootstrapStepEnabled agrees the dispatch skipped DOTNET under WINDOWS_DIY_ONLY=CAPNP"
+    Assert-Equal -Expected $true -Actual (Test-BootstrapStepEnabled "CAPNP") `
+      -Message "Test-BootstrapStepEnabled keeps the allowlisted component enabled"
+  } finally {
+    Remove-Item Env:\WINDOWS_DIY_ONLY -ErrorAction SilentlyContinue
+  }
+  Assert-Equal -Expected $false -Actual (Test-BootstrapAllowlistActive) `
+    -Message "no allowlist is active when WINDOWS_DIY_ONLY is unset"
+  Assert-Equal -Expected $true -Actual (Test-BootstrapStepEnabled "TTD") `
+    -Message "with no allowlist set, every component is enabled as before"
+
+  # env.ps1 defaults WINDOWS_DIY_SKIP_TTD_PROBE from this composition. The
+  # probe is a Get-AppxPackage call, which is the least reliable thing the
+  # bootstrap does on a CI guest, so it must not run for a caller that did not
+  # ask for TTD -- and must still run for one that did.
+  function Test-TtdProbeSkippedByDefault {
+    return ((Test-BootstrapAllowlistActive) -and -not (Test-BootstrapStepEnabled "TTD"))
+  }
+  Assert-Equal -Expected $false -Actual (Test-TtdProbeSkippedByDefault) `
+    -Message "with no allowlist, the TTD/AppX probe still runs by default"
+  $env:WINDOWS_DIY_ONLY = "CAPNP"
+  try {
+    Assert-Equal -Expected $true -Actual (Test-TtdProbeSkippedByDefault) `
+      -Message "under WINDOWS_DIY_ONLY=CAPNP the TTD/AppX probe is skipped by default"
+    $env:WINDOWS_DIY_ONLY = "CAPNP,TTD"
+    Assert-Equal -Expected $false -Actual (Test-TtdProbeSkippedByDefault) `
+      -Message "but an allowlist that NAMES TTD still probes for it"
+  } finally {
+    Remove-Item Env:\WINDOWS_DIY_ONLY -ErrorAction SilentlyContinue
+  }
+
+  Reset-BootstrapStepRecords
+
+  # An invalid relocatability class must be rejected at the call site.
+  $rejected = $false
+  try {
+    Invoke-BootstrapStep -Step "EPSILON" -Relocatability "sometimes" -Root $installRoot -Action { }
+  } catch {
+    $rejected = $true
+  }
+  Assert-True -Condition $rejected -Message "an unknown relocatability class is rejected"
+
+} finally {
+  Remove-Item -LiteralPath $testRoot -Recurse -Force -ErrorAction SilentlyContinue
+  Reset-BootstrapStepRecords
+}
+
+# ---------------------------------------------------------------------------
+# Part 3 - the nargo linker verification.
+#
+# `ensure-nargo.ps1` refuses to hand cargo a `link.exe` it cannot show to be
+# MSVC's. The predicate that decides this is pure and filesystem-only, so it is
+# testable off Windows against real directories -- which matters, because the
+# lane it protects has never reached Phase 5 and no run has exercised it.
+#
+# The classified failure it exists for is a GNU coreutils `link` answering
+# rustc's `link.exe` invocation: "link: extra operand ... Try 'link --help'".
+# ---------------------------------------------------------------------------
+
+Write-Host "== nargo MSVC linker verification (ensure-nargo.ps1)"
+
+. (Join-Path $repoRoot "non-nix-build/windows/ensure-nargo.ps1")
+
+$linkerRoot = Join-Path ([IO.Path]::GetTempPath()) ("ct-linker-" + [Guid]::NewGuid().ToString('N'))
+try {
+  # A real MSVC-shaped directory: link.exe with cl.exe beside it.
+  $msvcDir = Join-Path $linkerRoot "VC/Tools/MSVC/14.44/bin/Hostx64/x64"
+  New-Item -ItemType Directory -Force -Path $msvcDir | Out-Null
+  foreach ($exe in @("link.exe", "cl.exe")) {
+    [IO.File]::WriteAllBytes((Join-Path $msvcDir $exe), (New-Object byte[] 4))
+  }
+
+  # A coreutils-shaped directory: link.exe alone, no cl.exe.
+  $msysDir = Join-Path $linkerRoot "msys64/usr/bin"
+  New-Item -ItemType Directory -Force -Path $msysDir | Out-Null
+  [IO.File]::WriteAllBytes((Join-Path $msysDir "link.exe"), (New-Object byte[] 4))
+
+  $msvcLink = Join-Path $msvcDir "link.exe"
+  $msysLink = Join-Path $msysDir "link.exe"
+
+  # Path 1: MSVC_PATH_ADDITIONS names the directory.
+  $v = Test-MsvcLinkerPath -LinkExePath $msvcLink -MsvcPathAdditions "$msvcDir;C:\Windows\System32"
+  Assert-Equal -Expected $true -Actual $v.isMsvc `
+    -Message "a link.exe inside an MSVC_PATH_ADDITIONS directory is accepted"
+
+  # Path 2 -- THE ONE THAT MATTERS. export-msvc-env.ps1 exits silently when
+  # Build Tools are absent, so MSVC_PATH_ADDITIONS is empty on exactly the
+  # runs this check is for. The cl.exe-sibling test must still decide.
+  $v = Test-MsvcLinkerPath -LinkExePath $msvcLink -MsvcPathAdditions ""
+  Assert-Equal -Expected $true -Actual $v.isMsvc `
+    -Message "with no MSVC_PATH_ADDITIONS, a link.exe beside cl.exe is still accepted"
+  Assert-True -Condition ($v.reason -like "*cl.exe*") `
+    -Message "and the acceptance says it was decided by the cl.exe sibling"
+
+  # The coreutils link.exe must be rejected under BOTH configurations --
+  # including when MSVC_PATH_ADDITIONS is absent, which is where the previous
+  # revision of this check warned and continued.
+  $v = Test-MsvcLinkerPath -LinkExePath $msysLink -MsvcPathAdditions ""
+  Assert-Equal -Expected $false -Actual $v.isMsvc `
+    -Message "a coreutils link.exe is REJECTED even when MSVC_PATH_ADDITIONS is empty"
+  $v = Test-MsvcLinkerPath -LinkExePath $msysLink -MsvcPathAdditions $msvcDir
+  Assert-Equal -Expected $false -Actual $v.isMsvc `
+    -Message "a coreutils link.exe is rejected when MSVC additions name a different directory"
+
+  # A trailing separator on the published additions must not make a match fail;
+  # export-msvc-env.ps1 emits vcvarsall's PATH verbatim and those entries vary.
+  $v = Test-MsvcLinkerPath -LinkExePath $msvcLink -MsvcPathAdditions "$msvcDir\"
+  Assert-Equal -Expected $true -Actual $v.isMsvc `
+    -Message "a trailing separator on an MSVC_PATH_ADDITIONS entry still matches"
+} finally {
+  Remove-Item -LiteralPath $linkerRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "bootstrap-decomposition: $($script:Checks - $script:Failures)/$($script:Checks) checks passed"
+if ($script:Failures -gt 0) {
+  throw "bootstrap-decomposition: $($script:Failures) check(s) failed."
+}

--- a/ci/test/download-stall-bound.ps1
+++ b/ci/test/download-stall-bound.ps1
@@ -485,6 +485,70 @@ try {
   }
 
   # -------------------------------------------------------------------------
+  # Part 6c - the total budget is shared across RETRIES.
+  #
+  # This is the check that nearly did not exist, and it matters more than it
+  # looks. Bounding a single attempt is not the same as bounding the operation:
+  # Invoke-WithRetry makes 4 attempts, so a per-attempt budget would give a
+  # worst case of 4 x the budget plus backoff. With the shipped defaults that is
+  # ~120 minutes for one component -- longer than the job cap the Windows jobs
+  # carry, which means the job would be killed with no error at all. That is the
+  # exact failure mode the rest of this file exists to eliminate, reintroduced
+  # by the retry wrapper.
+  # -------------------------------------------------------------------------
+
+  Write-Host "== the total budget is shared across retries, not per attempt"
+
+  $sw = [System.Diagnostics.Stopwatch]::StartNew()
+  Assert-Equal -Expected 0 -Actual (Get-DownloadDeadlineSeconds -Elapsed $sw -Budget 0 -Url "http://x") `
+    -Message "a deferred budget (0) stays deferred rather than becoming a deadline"
+
+  $remaining = Get-DownloadDeadlineSeconds -Elapsed $sw -Budget 100 -Url "http://x"
+  Assert-True -Condition ($remaining -gt 90 -and $remaining -le 100) `
+    -Message "the first attempt gets essentially the whole budget (got ${remaining}s of 100s)"
+
+  # A stopwatch that has already run past the budget stands in for "three
+  # attempts have already been made"; the fourth must be refused outright
+  # rather than handed another full budget.
+  $spent = [System.Diagnostics.Stopwatch]::StartNew()
+  Start-Sleep -Milliseconds 1200
+  $refused = $false
+  $message = ""
+  try {
+    Get-DownloadDeadlineSeconds -Elapsed $spent -Budget 1 -Url "http://example.invalid/a.bin" | Out-Null
+  } catch {
+    $refused = $true
+    $message = [string]$_.Exception.Message
+  }
+  Assert-True -Condition $refused `
+    -Message "once the shared budget is spent, a further attempt is REFUSED rather than given a fresh one"
+  Assert-True -Condition ($message -match "across retries") `
+    -Message "and the error says the budget was exhausted across retries: '$message'"
+
+  # End to end: a permanently stalled server must not be able to consume
+  # attempts x budget. With a 4s shared budget and a 2s stall bound, all four
+  # attempts together have to finish inside the budget plus backoff, NOT inside
+  # 4 x budget.
+  $server = $null
+  try {
+    $server = Start-StallServer -Mode "trickle"
+    $out = Join-Path $scratchRoot "sharedbudget.bin"
+    [Environment]::SetEnvironmentVariable("WINDOWS_DIY_DOWNLOAD_TIMEOUT_SECONDS", "4")
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $threw = $false
+    try { Download-File -Url $server.Url -OutFile $out } catch { $threw = $true }
+    $sw.Stop()
+
+    Assert-True -Condition $threw -Message "a trickling server still fails Download-File"
+    Assert-True -Condition ($sw.Elapsed.TotalSeconds -lt 20) `
+      -Message "and all retries together stay near the SHARED budget, not 4x it (took $([int]$sw.Elapsed.TotalSeconds)s, budget 4s)"
+  } finally {
+    [Environment]::SetEnvironmentVariable("WINDOWS_DIY_DOWNLOAD_TIMEOUT_SECONDS", $null)
+    Stop-StallServer -Server $server
+  }
+
+  # -------------------------------------------------------------------------
   # Part 7 - the debugger cannot strand a job.
   # -------------------------------------------------------------------------
 

--- a/ci/test/download-stall-bound.ps1
+++ b/ci/test/download-stall-bound.ps1
@@ -1,0 +1,518 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# Gate for the wall-clock bounds on bootstrap downloads and on the native
+# commands the MSYS2 leg shells out to.
+#
+# This test exists because the Windows lane was not being kept red by any
+# failure. It was being kept red by a HANG: jobs went silent inside the
+# toolchain bootstrap and were killed hours later by the workflow timeout,
+# having produced no error at all. A step that fails is a step you can read;
+# a step that stalls is a step that burns a scarce Windows runner slot and
+# tells you nothing.
+#
+# So the checks here are deliberately NEGATIVE checks. A timeout that has only
+# ever been exercised on the happy path is not tested -- the interesting
+# question is whether it fires, and how fast, when the operation really does
+# stall. Every bound below is driven against a server or a child process that
+# genuinely never finishes.
+#
+# The first group is the one that justifies the implementation existing at
+# all: it pins the behaviour of `Invoke-WebRequest -OutFile`, WITH and WITHOUT
+# `-TimeoutSec`, against a mid-body stall. Both hang. `-TimeoutSec` bounds the
+# request up to the response headers and does not bound the body read, so the
+# obvious one-line fix would not have fixed anything. If a future PowerShell
+# changes that, this group starts failing and the hand-rolled streaming
+# downloader can be reconsidered -- which is the point of asserting it rather
+# than writing it in a comment.
+#
+# NO MOCKS. Per the workspace policy on mock objects, this file uses none. The
+# stall is produced by a real TCP server that really does send response
+# headers and then really does stop sending; the downloader under test is the
+# real one from toolchain-utils.ps1, doing real socket reads into a real file
+# on disk. The bounded-native-command checks drive a real child process. The
+# only thing that is synthetic is the far end of the socket, which is the
+# test's own subject matter -- there is no other way to observe a stall on
+# demand.
+#
+# Runs on Linux/macOS pwsh as well as Windows: nothing here needs a Windows
+# API.
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$utilsPath = Join-Path $repoRoot "non-nix-build/windows/toolchain-utils.ps1"
+
+if (-not (Test-Path -LiteralPath $utilsPath -PathType Leaf)) {
+  throw "toolchain-utils.ps1 not found at '$utilsPath'."
+}
+. $utilsPath
+
+$script:Failures = 0
+$script:Checks = 0
+
+function Assert-True {
+  param([bool]$Condition, [string]$Message)
+  $script:Checks++
+  if (-not $Condition) {
+    $script:Failures++
+    Write-Host "  FAIL: $Message"
+  } else {
+    Write-Host "  ok:   $Message"
+  }
+}
+
+function Assert-Equal {
+  param($Expected, $Actual, [string]$Message)
+  Assert-True -Condition ($Expected -eq $Actual) -Message "$Message (expected '$Expected', got '$Actual')"
+}
+
+function Get-FreeTcpPort {
+  $probe = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+  $probe.Start()
+  $port = $probe.LocalEndpoint.Port
+  $probe.Stop()
+  return $port
+}
+
+function Get-PwshPath {
+  $path = [System.Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+  if ([string]::IsNullOrWhiteSpace($path)) {
+    throw "Could not determine the running pwsh path."
+  }
+  return $path
+}
+
+# A one-shot HTTP server with three behaviours, run in a background job so the
+# test process can be the client.
+#
+#   full   - send headers and the whole body, then close.
+#   stall  - send headers and a first chunk, then stop sending and hold the
+#            connection open. This is the shape that hung CI.
+#   trickle- send headers and then one byte every 200ms, forever. This never
+#            trips an inactivity bound; only a total budget catches it.
+$serverScript = {
+  param($Port, $Mode, $BodySize, $ReadyFile)
+
+  $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, $Port)
+  $listener.Start()
+  # Signal readiness out of band. The obvious handshake -- have the parent
+  # connect to check the port is open -- cannot be used here, because this
+  # listener is one-shot: the probe connection would BE the accepted
+  # connection, and the download under test would then get ECONNREFUSED and
+  # "pass" the stall assertions for entirely the wrong reason.
+  New-Item -ItemType File -Path $ReadyFile -Force | Out-Null
+  try {
+    $client = $listener.AcceptTcpClient()
+    $stream = $client.GetStream()
+
+    $request = [byte[]]::new(65536)
+    $stream.Read($request, 0, $request.Length) | Out-Null
+
+    $declared = if ($Mode -eq "trickle") { 1073741824 } else { $BodySize }
+    $header = "HTTP/1.1 200 OK`r`nContent-Length: $declared`r`nContent-Type: application/octet-stream`r`nConnection: close`r`n`r`n"
+    $headerBytes = [System.Text.Encoding]::ASCII.GetBytes($header)
+    $stream.Write($headerBytes, 0, $headerBytes.Length)
+    $stream.Flush()
+
+    switch ($Mode) {
+      "full" {
+        $body = [byte[]]::new($BodySize)
+        for ($i = 0; $i -lt $BodySize; $i++) { $body[$i] = [byte](65 + ($i % 26)) }
+        $stream.Write($body, 0, $body.Length)
+        $stream.Flush()
+      }
+      "stall" {
+        $chunk = [byte[]]::new(4096)
+        $stream.Write($chunk, 0, $chunk.Length)
+        $stream.Flush()
+        Start-Sleep -Seconds 900
+      }
+      "trickle" {
+        $one = [byte[]]::new(1)
+        while ($true) {
+          $stream.Write($one, 0, 1)
+          $stream.Flush()
+          Start-Sleep -Milliseconds 200
+        }
+      }
+    }
+  } finally {
+    $listener.Stop()
+  }
+}
+
+function Start-StallServer {
+  param([string]$Mode, [int]$BodySize = 65536)
+
+  $port = Get-FreeTcpPort
+  $readyFile = Join-Path ([System.IO.Path]::GetTempPath()) ("ct-stall-ready-" + [Guid]::NewGuid().ToString("N"))
+  $job = Start-Job -ScriptBlock $serverScript -ArgumentList $port, $Mode, $BodySize, $readyFile
+
+  # Wait for the listener to be up, rather than sleeping a guessed interval
+  # and racing it.
+  $deadline = (Get-Date).AddSeconds(60)
+  while ((Get-Date) -lt $deadline -and -not (Test-Path -LiteralPath $readyFile -PathType Leaf)) {
+    Start-Sleep -Milliseconds 100
+  }
+  if (-not (Test-Path -LiteralPath $readyFile -PathType Leaf)) {
+    throw "The '$Mode' stall server never signalled readiness on port $port."
+  }
+
+  return [pscustomobject]@{
+    Port      = $port
+    Job       = $job
+    ReadyFile = $readyFile
+    Url       = "http://127.0.0.1:$port/artifact.bin"
+  }
+}
+
+function Stop-StallServer {
+  param($Server)
+  if ($null -eq $Server) { return }
+  Stop-Job -Job $Server.Job -ErrorAction SilentlyContinue
+  Remove-Job -Job $Server.Job -Force -ErrorAction SilentlyContinue
+  Remove-Item -LiteralPath $Server.ReadyFile -Force -ErrorAction SilentlyContinue
+}
+
+$scratchRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("ct-stall-test-" + [Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Force -Path $scratchRoot | Out-Null
+
+try {
+
+  # -------------------------------------------------------------------------
+  # Part 1 - the premise: Invoke-WebRequest cannot express this bound.
+  # -------------------------------------------------------------------------
+
+  Write-Host "== Invoke-WebRequest -OutFile does not bound a mid-body stall"
+
+  foreach ($variant in @(
+      @{ Name = "without -TimeoutSec"; Timeout = 0 },
+      @{ Name = "with -TimeoutSec 5";  Timeout = 5 }
+    )) {
+
+    # A fresh stall server per variant: the server is one-shot.
+    $server = $null
+    try {
+      $server = Start-StallServer -Mode "stall"
+      $out = Join-Path $scratchRoot ("iwr-" + [Guid]::NewGuid().ToString("N") + ".bin")
+
+      # Run the download in a child job so the test can outlive the hang it is
+      # provoking. If the job is still running well past any timeout that was
+      # asked for, the timeout did not cover the body read.
+      $probe = Start-Job -ScriptBlock {
+        param($Url, $Out, $TimeoutSec)
+        if ($TimeoutSec -gt 0) {
+          Invoke-WebRequest -Uri $Url -OutFile $Out -UseBasicParsing -TimeoutSec $TimeoutSec
+        } else {
+          Invoke-WebRequest -Uri $Url -OutFile $Out -UseBasicParsing
+        }
+      } -ArgumentList $server.Url, $out, $variant.Timeout
+
+      $finished = $null -ne (Wait-Job -Job $probe -Timeout 25)
+      Stop-Job -Job $probe -ErrorAction SilentlyContinue
+      Remove-Job -Job $probe -Force -ErrorAction SilentlyContinue
+
+      Assert-True -Condition (-not $finished) `
+        -Message "Invoke-WebRequest $($variant.Name) is STILL RUNNING 25s into a mid-body stall (this is the hang the bound replaces)"
+    } finally {
+      Stop-StallServer -Server $server
+    }
+  }
+
+  # -------------------------------------------------------------------------
+  # Part 2 - the bound fires, quickly, with a message that names the cause.
+  # -------------------------------------------------------------------------
+
+  Write-Host "== Invoke-BoundedDownload fails fast on a stalled transfer"
+
+  $server = $null
+  try {
+    $server = Start-StallServer -Mode "stall"
+    $out = Join-Path $scratchRoot "stalled.bin"
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $threw = $false
+    $message = ""
+    try {
+      Invoke-BoundedDownload -Url $server.Url -OutFile $out -StallSeconds 5 -TotalSeconds 120 -ProgressSeconds 1 | Out-Null
+    } catch {
+      $threw = $true
+      $message = [string]$_.Exception.Message
+    }
+    $sw.Stop()
+
+    Assert-True -Condition $threw `
+      -Message "a mid-body stall THROWS instead of blocking"
+    Assert-True -Condition ($sw.Elapsed.TotalSeconds -lt 25) `
+      -Message "and it throws promptly, at the bound rather than at the job timeout (took $([int]$sw.Elapsed.TotalSeconds)s, bound was 5s)"
+    Assert-True -Condition ($sw.Elapsed.TotalSeconds -ge 4) `
+      -Message "and not before the bound it was given (took $([int]$sw.Elapsed.TotalSeconds)s)"
+    Assert-True -Condition ($message -match "stalled") `
+      -Message "the error says the transfer stalled: '$message'"
+    Assert-True -Condition ($message -match [regex]::Escape($server.Url)) `
+      -Message "the error names the URL that stalled, so the log identifies the component"
+    Assert-True -Condition (-not (Test-Path -LiteralPath $out -PathType Leaf)) `
+      -Message "the truncated output file is removed, so a later run cannot mistake it for a cached artefact"
+  } finally {
+    Stop-StallServer -Server $server
+  }
+
+  # -------------------------------------------------------------------------
+  # Part 3 - a transfer that never stalls but never finishes is still bounded.
+  # -------------------------------------------------------------------------
+
+  Write-Host "== Invoke-BoundedDownload enforces a total budget on a trickling transfer"
+
+  $server = $null
+  try {
+    $server = Start-StallServer -Mode "trickle"
+    $out = Join-Path $scratchRoot "trickle.bin"
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $threw = $false
+    $message = ""
+    try {
+      # The inactivity bound is generous relative to the 200ms trickle, so it
+      # can never fire. Only the total budget can end this.
+      Invoke-BoundedDownload -Url $server.Url -OutFile $out -StallSeconds 30 -TotalSeconds 6 -ProgressSeconds 2 | Out-Null
+    } catch {
+      $threw = $true
+      $message = [string]$_.Exception.Message
+    }
+    $sw.Stop()
+
+    Assert-True -Condition $threw `
+      -Message "a transfer that trickles forever THROWS rather than running to the job timeout"
+    Assert-True -Condition ($message -match "total budget") `
+      -Message "and the error distinguishes the total budget from a stall: '$message'"
+    Assert-True -Condition ($sw.Elapsed.TotalSeconds -lt 30) `
+      -Message "the total budget is honoured promptly (took $([int]$sw.Elapsed.TotalSeconds)s, budget was 6s)"
+  } finally {
+    Stop-StallServer -Server $server
+  }
+
+  # -------------------------------------------------------------------------
+  # Part 4 - the happy path still downloads bytes correctly.
+  # -------------------------------------------------------------------------
+
+  Write-Host "== Invoke-BoundedDownload still transfers a healthy response"
+
+  $server = $null
+  try {
+    $bodySize = 262144
+    $server = Start-StallServer -Mode "full" -BodySize $bodySize
+    $out = Join-Path $scratchRoot "full.bin"
+
+    $written = Invoke-BoundedDownload -Url $server.Url -OutFile $out -StallSeconds 20 -TotalSeconds 60 -ProgressSeconds 1
+
+    Assert-Equal -Expected $bodySize -Actual $written `
+      -Message "the downloader reports the number of bytes it wrote"
+    Assert-True -Condition (Test-Path -LiteralPath $out -PathType Leaf) `
+      -Message "the output file exists"
+    $actual = [System.IO.File]::ReadAllBytes($out)
+    Assert-Equal -Expected $bodySize -Actual $actual.Length `
+      -Message "the output file is the full declared length"
+
+    $corrupt = $false
+    for ($i = 0; $i -lt $actual.Length; $i++) {
+      if ($actual[$i] -ne [byte](65 + ($i % 26))) { $corrupt = $true; break }
+    }
+    Assert-True -Condition (-not $corrupt) `
+      -Message "the bytes on disk are the bytes the server sent, in order"
+  } finally {
+    Stop-StallServer -Server $server
+  }
+
+  # -------------------------------------------------------------------------
+  # Part 5 - the same guarantee for the native commands the MSYS2 leg runs.
+  # -------------------------------------------------------------------------
+
+  Write-Host "== Invoke-BoundedNativeCommand bounds a child that never exits"
+
+  $pwshPath = Get-PwshPath
+
+  $sw = [System.Diagnostics.Stopwatch]::StartNew()
+  $threw = $false
+  $message = ""
+  try {
+    Invoke-BoundedNativeCommand `
+      -FilePath $pwshPath `
+      -ArgumentList @("-NoProfile", "-Command", "Start-Sleep -Seconds 900") `
+      -Activity "a child that never exits" `
+      -TimeoutSeconds 5 | Out-Null
+  } catch {
+    $threw = $true
+    $message = [string]$_.Exception.Message
+  }
+  $sw.Stop()
+
+  Assert-True -Condition $threw `
+    -Message "a child that never exits is killed and THROWS"
+  Assert-True -Condition ($sw.Elapsed.TotalSeconds -lt 25) `
+    -Message "the kill happens at the bound (took $([int]$sw.Elapsed.TotalSeconds)s, bound was 5s)"
+  Assert-True -Condition ($message -match "did not finish within") `
+    -Message "the error says the command overran its bound: '$message'"
+  Assert-True -Condition ($message -match "a child that never exits") `
+    -Message "the error names the activity, not just a process id"
+
+  Write-Host "== Invoke-BoundedNativeCommand gives the child an empty stdin"
+
+  # A prompt in CI is indistinguishable from a hang unless stdin is closed.
+  # With an empty stdin the read returns EOF immediately, so a child that
+  # would otherwise wait forever exits on its own.
+  $sw = [System.Diagnostics.Stopwatch]::StartNew()
+  $exit = -1
+  $threw = $false
+  try {
+    $exit = Invoke-BoundedNativeCommand `
+      -FilePath $pwshPath `
+      -ArgumentList @("-NoProfile", "-Command", "`$null = [Console]::In.ReadToEnd(); exit 7") `
+      -Activity "a child that reads stdin" `
+      -TimeoutSeconds 20
+  } catch {
+    $threw = $true
+  }
+  $sw.Stop()
+
+  Assert-True -Condition (-not $threw) `
+    -Message "a child that reads stdin does NOT block: it sees EOF and exits"
+  Assert-Equal -Expected 7 -Actual $exit `
+    -Message "and its real exit code is returned to the caller"
+  Assert-True -Condition ($sw.Elapsed.TotalSeconds -lt 20) `
+    -Message "it exits well inside the bound (took $([int]$sw.Elapsed.TotalSeconds)s)"
+
+  $exit = Invoke-BoundedNativeCommand `
+    -FilePath $pwshPath `
+    -ArgumentList @("-NoProfile", "-Command", "exit 0") `
+    -Activity "a child that succeeds" `
+    -TimeoutSeconds 60
+  Assert-Equal -Expected 0 -Actual $exit `
+    -Message "a successful child still reports exit 0"
+
+  # -------------------------------------------------------------------------
+  # Part 6 - the bounds are configurable, and reject nonsense loudly.
+  # -------------------------------------------------------------------------
+
+  Write-Host "== the bounds are configurable"
+
+  Assert-Equal -Expected 42 -Actual (Get-PositiveIntSetting -Name "CT_TEST_UNSET_BOUND" -Default 42) `
+    -Message "an unset override falls back to the default"
+
+  [Environment]::SetEnvironmentVariable("CT_TEST_BOUND", "17")
+  try {
+    Assert-Equal -Expected 17 -Actual (Get-PositiveIntSetting -Name "CT_TEST_BOUND" -Default 42) `
+      -Message "a set override wins over the default"
+  } finally {
+    [Environment]::SetEnvironmentVariable("CT_TEST_BOUND", $null)
+  }
+
+  foreach ($bad in @("0", "-5", "soon")) {
+    [Environment]::SetEnvironmentVariable("CT_TEST_BOUND", $bad)
+    try {
+      $rejected = $false
+      try {
+        Get-PositiveIntSetting -Name "CT_TEST_BOUND" -Default 42 | Out-Null
+      } catch {
+        $rejected = $true
+      }
+      Assert-True -Condition $rejected `
+        -Message "an override of '$bad' is rejected rather than silently ignored"
+    } finally {
+      [Environment]::SetEnvironmentVariable("CT_TEST_BOUND", $null)
+    }
+  }
+
+  # -------------------------------------------------------------------------
+  # Part 6b - the pre-existing operator knob keeps working, including its
+  # documented "0" escape, which must NOT be allowed to restore an unbounded
+  # download. 0 opts out of the TOTAL budget only; the inactivity clock still
+  # has to terminate the transfer, because that is the bound the lane needed.
+  # -------------------------------------------------------------------------
+
+  Write-Host "== WINDOWS_DIY_DOWNLOAD_TIMEOUT_SECONDS keeps its meaning"
+
+  [Environment]::SetEnvironmentVariable("WINDOWS_DIY_DOWNLOAD_TIMEOUT_SECONDS", "900")
+  try {
+    Assert-Equal -Expected 900 -Actual (Get-DownloadTimeoutSeconds) `
+      -Message "an explicit total budget is passed through"
+  } finally {
+    [Environment]::SetEnvironmentVariable("WINDOWS_DIY_DOWNLOAD_TIMEOUT_SECONDS", $null)
+  }
+
+  Assert-Equal -Expected 0 -Actual (Get-DownloadTimeoutSeconds) `
+    -Message "unset defers to the bound's own default rather than imposing one here"
+
+  [Environment]::SetEnvironmentVariable("WINDOWS_DIY_DOWNLOAD_TIMEOUT_SECONDS", "-1")
+  try {
+    $rejected = $false
+    try { Get-DownloadTimeoutSeconds | Out-Null } catch { $rejected = $true }
+    Assert-True -Condition $rejected -Message "a negative total budget is rejected"
+  } finally {
+    [Environment]::SetEnvironmentVariable("WINDOWS_DIY_DOWNLOAD_TIMEOUT_SECONDS", $null)
+  }
+
+  # The load-bearing one: "0" used to mean "wait forever". It must now mean
+  # "no total budget", with the stall clock still ending a dead transfer.
+  [Environment]::SetEnvironmentVariable("WINDOWS_DIY_DOWNLOAD_TIMEOUT_SECONDS", "0")
+  $server = $null
+  try {
+    Assert-True -Condition ((Get-DownloadTimeoutSeconds) -gt 86400) `
+      -Message "0 still opts out of any practical total budget"
+
+    $server = Start-StallServer -Mode "stall"
+    $out = Join-Path $scratchRoot "optout.bin"
+
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $threw = $false
+    $message = ""
+    try {
+      Invoke-BoundedDownload -Url $server.Url -OutFile $out `
+        -StallSeconds 5 -TotalSeconds (Get-DownloadTimeoutSeconds) -ProgressSeconds 1 | Out-Null
+    } catch {
+      $threw = $true
+      $message = [string]$_.Exception.Message
+    }
+    $sw.Stop()
+
+    Assert-True -Condition $threw `
+      -Message "but a stalled transfer STILL fails, even with the total budget opted out"
+    Assert-True -Condition ($sw.Elapsed.TotalSeconds -lt 25) `
+      -Message "and it still fails at the inactivity bound (took $([int]$sw.Elapsed.TotalSeconds)s)"
+    Assert-True -Condition ($message -match "stalled") `
+      -Message "reported as a stall, not as a budget overrun: '$message'"
+  } finally {
+    Stop-StallServer -Server $server
+    [Environment]::SetEnvironmentVariable("WINDOWS_DIY_DOWNLOAD_TIMEOUT_SECONDS", $null)
+  }
+
+  # -------------------------------------------------------------------------
+  # Part 7 - the debugger cannot strand a job.
+  # -------------------------------------------------------------------------
+
+  Write-Host "== the interactive-debugger guard"
+
+  $savedPreference = $ErrorActionPreference
+  try {
+    $global:ErrorActionPreference = "Break"
+    $applied = @(Assert-NonInteractiveDebugger)
+    Assert-Equal -Expected "Stop" -Actual $global:ErrorActionPreference `
+      -Message "an inherited ErrorActionPreference of 'Break' is forced back to 'Stop'"
+    Assert-True -Condition (@($applied | Where-Object { $_ -match "Break" }).Count -eq 1) `
+      -Message "and the guard REPORTS that it had to intervene, rather than fixing it silently"
+  } finally {
+    $global:ErrorActionPreference = $savedPreference
+  }
+
+  $applied = @(Assert-NonInteractiveDebugger)
+  Assert-Equal -Expected 0 -Actual $applied.Count `
+    -Message "on a clean host the guard reports nothing"
+
+} finally {
+  Remove-Item -LiteralPath $scratchRoot -Recurse -Force -ErrorAction SilentlyContinue
+  Get-Job -ErrorAction SilentlyContinue | Remove-Job -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "download-stall-bound: $($script:Checks - $script:Failures)/$($script:Checks) checks passed"
+if ($script:Failures -gt 0) {
+  throw "download-stall-bound: $($script:Failures) check(s) failed."
+}

--- a/env.ps1
+++ b/env.ps1
@@ -1072,6 +1072,13 @@ $toolchain = Parse-ToolchainVersions -Path $toolchainPath
 
 # Dot-source ensure modules for install-on-demand bootstrap.
 . "$windowsDir/toolchain-utils.ps1"
+
+# Before any bootstrap step runs, make sure a debugger prompt cannot strand
+# this job. See Assert-NonInteractiveDebugger for the hazard and its limits.
+foreach ($guard in (Assert-NonInteractiveDebugger)) {
+  Write-Warning "Interactive-debugger guard: $guard."
+}
+
 . "$windowsDir/ensure-rust.ps1"
 . "$windowsDir/ensure-just.ps1"
 . "$windowsDir/ensure-nextest.ps1"

--- a/env.ps1
+++ b/env.ps1
@@ -1182,44 +1182,90 @@ if (-not $doSync -and $forceTtd -and (Test-BootstrapStepEnabled "TTD")) {
 if ($doSync) {
   $arch = Get-WindowsArch
 
+  # Each gated component runs through Invoke-BootstrapStep, which applies the
+  # same WINDOWS_DIY_SKIP_<NAME> gate Test-BootstrapStepEnabled did and
+  # additionally records wall clock, install size and relocatability class.
+  # That table -- written by Write-BootstrapStepReport at the end of this
+  # block -- is the per-component decomposition any sizing of this bootstrap
+  # is derived from.
+  #
+  # The -Relocatability value is the INSTALL MECHANISM, read off the
+  # corresponding ensure-*.ps1: an archive extraction or an in-place build is
+  # "relocatable", a vendor installer is "installer". Do not change one
+  # without changing the script it describes.
+  #
+  # `ci/test/bootstrap-decomposition.ps1` parses this block and fails if any
+  # Ensure-* call here bypasses the wrapper, so a component added later
+  # cannot silently fall out of the decomposition.
+
+  # The dispatch is wrapped so the decomposition is written even when a
+  # component throws. A failing run's timings are the MOST useful ones right
+  # now -- they are what identifies the component that blocks the lane -- and
+  # letting the exception skip the report would leave the slowest and most
+  # interesting runs unmeasured.
+  try {
+
   # Phase 1: No dependencies
-  if (Test-BootstrapStepEnabled "TTD")  { Ensure-Ttd -Root $installRoot -Toolchain $toolchain }
-  if (Test-BootstrapStepEnabled "NODE") { Ensure-Node -Root $installRoot -Arch $arch -Toolchain $toolchain }
-  if (Test-BootstrapStepEnabled "UV")   { Ensure-Uv   -Root $installRoot -Arch $arch -Toolchain $toolchain }
-  if (Test-BootstrapStepEnabled "GCC")  { Ensure-Gcc  -Root $installRoot -Toolchain $toolchain }
-  if (Test-BootstrapStepEnabled "GNAT") { Ensure-Gnat -Root $installRoot -Toolchain $toolchain }
-  if (Test-BootstrapStepEnabled "GO")    { Ensure-Go    -Root $installRoot -Arch $arch -Toolchain $toolchain }
-  if (Test-BootstrapStepEnabled "LDC")   { Ensure-Ldc   -Root $installRoot -Arch $arch -Toolchain $toolchain }
-  if (Test-BootstrapStepEnabled "VLANG") { Ensure-Vlang -Root $installRoot -Arch $arch -Toolchain $toolchain }
-  if (Test-BootstrapStepEnabled "FPC")   { Ensure-Fpc   -Root $installRoot -Arch $arch -Toolchain $toolchain }
-  if (Test-BootstrapStepEnabled "ZSTD") { Ensure-Zstd -Root $installRoot -Arch $arch -Toolchain $toolchain }
+  Invoke-BootstrapStep -Step "TTD"   -Relocatability relocatable -Root $installRoot -Action { Ensure-Ttd   -Root $installRoot -Toolchain $toolchain }
+  Invoke-BootstrapStep -Step "NODE"  -Relocatability relocatable -Root $installRoot -Action { Ensure-Node  -Root $installRoot -Arch $arch -Toolchain $toolchain }
+  Invoke-BootstrapStep -Step "UV"    -Relocatability relocatable -Root $installRoot -Action { Ensure-Uv    -Root $installRoot -Arch $arch -Toolchain $toolchain }
+  Invoke-BootstrapStep -Step "GCC"   -Relocatability relocatable -Root $installRoot -Action { Ensure-Gcc   -Root $installRoot -Toolchain $toolchain }
+  Invoke-BootstrapStep -Step "GNAT"  -Relocatability relocatable -Root $installRoot -Action { Ensure-Gnat  -Root $installRoot -Toolchain $toolchain }
+  Invoke-BootstrapStep -Step "GO"    -Relocatability relocatable -Root $installRoot -Action { Ensure-Go    -Root $installRoot -Arch $arch -Toolchain $toolchain }
+  Invoke-BootstrapStep -Step "LDC"   -Relocatability relocatable -Root $installRoot -Action { Ensure-Ldc   -Root $installRoot -Arch $arch -Toolchain $toolchain }
+  Invoke-BootstrapStep -Step "VLANG" -Relocatability relocatable -Root $installRoot -Action { Ensure-Vlang -Root $installRoot -Arch $arch -Toolchain $toolchain }
+  # FPC is the one component installed by a vendor installer rather than an
+  # archive: FreePascal ships an Inno Setup .exe (ensure-fpc.ps1:45-50,
+  # /VERYSILENT), so it may write outside the install root and is not a
+  # store candidate without repackaging.
+  Invoke-BootstrapStep -Step "FPC"   -Relocatability installer   -Root $installRoot -Action { Ensure-Fpc   -Root $installRoot -Arch $arch -Toolchain $toolchain }
+  Invoke-BootstrapStep -Step "ZSTD"  -Relocatability relocatable -Root $installRoot -Action { Ensure-Zstd  -Root $installRoot -Arch $arch -Toolchain $toolchain }
   # Ensure-Zlib must run after Ensure-Gcc (depends on mingw32-make + gcc).
-  if (Test-BootstrapStepEnabled "ZLIB") { Ensure-Zlib -Root $installRoot -Arch $arch -Toolchain $toolchain }
-  if (Test-BootstrapStepEnabled "LLVM") { Ensure-Llvm -Root $installRoot -Arch $arch -Toolchain $toolchain }
+  Invoke-BootstrapStep -Step "ZLIB"  -Relocatability relocatable -Root $installRoot -Action { Ensure-Zlib  -Root $installRoot -Arch $arch -Toolchain $toolchain }
+  Invoke-BootstrapStep -Step "LLVM"  -Relocatability relocatable -Root $installRoot -Action { Ensure-Llvm  -Root $installRoot -Arch $arch -Toolchain $toolchain }
   # Clingo is the ASP solver `repro` and its child `extract_runner.exe`
   # dlopen at runtime via `clingo.dll`. It has no other build-system
   # dependency; install it whenever the user does not opt out via
   # WINDOWS_DIY_SKIP_CLINGO=1.
-  if (Test-BootstrapStepEnabled "CLINGO") { Ensure-Clingo -Root $installRoot -Arch $arch -Toolchain $toolchain }
+  Invoke-BootstrapStep -Step "CLINGO" -Relocatability relocatable -Root $installRoot -Action { Ensure-Clingo -Root $installRoot -Arch $arch -Toolchain $toolchain }
 
   # Phase 2: Rust (no deps on other managed tools)
-  if (Test-BootstrapStepEnabled "RUST") { Ensure-Rust -Root $installRoot -Arch $arch -Toolchain $toolchain }
+  Invoke-BootstrapStep -Step "RUST" -Relocatability relocatable -Root $installRoot -Action { Ensure-Rust -Root $installRoot -Arch $arch -Toolchain $toolchain }
 
   # Phase 3: Depends on Rust/cargo
-  if (Test-BootstrapStepEnabled "JUST") { Ensure-Just -Root $installRoot -Toolchain $toolchain }
-  if (Test-BootstrapStepEnabled "NEXTEST") { Ensure-Nextest -Root $installRoot -Toolchain $toolchain }
+  Invoke-BootstrapStep -Step "JUST"    -Relocatability relocatable -Root $installRoot -Action { Ensure-Just    -Root $installRoot -Toolchain $toolchain }
+  Invoke-BootstrapStep -Step "NEXTEST" -Relocatability relocatable -Root $installRoot -Action { Ensure-Nextest -Root $installRoot -Toolchain $toolchain }
 
   # Phase 4: May need MSYS2 for source builds
-  if (Test-BootstrapStepEnabled "NIM")   { Ensure-Nim   -Root $installRoot -Arch $arch -Toolchain $toolchain }
-  if (Test-BootstrapStepEnabled "CAPNP") { Ensure-Capnp -Root $installRoot -Arch $arch -Toolchain $toolchain }
-  if (Test-BootstrapStepEnabled "TUP")   { Ensure-Tup   -Root $installRoot -Toolchain $toolchain }
+  Invoke-BootstrapStep -Step "NIM"   -Relocatability relocatable -Root $installRoot -Action { Ensure-Nim   -Root $installRoot -Arch $arch -Toolchain $toolchain }
+  Invoke-BootstrapStep -Step "CAPNP" -Relocatability relocatable -Root $installRoot -Action { Ensure-Capnp -Root $installRoot -Arch $arch -Toolchain $toolchain }
+  Invoke-BootstrapStep -Step "TUP"   -Relocatability relocatable -Root $installRoot -Action { Ensure-Tup   -Root $installRoot -Toolchain $toolchain }
 
   # Phase 5: Depends on Rust + MSYS2
-  if (Test-BootstrapStepEnabled "NARGO") { Ensure-Nargo -Root $installRoot -Toolchain $toolchain -RepoRoot $repoRoot }
+  Invoke-BootstrapStep -Step "NARGO" -Relocatability relocatable -Root $installRoot -Action { Ensure-Nargo -Root $installRoot -Toolchain $toolchain -RepoRoot $repoRoot }
 
   # Phase 6: dotnet and tools that depend on it
-  if (Test-BootstrapStepEnabled "DOTNET")    { Ensure-Dotnet    -Root $installRoot -Toolchain $toolchain }
-  if (Test-BootstrapStepEnabled "CT_REMOTE") { Ensure-CtRemote -Root $installRoot -Arch $arch -Toolchain $toolchain -WindowsDir $windowsDir }
+  Invoke-BootstrapStep -Step "DOTNET"    -Relocatability relocatable -Root $installRoot -Action { Ensure-Dotnet   -Root $installRoot -Toolchain $toolchain }
+  Invoke-BootstrapStep -Step "CT_REMOTE" -Relocatability relocatable -Root $installRoot -Action { Ensure-CtRemote -Root $installRoot -Arch $arch -Toolchain $toolchain -WindowsDir $windowsDir }
+
+  } finally {
+    # Publish the decomposition. An incomplete run is recorded as incomplete
+    # (`complete: false` plus the skipped/failed lists) rather than omitted,
+    # because a median over runs that never completed, with nothing saying
+    # so, is how this bootstrap's cost gets mis-stated.
+    #
+    # A failure to WRITE the report must not mask the failure that caused
+    # the run to abort, so this is best-effort and warns rather than throws.
+    try {
+      $decompositionDir = [Environment]::GetEnvironmentVariable("WINDOWS_DIY_REPORT_DIR")
+      if ([string]::IsNullOrWhiteSpace($decompositionDir)) {
+        $decompositionDir = Join-Path $repoRoot ".tmp/windows-diy"
+      }
+      Write-BootstrapStepReport -Root $installRoot -OutputDir $decompositionDir | Out-Null
+    } catch {
+      Write-Warning "Failed to write the env.ps1 component decomposition: $($_.Exception.Message)"
+    }
+  }
 }
 
 $arch = Get-WindowsArch
@@ -1259,7 +1305,15 @@ $dotnetExe = Join-Path $dotnetRoot "dotnet.exe"
 # error, but the explicit gate is useful when the caller wants to avoid
 # the probe entirely (e.g. faster startup, or environments where Appx
 # behaves unpredictably).
-$skipTtdProbe = ConvertTo-BoolFromEnv -Name "WINDOWS_DIY_SKIP_TTD_PROBE" -Default $false
+#
+# It also defaults ON under WINDOWS_DIY_ONLY unless TTD is one of the named
+# components. Probing for a component the caller did not ask for buys nothing
+# and costs a `Get-AppxPackage` call, which is the least reliable thing this
+# script does on a CI guest -- "Server execution failed" / "The remote
+# procedure call failed" is a routine outcome there. An explicit
+# WINDOWS_DIY_SKIP_TTD_PROBE still wins in both directions.
+$skipTtdProbe = ConvertTo-BoolFromEnv -Name "WINDOWS_DIY_SKIP_TTD_PROBE" `
+  -Default ((Test-BootstrapAllowlistActive) -and -not (Test-BootstrapStepEnabled "TTD"))
 if ($skipTtdProbe) {
   Write-Host "WINDOWS_DIY_SKIP_TTD_PROBE=1 - skipping Resolve-TtdRuntimeInfo (TTD treated as absent)."
   $ttdRuntime = [ordered]@{
@@ -1457,7 +1511,10 @@ $clingoBinDir = Join-Path $clingoDir "bin"
 # manually after sourcing env.ps1. Ensure-NodeModulesJunction and
 # Ensure-GoldenLayoutAsset are already silent no-ops when their targets don't
 # exist, so they stay unconditional.
-if ($doSync) {
+# ...and not at all under WINDOWS_DIY_ONLY: yarn-installing codetracer's own
+# node-packages is part of making CODETRACER buildable, not part of providing
+# the one pinned component a satellite repo asked for.
+if ($doSync -and -not (Test-BootstrapAllowlistActive)) {
   Ensure-NodeTooling -RepoRoot $repoRoot -NodePackagesBin $nodePackagesBin -NodeDir $nodeDir
 }
 Ensure-NodeModulesJunction -RepoRoot $repoRoot
@@ -1561,10 +1618,25 @@ if (Test-Path -LiteralPath $llvmLibDir -PathType Container) {
 
 $clExe = Resolve-ClExePath
 if ([string]::IsNullOrWhiteSpace($clExe)) {
-  throw "cl.exe was not found on PATH and MSVC_BIN_DIR did not resolve it. Install Visual Studio Build Tools with the MSVC toolchain (e.g., 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64' or 'Microsoft.VisualStudio.Component.VC.Tools.ARM64')."
+  # MSVC is a requirement of BUILDING codetracer, not of every component
+  # env.ps1 can install. Under WINDOWS_DIY_ONLY the caller asked for a named
+  # subset -- `codetracer-trace-format` asks for CAPNP, whose x64 path
+  # extracts a pinned prebuilt archive and needs no compiler at all -- so
+  # demanding cl.exe there would fail a run that got exactly what it wanted.
+  # Outside that mode nothing changes: the absence is still fatal.
+  if (Test-BootstrapAllowlistActive) {
+    Write-Warning ("cl.exe was not found, and WINDOWS_DIY_ONLY is set, so this is not treated " +
+                   "as fatal. WINDOWS_DIY_CL_EXE will be empty and anything that needs MSVC " +
+                   "will fail at the point of use.")
+  } else {
+    throw "cl.exe was not found on PATH and MSVC_BIN_DIR did not resolve it. Install Visual Studio Build Tools with the MSVC toolchain (e.g., 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64' or 'Microsoft.VisualStudio.Component.VC.Tools.ARM64')."
+  }
 }
 [Environment]::SetEnvironmentVariable("WINDOWS_DIY_CL_EXE", $clExe, "Process")
-if (-not [string]::IsNullOrWhiteSpace($msvcToolsetPinnedVersion)) {
+# The toolset-version assertion reads the version out of the resolved cl.exe,
+# so it is only meaningful when one was found.
+if (-not [string]::IsNullOrWhiteSpace($msvcToolsetPinnedVersion) -and
+    -not [string]::IsNullOrWhiteSpace($clExe)) {
   $actualMsvcToolsetVersion = Resolve-MsvcToolsetVersion
   Assert-MsvcToolsetVersion -ActualVersion $actualMsvcToolsetVersion -PinnedVersion $msvcToolsetPinnedVersion
   [Environment]::SetEnvironmentVariable("WINDOWS_DIY_MSVC_TOOLSET_VERSION", $actualMsvcToolsetVersion, "Process")
@@ -1679,7 +1751,12 @@ Prepend-PathEntries -Entries @(
   $clingoBinDir
 )
 
-$ensureParser = ConvertTo-BoolFromEnv -Name "WINDOWS_DIY_ENSURE_TREE_SITTER_NIM_PARSER" -Default $true
+# Default off under WINDOWS_DIY_ONLY: the tree-sitter Nim parser is one of
+# codetracer's own build inputs, not a component any caller can request, and
+# regenerating it needs bash + a codetracer checkout. An explicit
+# WINDOWS_DIY_ENSURE_TREE_SITTER_NIM_PARSER still wins in both directions.
+$ensureParser = ConvertTo-BoolFromEnv -Name "WINDOWS_DIY_ENSURE_TREE_SITTER_NIM_PARSER" `
+  -Default (-not (Test-BootstrapAllowlistActive))
 if ($ensureParser) {
   # Prefer the Git Bash discovered earlier (WINDOWS_DIY_GIT_BASH_BIN).
   # On hosted Windows Server 2022, `Get-Command bash` resolves to
@@ -1711,7 +1788,11 @@ if ($ensureParser) {
   & $bashExe $tsParserScript
 }
 
-& (Join-Path $windowsDir "setup-codetracer-runtime-env.ps1") -RepoRoot $repoRoot
+# Codetracer's own runtime env (recorder/backend discovery). Out of scope for a
+# caller that named a component subset via WINDOWS_DIY_ONLY.
+if (-not (Test-BootstrapAllowlistActive)) {
+  & (Join-Path $windowsDir "setup-codetracer-runtime-env.ps1") -RepoRoot $repoRoot
+}
 
 # Keep shims first-class after runtime setup path mutations.
 Prepend-PathEntries -Entries @($shimsDir)

--- a/non-nix-build/windows/ensure-nargo.ps1
+++ b/non-nix-build/windows/ensure-nargo.ps1
@@ -1,6 +1,63 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
+function Test-MsvcLinkerPath {
+  <#
+    .SYNOPSIS
+      Decide whether a resolved `link.exe` is MSVC's, and say how it was decided.
+
+    .DESCRIPTION
+      Returns a hashtable @{ isMsvc = <bool>; reason = <string> }.
+
+      TWO independent tests, because the interesting case is the one where the
+      first is unavailable:
+
+        1. `MsvcPathAdditions` lists the directories vcvarsall contributed
+           (published by `export-msvc-env.ps1:181-183`). A `link.exe` resolved
+           from one of them is MSVC's.
+        2. Failing that, MSVC's `link.exe` sits in the same directory as
+           `cl.exe`. GNU coreutils' `link.exe` -- which MSYS2 and Git-Bash both
+           ship, and which takes exactly two operands -- does not, and neither
+           ships the other. This test needs nothing from export-msvc-env.ps1.
+
+      (2) is load-bearing rather than a nicety. `export-msvc-env.ps1` `exit 0`s
+      SILENTLY when vswhere or the VC tools are missing, so on a machine
+      without Build Tools it publishes no MSVC_PATH_ADDITIONS at all -- which
+      is the state the observed CI failures were actually in. Relying on (1)
+      alone would give up on precisely the runs this check exists to diagnose.
+
+      It is a path/filesystem test rather than a `--version` probe on purpose:
+      MSVC's link.exe rejects `--version` with a non-zero exit, and under
+      `$ErrorActionPreference = 'Stop'` on pwsh 7.4+ a non-zero native exit is
+      itself terminating, so probing would trade one opaque failure for
+      another.
+  #>
+  param(
+    [Parameter(Mandatory = $true)][string]$LinkExePath,
+    [AllowNull()][AllowEmptyString()][string]$MsvcPathAdditions
+  )
+
+  $linkDir = (Split-Path -Parent $LinkExePath).TrimEnd('\').TrimEnd('/')
+
+  if (-not [string]::IsNullOrWhiteSpace($MsvcPathAdditions)) {
+    $msvcDirs = @($MsvcPathAdditions -split ";" |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+      ForEach-Object { $_.Trim().TrimEnd('\').TrimEnd('/') })
+    if ($msvcDirs -contains $linkDir) {
+      return @{ isMsvc = $true; reason = "it is in an MSVC_PATH_ADDITIONS directory" }
+    }
+  }
+
+  if (Test-Path -LiteralPath (Join-Path $linkDir "cl.exe") -PathType Leaf) {
+    return @{ isMsvc = $true; reason = "cl.exe sits beside it in '$linkDir'" }
+  }
+
+  return @{
+    isMsvc = $false
+    reason = "it is in neither an MSVC_PATH_ADDITIONS directory nor a directory containing cl.exe"
+  }
+}
+
 function Ensure-Nargo {
   param(
     [Parameter(Mandatory = $true)][string]$Root,
@@ -123,7 +180,98 @@ function Ensure-Nargo {
       Set-Item -Path "Env:$name" -Value $value
     }
   }
+  # PATH ORDER MATTERS HERE, and this block exists because getting it wrong is
+  # one of the two ways the observed failure can arise.
+  #
+  # `nargo_cli` is an MSVC-target Rust build: rustc drives `link.exe` and
+  # expects MSVC's linker. MSYS2 (like Git-Bash) also ships a `link.exe` --
+  # GNU coreutils' `link(1)`, which makes a hard link and accepts exactly two
+  # operands. When that one wins the PATH lookup, rustc's link line is read as
+  # a coreutils invocation and every crate with a build script dies with
+  #
+  #     error: linking with `link.exe` failed: exit code: 1
+  #       = note: link: extra operand '...build_script_build...rcgu.o'
+  #               Try 'link --help' for more information.
+  #
+  # That message is what CI has actually been failing with here, and it aborts
+  # at the `throw` below -- i.e. cargo failed -- NOT at the "did not produce a
+  # nargo executable" throw further down. The class is recorded at
+  # `codetracer-specs/Planned-Work/Windows-Test-Suite-Health.md:416-424`
+  # ("the same `cargo test --lib` passes from PowerShell").
+  #
+  # NOTE what the message does and does not tell you. It proves a coreutils
+  # `link` answered; it does NOT prove MSVC's linker was present and lost the
+  # lookup, because `export-msvc-env.ps1` exits silently when Build Tools are
+  # missing and so leaves no trace either way. Treat "shadowed" as one of two
+  # live possibilities, not as the diagnosis.
+  #
+  # It is a DIFFERENT message from the one `ensure-just.ps1:37-39` and
+  # `ensure-nextest.ps1:36-38` describe -- "linker `link.exe` NOT FOUND",
+  # meaning no link.exe was found at all. Both occur on this bootstrap, in
+  # different runs, and their signatures are mutually exclusive: a log shows
+  # "extra operand" or "not found", never both.
+  #
+  # `export-msvc-env.ps1:149-158` deliberately emits its PATH with the MSVC
+  # additions FIRST, "they must win over any older toolset already on PATH",
+  # and publishes those additions separately as `MSVC_PATH_ADDITIONS`
+  # (`:181-183`) "so a caller that would rather PREPEND than replace can do so
+  # without re-deriving the delta". Prepending MSYS2's `mingw64/bin` -- which
+  # this build genuinely needs for clang -- undoes that ordering, so the MSVC
+  # additions are put back in front afterwards. clang is still resolved from
+  # MSYS2 because the MSVC additions do not contain one.
   $env:Path = "$msysMingwBinDir;$($env:Path)"
+  $msvcPathAdditions = [Environment]::GetEnvironmentVariable("MSVC_PATH_ADDITIONS")
+  if (-not [string]::IsNullOrWhiteSpace($msvcPathAdditions)) {
+    $env:Path = "$msvcPathAdditions;$($env:Path)"
+  }
+
+  # Belt and braces: pin the linker by absolute path so the build no longer
+  # depends on PATH order at all. Cargo reads
+  # `CARGO_TARGET_<TRIPLE>_LINKER` for the target triple and, for build
+  # scripts and proc macros, the HOST triple -- which is the same
+  # `x86_64-pc-windows-msvc` here, and build scripts are exactly where the
+  # failure above surfaced (`proc-macro2`, `quote`).
+  $resolvedLink = Get-Command link.exe -CommandType Application -ErrorAction SilentlyContinue |
+    Select-Object -First 1
+  if ($null -eq $resolvedLink) {
+    throw "nargo bootstrap needs MSVC's link.exe on PATH but none was found. " +
+          "export-msvc-env.ps1 should have supplied it; check that Visual Studio " +
+          "Build Tools with the C++ workload are installed."
+  }
+  # Fail loudly and EARLY with a diagnosis, rather than ~10 min into a cargo
+  # build with an opaque `link: extra operand` note. The check is a path
+  # comparison rather than a `--version` probe on purpose: MSVC's link.exe
+  # rejects `--version` with a non-zero exit, and under
+  # `$ErrorActionPreference = 'Stop'` on pwsh 7.4+ a non-zero native exit is
+  # itself terminating, so probing would trade one opaque failure for another.
+  #
+  # What the logs establish is that a GNU coreutils `link` answered rustc's
+  # `link.exe` invocation. Whether it SHADOWED a present MSVC linker or
+  # SUBSTITUTED for an absent one is NOT determinable from them, because
+  # export-msvc-env.ps1 exits silently when MSVC is missing and so leaves no
+  # trace of which case obtained. Both readings are handled: the PATH
+  # reordering above restores MSVC-first order when MSVC is there, and
+  # Test-MsvcLinkerPath fails fast below, naming the culprit, when it is not.
+  $verdict = Test-MsvcLinkerPath -LinkExePath $resolvedLink.Source `
+                                 -MsvcPathAdditions $msvcPathAdditions
+  if (-not $verdict.isMsvc) {
+    $additionsForMessage = if ([string]::IsNullOrWhiteSpace($msvcPathAdditions)) {
+      "<empty -- export-msvc-env.ps1 published none, which is what it does when Build Tools are absent>"
+    } else {
+      $msvcPathAdditions
+    }
+    throw "The first 'link.exe' on PATH is '$($resolvedLink.Source)', and " +
+          "$($verdict.reason), so it is not MSVC's linker " +
+          "(MSVC_PATH_ADDITIONS=$additionsForMessage). MSYS2 and Git-Bash both ship " +
+          "GNU coreutils' link(1) under that name, and an MSVC-target cargo build " +
+          "fails with 'link: extra operand' when it wins the lookup. Either Visual " +
+          "Studio Build Tools with the C++ workload are not installed on this " +
+          "machine, or they are installed but lost the PATH lookup. " +
+          "See Windows-Test-Suite-Health.md:416-424."
+  }
+
+  $env:CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER = $resolvedLink.Source
+  Write-Host "nargo bootstrap will link with $($resolvedLink.Source) ($($verdict.reason))"
 
   Push-Location $sourceDir
   try {

--- a/non-nix-build/windows/toolchain-utils.ps1
+++ b/non-nix-build/windows/toolchain-utils.ps1
@@ -389,6 +389,41 @@ function Invoke-BoundedDownload {
   }
 }
 
+# THE TOTAL BUDGET IS SHARED ACROSS RETRIES, AND THAT IS NOT A DETAIL.
+#
+# `Invoke-WithRetry` makes 4 attempts. If each attempt were given the FULL
+# total budget, the worst case would be 4 x 1800s plus backoff = ~120 minutes
+# for a single component -- longer than the `timeout-minutes` the eph-win-x64
+# jobs now carry. The job cap would fire first, killing the job with no error
+# and no indication of which download was responsible, which is precisely the
+# failure this whole change exists to remove. Bounding one attempt is not the
+# same as bounding the operation.
+#
+# So the deadline is computed ONCE, outside the retry loop, and each attempt is
+# given only the time that remains. The retries still buy what they are for --
+# a connection reset or a 5xx fails fast and is worth re-trying -- without the
+# multiplier turning a bounded download back into an unbounded one.
+#
+# The stall clock is deliberately NOT shared: it is a per-attempt inactivity
+# bound, and re-arming it on a fresh connection is the correct behaviour.
+function Get-DownloadDeadlineSeconds {
+  param(
+    [Parameter(Mandatory = $true)][System.Diagnostics.Stopwatch]$Elapsed,
+    [Parameter(Mandatory = $true)][int]$Budget,
+    [Parameter(Mandatory = $true)][string]$Url
+  )
+
+  # 0 means "defer to Invoke-BoundedDownload's own default/override"; there is
+  # no shared deadline to enforce in that case beyond what it applies itself.
+  if ($Budget -le 0) { return 0 }
+
+  $remaining = [int][Math]::Floor($Budget - $Elapsed.Elapsed.TotalSeconds)
+  if ($remaining -le 0) {
+    throw "Download of '$Url' exhausted its total budget of ${Budget}s across retries."
+  }
+  return $remaining
+}
+
 function Download-File {
   param(
     [Parameter(Mandatory = $true)][string]$Url,
@@ -396,8 +431,10 @@ function Download-File {
   )
 
   $timeoutSeconds = Get-DownloadTimeoutSeconds
+  $elapsed = [System.Diagnostics.Stopwatch]::StartNew()
   Invoke-WithRetry -Script {
-    Invoke-BoundedDownload -Url $Url -OutFile $OutFile -TotalSeconds $timeoutSeconds
+    $remaining = Get-DownloadDeadlineSeconds -Elapsed $elapsed -Budget $timeoutSeconds -Url $Url
+    Invoke-BoundedDownload -Url $Url -OutFile $OutFile -TotalSeconds $remaining
   } | Out-Null
 }
 
@@ -405,10 +442,13 @@ function Download-String {
   param([Parameter(Mandatory = $true)][string]$Url)
 
   $timeoutSeconds = Get-DownloadTimeoutSeconds
+  $elapsed = [System.Diagnostics.Stopwatch]::StartNew()
   $scratch = Join-Path ([System.IO.Path]::GetTempPath()) ("ct-download-" + [Guid]::NewGuid().ToString("N"))
   try {
     Invoke-WithRetry -Script {
-      Invoke-BoundedDownload -Url $Url -OutFile $scratch -TotalSeconds $timeoutSeconds
+      # Shared across retries -- see the note above Download-File.
+      $remaining = Get-DownloadDeadlineSeconds -Elapsed $elapsed -Budget $timeoutSeconds -Url $Url
+      Invoke-BoundedDownload -Url $Url -OutFile $scratch -TotalSeconds $remaining
     } | Out-Null
     $content = [System.IO.File]::ReadAllBytes($scratch)
   } finally {

--- a/non-nix-build/windows/toolchain-utils.ps1
+++ b/non-nix-build/windows/toolchain-utils.ps1
@@ -3,38 +3,114 @@ $ErrorActionPreference = "Stop"
 
 # HOW LONG A SINGLE TOOLCHAIN DOWNLOAD MAY BLOCK BEFORE IT IS A FAILURE.
 #
-# `Invoke-WebRequest` has NO default timeout: `-TimeoutSec` unset means
-# infinite, and under `pwsh` (HttpClient) the value covers the whole transfer,
-# body included -- not just the response headers. Every toolchain in this file
-# is fetched through `Download-File` / `Download-String`, so before this
-# constant existed a single stalled socket parked the ENTIRE Windows dev-env
-# bootstrap forever. `Invoke-WithRetry` did not help: it bounds the number of
-# attempts (4), never the duration of one, so 4 x infinite is still infinite.
+# Every toolchain in this file is fetched through `Download-File` /
+# `Download-String`, and before these bounds existed a single stalled socket
+# parked the ENTIRE Windows dev-env bootstrap. `Invoke-WithRetry` did not help:
+# it bounds the number of attempts (4), never the duration of one, so 4 x
+# infinite is still infinite.
 #
-# This is not theoretical. On 2026-09-04 run 33880354195, `windows-rust-components`
-# sat in `Setup dev env` from 14:37:32 to 20:05:35 and `origin-DAP (materialized
-# Python, Windows)` sat in `Setup db-backend siblings` from 14:20:59 to
-# 20:05:50 -- both released only by GitHub's DEFAULT 360-minute job timeout,
-# because neither job sets `timeout-minutes` either. For those six hours they
-# held the `Codetracer CI-dev` concurrency group `in_progress`, which is what
-# starved every other verdict on the branch.
+# CORRECTION, and it is the whole reason this file no longer uses
+# `Invoke-WebRequest` for downloads. An earlier revision of this comment stated
+# that under `pwsh` (HttpClient) `-TimeoutSec` "covers the whole transfer, body
+# included -- not just the response headers". THAT IS FALSE, and the fix built
+# on it did not work. `Invoke-WebRequest -OutFile` reads the response with
+# `HttpCompletionOption.ResponseHeadersRead` and then streams to disk, so the
+# HttpClient timeout `-TimeoutSec` sets expires only up to the response
+# HEADERS; once the body has started arriving nothing bounds the read. Measured
+# on pwsh 7 against a server that sends headers, sends a few bytes, and then
+# stops: `-TimeoutSec 5` was still running 90 seconds later. A mid-body stall
+# -- which is the shape actually observed on this lane -- is therefore NOT
+# bounded by `-TimeoutSec` at any value.
+#
+# `ci/test/download-stall-bound.ps1` asserts this against a real loopback
+# server rather than restating it, so the day a future PowerShell changes it,
+# the test says so instead of a comment continuing to be believed.
+#
+# This function survives as the operator knob it always was; it now resolves
+# the TOTAL budget for `Invoke-BoundedDownload`, which additionally enforces an
+# inactivity bound that no `Invoke-WebRequest` option can express.
 #
 # The value has to clear the largest asset this bootstrap pulls: the WinDbg
 # msixbundle in ensure-ttd.ps1 is ~767 MB, so a total-transfer budget of a few
 # minutes would convert a slow link into a spurious red. 30 minutes is ~0.4 MB/s
 # sustained for that asset -- far below any healthy runner, far above a socket
 # that has stopped moving. Override for a genuinely slow network with
-# WINDOWS_DIY_DOWNLOAD_TIMEOUT_SECONDS; 0 restores the old infinite behaviour
-# and is deliberately spelled as an opt-in rather than left as the default.
+# WINDOWS_DIY_DOWNLOAD_TIMEOUT_SECONDS.
+#
+# 0 keeps its documented meaning of "no TOTAL budget", so an operator who set
+# it does not silently get a new cap. It no longer means "no bound at all":
+# the inactivity clock still applies and still guarantees termination, which is
+# the property the lane actually needed.
 function Get-DownloadTimeoutSeconds {
   $raw = [Environment]::GetEnvironmentVariable("WINDOWS_DIY_DOWNLOAD_TIMEOUT_SECONDS")
-  if ([string]::IsNullOrWhiteSpace($raw)) { return 1800 }
+  if ([string]::IsNullOrWhiteSpace($raw)) {
+    # Fall through to the bound's own default/override resolution.
+    return 0
+  }
 
   $parsed = 0
   if (-not [int]::TryParse($raw.Trim(), [ref]$parsed) -or $parsed -lt 0) {
     throw "WINDOWS_DIY_DOWNLOAD_TIMEOUT_SECONDS must be a non-negative integer (got '$raw')."
   }
+  if ($parsed -eq 0) { return [int]::MaxValue }
   return $parsed
+}
+
+function Assert-NonInteractiveDebugger {
+  <#
+    .SYNOPSIS
+      Make the PowerShell debugger unreachable, and report whether it was.
+
+    .DESCRIPTION
+      A CI job has no terminal, so a debugger prompt is not a debugging aid --
+      it is a block that nothing will ever answer. One bootstrap job did reach
+      it:
+
+          Entering debug mode. Use h or ? for help.
+          At ...\Microsoft.PowerShell.Archive.psm1:418 char:79
+          [DBG]: PS C:\actions-runner\_work\codetracer\codetracer>>
+
+      Be precise about what that job proves, because the tempting reading is
+      wrong. It is NOT an instance of the multi-hour bootstrap hang, and this
+      guard is not the fix for that. The break landed 0.6s BEFORE the runner's
+      "The operation was canceled", in `Expand-Archive`'s partial-expansion
+      cleanup path -- i.e. the host broke into the debugger while unwinding in
+      response to the cancellation, rather than the debugger causing it. The
+      job then ran its post-steps and completed normally. Nothing waited on the
+      prompt.
+
+      So this is a latent hazard rather than an observed outage: on a host that
+      DID arrive with the debugger reachable, the same break on a real error
+      would block instead of unwinding. Nothing in this repository sets
+      `$ErrorActionPreference = 'Break'` or
+      calls `Set-PSBreakpoint`, and the workflow's `shell: pwsh` expands to
+      `pwsh -command ". '{0}'"` with neither `-NonInteractive` nor
+      `-NoProfile`. So the debugger is reachable through host state this repo
+      does not own -- a machine or user profile on the runner image being the
+      obvious candidate -- and the durable fix is to refuse to inherit it
+      rather than to hope it is absent.
+
+      Returns the guards it actually had to apply, so a caller can log that
+      the runner arrived in this state instead of silently papering over it.
+  #>
+
+  $applied = @()
+
+  if ($ErrorActionPreference -eq "Break") {
+    $script:ErrorActionPreference = "Stop"
+    $global:ErrorActionPreference = "Stop"
+    $applied += "ErrorActionPreference was 'Break'; forced to 'Stop'"
+  }
+
+  $breakpoints = @(Get-PSBreakpoint -ErrorAction SilentlyContinue)
+  if ($breakpoints.Count -gt 0) {
+    $breakpoints | Remove-PSBreakpoint -ErrorAction SilentlyContinue
+    $applied += "removed $($breakpoints.Count) inherited breakpoint(s)"
+  }
+
+  Set-PSDebug -Off
+
+  return $applied
 }
 
 function Invoke-WithRetry {
@@ -118,6 +194,201 @@ function Assert-FileSha256 {
   }
 }
 
+# Bootstrap downloads are bounded in wall-clock time, and the bound is on
+# INACTIVITY rather than only on the total.
+#
+# `Invoke-WebRequest -OutFile` cannot express this. Its `-TimeoutSec` covers
+# the request up to the response headers; once the body has started arriving
+# it does not bound the read at all, so a connection that delivers headers and
+# then stops sending bytes blocks forever. That is measured, not assumed --
+# `ci/test/download-stall-bound.ps1` asserts it against a server that stalls
+# mid-body, with and without `-TimeoutSec`, and both hang. Retrying does not
+# help either: `Invoke-WithRetry` only re-runs on a throw, and a stalled
+# stream never throws.
+#
+# So the download is streamed by hand with two clocks:
+#
+#   * a STALL clock, reset on every chunk that actually arrives, which is what
+#     catches the mid-body stall; and
+#   * a TOTAL clock, which catches a transfer that trickles just fast enough
+#     to keep resetting the stall clock but will never finish.
+#
+# Progress is printed on an interval as well, so a slow-but-live download is
+# distinguishable from a dead one in the log rather than looking identical to
+# it. Both are recoverable positions; six hours of silence is not.
+$script:DownloadStallSecondsDefault = 120
+$script:DownloadTotalSecondsDefault = 1800
+$script:DownloadProgressSecondsDefault = 30
+
+function Get-PositiveIntSetting {
+  param(
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][int]$Default
+  )
+
+  $raw = [Environment]::GetEnvironmentVariable($Name)
+  if ([string]::IsNullOrWhiteSpace($raw)) {
+    return $Default
+  }
+
+  $parsed = 0
+  if (-not [int]::TryParse($raw.Trim(), [ref]$parsed) -or $parsed -le 0) {
+    throw "Invalid $Name value '$raw'. Expected a positive whole number of seconds."
+  }
+
+  return $parsed
+}
+
+function Format-DownloadBytes {
+  param([Parameter(Mandatory = $true)][long]$Bytes)
+
+  if ($Bytes -ge 1048576) {
+    return ("{0:N1} MiB" -f ($Bytes / 1048576))
+  }
+  if ($Bytes -ge 1024) {
+    return ("{0:N1} KiB" -f ($Bytes / 1024))
+  }
+  return "$Bytes B"
+}
+
+function Invoke-BoundedDownload {
+  <#
+    .SYNOPSIS
+      Stream $Url to $OutFile, failing loudly if the transfer stalls or
+      overruns its total budget.
+
+    .DESCRIPTION
+      Throws on a stall, so the caller's Invoke-WithRetry can retry a
+      genuinely transient stall, and so the FINAL failure is a real error
+      with a real message instead of a job that is killed hours later by the
+      workflow timeout with no indication of where it stopped.
+  #>
+  param(
+    [Parameter(Mandatory = $true)][string]$Url,
+    [Parameter(Mandatory = $true)][string]$OutFile,
+    [int]$StallSeconds = 0,
+    [int]$TotalSeconds = 0,
+    [int]$ProgressSeconds = 0
+  )
+
+  if ($StallSeconds -le 0) {
+    $StallSeconds = Get-PositiveIntSetting -Name "CODETRACER_DOWNLOAD_STALL_SECONDS" -Default $script:DownloadStallSecondsDefault
+  }
+  if ($TotalSeconds -le 0) {
+    $TotalSeconds = Get-PositiveIntSetting -Name "CODETRACER_DOWNLOAD_TIMEOUT_SECONDS" -Default $script:DownloadTotalSecondsDefault
+  }
+  if ($ProgressSeconds -le 0) {
+    $ProgressSeconds = Get-PositiveIntSetting -Name "CODETRACER_DOWNLOAD_PROGRESS_SECONDS" -Default $script:DownloadProgressSecondsDefault
+  }
+
+  $parent = Split-Path -Parent $OutFile
+  if (-not [string]::IsNullOrWhiteSpace($parent) -and -not (Test-Path -LiteralPath $parent -PathType Container)) {
+    New-Item -ItemType Directory -Force -Path $parent | Out-Null
+  }
+
+  $client = $null
+  $response = $null
+  $source = $null
+  $target = $null
+  $cts = $null
+  $total = [long]0
+  $completed = $false
+  $overall = [System.Diagnostics.Stopwatch]::StartNew()
+
+  try {
+    $cts = [System.Threading.CancellationTokenSource]::new()
+    $client = [System.Net.Http.HttpClient]::new()
+    # The HttpClient-level timeout is deliberately infinite: the two clocks
+    # below are the bound, and an HttpClient timeout would abort a large but
+    # perfectly healthy download.
+    $client.Timeout = [System.Threading.Timeout]::InfiniteTimeSpan
+
+    $cts.CancelAfter([TimeSpan]::FromSeconds([Math]::Min($StallSeconds, $TotalSeconds)))
+
+    $request = [System.Net.Http.HttpRequestMessage]::new([System.Net.Http.HttpMethod]::Get, $Url)
+    $response = $client.SendAsync(
+      $request,
+      [System.Net.Http.HttpCompletionOption]::ResponseHeadersRead,
+      $cts.Token).GetAwaiter().GetResult()
+    $response.EnsureSuccessStatusCode() | Out-Null
+
+    $expected = [long]0
+    if ($null -ne $response.Content.Headers.ContentLength) {
+      $expected = [long]$response.Content.Headers.ContentLength
+    }
+
+    $source = $response.Content.ReadAsStreamAsync().GetAwaiter().GetResult()
+    $target = [System.IO.FileStream]::new(
+      $OutFile,
+      [System.IO.FileMode]::Create,
+      [System.IO.FileAccess]::Write,
+      [System.IO.FileShare]::None)
+
+    $buffer = [byte[]]::new(131072)
+    $lastReport = [double]0
+
+    while ($true) {
+      $remaining = $TotalSeconds - $overall.Elapsed.TotalSeconds
+      if ($remaining -le 0) {
+        throw "Download of '$Url' exceeded its total budget of ${TotalSeconds}s after $(Format-DownloadBytes -Bytes $total). Raise CODETRACER_DOWNLOAD_TIMEOUT_SECONDS if this mirror is legitimately this slow."
+      }
+
+      # Re-arm the inactivity clock before each read, never letting it run
+      # past the total budget.
+      $window = [Math]::Min([double]$StallSeconds, $remaining)
+      $cts.CancelAfter([TimeSpan]::FromSeconds($window))
+
+      $read = $source.ReadAsync($buffer, 0, $buffer.Length, $cts.Token).GetAwaiter().GetResult()
+      if ($read -le 0) { break }
+
+      $target.Write($buffer, 0, $read)
+      $total += $read
+
+      if (($overall.Elapsed.TotalSeconds - $lastReport) -ge $ProgressSeconds) {
+        $lastReport = $overall.Elapsed.TotalSeconds
+        $sofar = Format-DownloadBytes -Bytes $total
+        if ($expected -gt 0) {
+          $pct = [Math]::Round(($total * 100.0) / $expected, 1)
+          Write-Host "  ... $sofar of $(Format-DownloadBytes -Bytes $expected) ($pct%) after $([int]$overall.Elapsed.TotalSeconds)s"
+        } else {
+          Write-Host "  ... $sofar after $([int]$overall.Elapsed.TotalSeconds)s"
+        }
+      }
+    }
+
+    $target.Flush()
+    if ($expected -gt 0 -and $total -ne $expected) {
+      throw "Download of '$Url' ended early: got $(Format-DownloadBytes -Bytes $total) of $(Format-DownloadBytes -Bytes $expected)."
+    }
+
+    $completed = $true
+    return $total
+  } catch [System.OperationCanceledException] {
+    # Both clocks cancel the same token, so the token alone does not say which
+    # one fired. Ask the elapsed time instead: a transfer that trickled just
+    # fast enough to keep resetting the inactivity clock, and then ran out its
+    # total budget mid-read, must not be reported as a stall -- the two have
+    # different remedies, and mislabelling them sends the reader after the
+    # wrong one.
+    if ($overall.Elapsed.TotalSeconds -ge $TotalSeconds) {
+      throw "Download of '$Url' exceeded its total budget of ${TotalSeconds}s after $(Format-DownloadBytes -Bytes $total). Raise CODETRACER_DOWNLOAD_TIMEOUT_SECONDS if this mirror is legitimately this slow."
+    }
+    throw "Download of '$Url' stalled: no data for ${StallSeconds}s (received $(Format-DownloadBytes -Bytes $total)). Bounds are CODETRACER_DOWNLOAD_STALL_SECONDS / CODETRACER_DOWNLOAD_TIMEOUT_SECONDS."
+  } finally {
+    if ($null -ne $target) { $target.Dispose() }
+    if ($null -ne $source) { $source.Dispose() }
+    if ($null -ne $response) { $response.Dispose() }
+    if ($null -ne $client) { $client.Dispose() }
+    if ($null -ne $cts) { $cts.Dispose() }
+    # Never leave a half-written file where a later run could mistake it for
+    # a cached artefact. The SHA gate would catch it, but the error it
+    # produces would name a checksum rather than the truncated transfer.
+    if (-not $completed -and (Test-Path -LiteralPath $OutFile -PathType Leaf)) {
+      Remove-Item -LiteralPath $OutFile -Force -ErrorAction SilentlyContinue
+    }
+  }
+}
+
 function Download-File {
   param(
     [Parameter(Mandatory = $true)][string]$Url,
@@ -126,14 +397,7 @@ function Download-File {
 
   $timeoutSeconds = Get-DownloadTimeoutSeconds
   Invoke-WithRetry -Script {
-    # A zero timeout is git's/PowerShell's "wait forever"; only pass the
-    # parameter when the operator has NOT asked for that, so the opt-out is a
-    # real opt-out rather than `-TimeoutSec 0` meaning something subtly else.
-    if ($timeoutSeconds -gt 0) {
-      Invoke-WebRequest -Uri $Url -OutFile $OutFile -UseBasicParsing -TimeoutSec $timeoutSeconds
-    } else {
-      Invoke-WebRequest -Uri $Url -OutFile $OutFile -UseBasicParsing
-    }
+    Invoke-BoundedDownload -Url $Url -OutFile $OutFile -TotalSeconds $timeoutSeconds
   } | Out-Null
 }
 
@@ -141,11 +405,15 @@ function Download-String {
   param([Parameter(Mandatory = $true)][string]$Url)
 
   $timeoutSeconds = Get-DownloadTimeoutSeconds
-  $content = Invoke-WithRetry -Script {
-    if ($timeoutSeconds -gt 0) {
-      (Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec $timeoutSeconds).Content
-    } else {
-      (Invoke-WebRequest -Uri $Url -UseBasicParsing).Content
+  $scratch = Join-Path ([System.IO.Path]::GetTempPath()) ("ct-download-" + [Guid]::NewGuid().ToString("N"))
+  try {
+    Invoke-WithRetry -Script {
+      Invoke-BoundedDownload -Url $Url -OutFile $scratch -TotalSeconds $timeoutSeconds
+    } | Out-Null
+    $content = [System.IO.File]::ReadAllBytes($scratch)
+  } finally {
+    if (Test-Path -LiteralPath $scratch -PathType Leaf) {
+      Remove-Item -LiteralPath $scratch -Force -ErrorAction SilentlyContinue
     }
   }
 
@@ -161,6 +429,65 @@ function Download-String {
   }
 
   return [string]$content
+}
+
+$script:NativeCommandTimeoutSecondsDefault = 1800
+
+function Invoke-BoundedNativeCommand {
+  <#
+    .SYNOPSIS
+      Run a native command with a wall-clock bound and a closed stdin.
+
+    .DESCRIPTION
+      Two hazards, and stdin is the one that is easy to miss.
+
+      A bootstrap step that shells out to a package manager or an archiver
+      inherits the runner's stdin. If the child ever decides to prompt, it
+      blocks on a read that nothing will ever answer, and the job dies at the
+      workflow timeout with the prompt buried in a log nobody watches. Giving
+      the child an empty stdin turns that into an immediate EOF, so a prompt
+      becomes a fast failure instead of a silent one.
+
+      The timeout covers the other half: a child that is not prompting but is
+      simply stuck -- a package mirror that accepted the connection and then
+      stopped sending, say -- and would otherwise run out the clock.
+
+    .PARAMETER Activity
+      Human-readable description used in the timeout message, so the failure
+      names the step rather than just a process id.
+  #>
+  param(
+    [Parameter(Mandatory = $true)][string]$FilePath,
+    [Parameter(Mandatory = $true)][string[]]$ArgumentList,
+    [Parameter(Mandatory = $true)][string]$Activity,
+    [int]$TimeoutSeconds = 0
+  )
+
+  if ($TimeoutSeconds -le 0) {
+    $TimeoutSeconds = Get-PositiveIntSetting -Name "CODETRACER_NATIVE_COMMAND_TIMEOUT_SECONDS" -Default $script:NativeCommandTimeoutSecondsDefault
+  }
+
+  $emptyStdin = Join-Path ([System.IO.Path]::GetTempPath()) ("ct-stdin-" + [Guid]::NewGuid().ToString("N"))
+  New-Item -ItemType File -Path $emptyStdin -Force | Out-Null
+
+  $process = $null
+  try {
+    $process = Start-Process -FilePath $FilePath `
+      -ArgumentList $ArgumentList `
+      -NoNewWindow `
+      -PassThru `
+      -RedirectStandardInput $emptyStdin
+
+    if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+      try { $process.Kill($true) } catch { try { $process.Kill() } catch { } }
+      throw "$Activity did not finish within ${TimeoutSeconds}s and was killed. Raise CODETRACER_NATIVE_COMMAND_TIMEOUT_SECONDS if this step is legitimately this slow."
+    }
+
+    return $process.ExitCode
+  } finally {
+    if ($null -ne $process) { $process.Dispose() }
+    Remove-Item -LiteralPath $emptyStdin -Force -ErrorAction SilentlyContinue
+  }
 }
 
 function Ensure-CleanDirectory {
@@ -965,6 +1292,11 @@ function Ensure-TupMsys2BuildPrereqs {
     }
   }
 
+  # Announce it. Every other bootstrap download says what it is fetching
+  # before it fetches it; this one did not, which is why a stall here
+  # produced a log whose last line was the PREVIOUS component finishing and
+  # gave no hint that MSYS2 was even involved.
+  Write-Host "Downloading MSYS2 base $version from $assetUrl ..."
   Download-File -Url $assetUrl -OutFile $archivePath
   try {
     Assert-FileSha256 -Path $archivePath -Expected $expectedSha
@@ -980,21 +1312,34 @@ function Ensure-TupMsys2BuildPrereqs {
   Ensure-CleanDirectory -Path $msys2Root
   New-Item -ItemType Directory -Force -Path $msys2Root | Out-Null
   $tarExe = Get-WindowsTarExe
-  # Keep native command output visible in the console while preventing it from
-  # becoming function pipeline output (which would corrupt the hashtable return value).
-  & $tarExe -xJf $archivePath -C $msys2Root | Out-Host
-  if ($LASTEXITCODE -ne 0) {
-    throw "Failed to extract MSYS2 Tup prerequisite archive '$archivePath'."
+  # Bounded, and with a closed stdin: native output still reaches the console
+  # (so it cannot become function pipeline output and corrupt the hashtable
+  # return value), but neither leg can now block the job indefinitely.
+  Write-Host "Extracting MSYS2 base archive to $msys2Root ..."
+  $tarExit = Invoke-BoundedNativeCommand `
+    -FilePath $tarExe `
+    -ArgumentList @("-xJf", $archivePath, "-C", $msys2Root) `
+    -Activity "MSYS2 Tup prerequisite archive extraction"
+  if ($tarExit -ne 0) {
+    throw "Failed to extract MSYS2 Tup prerequisite archive '$archivePath' (exit $tarExit)."
   }
   if (-not (Test-Path -LiteralPath $msysBashExe -PathType Leaf)) {
     throw "MSYS2 Tup prerequisite bootstrap did not produce '$msysBashExe'."
   }
 
   $packageArgs = ($packages | ForEach-Object { $_.Trim() }) -join " "
+  # `--noconfirm` was already here, so pacman is not waiting on a [Y/n]. What
+  # it can still do is wait on a mirror that has gone quiet mid-transfer, and
+  # `-lc` means a prompt from anything pacman itself invokes would inherit the
+  # runner's stdin. The bound and the empty stdin close both.
   $packageInstallCommand = "set -euo pipefail; pacman -Sy --noconfirm --needed $packageArgs"
-  & $msysBashExe -lc $packageInstallCommand | Out-Host
-  if ($LASTEXITCODE -ne 0) {
-    throw "Failed to install Tup MSYS2 prerequisite packages ($packageArgs)."
+  Write-Host "Installing MSYS2 packages: $packageArgs"
+  $pacmanExit = Invoke-BoundedNativeCommand `
+    -FilePath $msysBashExe `
+    -ArgumentList @("-lc", $packageInstallCommand) `
+    -Activity "MSYS2 pacman install of Tup prerequisites"
+  if ($pacmanExit -ne 0) {
+    throw "Failed to install Tup MSYS2 prerequisite packages ($packageArgs) (exit $pacmanExit)."
   }
 
   $mingwGccExe = Join-Path $msysInstallRoot "mingw64/bin/gcc.exe"

--- a/non-nix-build/windows/toolchain-utils.ps1
+++ b/non-nix-build/windows/toolchain-utils.ps1
@@ -172,22 +172,420 @@ function Ensure-CleanDirectory {
   New-Item -ItemType Directory -Force -Path $Path | Out-Null
 }
 
-function Test-BootstrapStepEnabled {
+function Test-BootstrapAllowlistActive {
+  <#
+    .SYNOPSIS
+      True when WINDOWS_DIY_ONLY restricts this run to a named subset.
+
+    .DESCRIPTION
+      A caller that sets WINDOWS_DIY_ONLY is asking for a SUBSET of
+      codetracer's dev env -- typically a satellite repo that needs one
+      pinned tool. Everything in `env.ps1` that exists to make CODETRACER
+      ITSELF buildable (its node-packages tooling, its tree-sitter Nim
+      parser, its runtime env, the hard requirement on MSVC's cl.exe) is
+      then out of scope, and asserting it would fail a run that got exactly
+      what it asked for.
+
+      This is deliberately a single predicate rather than a set of opt-outs
+      the caller has to remember: a satellite repo that had to name each
+      extra separately would silently start failing the day a new one is
+      added, which is the same defect that makes a subtractive component
+      list unusable.
+  #>
+  return -not [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable("WINDOWS_DIY_ONLY"))
+}
+
+function Get-BootstrapStepSkipReason {
+  <#
+    .SYNOPSIS
+      Why this component will not run, or $null if it will.
+
+    .DESCRIPTION
+      THE single decision point for whether a gated component is wanted.
+      Two gates feed it and they answer different questions:
+
+        WINDOWS_DIY_ONLY          positive allowlist -- "just these".
+        WINDOWS_DIY_SKIP_<STEP>   subtractive        -- "all but this".
+
+      They compose, and neither silently overrides the other: a component
+      must be listed by the allowlist (when one is given) AND not be
+      individually skipped.
+
+      It matters that this is ONE function. `env.ps1` consults the same
+      question twice per component -- once to dispatch it, and once again
+      afterwards to decide whether to ASSERT the tool is present (see the
+      `WINDOWS_DIY_ENSURE_TTD` / `WINDOWS_DIY_ENSURE_DOTNET` defaults). If
+      the two consultations can disagree, a component is skipped and then
+      demanded, and the run fails on the absence of something it was told
+      not to install.
+  #>
   param([Parameter(Mandatory = $true)][string]$Step)
+
+  $onlyRaw = [Environment]::GetEnvironmentVariable("WINDOWS_DIY_ONLY")
+  if (-not [string]::IsNullOrWhiteSpace($onlyRaw)) {
+    $only = @($onlyRaw -split "[,;\s]+" |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+      ForEach-Object { $_.Trim().ToUpperInvariant() })
+    if ($only -notcontains $Step.ToUpperInvariant()) {
+      return "not listed in WINDOWS_DIY_ONLY"
+    }
+  }
 
   $envName = "WINDOWS_DIY_SKIP_$Step"
   $rawValue = [Environment]::GetEnvironmentVariable($envName)
-  if ([string]::IsNullOrWhiteSpace($rawValue)) {
-    return $true
+  if (-not [string]::IsNullOrWhiteSpace($rawValue)) {
+    $value = $rawValue.Trim().ToLowerInvariant()
+    if ($value -in @("1", "true", "yes", "on")) {
+      return "$envName=$rawValue is set"
+    }
   }
 
-  $value = $rawValue.Trim().ToLowerInvariant()
-  if ($value -in @("1", "true", "yes", "on")) {
-    Write-Warning "Skipping bootstrap step '$Step' because $envName=$rawValue."
+  return $null
+}
+
+function Test-BootstrapStepEnabled {
+  param([Parameter(Mandatory = $true)][string]$Step)
+
+  $reason = Get-BootstrapStepSkipReason -Step $Step
+  if ($null -ne $reason) {
+    Write-Warning "Skipping bootstrap step '$Step': $reason."
     return $false
   }
 
   return $true
+}
+
+# ---------------------------------------------------------------------------
+# Bootstrap step accounting
+#
+# Every gated component in `env.ps1`'s dispatch block runs through
+# `Invoke-BootstrapStep`, which times it, records whether it ran or was
+# skipped, and notes which install-root directories it created. At the end of
+# a bootstrap `Write-BootstrapStepReport` turns that into a machine-readable
+# per-component table: name, declared relocatability class, wall clock,
+# on-disk size, and the directories the size came from.
+#
+# WHY THE DISPATCH BLOCK PRODUCES THE TABLE, rather than a separate list of
+# components maintained alongside it: a separate list rots silently. A
+# component added to the dispatch later would simply be absent from the
+# decomposition, and the absence would look exactly like a component that
+# installs nothing. Because the table is emitted BY the dispatch, a new
+# component appears in it automatically, and the AST gate in
+# `ci/test/bootstrap-decomposition.ps1` refuses a dispatch line that does not
+# go through this wrapper.
+#
+# SIZES ARE MEASURED ONCE, AT THE END, not per step. Walking a multi-gigabyte
+# install root 22 times would cost more than several of the installs being
+# measured. What each step records live is the cheap part -- wall clock, and a
+# top-level directory listing before and after -- and the expensive recursive
+# sizing happens a single time in `Write-BootstrapStepReport`, attributed back
+# to whichever step created each directory.
+# ---------------------------------------------------------------------------
+
+# Valid relocatability classes. This is the property a caller needs in order
+# to decide whether a component can live in a shared immutable store at all.
+#
+# These describe the install MECHANISM, which is a static property of the
+# Ensure-* script and can be read off it. They deliberately do NOT claim the
+# installed bits are position-independent: proving that requires moving a
+# store entry and re-running it, which is a separate measurement, not a
+# declaration made here.
+#   relocatable - installed by extracting an archive or building in place
+#                 under the install root; nothing was written outside it.
+#                 A store CANDIDATE.
+#   junction    - install materialises junctions/symlinks inside the install
+#                 root. Movable only if the links are rebuilt.
+#   installer   - a vendor installer (.exe/.msi/winget/AppX) ran and may have
+#                 written outside the install root, e.g. into Program Files
+#                 or the registry. NOT a store candidate without repackaging.
+$script:BootstrapRelocatabilityClasses = @("relocatable", "junction", "installer")
+
+$script:BootstrapStepRecords = [System.Collections.Generic.List[object]]::new()
+
+function Get-BootstrapStepRecords {
+  return $script:BootstrapStepRecords.ToArray()
+}
+
+function Reset-BootstrapStepRecords {
+  $script:BootstrapStepRecords.Clear()
+}
+
+function Get-InstallRootTopLevelNames {
+  param([Parameter(Mandatory = $true)][string]$Root)
+
+  if (-not (Test-Path -LiteralPath $Root -PathType Container)) {
+    return @()
+  }
+  return @(Get-ChildItem -LiteralPath $Root -Directory -Force -ErrorAction SilentlyContinue |
+    ForEach-Object { $_.Name })
+}
+
+function Invoke-BootstrapStep {
+  <#
+    .SYNOPSIS
+      Run one gated bootstrap component, honouring WINDOWS_DIY_SKIP_<Step>,
+      and record what it cost.
+
+    .PARAMETER Step
+      The gate name, e.g. "CAPNP". `WINDOWS_DIY_SKIP_<Step>` disables it.
+
+    .PARAMETER Relocatability
+      How this component installs; one of $BootstrapRelocatabilityClasses.
+      Declared at the call site because it is a static property of the
+      Ensure-* script, not something that can be inferred from the result.
+      `Write-BootstrapStepReport` cross-checks the "relocatable" claim
+      against the reparse points it actually finds, so a wrong declaration
+      is caught rather than trusted.
+
+    .PARAMETER Root
+      The install root, used to attribute created directories.
+
+    .PARAMETER Action
+      The Ensure-* invocation.
+  #>
+  param(
+    [Parameter(Mandatory = $true)][string]$Step,
+    [Parameter(Mandatory = $true)][ValidateSet("relocatable", "junction", "installer")][string]$Relocatability,
+    [Parameter(Mandatory = $true)][string]$Root,
+    [Parameter(Mandatory = $true)][scriptblock]$Action
+  )
+
+  # Two gates, and they answer different questions.
+  #
+  # WINDOWS_DIY_SKIP_<STEP> is subtractive: "codetracer's dev env, minus this
+  # component". WINDOWS_DIY_ONLY is a positive allowlist: "just these
+  # components". A satellite repo wants the second -- `codetracer-trace-format`
+  # needs Cap'n Proto and nothing else, and expressing that as twenty-one
+  # skip variables would be both unreadable and silently wrong the moment a
+  # twenty-third component is added, because the new one would default to ON.
+  #
+  # The allowlist is also the shape a per-project overlay needs: it NAMES the
+  # pinned components that project wants, rather than subtracting from a
+  # whole-repo default.
+  #
+  # BOTH gates live in Get-BootstrapStepSkipReason rather than here, because
+  # `env.ps1` asks the same question a second time -- after the dispatch, to
+  # decide whether to ASSERT a tool is present. Evaluating the allowlist only
+  # at this call site made the two answers disagree: a component was skipped
+  # here and then demanded there, and the run failed on the absence of
+  # something it had been told not to install.
+  $skipReason = Get-BootstrapStepSkipReason -Step $Step
+
+  if ($null -ne $skipReason) {
+    $script:BootstrapStepRecords.Add([pscustomobject]@{
+      step = $Step
+      relocatability = $Relocatability
+      status = "skipped"
+      skip_variable = "WINDOWS_DIY_SKIP_$Step"
+      skip_reason = $skipReason
+      seconds = 0.0
+      created_dirs = @()
+      error = $null
+    })
+    return
+  }
+
+  $before = Get-InstallRootTopLevelNames -Root $Root
+  $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+  $status = "ok"
+  $errorText = $null
+  try {
+    & $Action
+  } catch {
+    # Record the cost of the failure before rethrowing. A component that
+    # dies 40 minutes in is a fact the decomposition needs. Timing this
+    # bootstrap from runs that never completed is how a provisioning cost
+    # gets mis-stated, and an unrecorded failure is how that happens.
+    $status = "failed"
+    $errorText = $_.Exception.Message
+    throw
+  } finally {
+    $stopwatch.Stop()
+    $after = Get-InstallRootTopLevelNames -Root $Root
+    $created = @($after | Where-Object { $before -notcontains $_ })
+    $script:BootstrapStepRecords.Add([pscustomobject]@{
+      step = $Step
+      relocatability = $Relocatability
+      status = $status
+      skip_variable = "WINDOWS_DIY_SKIP_$Step"
+      skip_reason = $null
+      seconds = [math]::Round($stopwatch.Elapsed.TotalSeconds, 3)
+      created_dirs = $created
+      error = $errorText
+    })
+  }
+}
+
+function Measure-DirectorySize {
+  <#
+    .SYNOPSIS
+      Recursive on-disk size in bytes, plus a reparse-point count.
+
+    .DESCRIPTION
+      Reparse points are counted but NOT followed, and their targets are not
+      added to the byte total. Following them would double-count a junction
+      into a directory that is itself inside the install root -- which is
+      exactly the shape `Ensure-NodeModulesJunction` creates -- and would
+      make the install-root total too large by an amount that varies with
+      how many junctions happen to exist.
+  #>
+  param([Parameter(Mandatory = $true)][string]$Path)
+
+  $bytes = [long]0
+  $files = [long]0
+  $reparsePoints = [long]0
+
+  if (-not (Test-Path -LiteralPath $Path)) {
+    return [pscustomobject]@{ bytes = $bytes; files = $files; reparse_points = $reparsePoints }
+  }
+
+  $stack = [System.Collections.Generic.Stack[string]]::new()
+  $stack.Push($Path)
+  while ($stack.Count -gt 0) {
+    $current = $stack.Pop()
+    $entries = @()
+    try {
+      $entries = @(Get-ChildItem -LiteralPath $current -Force -ErrorAction Stop)
+    } catch {
+      continue
+    }
+    foreach ($entry in $entries) {
+      $isReparse = (($entry.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0)
+      if ($isReparse) {
+        $reparsePoints++
+        continue
+      }
+      if ($entry.PSIsContainer) {
+        $stack.Push($entry.FullName)
+      } else {
+        $bytes += [long]$entry.Length
+        $files++
+      }
+    }
+  }
+
+  return [pscustomobject]@{ bytes = $bytes; files = $files; reparse_points = $reparsePoints }
+}
+
+function Write-BootstrapStepReport {
+  <#
+    .SYNOPSIS
+      Emit the per-component decomposition and the install-root total.
+
+    .DESCRIPTION
+      Writes `<OutputDir>/windows-env-decomposition.json` (machine-readable,
+      the artifact to commit) and a short human-readable summary to the
+      host. Anything that sizes this bootstrap derives from it, so it records
+      the denominator too: whether the run completed, and which components
+      were skipped. A "green" run with components skipped is a different fact
+      from a green run without, and the file says which it was.
+  #>
+  param(
+    [Parameter(Mandatory = $true)][string]$Root,
+    [Parameter(Mandatory = $true)][string]$OutputDir
+  )
+
+  $records = Get-BootstrapStepRecords
+  $rows = @()
+  $attributed = @{}
+
+  foreach ($record in $records) {
+    $bytes = [long]0
+    $files = [long]0
+    $reparse = [long]0
+    foreach ($dir in $record.created_dirs) {
+      $full = Join-Path $Root $dir
+      $measured = Measure-DirectorySize -Path $full
+      $bytes += $measured.bytes
+      $files += $measured.files
+      $reparse += $measured.reparse_points
+      $attributed[$dir] = $record.step
+    }
+
+    # Cross-check the declared class against what is on disk. A component
+    # declared "relocatable" that produced reparse points is mis-declared,
+    # and a later store-safety assumption would inherit the error.
+    $relocatabilityWarning = $null
+    if ($record.relocatability -eq "relocatable" -and $reparse -gt 0) {
+      $relocatabilityWarning =
+        "declared relocatable but $reparse reparse point(s) found under its install directories"
+      Write-Warning "Bootstrap step '$($record.step)': $relocatabilityWarning"
+    }
+
+    $rows += [pscustomobject]@{
+      step = $record.step
+      status = $record.status
+      relocatability = $record.relocatability
+      relocatability_warning = $relocatabilityWarning
+      seconds = $record.seconds
+      bytes = $bytes
+      files = $files
+      reparse_points = $reparse
+      install_dirs = @($record.created_dirs)
+      skip_variable = $record.skip_variable
+      skip_reason = $record.skip_reason
+      error = $record.error
+    }
+  }
+
+  $rootMeasured = Measure-DirectorySize -Path $Root
+  $unattributed = @(Get-InstallRootTopLevelNames -Root $Root |
+    Where-Object { -not $attributed.ContainsKey($_) })
+
+  $skipped = @($rows | Where-Object { $_.status -eq "skipped" } | ForEach-Object { $_.step })
+  $failed = @($rows | Where-Object { $_.status -eq "failed" } | ForEach-Object { $_.step })
+
+  # Architecture is a label on the measurement, not part of it. Get-WindowsArch
+  # goes through CIM, which is Windows-only and can fail on a loaded box; a
+  # report that cannot say which architecture it came from is far more useful
+  # than no report at all, and this function is called from a `finally` whose
+  # whole purpose is to survive a failed provision.
+  $arch = "unknown"
+  try { $arch = Get-WindowsArch } catch { $arch = "unknown" }
+
+  $report = [pscustomobject]@{
+    schema = "codetracer.windows-env-decomposition.v1"
+    generated_at_utc = (Get-Date).ToUniversalTime().ToString("o")
+    os = "windows"
+    arch = $arch
+    install_root = $Root
+    # The install-root total. Reported as the whole-root
+    # measurement rather than the sum of the per-step rows, because a step
+    # that writes into a directory an earlier step created contributes to
+    # the root total but is not attributed to a directory of its own.
+    install_root_bytes = $rootMeasured.bytes
+    install_root_files = $rootMeasured.files
+    install_root_reparse_points = $rootMeasured.reparse_points
+    total_seconds = [math]::Round((($rows | Measure-Object -Property seconds -Sum).Sum), 3)
+    # A run with skips is not the same fact as a run without. Recorded here
+    # so a consumer of this file cannot mistake one for the other.
+    complete = ($skipped.Count -eq 0 -and $failed.Count -eq 0)
+    skipped_steps = $skipped
+    failed_steps = $failed
+    unattributed_install_dirs = $unattributed
+    components = $rows
+  }
+
+  New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+  $jsonPath = Join-Path $OutputDir "windows-env-decomposition.json"
+  $report | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $jsonPath -Encoding UTF8
+
+  Write-Host ""
+  Write-Host "env.ps1 per-component decomposition ($($rows.Count) components):"
+  foreach ($row in ($rows | Sort-Object -Property seconds -Descending)) {
+    $mb = [math]::Round($row.bytes / 1MB, 1)
+    Write-Host ("  {0,-12} {1,-11} {2,10:N1}s {3,10} MB  {4}" -f `
+      $row.step, $row.status, $row.seconds, $mb, $row.relocatability)
+  }
+  Write-Host ("  TOTAL install root: {0:N1} MB in {1:N0} files ({2} reparse points)" -f `
+    ($rootMeasured.bytes / 1MB), $rootMeasured.files, $rootMeasured.reparse_points)
+  if (-not $report.complete) {
+    Write-Host ("  NOTE: incomplete run - skipped [{0}] failed [{1}]" -f `
+      ($skipped -join ","), ($failed -join ","))
+  }
+  Write-Host "Wrote $jsonPath"
+
+  return $jsonPath
 }
 
 function ConvertTo-InstallRelativePath {


### PR DESCRIPTION
Windows provisioning jobs were being killed at the job timeout after a median 217 minutes of total silence, 26 of 28 retained logs going quiet on the same line. The cause: `Invoke-WebRequest -OutFile` puts no bound on the body read, and `-TimeoutSec` does not fix it — measured against a mid-body-stalling server, `-TimeoutSec 5` was still running at 90 seconds.

Downloads are now bounded on inactivity (re-armed per chunk) as well as total budget, with one deadline shared across retries rather than per attempt. `tar` and `pacman` are bounded and given empty stdin, so a prompt becomes EOF rather than a block. The MSYS2 download is announced — it was the only unannounced one, which is why a stall there produced a log whose last line was the previous component finishing.

Adds per-component bootstrap accounting and a narrow dispatch-only probe of that leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)