### PR TITLE
fix(mcp): dispatch the two advertised origin tools, and sync the meta.dat flag mask

### DIFF
--- a/docs/book-isonim/content/reference/mcp-tools.md
+++ b/docs/book-isonim/content/reference/mcp-tools.md
@@ -24,59 +24,60 @@ milestone. For the full tool list see the tool registration in
 
 ### `get_value_origin`
 
-Returns the canonical `OriginChain` for a queried variable at a chosen
-step. This is a one-shot fallback for callers that only want a single
-chain — the **preferred** multi-step path is to send a Python script
-through the existing `exec_script` tool and call
+Returns the canonical `OriginChain` for a variable at a chosen source
+location: where the value came from, hop by hop, down to the literal,
+computation, or parameter that produced it.
+
+The query is anchored at a **source location**, not at a step id. An MCP
+call is stateless and `ct/open-trace` rewinds the replay to the program
+entry, where no interesting variable is live yet; the tool therefore sets
+a breakpoint at `path`:`line`, runs to it, and queries the step it
+stopped on — the same sequence the per-language `origin_*_dap_test.rs`
+suites use. If the line is never reached, the call fails rather than
+answering about whatever step the replay ended on.
+
+For multi-query sessions that reuse one loaded trace, prefer sending a
+Python script through the `exec_script` tool and calling
 `trace.value_origin("<variable>", step=..., frame=..., max_hops=...)`
 inside it. The Python binding composes with `trace.locals()`,
-`trace.history()`, breakpoints and watchpoints, and reuses the loaded
-trace + classifier pattern set across calls.
+`trace.history()`, breakpoints and watchpoints, and keeps the trace and
+classifier pattern set loaded across calls.
 
 #### Input schema
 
-| Field         | Type      | Required | Description                                                                                                                                                                  |
-| ------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `trace_path`  | `string`  | yes      | Either a local path to a `.ct` trace folder or an observability dive-in URL (see `exec_script` for URL format).                                                              |
-| `variable`    | `string`  | yes      | Variable identifier to query. V1 is identifier-only; dotted paths are reserved for a future milestone.                                                                       |
-| `step`        | `integer` | no       | Optional step id. Defaults to the current execution point of the session.                                                                                                    |
-| `frame`       | `integer` | no       | Optional DAP frame id. Defaults to the topmost frame.                                                                                                                        |
-| `max_hops`    | `integer` | no       | Maximum hops in this batch (default 16). Prefer `lazy` + `continuation_token` over bumping this above ~32.                                                                   |
-| `lazy`        | `boolean` | no       | When `true`, the backend may return early with a `continuationToken`. Default `false`.                                                                                       |
-| `session_id`  | `string`  | no       | Optional session identifier — when reused across calls the trace and classifier pattern set stay loaded, avoiding a re-load. Same semantics as `exec_script.session_id`.    |
+| Field        | Type      | Required | Description                                                                                                                                  |
+| ------------ | --------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `trace_path` | `string`  | yes      | Either a local path to a `.ct` trace folder or an observability dive-in URL (see `exec_script` for URL format).                              |
+| `path`       | `string`  | yes      | Source file of the query line. May be a suffix of the recorded path (`main.py`); it is resolved against the trace's source file list, and an ambiguous suffix is an error. |
+| `line`       | `number`  | yes      | 1-based line to run to before querying. The variable must be live there.                                                                     |
+| `variable`   | `string`  | yes      | Variable identifier to query. V1 is identifier-only; dotted paths are reserved for a future milestone.                                        |
+| `max_hops`   | `number`  | no       | Maximum hops in this batch (default 16). Backends clamp it to their own tier limit.                                                          |
 
 #### Output shape
 
-The tool returns the canonical `OriginChain` JSON pretty-printed in the
-MCP text content envelope. The body matches the wire shape from spec
-§4.1:
+The tool returns the spec §3.2 text rendering of the chain followed by
+the canonical `OriginChain` JSON (spec §4.1) under a
+`Canonical OriginChain JSON:` heading, so an agent can either read it or
+parse it:
 
-```json
-{
-  "hops": [
-    {
-      "kind": "TrivialCopy",
-      "stepId": 41,
-      "location": { "path": "main.py", "line": 6, "column": 0 },
-      "source": "b = helper(a)",
-      "frameTransition": { "kind": "ParameterPass", "from": "main", "to": "helper" }
-    },
-    { "kind": "TrivialCopy", "stepId": 38, "location": { "path": "main.py", "line": 5 }, "source": "a = 10" }
-  ],
-  "terminator": {
-    "kind": "Literal",
-    "expression": "10",
-    "location": { "path": "main.py", "line": 5 }
-  },
-  "truncated": false,
-  "continuationToken": null,
-  "metrics": { "elapsedMs": 12, "hopsWalked": 2 },
-  "confidence": 1.0
-}
+```
+Origin chain for 'c' @ step=7
+  hops=3 terminator=literal truncated=no
+
+  0. [=] main.py:12
+     c = b
+  1. [=] main.py:11
+     b = a
+  2. [L] main.py:10
+     a = 10
+  [lit] 10
+      @ main
 ```
 
-When `truncated` is `true`, pass `continuationToken` back as the
-`continuationToken` argument on the next call to resume the walk.
+Note that a recorded step carries the program state on *entering* a
+line, so each hop's `location` is the step at which the value first
+becomes observable — one step after the assignment named by that hop's
+`sourceText`.
 
 #### Example call
 
@@ -89,8 +90,9 @@ When `truncated` is `true`, pass `continuationToken` back as the
     "name": "get_value_origin",
     "arguments": {
       "trace_path": "/traces/my-bug.ct",
-      "variable": "total",
-      "step": 137,
+      "path": "main.py",
+      "line": 12,
+      "variable": "c",
       "max_hops": 8
     }
   }
@@ -99,32 +101,41 @@ When `truncated` is `true`, pass `continuationToken` back as the
 
 ### `resolve_variable_step`
 
-Returns the most recent step id at which `variable` was assigned in the
-trace. Pair it with `get_value_origin` when you want the chain at the
-assignment site rather than the caller's current step.
+The first hop of the same chain: where the value a variable holds at
+`path`:`line` came from, without walking the rest of the way back. Pair
+it with `get_value_origin` when you want the full provenance.
 
 #### Input schema
 
-| Field        | Type      | Required | Description                                                |
-| ------------ | --------- | -------- | ---------------------------------------------------------- |
-| `trace_path` | `string`  | yes      | Path to the trace folder (or dive-in URL).                 |
-| `variable`   | `string`  | yes      | Variable identifier to look up.                            |
-| `frame`      | `integer` | no       | Optional DAP frame id (scopes the search to that frame).   |
-| `session_id` | `string`  | no       | Optional session identifier; same semantics as above.      |
+| Field        | Type     | Required | Description                                            |
+| ------------ | -------- | -------- | ------------------------------------------------------ |
+| `trace_path` | `string` | yes      | Path to the trace folder (or dive-in URL).             |
+| `path`       | `string` | yes      | Source file of the query line (suffix match allowed).  |
+| `line`       | `number` | yes      | 1-based line to run to before querying.                |
+| `variable`   | `string` | yes      | Variable identifier to resolve.                        |
 
 #### Output shape
 
 ```json
 {
-  "stepId": 138,
-  "variable": "total",
-  "location": { "path": "main.py", "line": 53, "column": 4 }
+  "variable": "a",
+  "stepId": 5,
+  "location": { "path": "main.py", "line": 10, "functionName": "main" },
+  "assignment": "    a = 10",
+  "originKind": "literal",
+  "sourceVariable": null
 }
 ```
 
-The formatter scans `ct/load-history` updates in reverse and returns the
-first match. When no assignment is found the call fails with the
-backend's error message.
+`stepId` / `location` are the earliest step at which the variable is
+observed holding this value; `assignment` is the statement that produced
+it. Because of the entering-a-line step semantics above, `location.line`
+is the line *after* the assignment statement — both are reported so the
+answer is not ambiguous.
+
+When no assignment can be resolved the call fails with an explicit
+message naming the variable. It never answers with an empty success: an
+empty answer would be indistinguishable from an unimplemented tool.
 
 #### Example call
 
@@ -137,7 +148,9 @@ backend's error message.
     "name": "resolve_variable_step",
     "arguments": {
       "trace_path": "/traces/my-bug.ct",
-      "variable": "total"
+      "path": "main.py",
+      "line": 12,
+      "variable": "a"
     }
   }
 }
@@ -147,12 +160,22 @@ backend's error message.
 
 | Item                                       | Location                                                              |
 | ------------------------------------------ | --------------------------------------------------------------------- |
-| Tool registration                          | `src/backend-manager/src/mcp_server.rs::get_value_origin_tool`        |
+| Tool table (schemas **and** dispatch)      | `src/backend-manager/src/mcp_server.rs::TOOLS`                        |
+| Tool schemas                               | `src/backend-manager/src/mcp_server.rs::get_value_origin_tool`        |
 |                                            | `src/backend-manager/src/mcp_server.rs::resolve_variable_step_tool`   |
 | Tool handlers                              | `src/backend-manager/src/mcp_server.rs::handle_get_value_origin`      |
 |                                            | `src/backend-manager/src/mcp_server.rs::handle_resolve_variable_step` |
+| Shared origin query (open / break / walk)  | `src/backend-manager/src/mcp_server.rs::run_origin_query`             |
+| Python bridge route (`trace.value_origin`) | `src/backend-manager/src/backend_manager.rs::handle_py_origin_chain`  |
 | Response formatters                        | `src/backend-manager/src/python_bridge.rs`                            |
 | Wire-shape definitions                     | `src/db-backend/src/task.rs` (Rust) / `python-api/codetracer/origin.py` (Python) |
+| End-to-end tests                           | `src/backend-manager/tests/mcp_origin_test.rs`                        |
+| Advertise/dispatch divergence check        | `src/backend-manager/tests/mcp_tool_surface_test.rs`                  |
+
+`TOOLS` is the single source of truth for the tool surface: `tools/list`
+advertises from it and `tools/call` dispatches from it, so a tool cannot
+be advertised without being callable. Add new tools there, never to a
+separate list.
 
 For the user-facing walkthrough, see
 [Value Origin Tracking](../usage_guide/value-origin-tracking.md).

--- a/docs/book-isonim/content/usage_guide/value-origin-tracking.md
+++ b/docs/book-isonim/content/usage_guide/value-origin-tracking.md
@@ -341,13 +341,13 @@ the full flag table.
 The CodeTracer MCP server registers two tools that surface origin
 tracking to LLM agents directly:
 
-- **`get_value_origin`** — one-shot lookup. Returns the canonical
-  `OriginChain` JSON for `variable` at `step`/`frame`. Use this when you
-  only need a single chain without authoring a script.
-- **`resolve_variable_step`** — helper that maps a variable name to the
-  most recent step at which it was assigned. Pair it with
-  `get_value_origin` when you want the chain at the assignment site
-  rather than the current step.
+- **`get_value_origin`** — one-shot lookup. Runs to `path`:`line`,
+  then returns the canonical `OriginChain` for `variable` at that step.
+  Use this when you only need a single chain without authoring a script.
+- **`resolve_variable_step`** — the first hop of that same chain: where
+  the value the variable holds at `path`:`line` came from, reported as
+  the step at which it becomes observable plus the statement that
+  assigned it.
 
 The **preferred** multi-step path is to send a Python script through the
 existing `exec_script` MCP tool and call `trace.value_origin(...)`

--- a/docs/book/src/reference/mcp-tools.md
+++ b/docs/book/src/reference/mcp-tools.md
@@ -20,59 +20,60 @@ milestone. For the full tool list see the tool registration in
 
 ### `get_value_origin`
 
-Returns the canonical `OriginChain` for a queried variable at a chosen
-step. This is a one-shot fallback for callers that only want a single
-chain — the **preferred** multi-step path is to send a Python script
-through the existing `exec_script` tool and call
+Returns the canonical `OriginChain` for a variable at a chosen source
+location: where the value came from, hop by hop, down to the literal,
+computation, or parameter that produced it.
+
+The query is anchored at a **source location**, not at a step id. An MCP
+call is stateless and `ct/open-trace` rewinds the replay to the program
+entry, where no interesting variable is live yet; the tool therefore sets
+a breakpoint at `path`:`line`, runs to it, and queries the step it
+stopped on — the same sequence the per-language `origin_*_dap_test.rs`
+suites use. If the line is never reached, the call fails rather than
+answering about whatever step the replay ended on.
+
+For multi-query sessions that reuse one loaded trace, prefer sending a
+Python script through the `exec_script` tool and calling
 `trace.value_origin("<variable>", step=..., frame=..., max_hops=...)`
 inside it. The Python binding composes with `trace.locals()`,
-`trace.history()`, breakpoints and watchpoints, and reuses the loaded
-trace + classifier pattern set across calls.
+`trace.history()`, breakpoints and watchpoints, and keeps the trace and
+classifier pattern set loaded across calls.
 
 #### Input schema
 
-| Field         | Type      | Required | Description                                                                                                                                                                  |
-| ------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `trace_path`  | `string`  | yes      | Either a local path to a `.ct` trace folder or an observability dive-in URL (see `exec_script` for URL format).                                                              |
-| `variable`    | `string`  | yes      | Variable identifier to query. V1 is identifier-only; dotted paths are reserved for a future milestone.                                                                       |
-| `step`        | `integer` | no       | Optional step id. Defaults to the current execution point of the session.                                                                                                    |
-| `frame`       | `integer` | no       | Optional DAP frame id. Defaults to the topmost frame.                                                                                                                        |
-| `max_hops`    | `integer` | no       | Maximum hops in this batch (default 16). Prefer `lazy` + `continuation_token` over bumping this above ~32.                                                                   |
-| `lazy`        | `boolean` | no       | When `true`, the backend may return early with a `continuationToken`. Default `false`.                                                                                       |
-| `session_id`  | `string`  | no       | Optional session identifier — when reused across calls the trace and classifier pattern set stay loaded, avoiding a re-load. Same semantics as `exec_script.session_id`.    |
+| Field        | Type      | Required | Description                                                                                                                                  |
+| ------------ | --------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `trace_path` | `string`  | yes      | Either a local path to a `.ct` trace folder or an observability dive-in URL (see `exec_script` for URL format).                              |
+| `path`       | `string`  | yes      | Source file of the query line. May be a suffix of the recorded path (`main.py`); it is resolved against the trace's source file list, and an ambiguous suffix is an error. |
+| `line`       | `number`  | yes      | 1-based line to run to before querying. The variable must be live there.                                                                     |
+| `variable`   | `string`  | yes      | Variable identifier to query. V1 is identifier-only; dotted paths are reserved for a future milestone.                                        |
+| `max_hops`   | `number`  | no       | Maximum hops in this batch (default 16). Backends clamp it to their own tier limit.                                                          |
 
 #### Output shape
 
-The tool returns the canonical `OriginChain` JSON pretty-printed in the
-MCP text content envelope. The body matches the wire shape from spec
-§4.1:
+The tool returns the spec §3.2 text rendering of the chain followed by
+the canonical `OriginChain` JSON (spec §4.1) under a
+`Canonical OriginChain JSON:` heading, so an agent can either read it or
+parse it:
 
-```json
-{
-  "hops": [
-    {
-      "kind": "TrivialCopy",
-      "stepId": 41,
-      "location": { "path": "main.py", "line": 6, "column": 0 },
-      "source": "b = helper(a)",
-      "frameTransition": { "kind": "ParameterPass", "from": "main", "to": "helper" }
-    },
-    { "kind": "TrivialCopy", "stepId": 38, "location": { "path": "main.py", "line": 5 }, "source": "a = 10" }
-  ],
-  "terminator": {
-    "kind": "Literal",
-    "expression": "10",
-    "location": { "path": "main.py", "line": 5 }
-  },
-  "truncated": false,
-  "continuationToken": null,
-  "metrics": { "elapsedMs": 12, "hopsWalked": 2 },
-  "confidence": 1.0
-}
+```
+Origin chain for 'c' @ step=7
+  hops=3 terminator=literal truncated=no
+
+  0. [=] main.py:12
+     c = b
+  1. [=] main.py:11
+     b = a
+  2. [L] main.py:10
+     a = 10
+  [lit] 10
+      @ main
 ```
 
-When `truncated` is `true`, pass `continuationToken` back as the
-`continuationToken` argument on the next call to resume the walk.
+Note that a recorded step carries the program state on *entering* a
+line, so each hop's `location` is the step at which the value first
+becomes observable — one step after the assignment named by that hop's
+`sourceText`.
 
 #### Example call
 
@@ -85,8 +86,9 @@ When `truncated` is `true`, pass `continuationToken` back as the
     "name": "get_value_origin",
     "arguments": {
       "trace_path": "/traces/my-bug.ct",
-      "variable": "total",
-      "step": 137,
+      "path": "main.py",
+      "line": 12,
+      "variable": "c",
       "max_hops": 8
     }
   }
@@ -95,32 +97,41 @@ When `truncated` is `true`, pass `continuationToken` back as the
 
 ### `resolve_variable_step`
 
-Returns the most recent step id at which `variable` was assigned in the
-trace. Pair it with `get_value_origin` when you want the chain at the
-assignment site rather than the caller's current step.
+The first hop of the same chain: where the value a variable holds at
+`path`:`line` came from, without walking the rest of the way back. Pair
+it with `get_value_origin` when you want the full provenance.
 
 #### Input schema
 
-| Field        | Type      | Required | Description                                                |
-| ------------ | --------- | -------- | ---------------------------------------------------------- |
-| `trace_path` | `string`  | yes      | Path to the trace folder (or dive-in URL).                 |
-| `variable`   | `string`  | yes      | Variable identifier to look up.                            |
-| `frame`      | `integer` | no       | Optional DAP frame id (scopes the search to that frame).   |
-| `session_id` | `string`  | no       | Optional session identifier; same semantics as above.      |
+| Field        | Type     | Required | Description                                            |
+| ------------ | -------- | -------- | ------------------------------------------------------ |
+| `trace_path` | `string` | yes      | Path to the trace folder (or dive-in URL).             |
+| `path`       | `string` | yes      | Source file of the query line (suffix match allowed).  |
+| `line`       | `number` | yes      | 1-based line to run to before querying.                |
+| `variable`   | `string` | yes      | Variable identifier to resolve.                        |
 
 #### Output shape
 
 ```json
 {
-  "stepId": 138,
-  "variable": "total",
-  "location": { "path": "main.py", "line": 53, "column": 4 }
+  "variable": "a",
+  "stepId": 5,
+  "location": { "path": "main.py", "line": 10, "functionName": "main" },
+  "assignment": "    a = 10",
+  "originKind": "literal",
+  "sourceVariable": null
 }
 ```
 
-The formatter scans `ct/load-history` updates in reverse and returns the
-first match. When no assignment is found the call fails with the
-backend's error message.
+`stepId` / `location` are the earliest step at which the variable is
+observed holding this value; `assignment` is the statement that produced
+it. Because of the entering-a-line step semantics above, `location.line`
+is the line *after* the assignment statement — both are reported so the
+answer is not ambiguous.
+
+When no assignment can be resolved the call fails with an explicit
+message naming the variable. It never answers with an empty success: an
+empty answer would be indistinguishable from an unimplemented tool.
 
 #### Example call
 
@@ -133,7 +144,9 @@ backend's error message.
     "name": "resolve_variable_step",
     "arguments": {
       "trace_path": "/traces/my-bug.ct",
-      "variable": "total"
+      "path": "main.py",
+      "line": 12,
+      "variable": "a"
     }
   }
 }
@@ -143,12 +156,22 @@ backend's error message.
 
 | Item                                       | Location                                                              |
 | ------------------------------------------ | --------------------------------------------------------------------- |
-| Tool registration                          | `src/backend-manager/src/mcp_server.rs::get_value_origin_tool`        |
+| Tool table (schemas **and** dispatch)      | `src/backend-manager/src/mcp_server.rs::TOOLS`                        |
+| Tool schemas                               | `src/backend-manager/src/mcp_server.rs::get_value_origin_tool`        |
 |                                            | `src/backend-manager/src/mcp_server.rs::resolve_variable_step_tool`   |
 | Tool handlers                              | `src/backend-manager/src/mcp_server.rs::handle_get_value_origin`      |
 |                                            | `src/backend-manager/src/mcp_server.rs::handle_resolve_variable_step` |
+| Shared origin query (open / break / walk)  | `src/backend-manager/src/mcp_server.rs::run_origin_query`             |
+| Python bridge route (`trace.value_origin`) | `src/backend-manager/src/backend_manager.rs::handle_py_origin_chain`  |
 | Response formatters                        | `src/backend-manager/src/python_bridge.rs`                            |
 | Wire-shape definitions                     | `src/db-backend/src/task.rs` (Rust) / `python-api/codetracer/origin.py` (Python) |
+| End-to-end tests                           | `src/backend-manager/tests/mcp_origin_test.rs`                        |
+| Advertise/dispatch divergence check        | `src/backend-manager/tests/mcp_tool_surface_test.rs`                  |
+
+`TOOLS` is the single source of truth for the tool surface: `tools/list`
+advertises from it and `tools/call` dispatches from it, so a tool cannot
+be advertised without being callable. Add new tools there, never to a
+separate list.
 
 For the user-facing walkthrough, see
 [Value Origin Tracking](../usage_guide/value-origin-tracking.md).

--- a/docs/book/src/usage_guide/value-origin-tracking.md
+++ b/docs/book/src/usage_guide/value-origin-tracking.md
@@ -331,13 +331,13 @@ the full flag table.
 The CodeTracer MCP server registers two tools that surface origin
 tracking to LLM agents directly:
 
-- **`get_value_origin`** — one-shot lookup. Returns the canonical
-  `OriginChain` JSON for `variable` at `step`/`frame`. Use this when you
-  only need a single chain without authoring a script.
-- **`resolve_variable_step`** — helper that maps a variable name to the
-  most recent step at which it was assigned. Pair it with
-  `get_value_origin` when you want the chain at the assignment site
-  rather than the current step.
+- **`get_value_origin`** — one-shot lookup. Runs to `path`:`line`,
+  then returns the canonical `OriginChain` for `variable` at that step.
+  Use this when you only need a single chain without authoring a script.
+- **`resolve_variable_step`** — the first hop of that same chain: where
+  the value the variable holds at `path`:`line` came from, reported as
+  the step at which it becomes observable plus the statement that
+  assigned it.
 
 The **preferred** multi-step path is to send a Python script through the
 existing `exec_script` MCP tool and call `trace.value_origin(...)`

--- a/src/backend-manager/src/backend_manager.rs
+++ b/src/backend-manager/src/backend_manager.rs
@@ -2426,6 +2426,7 @@ impl BackendManager {
                     "ct/py-read-source" => self.handle_py_read_source(seq, args).await,
                     "ct/py-processes" => self.handle_py_processes(seq, args).await,
                     "ct/py-select-process" => self.handle_py_select_process(seq, args).await,
+                    "ct/py-origin-chain" => self.handle_py_origin_chain(seq, args).await,
                     "ct/py-memory-diff" => self.handle_py_memory_diff(seq, args).await,
                     "ct/mcrMemoryDiff" => self.handle_py_memory_diff(seq, args).await,
                     "ct/py-memory-diff-record-vs-replay" => {
@@ -2444,9 +2445,24 @@ impl BackendManager {
                             && let Some(id) = id.as_u64()
                         {
                             let backend_id = id as usize;
+                            // `replay-id` is a *routing* directive for this
+                            // daemon, not part of any backend command's
+                            // argument schema — note the kebab-case, unlike
+                            // every camelCase DAP field.  Strip it before
+                            // forwarding: several backend argument structs
+                            // (e.g. `CtOriginChainArguments`) are
+                            // `#[serde(deny_unknown_fields)]` and reject the
+                            // whole request when it survives the hop.
+                            let mut forwarded = message.clone();
+                            if let Some(args) = forwarded
+                                .get_mut("arguments")
+                                .and_then(Value::as_object_mut)
+                            {
+                                args.remove("replay-id");
+                            }
                             // Reset TTL for the session that owns this replay.
                             self.reset_ttl_for_backend_id(backend_id);
-                            return self.message(backend_id, message).await;
+                            return self.message(backend_id, forwarded).await;
                         }
                         // Reset TTL for the currently selected replay.
                         self.reset_ttl_for_backend_id(self.selected);
@@ -4955,6 +4971,170 @@ impl BackendManager {
                 backend_seq: dap_seq,
                 response_command: "ct/py-read-source".to_string(),
                 expression: String::new(),
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Handles `ct/py-origin-chain` requests from Python clients.
+    ///
+    /// Backs `Trace.value_origin(...)` (M8 of the Value Origin Tracking
+    /// milestones) by translating the request into the backend's
+    /// `ct/originChain` DAP command and registering a pending request
+    /// whose response is forwarded verbatim (spec §4.1 is the public
+    /// wire contract — see
+    /// [`python_bridge::format_origin_chain_response`]).
+    ///
+    /// Without this route the command fell through to the generic
+    /// "forward to the selected replay" arm, which handed the backend a
+    /// `ct/py-origin-chain` command it does not implement — so every
+    /// `trace.value_origin(...)` call raised `TraceError`, and the
+    /// `PendingPyRequestKind::OriginChain` arm below was unreachable.
+    ///
+    /// # Wire protocol
+    ///
+    /// **Request** (from the Python client):
+    /// ```json
+    /// {
+    ///   "type": "request",
+    ///   "command": "ct/py-origin-chain",
+    ///   "seq": 1,
+    ///   "arguments": {
+    ///     "tracePath": "/path/to/trace",
+    ///     "variableName": "total",
+    ///     "maxHops": 16,
+    ///     "lazy": false,
+    ///     "stepId": 137,
+    ///     "frameId": 0
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Response:** the backend's `OriginChain` body, unmodified.
+    async fn handle_py_origin_chain(
+        &mut self,
+        seq: i64,
+        args: Option<&Value>,
+    ) -> Result<(), Box<dyn Error>> {
+        let trace_path_str = match args
+            .and_then(|a| a.get("tracePath"))
+            .and_then(Value::as_str)
+        {
+            Some(p) => p.to_string(),
+            None => {
+                self.send_py_command_error(
+                    seq,
+                    "ct/py-origin-chain",
+                    "missing 'tracePath' in arguments",
+                );
+                return Ok(());
+            }
+        };
+
+        let variable_name = match args
+            .and_then(|a| a.get("variableName"))
+            .and_then(Value::as_str)
+        {
+            Some(v) if !v.is_empty() => v.to_string(),
+            _ => {
+                self.send_py_command_error(
+                    seq,
+                    "ct/py-origin-chain",
+                    "missing 'variableName' in arguments",
+                );
+                return Ok(());
+            }
+        };
+
+        let trace_path = PathBuf::from(&trace_path_str);
+
+        let backend_id = match self.backend_id_for_trace(&trace_path) {
+            Some(id) => id,
+            None => {
+                self.send_py_command_error(
+                    seq,
+                    "ct/py-origin-chain",
+                    &self.no_session_error_message(&trace_path_str),
+                );
+                return Ok(());
+            }
+        };
+
+        self.reset_ttl_for_backend_id(backend_id);
+
+        // Negative frame / step mean "topmost frame" / "current step" on
+        // the backend side, which is exactly what an omitted argument
+        // should mean here.
+        let frame_id = args
+            .and_then(|a| a.get("frameId"))
+            .and_then(Value::as_i64)
+            .unwrap_or(-1);
+        let step_id = args
+            .and_then(|a| a.get("stepId"))
+            .and_then(Value::as_i64)
+            .unwrap_or(-1);
+        let max_hops = args
+            .and_then(|a| a.get("maxHops"))
+            .and_then(Value::as_u64)
+            .unwrap_or(16);
+        let lazy = args
+            .and_then(|a| a.get("lazy"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+
+        let dap_seq = match self.daemon_state.as_mut() {
+            Some(ds) => ds.py_bridge.next_seq(),
+            None => return Ok(()),
+        };
+
+        // `CtOriginChainArguments` is `#[serde(deny_unknown_fields)]`, so
+        // every key here must be one of its camelCase fields — do not
+        // forward the client's argument object wholesale (it carries
+        // `tracePath`, which the backend would reject).
+        let mut backend_args = serde_json::json!({
+            "variableName": variable_name,
+            "variablePath": [],
+            "frameId": frame_id,
+            "stepId": step_id,
+            "threadId": 0,
+            "maxHops": max_hops,
+            "lazy": lazy,
+            "sessionId": "",
+            "classifySource": true,
+        });
+        if let Some(token) = args
+            .and_then(|a| a.get("continuationToken"))
+            .and_then(Value::as_str)
+        {
+            backend_args["continuationToken"] = serde_json::json!(token);
+        }
+
+        let dap_request = serde_json::json!({
+            "type": "request",
+            "command": "ct/originChain",
+            "seq": dap_seq,
+            "arguments": backend_args,
+        });
+
+        if let Err(e) = self.message(backend_id, dap_request).await {
+            self.send_py_command_error(
+                seq,
+                "ct/py-origin-chain",
+                &format!("failed to send command to backend: {e}"),
+            );
+            return Ok(());
+        }
+
+        let client_id = self.lookup_client_for_seq(seq).unwrap_or(0);
+        if let Some(ds) = self.daemon_state.as_mut() {
+            ds.py_bridge.pending_requests.push(PendingPyRequest {
+                kind: PendingPyRequestKind::OriginChain,
+                client_id,
+                original_seq: seq,
+                backend_seq: dap_seq,
+                response_command: "ct/py-origin-chain".to_string(),
+                expression: variable_name,
             });
         }
 

--- a/src/backend-manager/src/mcp_server.rs
+++ b/src/backend-manager/src/mcp_server.rs
@@ -38,10 +38,12 @@
 //! - `trace:///home/user/traces/my-program/source/src/main.nim` - source file
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::io::BufRead;
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
 use std::path::PathBuf;
+use std::pin::Pin;
 use std::time::{Duration, Instant};
 
 use serde_json::{Value, json};
@@ -245,17 +247,22 @@ fn find_recording_by_id_tool() -> Value {
 
 /// Returns the JSON schema for the `get_value_origin` tool.
 ///
-/// The MCP tool surface intentionally steers callers toward
-/// `exec_script` + `trace.value_origin(...)` for full programmatic
-/// access; this top-level tool is a discovery handle that points
-/// agents at the Python scripting workflow rather than duplicating
-/// it.  The description names both `exec_script` and `value_origin`
-/// so the test in `tests/mcp_origin_test.rs::test_mcp_get_value_origin
-/// _description_points_at_scripting` can verify the steering.
+/// The query is anchored at a source location (`path` + `line`) rather
+/// than at a step id: an MCP call is stateless, and `ct/open-trace`
+/// rewinds the replay to the program entry, where no interesting
+/// variable is live yet.  The handler therefore sets a breakpoint at
+/// `path:line`, continues to it, and asks the backend for the chain at
+/// the step it stopped on — the same sequence the per-language
+/// `origin_*_dap_test.rs` suites use.
+///
+/// The description still names both `exec_script` and `value_origin`
+/// because the Python binding remains the right tool for multi-query
+/// sessions; `tests/mcp_origin_test.rs::test_mcp_get_value_origin
+/// _description_points_at_scripting` asserts both names are present.
 fn get_value_origin_tool() -> Value {
     json!({
         "name": "get_value_origin",
-        "description": "Return the origin chain for a recorded value.  Prefer the scripting workflow: call `exec_script` with a Python script that invokes `trace.value_origin(path, line, variable)` to get programmatic access to the full chain (steps, scopes, source locations).  This top-level tool is a discovery handle; use `exec_script` + `trace.value_origin` for production queries.",
+        "description": "Return the backward dataflow (origin) chain for a recorded value: where the value in `variable` at `path`:`line` came from, hop by hop, down to the literal / computation / parameter that produced it. Sets a breakpoint at `path`:`line`, runs to it, and returns the canonical OriginChain (hops, terminator, confidence, metrics). For multi-query sessions that reuse one loaded trace, call `exec_script` with a Python script that uses `trace.value_origin(...)` instead.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -265,15 +272,19 @@ fn get_value_origin_tool() -> Value {
                 },
                 "path": {
                     "type": "string",
-                    "description": "Source file path (within the trace) of the variable's defining line."
+                    "description": "Source file path of the query line. May be a suffix of the recorded path (e.g. `main.py`); it is resolved against the trace's source file list."
                 },
                 "line": {
                     "type": "number",
-                    "description": "1-based line number where the variable is defined or last assigned."
+                    "description": "1-based line number to run to before querying. The variable must be live at this line."
                 },
                 "variable": {
                     "type": "string",
-                    "description": "Variable name to trace the origin of."
+                    "description": "Variable name to trace the origin of. Identifier only; dotted paths are not supported yet."
+                },
+                "max_hops": {
+                    "type": "number",
+                    "description": "Maximum hops to walk in this request (default 16). Backends clamp this to their own tier limit."
                 }
             },
             "required": ["trace_path", "path", "line", "variable"]
@@ -283,13 +294,14 @@ fn get_value_origin_tool() -> Value {
 
 /// Returns the JSON schema for the `resolve_variable_step` tool.
 ///
-/// Companion to `get_value_origin`: this tool resolves a single
-/// variable name at the latest matching step rather than returning
-/// the full origin chain.
+/// Companion to `get_value_origin`: same query, but it answers only the
+/// first hop — the step at which `variable` last received the value it
+/// holds at `path:line`.  It takes the same location anchor for the same
+/// reason (see [`get_value_origin_tool`]).
 fn resolve_variable_step_tool() -> Value {
     json!({
         "name": "resolve_variable_step",
-        "description": "Resolve a variable to its latest assigning step in the trace.  Returns the step location (path, line, function) and the value as observed at that step.  For the full origin chain, use `get_value_origin` or the `trace.value_origin` Python API via `exec_script`.",
+        "description": "Resolve a variable to the step that assigned the value it holds at `path`:`line`. Returns that step's id and source location (path, line, function) plus the assigning source text. This is the first hop of the origin chain; for the whole chain use `get_value_origin`, or the `trace.value_origin` Python API via `exec_script`.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -297,12 +309,20 @@ fn resolve_variable_step_tool() -> Value {
                     "type": "string",
                     "description": "Either a local path to a `.ct` trace folder OR an observability dive-in URL."
                 },
+                "path": {
+                    "type": "string",
+                    "description": "Source file path of the query line. May be a suffix of the recorded path; it is resolved against the trace's source file list."
+                },
+                "line": {
+                    "type": "number",
+                    "description": "1-based line number to run to before querying. The variable must be live at this line."
+                },
                 "variable": {
                     "type": "string",
-                    "description": "Variable name to resolve to its latest assigning step."
+                    "description": "Variable name to resolve to its assigning step."
                 }
             },
-            "required": ["trace_path", "variable"]
+            "required": ["trace_path", "path", "line", "variable"]
         }
     })
 }
@@ -1086,32 +1106,188 @@ fn handle_initialize(id: &Value) -> Value {
     )
 }
 
+// ---------------------------------------------------------------------------
+// The tool table — the single source of truth for the MCP tool surface
+// ---------------------------------------------------------------------------
+
+/// The future returned by a tool's dispatch function.
+///
+/// Boxed because the entries of [`TOOLS`] must share one concrete type;
+/// `async fn`s each have an anonymous, mutually incompatible future type.
+type ToolFuture<'a> = Pin<Box<dyn Future<Output = Value> + 'a>>;
+
+/// A tool's dispatch function: same signature for every tool, so handlers
+/// that don't need `config` or `loaded_traces` simply ignore them.
+type ToolDispatch = for<'a> fn(
+    &'a Value,
+    Option<&'a Value>,
+    &'a McpServerConfig,
+    &'a mut HashMap<String, LoadedTrace>,
+) -> ToolFuture<'a>;
+
+/// One MCP tool: its advertised schema AND the handler that answers it.
+///
+/// Keeping both in one struct is what makes the historical defect
+/// unrepresentable.  `tools/list` used to be a hand-written array and
+/// `tools/call` a hand-written `match`; the two drifted, and
+/// `get_value_origin` / `resolve_variable_step` were advertised for
+/// several releases while `tools/call` answered `-32602 Unknown tool`.
+/// A `ToolDef` cannot be constructed without a `dispatch`, and both
+/// handlers below read the same [`TOOLS`] slice, so an advertised tool is
+/// a dispatched tool by construction.  Do not reintroduce a second list.
+struct ToolDef {
+    /// Tool name as it appears in `tools/list` and `tools/call`.
+    ///
+    /// Must equal the `"name"` field the `schema` function emits; the
+    /// `tool_names_match_their_schemas` unit test enforces that.
+    name: &'static str,
+    /// Builds the JSON schema advertised through `tools/list`.
+    schema: fn() -> Value,
+    /// Answers a `tools/call` for this tool.
+    dispatch: ToolDispatch,
+}
+
+/// Adapter functions turning each `async fn` handler into a [`ToolDispatch`].
+///
+/// A non-capturing closure would also coerce to the function pointer, but
+/// the higher-ranked lifetime in [`ToolDispatch`] is far easier to satisfy
+/// with named `fn`s.
+mod dispatch {
+    use super::*;
+
+    pub(super) fn exec_script<'a>(
+        id: &'a Value,
+        args: Option<&'a Value>,
+        config: &'a McpServerConfig,
+        traces: &'a mut HashMap<String, LoadedTrace>,
+    ) -> ToolFuture<'a> {
+        Box::pin(handle_exec_script(id, args, config, traces))
+    }
+
+    pub(super) fn trace_info<'a>(
+        id: &'a Value,
+        args: Option<&'a Value>,
+        config: &'a McpServerConfig,
+        traces: &'a mut HashMap<String, LoadedTrace>,
+    ) -> ToolFuture<'a> {
+        Box::pin(handle_trace_info(id, args, config, traces))
+    }
+
+    pub(super) fn list_source_files<'a>(
+        id: &'a Value,
+        args: Option<&'a Value>,
+        config: &'a McpServerConfig,
+        _traces: &'a mut HashMap<String, LoadedTrace>,
+    ) -> ToolFuture<'a> {
+        Box::pin(handle_list_source_files(id, args, config))
+    }
+
+    pub(super) fn read_source_file<'a>(
+        id: &'a Value,
+        args: Option<&'a Value>,
+        config: &'a McpServerConfig,
+        _traces: &'a mut HashMap<String, LoadedTrace>,
+    ) -> ToolFuture<'a> {
+        Box::pin(handle_read_source_file(id, args, config))
+    }
+
+    pub(super) fn find_recordings_by_window<'a>(
+        id: &'a Value,
+        args: Option<&'a Value>,
+        _config: &'a McpServerConfig,
+        _traces: &'a mut HashMap<String, LoadedTrace>,
+    ) -> ToolFuture<'a> {
+        Box::pin(handle_find_recordings_by_window(id, args))
+    }
+
+    pub(super) fn find_recording_by_id<'a>(
+        id: &'a Value,
+        args: Option<&'a Value>,
+        _config: &'a McpServerConfig,
+        _traces: &'a mut HashMap<String, LoadedTrace>,
+    ) -> ToolFuture<'a> {
+        Box::pin(handle_find_recording_by_id(id, args))
+    }
+
+    pub(super) fn get_value_origin<'a>(
+        id: &'a Value,
+        args: Option<&'a Value>,
+        config: &'a McpServerConfig,
+        traces: &'a mut HashMap<String, LoadedTrace>,
+    ) -> ToolFuture<'a> {
+        Box::pin(handle_get_value_origin(id, args, config, traces))
+    }
+
+    pub(super) fn resolve_variable_step<'a>(
+        id: &'a Value,
+        args: Option<&'a Value>,
+        config: &'a McpServerConfig,
+        traces: &'a mut HashMap<String, LoadedTrace>,
+    ) -> ToolFuture<'a> {
+        Box::pin(handle_resolve_variable_step(id, args, config, traces))
+    }
+}
+
+/// Every tool this server exposes, advertised and dispatched from here.
+const TOOLS: &[ToolDef] = &[
+    ToolDef {
+        name: "exec_script",
+        schema: exec_script_tool,
+        dispatch: dispatch::exec_script,
+    },
+    ToolDef {
+        name: "trace_info",
+        schema: trace_info_tool,
+        dispatch: dispatch::trace_info,
+    },
+    ToolDef {
+        name: "list_source_files",
+        schema: list_source_files_tool,
+        dispatch: dispatch::list_source_files,
+    },
+    ToolDef {
+        name: "read_source_file",
+        schema: read_source_file_tool,
+        dispatch: dispatch::read_source_file,
+    },
+    ToolDef {
+        name: "find_recordings_by_window",
+        schema: find_recordings_by_window_tool,
+        dispatch: dispatch::find_recordings_by_window,
+    },
+    ToolDef {
+        name: "find_recording_by_id",
+        schema: find_recording_by_id_tool,
+        dispatch: dispatch::find_recording_by_id,
+    },
+    ToolDef {
+        name: "get_value_origin",
+        schema: get_value_origin_tool,
+        dispatch: dispatch::get_value_origin,
+    },
+    ToolDef {
+        name: "resolve_variable_step",
+        schema: resolve_variable_step_tool,
+        dispatch: dispatch::resolve_variable_step,
+    },
+];
+
 /// Handles `tools/list` requests.
 ///
-/// Returns the list of available tools with their input schemas.
+/// Returns the list of available tools with their input schemas, derived
+/// from [`TOOLS`] — the same table `handle_tools_call` dispatches from.
 fn handle_tools_list(id: &Value) -> Value {
-    jsonrpc_result(
-        id,
-        json!({
-            "tools": [
-                exec_script_tool(),
-                trace_info_tool(),
-                list_source_files_tool(),
-                read_source_file_tool(),
-                find_recordings_by_window_tool(),
-                find_recording_by_id_tool(),
-                get_value_origin_tool(),
-                resolve_variable_step_tool(),
-            ]
-        }),
-    )
+    let tools: Vec<Value> = TOOLS.iter().map(|tool| (tool.schema)()).collect();
+    jsonrpc_result(id, json!({ "tools": tools }))
 }
 
 /// Handles `tools/call` requests.
 ///
-/// Dispatches to the appropriate tool handler based on the tool name.
-/// On successful trace operations, updates `loaded_traces` so that
-/// subsequent `resources/list` calls reflect the newly loaded trace.
+/// Looks the tool up in [`TOOLS`] and invokes its dispatch function.
+/// Because that is the same table `tools/list` advertises from, a tool
+/// can never be advertised without being callable.  On successful trace
+/// operations the handlers update `loaded_traces` so that subsequent
+/// `resources/list` calls reflect the newly loaded trace.
 async fn handle_tools_call(
     id: &Value,
     params: Option<&Value>,
@@ -1124,14 +1300,9 @@ async fn handle_tools_call(
         .unwrap_or("");
     let arguments = params.and_then(|p| p.get("arguments"));
 
-    match tool_name {
-        "exec_script" => handle_exec_script(id, arguments, config, loaded_traces).await,
-        "trace_info" => handle_trace_info(id, arguments, config, loaded_traces).await,
-        "list_source_files" => handle_list_source_files(id, arguments, config).await,
-        "read_source_file" => handle_read_source_file(id, arguments, config).await,
-        "find_recordings_by_window" => handle_find_recordings_by_window(id, arguments).await,
-        "find_recording_by_id" => handle_find_recording_by_id(id, arguments).await,
-        _ => jsonrpc_error(id, -32602, &format!("Unknown tool: {tool_name}")),
+    match TOOLS.iter().find(|tool| tool.name == tool_name) {
+        Some(tool) => (tool.dispatch)(id, arguments, config, loaded_traces).await,
+        None => jsonrpc_error(id, -32602, &format!("Unknown tool: {tool_name}")),
     }
 }
 
@@ -2447,6 +2618,478 @@ async fn handle_read_source_file(
 
     let duration_ms = start.elapsed().as_millis();
     jsonrpc_result(id, tool_result_text_with_timing(&content, duration_ms))
+}
+
+// ---------------------------------------------------------------------------
+// Value Origin Tracking tools (`get_value_origin`, `resolve_variable_step`)
+// ---------------------------------------------------------------------------
+
+/// Default hop budget for `get_value_origin`, matching
+/// `db_backend::task::DEFAULT_ORIGIN_MAX_HOPS` (spec §6.1.7).
+const DEFAULT_ORIGIN_MAX_HOPS: u64 = 16;
+
+/// The arguments both origin tools accept, after validation.
+struct OriginQuery {
+    trace_path: String,
+    source_path: String,
+    line: i64,
+    variable: String,
+    max_hops: u64,
+}
+
+/// Validate the shared argument set of the two origin tools.
+///
+/// Returns the tool-error text on failure so the caller can wrap it in
+/// its own timing envelope.
+fn parse_origin_arguments(arguments: Option<&Value>, max_hops: u64) -> Result<OriginQuery, String> {
+    let trace_path = arguments
+        .and_then(|a| a.get("trace_path"))
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or("Missing required argument: trace_path")?
+        .to_string();
+    let source_path = arguments
+        .and_then(|a| a.get("path"))
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or("Missing required argument: path (source file of the query line)")?
+        .to_string();
+    let line = arguments
+        .and_then(|a| a.get("line"))
+        .and_then(Value::as_i64)
+        .filter(|n| *n > 0)
+        .ok_or("Missing required argument: line (1-based line number)")?;
+    let variable = arguments
+        .and_then(|a| a.get("variable"))
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .ok_or("Missing required argument: variable")?
+        .to_string();
+    let max_hops = arguments
+        .and_then(|a| a.get("max_hops"))
+        .and_then(Value::as_u64)
+        .filter(|n| *n > 0)
+        .unwrap_or(max_hops);
+
+    Ok(OriginQuery {
+        trace_path,
+        source_path,
+        line,
+        variable,
+        max_hops,
+    })
+}
+
+/// Match a user-supplied source path against the paths recorded in the
+/// trace.
+///
+/// Agents naturally write `main.py` or `src/lib.rs`, while the trace
+/// stores the absolute path the recorder saw.  Accept an exact match
+/// first, then a unique path-component suffix match.  An ambiguous
+/// suffix is an error rather than a silent pick: answering about the
+/// wrong file would look like a wrong origin chain, not a wrong file.
+fn resolve_recorded_source_path(requested: &str, source_files: &[String]) -> Result<String, String> {
+    if source_files.iter().any(|f| f == requested) {
+        return Ok(requested.to_string());
+    }
+
+    let needle = std::path::Path::new(requested);
+    let matches: Vec<&String> = source_files
+        .iter()
+        .filter(|recorded| {
+            let recorded_path = std::path::Path::new(recorded.as_str());
+            recorded_path
+                .components()
+                .rev()
+                .zip(needle.components().rev())
+                .all(|(a, b)| a == b)
+                && recorded_path.components().count() >= needle.components().count()
+        })
+        .collect();
+
+    match matches.len() {
+        1 => Ok(matches[0].clone()),
+        0 => Err(format!(
+            "Source file {requested:?} is not part of this trace. Recorded source files: {}",
+            if source_files.is_empty() {
+                "(none reported)".to_string()
+            } else {
+                source_files.join(", ")
+            }
+        )),
+        _ => Err(format!(
+            "Source file {requested:?} is ambiguous within this trace — it matches {}. \
+             Pass a longer path suffix.",
+            matches
+                .iter()
+                .map(|m| m.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
+    }
+}
+
+/// Send a DAP request and return both the response and the last
+/// `ct/complete-move` event seen while waiting for it.
+///
+/// [`dap_request`] discards events; the `continue` handler reports where
+/// the replay actually stopped only through `ct/complete-move`, and the
+/// daemon broadcasts backend events to every connected client.  Capturing
+/// it is what lets `get_value_origin` say "the breakpoint was never hit"
+/// instead of quietly answering about the wrong step.
+async fn dap_request_capturing_move(
+    stream: &mut UnixStream,
+    command: &str,
+    seq: i64,
+    arguments: Value,
+    deadline_secs: u64,
+) -> Result<(Value, Option<Value>), String> {
+    let request = json!({
+        "type": "request",
+        "command": command,
+        "seq": seq,
+        "arguments": arguments,
+    });
+    let bytes = DapParser::to_bytes(&request);
+    stream
+        .write_all(&bytes)
+        .await
+        .map_err(|e| format!("failed to write to daemon: {e}"))?;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(deadline_secs);
+    let mut last_move: Option<Value> = None;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(format!("timeout waiting for {command} response"));
+        }
+
+        let msg = tokio::time::timeout(remaining, dap_read_message(stream))
+            .await
+            .map_err(|_| format!("timeout waiting for {command} response"))?
+            .map_err(|e| format!("failed to read daemon response: {e}"))?;
+
+        let msg_type = msg.get("type").and_then(Value::as_str).unwrap_or("");
+        if msg_type == "event" {
+            if msg.get("event").and_then(Value::as_str) == Some("ct/complete-move") {
+                last_move = msg
+                    .get("body")
+                    .and_then(|b| b.get("location"))
+                    .cloned()
+                    .or(last_move);
+            }
+            continue;
+        }
+        if msg_type == "response" {
+            let resp_seq = msg.get("request_seq").and_then(Value::as_i64).unwrap_or(-1);
+            if resp_seq != seq {
+                continue;
+            }
+        }
+        return Ok((msg, last_move));
+    }
+}
+
+/// Extract `message` from a failed DAP response.
+fn dap_failure_message(response: &Value, fallback: &str) -> String {
+    response
+        .get("message")
+        .and_then(Value::as_str)
+        .filter(|m| !m.is_empty())
+        .unwrap_or(fallback)
+        .to_string()
+}
+
+/// Run the shared origin query: open the trace, break at `path:line`,
+/// continue to it, and ask the backend for the origin chain.
+///
+/// Returns the canonical `OriginChain` body (spec §4.1) exactly as the
+/// backend produced it.  Every failure is reported as an error string —
+/// there is deliberately no "empty chain" success path, because an empty
+/// answer is indistinguishable from an unimplemented tool, which is the
+/// bug these tools were shipped with.
+async fn run_origin_query(
+    query: &OriginQuery,
+    config: &McpServerConfig,
+    loaded_traces: &mut HashMap<String, LoadedTrace>,
+) -> Result<Value, String> {
+    let trace_path = resolve_trace_path_or_url(&query.trace_path).await?;
+
+    let mut stream = connect_to_daemon(config)
+        .await
+        .map_err(|e| format!("Cannot connect to daemon: {e}"))?;
+
+    // 1. Open the trace (idempotent). Large traces can take a while, so
+    //    reuse the generous timeout `trace_info` / `ct trace origin` use.
+    let open_resp = dap_request(
+        &mut stream,
+        "ct/open-trace",
+        1,
+        json!({ "tracePath": trace_path }),
+        180,
+    )
+    .await
+    .map_err(|e| format!("Failed to open trace: {e}"))?;
+    if open_resp.get("success").and_then(Value::as_bool) != Some(true) {
+        return Err(format!(
+            "Failed to open trace: {}",
+            dap_failure_message(&open_resp, "unknown error")
+        ));
+    }
+    let open_body = open_resp.get("body").cloned().unwrap_or(json!({}));
+
+    // The daemon routes by `replay-id` and strips it before forwarding,
+    // so subsequent requests reach *this* trace's backend even when the
+    // daemon holds several sessions.
+    let replay_id = open_body
+        .get("backendId")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+
+    let source_files: Vec<String> = open_body
+        .get("sourceFiles")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(Value::as_str)
+                .map(String::from)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Cache metadata so `resources/list` sees this trace, exactly as
+    // `trace_info` does.
+    loaded_traces.insert(
+        trace_path.clone(),
+        LoadedTrace {
+            language: open_body
+                .get("language")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown")
+                .to_string(),
+            total_events: open_body
+                .get("totalEvents")
+                .and_then(Value::as_u64)
+                .unwrap_or(0),
+            source_files: source_files.clone(),
+            program: open_body
+                .get("program")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string(),
+            workdir: open_body
+                .get("workdir")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string(),
+        },
+    );
+
+    let recorded_source = resolve_recorded_source_path(&query.source_path, &source_files)?;
+
+    // 2. Break at the query line.
+    let bp_resp = dap_request(
+        &mut stream,
+        "setBreakpoints",
+        2,
+        json!({
+            "source": { "path": recorded_source },
+            "breakpoints": [{ "line": query.line }],
+            "replay-id": replay_id,
+        }),
+        30,
+    )
+    .await
+    .map_err(|e| format!("Failed to set breakpoint: {e}"))?;
+    if bp_resp.get("success").and_then(Value::as_bool) != Some(true) {
+        return Err(format!(
+            "Failed to set breakpoint at {recorded_source}:{}: {}",
+            query.line,
+            dap_failure_message(&bp_resp, "unknown error")
+        ));
+    }
+
+    // 3. Run to it. The backend answers the `continue` request only after
+    //    the move has completed, and reports the landing location through
+    //    the `ct/complete-move` event that precedes the response.
+    let (continue_resp, landed) = dap_request_capturing_move(
+        &mut stream,
+        "continue",
+        3,
+        json!({ "threadId": 1, "replay-id": replay_id }),
+        120,
+    )
+    .await
+    .map_err(|e| format!("Failed to run to {recorded_source}:{}: {e}", query.line))?;
+    if continue_resp.get("success").and_then(Value::as_bool) != Some(true) {
+        return Err(format!(
+            "Failed to run to {recorded_source}:{}: {}",
+            query.line,
+            dap_failure_message(&continue_resp, "unknown error")
+        ));
+    }
+
+    // Refuse to answer about the wrong step: if the replay did not stop
+    // on the requested line, the chain would describe a different program
+    // point than the caller asked about.
+    if let Some(location) = &landed {
+        let landed_line = location.get("line").and_then(Value::as_i64).unwrap_or(-1);
+        if landed_line != query.line {
+            let landed_path = location
+                .get("path")
+                .and_then(Value::as_str)
+                .unwrap_or("<unknown>");
+            return Err(format!(
+                "The breakpoint at {recorded_source}:{} was never hit — execution stopped at \
+                 {landed_path}:{landed_line} instead. Check that the line is executable and \
+                 that it is reached by this recording.",
+                query.line
+            ));
+        }
+    }
+
+    // 4. Ask for the chain at the step we stopped on. `stepId: -1` means
+    //    "the backend's current step", which is that breakpoint.
+    let origin_resp = dap_request(
+        &mut stream,
+        "ct/originChain",
+        4,
+        json!({
+            "variableName": query.variable,
+            "variablePath": [],
+            "frameId": -1,
+            "stepId": -1,
+            "threadId": 0,
+            "maxHops": query.max_hops,
+            "lazy": false,
+            "sessionId": "",
+            "classifySource": true,
+            "replay-id": replay_id,
+        }),
+        60,
+    )
+    .await
+    .map_err(|e| format!("ct/originChain request failed: {e}"))?;
+
+    if origin_resp.get("success").and_then(Value::as_bool) != Some(true) {
+        let detail = origin_resp
+            .get("body")
+            .and_then(|b| b.get("detail"))
+            .map(|d| format!(" ({d})"))
+            .unwrap_or_default();
+        return Err(format!(
+            "Cannot resolve the origin of {:?} at {recorded_source}:{}: {}{detail}",
+            query.variable,
+            query.line,
+            dap_failure_message(&origin_resp, "ct/originChain failed")
+        ));
+    }
+
+    Ok(origin_resp.get("body").cloned().unwrap_or(json!({})))
+}
+
+/// Handles the `get_value_origin` tool.
+///
+/// Returns the canonical `OriginChain` (spec §4.1) for `variable` as of
+/// `path:line`, rendered as the spec §3.2 text layout with the raw JSON
+/// appended so an agent can either read it or parse it.
+async fn handle_get_value_origin(
+    id: &Value,
+    arguments: Option<&Value>,
+    config: &McpServerConfig,
+    loaded_traces: &mut HashMap<String, LoadedTrace>,
+) -> Value {
+    let start = Instant::now();
+
+    let query = match parse_origin_arguments(arguments, DEFAULT_ORIGIN_MAX_HOPS) {
+        Ok(q) => q,
+        Err(e) => return jsonrpc_result(id, tool_result_error(&e)),
+    };
+
+    match run_origin_query(&query, config, loaded_traces).await {
+        Ok(chain) => {
+            let mut text = crate::origin_renderer::render_text(&chain);
+            text.push_str("\n\nCanonical OriginChain JSON:\n");
+            text.push_str(
+                &serde_json::to_string_pretty(&chain).unwrap_or_else(|_| chain.to_string()),
+            );
+            let duration_ms = start.elapsed().as_millis();
+            jsonrpc_result(id, tool_result_text_with_timing(&text, duration_ms))
+        }
+        Err(e) => {
+            let duration_ms = start.elapsed().as_millis();
+            jsonrpc_result(id, tool_result_error_with_timing(&e, duration_ms))
+        }
+    }
+}
+
+/// Handles the `resolve_variable_step` tool.
+///
+/// Answers the first hop of the same chain `get_value_origin` walks: the
+/// step that assigned the value `variable` holds at `path:line`.
+async fn handle_resolve_variable_step(
+    id: &Value,
+    arguments: Option<&Value>,
+    config: &McpServerConfig,
+    loaded_traces: &mut HashMap<String, LoadedTrace>,
+) -> Value {
+    let start = Instant::now();
+
+    // One hop is all this tool reports, so ask for one.
+    let query = match parse_origin_arguments(arguments, 1) {
+        Ok(mut q) => {
+            q.max_hops = 1;
+            q
+        }
+        Err(e) => return jsonrpc_result(id, tool_result_error(&e)),
+    };
+
+    let chain = match run_origin_query(&query, config, loaded_traces).await {
+        Ok(c) => c,
+        Err(e) => {
+            let duration_ms = start.elapsed().as_millis();
+            return jsonrpc_result(id, tool_result_error_with_timing(&e, duration_ms));
+        }
+    };
+
+    let duration_ms = start.elapsed().as_millis();
+    match variable_step_from_chain(&chain, &query.variable) {
+        Some(step) => {
+            let text = serde_json::to_string_pretty(&step).unwrap_or_else(|_| step.to_string());
+            jsonrpc_result(id, tool_result_text_with_timing(&text, duration_ms))
+        }
+        // No hop means the backend found no assignment for this variable.
+        // Say so; an empty success would read as "the tool does nothing".
+        None => jsonrpc_result(
+            id,
+            tool_result_error_with_timing(
+                &format!(
+                    "No assignment to {:?} is recorded on the path reaching {}:{}. The variable \
+                     may be a parameter bound at the recording boundary, or never written in \
+                     this recording.",
+                    query.variable, query.source_path, query.line
+                ),
+                duration_ms,
+            ),
+        ),
+    }
+}
+
+/// Project an `OriginChain` body down to the `resolve_variable_step`
+/// answer shape: the first hop's step id and location.
+fn variable_step_from_chain(chain: &Value, variable: &str) -> Option<Value> {
+    let hop = chain
+        .get("hops")
+        .and_then(Value::as_array)
+        .and_then(|hops| hops.first())?;
+    let step_id = hop.get("stepId").and_then(Value::as_i64)?;
+    Some(json!({
+        "stepId": step_id,
+        "variable": variable,
+        "location": hop.get("location").cloned().unwrap_or(Value::Null),
+        "kind": hop.get("kind").cloned().unwrap_or(Value::Null),
+        "source": hop.get("source").cloned().unwrap_or(Value::Null),
+    }))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/backend-manager/src/mcp_server.rs
+++ b/src/backend-manager/src/mcp_server.rs
@@ -295,13 +295,15 @@ fn get_value_origin_tool() -> Value {
 /// Returns the JSON schema for the `resolve_variable_step` tool.
 ///
 /// Companion to `get_value_origin`: same query, but it answers only the
-/// first hop — the step at which `variable` last received the value it
-/// holds at `path:line`.  It takes the same location anchor for the same
-/// reason (see [`get_value_origin_tool`]).
+/// first hop of the chain.  It takes the same location anchor for the
+/// same reason (see [`get_value_origin_tool`]), and reports both the
+/// step where the value becomes observable and the statement that
+/// assigned it — see [`variable_step_from_chain`] for why naming both
+/// matters.
 fn resolve_variable_step_tool() -> Value {
     json!({
         "name": "resolve_variable_step",
-        "description": "Resolve a variable to the step that assigned the value it holds at `path`:`line`. Returns that step's id and source location (path, line, function) plus the assigning source text. This is the first hop of the origin chain; for the whole chain use `get_value_origin`, or the `trace.value_origin` Python API via `exec_script`.",
+        "description": "Resolve where the value a variable holds at `path`:`line` came from, one hop back. Returns `stepId` + `location` (the earliest step at which the variable is observed holding that value), `assignment` (the source statement that produced it), `originKind`, and `sourceVariable`. Note that a recorded step carries the state on entering a line, so `location.line` is the line after the assignment statement. This is the first hop of the origin chain; for the whole chain use `get_value_origin`, or the `trace.value_origin` Python API via `exec_script`.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -3025,8 +3027,8 @@ async fn handle_get_value_origin(
 
 /// Handles the `resolve_variable_step` tool.
 ///
-/// Answers the first hop of the same chain `get_value_origin` walks: the
-/// step that assigned the value `variable` holds at `path:line`.
+/// Answers the first hop of the same chain `get_value_origin` walks:
+/// where the value `variable` holds at `path:line` came from.
 async fn handle_resolve_variable_step(
     id: &Value,
     arguments: Option<&Value>,
@@ -3076,7 +3078,17 @@ async fn handle_resolve_variable_step(
 }
 
 /// Project an `OriginChain` body down to the `resolve_variable_step`
-/// answer shape: the first hop's step id and location.
+/// answer shape: the chain's first hop.
+///
+/// Field naming here is deliberately literal about what the backend
+/// reports.  `stepId` / `location` are the earliest step at which the
+/// variable is observed holding this value; because a recorded step
+/// carries the state on *entering* a line, that is the step after the
+/// assignment executed.  `assignment` is the source statement that
+/// produced the value — for `c = b` on line 11 the pair is
+/// `location.line == 12`, `assignment == "    c = b"`.  Calling the
+/// step id "the assignment line" would be off by one step; naming both
+/// keeps the answer honest.
 fn variable_step_from_chain(chain: &Value, variable: &str) -> Option<Value> {
     let hop = chain
         .get("hops")
@@ -3084,11 +3096,12 @@ fn variable_step_from_chain(chain: &Value, variable: &str) -> Option<Value> {
         .and_then(|hops| hops.first())?;
     let step_id = hop.get("stepId").and_then(Value::as_i64)?;
     Some(json!({
-        "stepId": step_id,
         "variable": variable,
+        "stepId": step_id,
         "location": hop.get("location").cloned().unwrap_or(Value::Null),
-        "kind": hop.get("kind").cloned().unwrap_or(Value::Null),
-        "source": hop.get("source").cloned().unwrap_or(Value::Null),
+        "assignment": hop.get("sourceText").cloned().unwrap_or(Value::Null),
+        "originKind": hop.get("kind").cloned().unwrap_or(Value::Null),
+        "sourceVariable": hop.get("sourceVariable").cloned().unwrap_or(Value::Null),
     }))
 }
 

--- a/src/backend-manager/src/mcp_server.rs
+++ b/src/backend-manager/src/mcp_server.rs
@@ -2690,7 +2690,10 @@ fn parse_origin_arguments(arguments: Option<&Value>, max_hops: u64) -> Result<Or
 /// first, then a unique path-component suffix match.  An ambiguous
 /// suffix is an error rather than a silent pick: answering about the
 /// wrong file would look like a wrong origin chain, not a wrong file.
-fn resolve_recorded_source_path(requested: &str, source_files: &[String]) -> Result<String, String> {
+fn resolve_recorded_source_path(
+    requested: &str,
+    source_files: &[String],
+) -> Result<String, String> {
     if source_files.iter().any(|f| f == requested) {
         return Ok(requested.to_string());
     }

--- a/src/backend-manager/src/meta_dat.rs
+++ b/src/backend-manager/src/meta_dat.rs
@@ -57,14 +57,58 @@ pub const META_DAT_VERSION: u16 = 3;
 /// [`META_DAT_VERSION`].
 pub const SUPPORTED_META_DAT_VERSIONS: &[u16] = &[3];
 
+// The canonical flag list lives in
+// `src/db-backend/src/ctfs_trace_reader/meta_dat.rs` (and mirrors the Nim
+// writer's `meta_dat.nim`).  This module is a second, smaller reader for
+// the fields backend-manager needs, and its mask MUST cover the same bits:
+// a bit outside `KNOWN_FLAGS_MASK` makes `parse_meta_dat` reject the whole
+// container, which takes down every backend-manager trace surface
+// (`ct trace info` / `query` / `origin`, and all the MCP tools) for a
+// recording the db-backend opens perfectly well.  Bits 4..13 were added to
+// the canonical reader without being mirrored here, so every trace from a
+// current recorder failed with "unknown flag bits set".
+//
+// Blocks gated by bits 4..13 live in CTFS files or in the step stream, not
+// in the `meta.dat` tail this parser walks, so recognising them costs
+// nothing beyond letting the container open.
 const FLAG_HAS_MCR_FIELDS: u16 = 1 << 0;
 const FLAG_HAS_REPLAY_LAUNCH_FIELDS: u16 = 1 << 1;
 const FLAG_HAS_LAYOUT_SNAPSHOT: u16 = 1 << 2;
 const FLAG_HAS_TRACE_FILTER_PROVENANCE: u16 = 1 << 3;
+/// Bit 4 — column-aware step encoding (P6.3 / P6.4).
+const FLAG_HAS_COLUMN_AWARE_STEPS: u16 = 1 << 4;
+/// Bit 5 — alternate source views (`srcviews.dat` / `srcviews.off`).
+const FLAG_HAS_ALTERNATE_SOURCE_VIEWS: u16 = 1 << 5;
+/// Bit 6 — recorder advertises per-column breakpoint placement.
+const FLAG_SUPPORTS_COLUMN_BREAKPOINTS: u16 = 1 << 6;
+/// Bit 7 — recorder advertises per-column step motions.
+const FLAG_SUPPORTS_COLUMN_MOTIONS: u16 = 1 << 7;
+/// Bit 8 — dedicated `calls.dat` call stream (M17a/M17b).
+const FLAG_HAS_CALL_STREAM: u16 = 1 << 8;
+/// Bit 9 — dedicated `steps.dat` execution stream (M23a).
+const FLAG_HAS_STEP_STREAM: u16 = 1 << 9;
+/// Bit 10 — dedicated `values.dat` value stream (M23b).
+const FLAG_HAS_VALUE_STREAM: u16 = 1 << 10;
+/// Bit 11 — dedicated `events.dat` I/O event stream (M23c).
+const FLAG_HAS_IO_EVENT_STREAM: u16 = 1 << 11;
+/// Bit 12 — binary varint interning tables (M23d).
+const FLAG_HAS_INTERNING_TABLES: u16 = 1 << 12;
+/// Bit 13 — `spans.dat` / `spans.idx` / `spantype.ns` span stream (RS-M1).
+const FLAG_HAS_SPAN_STREAM: u16 = 1 << 13;
 const KNOWN_FLAGS_MASK: u16 = FLAG_HAS_MCR_FIELDS
     | FLAG_HAS_REPLAY_LAUNCH_FIELDS
     | FLAG_HAS_LAYOUT_SNAPSHOT
-    | FLAG_HAS_TRACE_FILTER_PROVENANCE;
+    | FLAG_HAS_TRACE_FILTER_PROVENANCE
+    | FLAG_HAS_COLUMN_AWARE_STEPS
+    | FLAG_HAS_ALTERNATE_SOURCE_VIEWS
+    | FLAG_SUPPORTS_COLUMN_BREAKPOINTS
+    | FLAG_SUPPORTS_COLUMN_MOTIONS
+    | FLAG_HAS_CALL_STREAM
+    | FLAG_HAS_STEP_STREAM
+    | FLAG_HAS_VALUE_STREAM
+    | FLAG_HAS_IO_EVENT_STREAM
+    | FLAG_HAS_INTERNING_TABLES
+    | FLAG_HAS_SPAN_STREAM;
 
 // ── Public types ─────────────────────────────────────────────────────────
 

--- a/src/backend-manager/tests/mcp_origin_test.rs
+++ b/src/backend-manager/tests/mcp_origin_test.rs
@@ -22,6 +22,7 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicI64, Ordering};
+use std::time::Duration;
 
 use serde_json::{Value, json};
 
@@ -111,12 +112,29 @@ struct McpClient {
 }
 
 impl McpClient {
+    /// Spawn an MCP server with no daemon wired up — enough for the
+    /// schema / registration tests, which never touch a trace.
     fn spawn(binary: &Path) -> Result<Self, String> {
-        let mut child = Command::new(binary)
+        Self::spawn_inner(binary, None)
+    }
+
+    /// Spawn an MCP server pointed at a specific daemon socket, so tool
+    /// calls reach a real `replay-server` over a real recording.
+    fn spawn_with_daemon(binary: &Path, socket: &Path) -> Result<Self, String> {
+        Self::spawn_inner(binary, Some(socket))
+    }
+
+    fn spawn_inner(binary: &Path, socket: Option<&Path>) -> Result<Self, String> {
+        let mut command = Command::new(binary);
+        command
             .args(["trace", "mcp"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
+            .stderr(Stdio::null());
+        if let Some(socket) = socket {
+            command.env("CODETRACER_DAEMON_SOCK", socket);
+        }
+        let mut child = command
             .spawn()
             .map_err(|e| format!("failed to spawn `{} trace mcp`: {e}", binary.display()))?;
         let stdin = child.stdin.take().ok_or("no stdin on MCP subprocess")?;
@@ -191,7 +209,6 @@ impl McpClient {
         }
     }
 
-    #[allow(dead_code)]
     fn call_tool(&mut self, name: &str, arguments: Value) -> Result<Value, String> {
         let id = self.send_request("tools/call", json!({"name": name, "arguments": arguments}))?;
         self.read_response(id)
@@ -298,12 +315,87 @@ fn test_mcp_resolve_variable_step_tool_registered() {
 
 // ---------------------------------------------------------------------------
 // End-to-end tests — gated on the recorder being installed.
+//
+// These drive the REAL surface an MCP client sees: the `trace mcp`
+// subprocess, speaking JSON-RPC on stdio, against a daemon running a real
+// `replay-server` over a real recording.  That matters here specifically:
+// `get_value_origin` and `resolve_variable_step` were advertised by
+// `tools/list` for several releases while `tools/call` answered
+// `-32602 Unknown tool`, and every layer *beneath* the MCP surface —
+// the classifier, `ct/originChain`, the per-language
+// `origin_*_dap_test.rs` suites — was green the whole time.  A test that
+// called the classifier directly would have proved nothing.
 // ---------------------------------------------------------------------------
 
-/// Helper: record the canonical Python fixture and return the trace
-/// directory. Returns `None` (with a SKIP line) when the recorder
-/// produces no `.ct` container, which happens when the native extension
-/// isn't installed.
+/// Locate a built `replay-server`, mirroring the probe in
+/// `real_recording_integration.rs`.
+fn find_replay_server() -> Option<PathBuf> {
+    let mut target_dir = std::env::current_exe().ok()?;
+    target_dir.pop();
+    if target_dir.ends_with("deps") {
+        target_dir.pop();
+    }
+    for name in ["replay-server", "db-backend"] {
+        let candidate = target_dir.join(format!("{}{}", name, std::env::consts::EXE_SUFFIX));
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let exe = std::env::consts::EXE_SUFFIX;
+    for relative in [
+        format!("../db-backend/target/debug/replay-server{exe}"),
+        format!("../db-backend/target/release/replay-server{exe}"),
+        format!("../build-debug/bin/replay-server{exe}"),
+    ] {
+        let path = manifest_dir.join(&relative);
+        if path.exists() {
+            return Some(path.canonicalize().unwrap_or(path));
+        }
+    }
+
+    if let Ok(from_env) = std::env::var("CODETRACER_REPLAY_SERVER_CMD") {
+        let path = PathBuf::from(from_env);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    None
+}
+
+/// The Python interpreter to drive the recorder with.
+fn python_command() -> String {
+    std::env::var("CODETRACER_PYTHON_CMD")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| {
+            ["python3.12", "python3.13", "python3", "python"]
+                .iter()
+                .find(|cmd| {
+                    Command::new(cmd)
+                        .arg("--version")
+                        .stdout(Stdio::null())
+                        .stderr(Stdio::null())
+                        .status()
+                        .map(|s| s.success())
+                        .unwrap_or(false)
+                })
+                .copied()
+                .unwrap_or("python3")
+                .to_string()
+        })
+}
+
+/// Record the named Python fixture and return the directory holding the
+/// resulting `.ct` container.
+///
+/// Returns `None` (with a `SKIPPED:` line) only for narrow, precisely
+/// identified environment problems — the recorder module not being
+/// importable, or the fixture source having moved.  A recorder that runs
+/// and fails is a hard error: that is a real bug, not an environment
+/// gap.
 fn record_python_fixture(scenario: &str) -> Option<PathBuf> {
     let source = fixture_source(scenario);
     if !source.exists() {
@@ -313,99 +405,450 @@ fn record_python_fixture(scenario: &str) -> Option<PathBuf> {
         ));
         return None;
     }
-    if !python_recorder_installed() {
+
+    let python = python_command();
+    let importable = Command::new(&python)
+        .args(["-c", "import codetracer_python_recorder"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !importable && !python_recorder_installed() {
         skip(
-            "Python recorder not found (install codetracer-python-recorder or set CODETRACER_PYTHON_RECORDER_PATH)",
+            "Python recorder not importable (install codetracer-python-recorder or set CODETRACER_PYTHON_RECORDER_PATH)",
         );
         return None;
     }
 
-    // SKIP — fully driving the recorder + DAP backend from this
-    // integration test requires the heavy `test_harness` machinery the
-    // db-backend test crate ships and which is not visible here (each
-    // integration test is its own crate). The
-    // `origin_python_dap_test.rs` test in db-backend already covers
-    // the `ct/originChain` path end-to-end against this fixture; this
-    // helper exists so future revisions can plug the recorder run in
-    // without changing the call sites.
-    skip(
-        "end-to-end recorder + MCP roundtrip not wired in this crate (covered by db-backend's origin_python_dap_test)",
+    // Short path: the daemon's Unix socket lives beside the trace, and an
+    // over-long socket path fails with `SUN_LEN`.
+    let root = PathBuf::from("/tmp").join(format!(
+        "ct-mcp-origin-{}-{}",
+        std::process::id(),
+        scenario
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    let trace_dir = root.join("trace");
+    std::fs::create_dir_all(&trace_dir).expect("cannot create trace dir");
+
+    // Record from a copy so the recorded source path lives beside the
+    // trace, which is where the DAP server resolves breakpoints from.
+    let source_copy = trace_dir.join("main.py");
+    std::fs::copy(&source, &source_copy).expect("cannot copy fixture source");
+
+    let output = Command::new(&python)
+        .args([
+            "-m",
+            "codetracer_python_recorder",
+            "--out-dir",
+            trace_dir.to_str().unwrap(),
+            source_copy.to_str().unwrap(),
+        ])
+        .current_dir(&trace_dir)
+        .env("CODETRACER_TRACE_FORMAT", "ctfs")
+        .output()
+        .expect("failed to spawn the Python recorder");
+    assert!(
+        output.status.success(),
+        "recording {scenario} failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
     );
-    None
+
+    let produced_ct = std::fs::read_dir(&trace_dir)
+        .ok()
+        .map(|entries| {
+            entries
+                .filter_map(Result::ok)
+                .any(|e| e.path().extension().is_some_and(|ext| ext == "ct"))
+        })
+        .unwrap_or(false);
+    if !produced_ct {
+        skip(&format!(
+            "recorder produced no .ct container in {} (native extension missing?)",
+            trace_dir.display()
+        ));
+        return None;
+    }
+
+    Some(trace_dir)
 }
 
+/// A daemon running a real `replay-server`, torn down on drop.
+struct TestDaemon {
+    child: Child,
+    socket: PathBuf,
+}
+
+impl Drop for TestDaemon {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = std::fs::remove_file(&self.socket);
+    }
+}
+
+/// Start a daemon whose socket lives under `root`, backed by a real
+/// `replay-server`.  Returns `None` (with a `SKIPPED:` line) when no
+/// `replay-server` has been built.
+fn start_daemon(binary: &Path, root: &Path) -> Option<TestDaemon> {
+    let replay_server = match find_replay_server() {
+        Some(p) => p,
+        None => {
+            skip(
+                "replay-server not built (cargo build --bin replay-server in src/db-backend), \
+                 so no real trace can be opened",
+            );
+            return None;
+        }
+    };
+
+    let socket = root.join("daemon.sock");
+    let _ = std::fs::remove_file(&socket);
+
+    let child = Command::new(binary)
+        .args(["daemon", "start"])
+        .env("CODETRACER_DAEMON_SOCKET", &socket)
+        .env("CODETRACER_REPLAY_SERVER_CMD", &replay_server)
+        .env("TMPDIR", root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("cannot spawn daemon");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    while std::time::Instant::now() < deadline {
+        if socket.exists() {
+            return Some(TestDaemon { child, socket });
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    let mut daemon = TestDaemon { child, socket };
+    let _ = daemon.child.kill();
+    panic!("daemon socket never appeared within 20s");
+}
+
+/// Everything an end-to-end origin test needs: a recorded trace, a live
+/// daemon, and an MCP client wired to it.
+struct OriginHarness {
+    _daemon: TestDaemon,
+    client: McpClient,
+    trace_path: String,
+}
+
+/// Build the harness for `scenario`, or return `None` after emitting a
+/// `SKIPPED:` line explaining precisely what was missing.
+fn origin_harness(scenario: &str) -> Option<OriginHarness> {
+    let binary = match find_binary() {
+        Some(b) => b,
+        None => {
+            skip("backend-manager binary not yet built");
+            return None;
+        }
+    };
+    let trace_dir = record_python_fixture(scenario)?;
+    let root = trace_dir.parent().expect("trace dir has a parent").to_path_buf();
+    let daemon = start_daemon(&binary, &root)?;
+
+    let client = match McpClient::spawn_with_daemon(&binary, &daemon.socket) {
+        Ok(c) => c,
+        Err(e) => panic!("cannot spawn MCP subprocess: {e}"),
+    };
+
+    Some(OriginHarness {
+        _daemon: daemon,
+        client,
+        trace_path: trace_dir.to_string_lossy().to_string(),
+    })
+}
+
+/// Unwrap a `tools/call` result into its text content, asserting the call
+/// did not come back as a tool error.
+fn expect_tool_text(response: &Value, what: &str) -> String {
+    assert!(
+        response.get("error").is_none(),
+        "{what} returned a JSON-RPC error (an advertised tool must at least dispatch): {response}"
+    );
+    let result = response
+        .get("result")
+        .unwrap_or_else(|| panic!("{what} returned neither result nor error: {response}"));
+    let text = result
+        .get("content")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|c| c.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default();
+    assert_ne!(
+        result.get("isError").and_then(Value::as_bool),
+        Some(true),
+        "{what} failed: {text}"
+    );
+    text
+}
+
+/// The canonical `simple_trivial_chain` answer, end to end through the
+/// MCP surface: `c -> b -> a -> Literal(10)`.
+///
+/// Asserted against `tests/fixtures/origin/python/simple_trivial_chain/ANSWERS.md`.
 #[test]
 fn test_mcp_get_value_origin_returns_canonical_chain() {
-    let Some(_trace_dir) = record_python_fixture("simple_trivial_chain") else {
+    let Some(mut harness) = origin_harness("simple_trivial_chain") else {
         return;
     };
-    // Reached only when the recorder is installed AND we wire the
-    // end-to-end harness — see SKIP path above for current status.
-    unreachable!("end-to-end path is skipped until harness sharing lands");
+
+    let response = harness
+        .client
+        .call_tool(
+            "get_value_origin",
+            json!({
+                "trace_path": harness.trace_path,
+                "path": "main.py",
+                "line": 12,
+                "variable": "c",
+            }),
+        )
+        .expect("get_value_origin call should complete");
+    let text = expect_tool_text(&response, "get_value_origin");
+
+    // The tool appends the canonical wire body after the rendered chain.
+    let json_start = text
+        .find('{')
+        .unwrap_or_else(|| panic!("no canonical JSON in get_value_origin output: {text}"));
+    let chain: Value = serde_json::from_str(text[json_start..].trim())
+        .unwrap_or_else(|e| panic!("canonical JSON did not parse ({e}): {}", &text[json_start..]));
+
+    let hops = chain
+        .get("hops")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("chain has no hops array: {chain}"));
+    assert_eq!(
+        hops.len(),
+        3,
+        "ANSWERS.md expects c -> b -> a; got {} hops: {chain}",
+        hops.len()
+    );
+    let kinds: Vec<&str> = hops
+        .iter()
+        .filter_map(|h| h.get("kind").and_then(Value::as_str))
+        .collect();
+    assert_eq!(
+        kinds,
+        vec!["trivialCopy", "trivialCopy", "literal"],
+        "unexpected hop kinds: {chain}"
+    );
+    let sources: Vec<&str> = hops
+        .iter()
+        .filter_map(|h| h.get("sourceText").and_then(Value::as_str))
+        .map(str::trim)
+        .collect();
+    assert_eq!(
+        sources,
+        vec!["c = b", "b = a", "a = 10"],
+        "unexpected assigning statements: {chain}"
+    );
+    assert_eq!(
+        chain
+            .get("terminator")
+            .and_then(|t| t.get("kind"))
+            .and_then(Value::as_str),
+        Some("literal"),
+        "ANSWERS.md expects a Literal terminator: {chain}"
+    );
+    assert_eq!(
+        chain
+            .get("terminator")
+            .and_then(|t| t.get("expression"))
+            .and_then(Value::as_str),
+        Some("10"),
+        "ANSWERS.md expects the chain to terminate at the literal 10: {chain}"
+    );
 }
 
+/// `resolve_variable_step` answers the first hop.
+///
+/// Queried for `a` at the `print(c)` line, the answer must point back at
+/// the `a = 10` assignment — not at the query line, which would mean the
+/// tool had merely echoed its own input.
 #[test]
 fn test_mcp_resolve_variable_step_finds_latest_step() {
-    let Some(_trace_dir) = record_python_fixture("simple_trivial_chain") else {
+    let Some(mut harness) = origin_harness("simple_trivial_chain") else {
         return;
     };
-    unreachable!("end-to-end path is skipped until harness sharing lands");
+
+    let response = harness
+        .client
+        .call_tool(
+            "resolve_variable_step",
+            json!({
+                "trace_path": harness.trace_path,
+                "path": "main.py",
+                "line": 12,
+                "variable": "a",
+            }),
+        )
+        .expect("resolve_variable_step call should complete");
+    let text = expect_tool_text(&response, "resolve_variable_step");
+    let answer: Value = serde_json::from_str(text.trim())
+        .unwrap_or_else(|e| panic!("resolve_variable_step output did not parse ({e}): {text}"));
+
+    assert_eq!(
+        answer.get("variable").and_then(Value::as_str),
+        Some("a"),
+        "answer must name the queried variable: {answer}"
+    );
+    assert_eq!(
+        answer.get("assignment").and_then(Value::as_str).map(str::trim),
+        Some("a = 10"),
+        "answer must name the statement that produced the value: {answer}"
+    );
+    assert_eq!(
+        answer.get("originKind").and_then(Value::as_str),
+        Some("literal"),
+        "`a = 10` is a literal assignment: {answer}"
+    );
+
+    // The reported step must be strictly before the query line, or the
+    // tool has told the caller nothing it did not already supply.
+    let line = answer
+        .get("location")
+        .and_then(|l| l.get("line"))
+        .and_then(Value::as_i64)
+        .unwrap_or_else(|| panic!("answer carries no location line: {answer}"));
+    assert!(
+        line < 12,
+        "the resolved step must precede the query line 12, got {line}: {answer}"
+    );
 }
 
+/// A variable that is never assigned must produce an explicit failure.
+///
+/// An empty-but-successful answer is indistinguishable from an
+/// unimplemented tool, which is precisely the defect these tools shipped
+/// with; this test pins the distinction.
 #[test]
-fn test_mcp_session_affinity_avoids_reload() {
-    let Some(_trace_dir) = record_python_fixture("simple_trivial_chain") else {
+fn test_mcp_resolve_variable_step_reports_missing_variable_explicitly() {
+    let Some(mut harness) = origin_harness("simple_trivial_chain") else {
         return;
     };
-    unreachable!("end-to-end path is skipped until harness sharing lands");
+
+    let response = harness
+        .client
+        .call_tool(
+            "resolve_variable_step",
+            json!({
+                "trace_path": harness.trace_path,
+                "path": "main.py",
+                "line": 12,
+                "variable": "no_such_variable",
+            }),
+        )
+        .expect("resolve_variable_step call should complete");
+
+    let result = response
+        .get("result")
+        .unwrap_or_else(|| panic!("expected a tool result: {response}"));
+    assert_eq!(
+        result.get("isError").and_then(Value::as_bool),
+        Some(true),
+        "an unresolvable variable must be reported as a tool error, not as an empty success: {response}"
+    );
+    let text = result
+        .get("content")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|c| c.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default();
+    assert!(
+        text.contains("no_such_variable"),
+        "the error must name the variable that could not be resolved: {text}"
+    );
 }
 
+/// A breakpoint that is never hit must not be answered about.
+///
+/// Line 3 is a comment: the replay runs to the end of the recording
+/// instead of stopping there.  Answering with whatever chain the final
+/// step happens to yield would be a wrong answer dressed as a right one.
+#[test]
+fn test_mcp_get_value_origin_refuses_an_unreached_line() {
+    let Some(mut harness) = origin_harness("simple_trivial_chain") else {
+        return;
+    };
+
+    let response = harness
+        .client
+        .call_tool(
+            "get_value_origin",
+            json!({
+                "trace_path": harness.trace_path,
+                "path": "main.py",
+                "line": 3,
+                "variable": "c",
+            }),
+        )
+        .expect("get_value_origin call should complete");
+    let result = response
+        .get("result")
+        .unwrap_or_else(|| panic!("expected a tool result: {response}"));
+    assert_eq!(
+        result.get("isError").and_then(Value::as_bool),
+        Some(true),
+        "a line the recording never reaches must be an error: {response}"
+    );
+}
+
+/// The scripting path the `get_value_origin` description points at must
+/// work too: `exec_script` running `trace.value_origin(...)`.
+///
+/// `ct/py-origin-chain` had a Python client, a response formatter and a
+/// pending-request variant, but no route in the daemon's dispatch — so
+/// every call raised `TraceError`.  This drives it through the MCP
+/// surface end to end.
 #[test]
 fn test_mcp_exec_script_trace_value_origin_returns_chain() {
-    let Some(_trace_dir) = record_python_fixture("simple_trivial_chain") else {
+    let Some(mut harness) = origin_harness("simple_trivial_chain") else {
         return;
     };
-    unreachable!("end-to-end path is skipped until harness sharing lands");
-}
 
-#[test]
-fn test_mcp_exec_script_value_origin_session_reuse() {
-    let Some(_trace_dir) = record_python_fixture("simple_trivial_chain") else {
-        return;
-    };
-    unreachable!("end-to-end path is skipped until harness sharing lands");
-}
+    // Step 7 is the `print(c)` step for this fixture — the same query
+    // point `get_value_origin` reaches via its breakpoint.
+    let script = r#"
+trace.goto_ticks(7)
+chain = trace.value_origin("c")
+print("HOPS", len(chain.hops))
+print("TERMINATOR", chain.terminator.kind.value)
+"#;
 
-#[test]
-fn test_cli_trace_origin_json_output() {
-    let Some(_trace_dir) = record_python_fixture("simple_trivial_chain") else {
-        return;
-    };
-    unreachable!("end-to-end path is skipped until harness sharing lands");
-}
+    let response = harness
+        .client
+        .call_tool(
+            "exec_script",
+            json!({ "trace_path": harness.trace_path, "script": script }),
+        )
+        .expect("exec_script call should complete");
+    let text = expect_tool_text(&response, "exec_script + trace.value_origin");
 
-#[test]
-fn test_cli_trace_origin_markdown_output() {
-    let Some(_trace_dir) = record_python_fixture("simple_trivial_chain") else {
-        return;
-    };
-    unreachable!("end-to-end path is skipped until harness sharing lands");
-}
-
-#[test]
-fn test_cli_trace_origin_text_output_matches_spec_layout() {
-    let Some(_trace_dir) = record_python_fixture("simple_trivial_chain") else {
-        return;
-    };
-    unreachable!("end-to-end path is skipped until harness sharing lands");
-}
-
-#[test]
-fn test_cli_trace_origin_honours_origin_patterns_toml() {
-    let Some(_trace_dir) = record_python_fixture("simple_trivial_chain") else {
-        return;
-    };
-    unreachable!("end-to-end path is skipped until harness sharing lands");
+    assert!(
+        text.contains("HOPS 3"),
+        "trace.value_origin should walk c -> b -> a: {text}"
+    );
+    assert!(
+        text.contains("TERMINATOR literal"),
+        "trace.value_origin should terminate at the literal 10: {text}"
+    );
 }
 
 #[test]

--- a/src/backend-manager/tests/mcp_origin_test.rs
+++ b/src/backend-manager/tests/mcp_origin_test.rs
@@ -786,6 +786,14 @@ fn test_mcp_resolve_variable_step_reports_missing_variable_explicitly() {
         text.contains("no_such_variable"),
         "the error must name the variable that could not be resolved: {text}"
     );
+    // Pin the *reason*, not merely "some error": otherwise a transport or
+    // wire-schema failure upstream of the walk would satisfy this test
+    // while proving nothing about the empty-answer case it exists for.
+    assert!(
+        text.contains("No assignment to"),
+        "the error must be the walked-and-found-nothing answer, not an \
+         unrelated failure: {text}"
+    );
 }
 
 /// A breakpoint that is never hit must not be answered about.
@@ -818,6 +826,22 @@ fn test_mcp_get_value_origin_refuses_an_unreached_line() {
         result.get("isError").and_then(Value::as_bool),
         Some(true),
         "a line the recording never reaches must be an error: {response}"
+    );
+    let text = result
+        .get("content")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|c| c.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default();
+    // Pin the reason, so an unrelated upstream failure cannot satisfy this.
+    assert!(
+        text.contains("was never hit"),
+        "the error must say the breakpoint was not reached: {text}"
     );
 }
 

--- a/src/backend-manager/tests/mcp_origin_test.rs
+++ b/src/backend-manager/tests/mcp_origin_test.rs
@@ -4,19 +4,23 @@
 //! - `resolve_variable_step` MCP tool — registration + schema.
 //! - `ct trace origin` CLI subcommand — registration only (the full
 //!   roundtrip needs a live daemon + recorder).
-//! - End-to-end smokes for `get_value_origin` against a canonical
-//!   Python fixture — SKIP cleanly when the Python recorder is not
-//!   installed in the dev shell.
+//! - End-to-end runs of both tools against the canonical
+//!   `simple_trivial_chain` Python fixture, recorded for real.
 //!
 //! The end-to-end tests drive the actual `backend-manager` binary as a
-//! subprocess speaking the MCP JSON-RPC protocol on stdin/stdout. This
-//! exercises the tool dispatch, schema, and (when the recorder is
-//! present) the full daemon → backend → `ct/originChain` path.
+//! subprocess speaking the MCP JSON-RPC protocol on stdin/stdout,
+//! against a daemon running a real `replay-server` over a real
+//! recording. That is deliberate: `get_value_origin` and
+//! `resolve_variable_step` were advertised by `tools/list` while
+//! `tools/call` answered `-32602 Unknown tool`, and every layer beneath
+//! the MCP surface was green throughout. Only a test that goes through
+//! `tools/call` can see that defect.
 //!
 //! SKIP discipline mirrors M3/M5/M6: narrow probes only, no broad
-//! heuristics. When the Python recorder is unavailable we emit a
-//! `SKIPPED: <precise reason>` line on stderr and `return` — never
-//! `panic!`. Genuine M8 bugs surface as hard failures.
+//! heuristics. When the Python recorder or `replay-server` is
+//! unavailable we emit a `SKIPPED: <precise reason>` line on stderr and
+//! `return` — never `panic!`. A recorder that runs and *fails*, by
+//! contrast, is a hard error. Genuine M8 bugs surface as failures.
 
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
@@ -423,11 +427,8 @@ fn record_python_fixture(scenario: &str) -> Option<PathBuf> {
 
     // Short path: the daemon's Unix socket lives beside the trace, and an
     // over-long socket path fails with `SUN_LEN`.
-    let root = PathBuf::from("/tmp").join(format!(
-        "ct-mcp-origin-{}-{}",
-        std::process::id(),
-        scenario
-    ));
+    let root =
+        PathBuf::from("/tmp").join(format!("ct-mcp-origin-{}-{}", std::process::id(), scenario));
     let _ = std::fs::remove_dir_all(&root);
     let trace_dir = root.join("trace");
     std::fs::create_dir_all(&trace_dir).expect("cannot create trace dir");
@@ -550,7 +551,10 @@ fn origin_harness(scenario: &str) -> Option<OriginHarness> {
         }
     };
     let trace_dir = record_python_fixture(scenario)?;
-    let root = trace_dir.parent().expect("trace dir has a parent").to_path_buf();
+    let root = trace_dir
+        .parent()
+        .expect("trace dir has a parent")
+        .to_path_buf();
     let daemon = start_daemon(&binary, &root)?;
 
     let client = match McpClient::spawn_with_daemon(&binary, &daemon.socket) {
@@ -622,8 +626,12 @@ fn test_mcp_get_value_origin_returns_canonical_chain() {
     let json_start = text
         .find('{')
         .unwrap_or_else(|| panic!("no canonical JSON in get_value_origin output: {text}"));
-    let chain: Value = serde_json::from_str(text[json_start..].trim())
-        .unwrap_or_else(|e| panic!("canonical JSON did not parse ({e}): {}", &text[json_start..]));
+    let chain: Value = serde_json::from_str(text[json_start..].trim()).unwrap_or_else(|e| {
+        panic!(
+            "canonical JSON did not parse ({e}): {}",
+            &text[json_start..]
+        )
+    });
 
     let hops = chain
         .get("hops")
@@ -705,7 +713,10 @@ fn test_mcp_resolve_variable_step_finds_latest_step() {
         "answer must name the queried variable: {answer}"
     );
     assert_eq!(
-        answer.get("assignment").and_then(Value::as_str).map(str::trim),
+        answer
+            .get("assignment")
+            .and_then(Value::as_str)
+            .map(str::trim),
         Some("a = 10"),
         "answer must name the statement that produced the value: {answer}"
     );

--- a/src/backend-manager/tests/mcp_tool_surface_test.rs
+++ b/src/backend-manager/tests/mcp_tool_surface_test.rs
@@ -1,0 +1,195 @@
+//! Class-closing check for the MCP tool surface.
+//!
+//! The defect this guards against: `tools/list` advertising a tool that
+//! `tools/call` does not dispatch, so a client that believes the server's
+//! own advertisement gets `-32602 Unknown tool: <name>`.  That happened
+//! for `get_value_origin` and `resolve_variable_step` — advertised since
+//! the M8 milestone, never wired into `handle_tools_call`.
+//!
+//! The permanent fix is structural: `mcp_server::TOOLS` is a single table
+//! whose entries carry BOTH a schema and a dispatch function, so an
+//! advertised-but-undispatched tool cannot be expressed.  This test is
+//! the behavioural backstop for that invariant — it needs no per-tool
+//! maintenance, because it derives the tool list from the server itself.
+//!
+//! It deliberately drives the real `trace mcp` subprocess over stdio, so
+//! it exercises the actual JSON-RPC dispatch rather than any in-process
+//! helper.  No daemon is required: every tool validates its required
+//! arguments before touching the daemon socket, so calling each tool with
+//! `{}` exercises dispatch and stops short of any I/O.
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+use serde_json::{Value, json};
+
+/// Locate the built `session-manager` / `backend-manager` binary next to
+/// this test binary inside `target/<profile>/`.
+fn find_binary() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let mut p = exe;
+    for _ in 0..4 {
+        p.pop();
+        for name in ["session-manager", "backend-manager"] {
+            let candidate = p.join(name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+struct McpStdio {
+    child: Child,
+    stdin: std::process::ChildStdin,
+    reader: BufReader<std::process::ChildStdout>,
+    next_id: i64,
+}
+
+impl McpStdio {
+    fn spawn(binary: &Path) -> McpStdio {
+        let mut child = Command::new(binary)
+            .args(["trace", "mcp"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            // Point the daemon socket at a path that cannot exist, so a
+            // handler that *did* reach the daemon fails fast instead of
+            // auto-starting a real one.
+            .env("CODETRACER_DAEMON_SOCK", "/nonexistent/mcp-tool-surface.sock")
+            .spawn()
+            .expect("failed to spawn `trace mcp`");
+        let stdin = child.stdin.take().expect("no stdin");
+        let stdout = child.stdout.take().expect("no stdout");
+        let mut c = McpStdio {
+            child,
+            stdin,
+            reader: BufReader::new(stdout),
+            next_id: 1,
+        };
+        let init = c.request("initialize", json!({}));
+        assert!(
+            init.get("result").is_some(),
+            "initialize must succeed: {init}"
+        );
+        c
+    }
+
+    fn request(&mut self, method: &str, params: Value) -> Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        let msg = json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params});
+        writeln!(self.stdin, "{msg}").expect("write to MCP stdin");
+        self.stdin.flush().expect("flush MCP stdin");
+        loop {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).expect("read MCP stdout");
+            assert!(n > 0, "MCP subprocess closed stdout while awaiting {method}");
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let value: Value =
+                serde_json::from_str(trimmed).unwrap_or_else(|e| panic!("bad JSON {trimmed}: {e}"));
+            if value.get("id").and_then(Value::as_i64) == Some(id) {
+                return value;
+            }
+        }
+    }
+}
+
+impl Drop for McpStdio {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Every tool the server advertises through `tools/list` must be
+/// dispatched by `tools/call`.
+///
+/// A tool that is advertised but not dispatched answers `-32602 Unknown
+/// tool: <name>` — the client asked for exactly what it was told exists.
+/// This is the check that must stay green; it derives its expectations
+/// from the server, so a newly added tool is covered automatically.
+#[test]
+fn every_advertised_tool_is_dispatched() {
+    let binary = find_binary().expect(
+        "backend-manager binary not built; run `cargo build --tests` in src/backend-manager",
+    );
+    let mut mcp = McpStdio::spawn(&binary);
+
+    let listed = mcp.request("tools/list", json!({}));
+    let tools = listed
+        .get("result")
+        .and_then(|r| r.get("tools"))
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("tools/list returned no tools array: {listed}"))
+        .clone();
+
+    // Population count: a silently empty list would make every assertion
+    // below vacuous.
+    assert!(
+        tools.len() >= 8,
+        "tools/list advertised only {} tools — the surface shrank unexpectedly: {listed}",
+        tools.len()
+    );
+
+    let mut undispatched: Vec<String> = Vec::new();
+    for tool in &tools {
+        let name = tool
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| panic!("advertised tool without a name: {tool}"))
+            .to_string();
+
+        let response = mcp.request("tools/call", json!({"name": name, "arguments": {}}));
+
+        // A dispatched tool answers with a `result` (usually a
+        // `Missing required argument` tool error, which is fine — the
+        // point is that dispatch happened).  An UNdispatched tool
+        // answers with the JSON-RPC error -32602 "Unknown tool: <name>".
+        if let Some(error) = response.get("error") {
+            let code = error.get("code").and_then(Value::as_i64).unwrap_or(0);
+            let message = error.get("message").and_then(Value::as_str).unwrap_or("");
+            if code == -32602 && message.starts_with("Unknown tool") {
+                undispatched.push(name.clone());
+                continue;
+            }
+            panic!("tools/call for advertised tool {name:?} failed unexpectedly: {response}");
+        }
+    }
+
+    assert!(
+        undispatched.is_empty(),
+        "these tools are advertised by tools/list but not dispatched by tools/call, \
+         so any client that trusts the advertisement gets `-32602 Unknown tool`: {undispatched:?}"
+    );
+}
+
+/// The inverse direction: a name the server does NOT advertise must be
+/// rejected with `-32602`.  Without this, "every advertised tool is
+/// dispatched" could be satisfied by a catch-all arm that pretends to
+/// handle anything.
+#[test]
+fn unadvertised_tool_names_are_rejected() {
+    let binary = find_binary().expect(
+        "backend-manager binary not built; run `cargo build --tests` in src/backend-manager",
+    );
+    let mut mcp = McpStdio::spawn(&binary);
+
+    let response = mcp.request(
+        "tools/call",
+        json!({"name": "definitely_not_a_codetracer_tool", "arguments": {}}),
+    );
+    let error = response
+        .get("error")
+        .unwrap_or_else(|| panic!("unknown tool must produce a JSON-RPC error: {response}"));
+    assert_eq!(
+        error.get("code").and_then(Value::as_i64),
+        Some(-32602),
+        "unknown tool must answer -32602: {response}"
+    );
+}

--- a/src/backend-manager/tests/mcp_tool_surface_test.rs
+++ b/src/backend-manager/tests/mcp_tool_surface_test.rs
@@ -58,7 +58,10 @@ impl McpStdio {
             // Point the daemon socket at a path that cannot exist, so a
             // handler that *did* reach the daemon fails fast instead of
             // auto-starting a real one.
-            .env("CODETRACER_DAEMON_SOCK", "/nonexistent/mcp-tool-surface.sock")
+            .env(
+                "CODETRACER_DAEMON_SOCK",
+                "/nonexistent/mcp-tool-surface.sock",
+            )
             .spawn()
             .expect("failed to spawn `trace mcp`");
         let stdin = child.stdin.take().expect("no stdin");
@@ -86,7 +89,10 @@ impl McpStdio {
         loop {
             let mut line = String::new();
             let n = self.reader.read_line(&mut line).expect("read MCP stdout");
-            assert!(n > 0, "MCP subprocess closed stdout while awaiting {method}");
+            assert!(
+                n > 0,
+                "MCP subprocess closed stdout while awaiting {method}"
+            );
             let trimmed = line.trim();
             if trimmed.is_empty() {
                 continue;


### PR DESCRIPTION
## Why

`handle_tools_list` advertised 8 MCP tools; `handle_tools_call` dispatched 6. An MCP client calling `get_value_origin` or `resolve_variable_step` — because the server said they exist — got `-32602 Unknown tool`.

Fixing that surfaced three more unwired promises:

- **`meta.dat` flag mask was a stale copy.** `backend-manager/src/meta_dat.rs` knew bits 0–3; the canonical reader at `src/db-backend/src/ctfs_trace_reader/meta_dat.rs` — same repo, same commit — knows 0–13. Every trace was rejected with `unknown flag bits set (flags=0x0f18)`, taking down all MCP tools *and* `ct trace info/query/origin`.
- **`ct trace origin` was fully broken.** The daemon forwarded `replay-id` inside `arguments`, where `CtOriginChainArguments` is `#[serde(deny_unknown_fields)]`. The feature's only existing caller errored out.
- **`ct/py-origin-chain` had no daemon route** — client, formatter and pending-request variant all existed; the command fell through to the generic forwarder.

## Approach

`TOOLS` is now one `&[ToolDef]` carrying both the schema fn and the dispatch fn. `tools/list` maps over it, `tools/call` looks up in it, and a `ToolDef` cannot be constructed without a `dispatch` — advertised-but-undispatched is unrepresentable rather than merely tested-against.

`tests/mcp_tool_surface_test.rs` is kept as a behavioural backstop: it derives the tool list from `tools/list` itself and calls every advertised name, so it needs no per-tool maintenance.

## Verification

Run RED first — the surface test named both missing tools before the fix. Each change was mutation-verified: reverting the dispatch fails 4 e2e tests with `-32602`; removing the daemon route reproduces the original `TraceError`; removing the `replay-id` strip fails 2 tests on the wire schema.

Driven end to end over stdio against a real recorded fixture and a locally built `replay-server`: `get_value_origin` returns the expected `c→b→a` chain terminating at `Literal 10`; `resolve_variable_step` returns step 5 / `a = 10`.

Six always-skipping stubs were deleted — their helper always returned `None` and the bodies were `unreachable!()`. That leaves `ct trace origin`'s json/markdown/text renderers without a test; noted rather than papered over.

Pre-existing and not caused here: `browser_stream_host::verify_reframing_*` fails identically on base sources, and `real_recording_integration`'s 75 failures are all the `MISSING PREREQUISITE: ct-native-replay` hard-fail.

Opened to obtain a CI verdict — this branch has never been built by CI, since the workflow does not trigger on arbitrary branch pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)