### PR TITLE
test(web-renderer): re-aim two mutation arms that were measuring nothing

### DIFF
--- a/ci/test/web-renderer-mounts.sh
+++ b/ci/test/web-renderer-mounts.sh
@@ -1854,13 +1854,28 @@ print(" ".join(r["name"] for r in rows))
 	r_clickerr="$(json route runClick.clickError)"
 	r_started="$(json route runClick.startedLine)"
 	r_refused="$(json route runClick.refusedLine)"
-	# THE SECOND CHANNEL, reported rather than asserted here. This pane's
-	# control refuses through the same `api.errorMessage` path the gutter's
-	# does, so the sentence the user is shown is available — but arm G is where
-	# it is ASSERTED, and adding a second assertion of the same fact here would
-	# inflate the tally without adding power. Carried so a red arm R names what
-	# the user saw instead of guessing.
+	# THE SECOND CHANNEL, reported rather than asserted here — AND EXPECTED TO
+	# BE EMPTY FOR THIS CONTROL, which the previous version of this comment got
+	# backwards. It said the pane's ▶ "refuses through the same
+	# `api.errorMessage` path the gutter's does". It does not, and the commit
+	# that wrote that sentence is the one that made it false:
+	# `test_results_vm.startRun` files the runner's sentence with
+	# `noteRunRefusal`, which appends a diagnostic and renders in the pane's
+	# `.test-results-failure` block. No notification is raised. The gutter's
+	# `runTestFromGutter` is the path that calls `api.errorMessage`.
+	#
+	# So the pane's refusal is read off `r_absence` and the failure block, and a
+	# `none` here is the CORRECT reading for this control rather than a silent
+	# product. Carried anyway, because a notification appearing on this press
+	# would mean the two controls had converged and this comment needs rewriting
+	# again.
 	r_refusenotice="$(json route runClick.refusalNotice)"
+	# The population behind the read — see arm G. `r_noticesbefore` counts the
+	# notifications the page already carried (the storage-durability sentence is
+	# always one of them), which are excluded from `refusalNotice` because they
+	# answer no question the click asked.
+	r_notices="$(json route runClick.notices)"
+	r_noticesbefore="$(json route runClick.noticesBefore)"
 	r_headbefore="$(json route runClick.headlineBefore)"
 	r_headafter="$(json route runClick.headlineAfter)"
 	r_results="$(json route runClick.resultsLine)"
@@ -1888,7 +1903,7 @@ print(" ".join(r["name"] for r in rows))
 		# console, the pane's absence line, the notification — and lets the
 		# reader see which of them were silent, rather than asserting in prose
 		# that all of them were.
-		ck fail "arm R: the click started nothing. Console refusal: '${r_refused:-none}'; on-screen notice: '${r_refusenotice:-none}'; pane absence line: ${r_absence:-0} character(s); headline went '${r_headbefore}' -> '${r_headafter}'. A control that looks live and runs nothing is the dead affordance — and whether the user was told WHY is the ${r_absence:-0}-character absence line and the notice above, not this sentence's assumption"
+		ck fail "arm R: the click started nothing. Console refusal: '${r_refused:-none}'; press-caused notice: '${r_refusenotice:-none}' (${r_notices} caused by the press, ${r_noticesbefore} already on screen and excluded); pane absence line: ${r_absence:-0} character(s); headline went '${r_headbefore}' -> '${r_headafter}'. A control that looks live and runs nothing is the dead affordance — and whether the user was told WHY is the ${r_absence:-0}-character absence line and the pane's failure block, not this sentence's assumption"
 		jsonraw route runClick.newConsole 2>/dev/null | head -3 | sed 's/^/      /'
 	fi
 	# ...AND THE RUN REACHED ITS VERDICTS. `nbpTest-started` proves the worker
@@ -2769,6 +2784,14 @@ print(" | ".join(l.replace("log: codetracer-noir-build: ", "")
 	fi
 
 	g_refusenotice="$(json gutter-run gutterRunClick.refusalNotice)"
+	# THE POPULATION BEHIND THE READ, so an empty `refusalNotice` can be told
+	# apart from a probe that never saw a notification at all. `json` collapses
+	# a list to its length, so these are counts: `g_notices` is what the PRESS
+	# caused, `g_noticesbefore` is what the page was already showing and the
+	# recorder deliberately excluded. Reported because run 34160263480 passed
+	# this arm's second-channel check by quoting one of the excluded ones.
+	g_notices="$(json gutter-run gutterRunClick.notices)"
+	g_noticesbefore="$(json gutter-run gutterRunClick.noticesBefore)"
 	if [ "${g_clicked}" = "true" ] && [ -n "${g_started}" ]; then
 		ck ok "arm G: pressing it STARTED a run — ${g_started}"
 	else
@@ -2817,9 +2840,9 @@ print(" | ".join(l.replace("log: codetracer-noir-build: ", "")
 	if [ -n "${g_started}" ]; then
 		ck ok "arm G: the press started a run, so no refusal was owed — and the product volunteered none (on-screen: ${g_refusenotice:-none})"
 	elif [ -n "${g_refusenotice}" ] || [ -n "${g_refused}" ]; then
-		ck ok "arm G: the press started no run and the product SAID WHY on the surface the user actually reads — on-screen: ${g_refusenotice:-none}; console: '${g_refused}'"
+		ck ok "arm G: the press started no run and the product SAID WHY on the surface the user actually reads — on-screen: ${g_refusenotice:-none}; console: '${g_refused}' (the on-screen sentence is one of ${g_notices} the press CAUSED; ${g_noticesbefore} pre-existing notice(s) were excluded from this read)"
 	else
-		ck fail "arm G: the press started no run and the user was told NOTHING — no console refusal and no notification on screen. Silence after a press is the reported defect in its worst form: the control looks live, does nothing, and states no reason"
+		ck fail "arm G: the press started no run and the user was told NOTHING — no console refusal and no notification caused by the press (${g_notices} press-caused notice(s); ${g_noticesbefore} notice(s) were already on screen before it and are NOT an answer to it). Silence after a press is the reported defect in its worst form: the control looks live, does nothing, and states no reason"
 	fi
 
 	# THE VERDICT, and it must name a passing test. `startNoirTestRecording`
@@ -3037,6 +3060,8 @@ else
 	z_started="$(json gutter-run-no-modules gutterRunClick.startedLine)"
 	z_refused="$(json gutter-run-no-modules gutterRunClick.refusedLine)"
 	z_notice="$(json gutter-run-no-modules gutterRunClick.refusalNotice)"
+	z_notices="$(json gutter-run-no-modules gutterRunClick.notices)"
+	z_noticesbefore="$(json gutter-run-no-modules gutterRunClick.noticesBefore)"
 	z_settled="$(json gutter-run-no-modules gutterRunClick.runningAfterSettle)"
 
 	# 1. THE MUTATION LANDED, and it landed on the RUN rather than on the
@@ -3064,12 +3089,23 @@ else
 	#    armed before the click, so a notification that is dismissed before the
 	#    read is still counted — an empty string here means the product never
 	#    said anything, not that the probe looked late.
+	#
+	#    AND IT MUST BE A NOTICE THE PRESS CAUSED. The page is already showing
+	#    the storage-durability sentence when this arm clicks, and the first
+	#    version of `refusalNotice` returned the first notice on the page that
+	#    was not the timeout — so this check could have been satisfied by a
+	#    notification about STORAGE while the run control said nothing at all.
+	#    That is not a hypothetical: it is how arm G passed on run 34160263480.
+	#    The recorder now keeps the pre-existing notices in a separate list and
+	#    `refusalNotice` is drawn only from what arrived after the press, and
+	#    both counts are printed so this line can be audited rather than
+	#    trusted.
 	if [ -n "${z_notice}" ] && [ "${z_settled}" = "0" ]; then
-		ck ok "arm Z: and the product told the user why, on screen and with no run left spinning — ${z_notice}"
+		ck ok "arm Z: and the product told the user why, on screen and with no run left spinning — ${z_notice} (one of ${z_notices} notice(s) the press caused; ${z_noticesbefore} pre-existing one(s) excluded)"
 	elif [ -n "${z_notice}" ]; then
 		ck fail "arm Z: the product explained itself (${z_notice}) but left ${z_settled} slot(s) spinning — a refusal that still shows a running control is the reported defect with a caption"
 	else
-		ck fail "arm Z: the press started no run, the console said nothing, and the screen said nothing either — this is the dead affordance exactly as reported, and it is invisible to every check that reads the console alone"
+		ck fail "arm Z: the press started no run, the console said nothing, and the screen said nothing either (${z_notices} press-caused notice(s); ${z_noticesbefore} pre-existing one(s) excluded as answering no question the click asked) — this is the dead affordance exactly as reported, and it is invisible to every check that reads the console alone"
 	fi
 fi
 echo

--- a/ci/test/web-renderer-mounts.sh
+++ b/ci/test/web-renderer-mounts.sh
@@ -1001,6 +1001,67 @@ mutate_no_wasm_worker() {
 	[ "${after}" = "0" ]
 }
 
+# Arm Z — THE DEPLOYMENT DECLARES NO WASM MODULES.
+#
+# THE MUTATION THAT GIVES THE SECOND CHANNEL ITS POWER, and it is a different
+# seam from arm P/Q's on purpose.
+#
+# `mutate_no_wasm_worker` deletes the worker SCRIPT, so the registry has modules
+# and cannot start them: the dispatch is refused inside `wasm_registry` and says
+# so ON THE CONSOLE (`nbpTest-refused ... reason=pkCancelled`). This mutation
+# empties `modules[]` in the deployment descriptor instead, which is a step
+# earlier and lands somewhere else entirely:
+#
+#   `web_platform.newWebPlatform` subtracts `capProcessSpawn` when
+#   `registry.modules.len == 0` ("the profile follows the registry",
+#   `web_boot.nim:127-137`), so `web_noir_build.noirTestRunAbsence()` returns
+#   `degradedBehaviour(profile, capProcessSpawn)` — a sentence — and
+#   `editorTestRunHook` returns it BEFORE any dispatch. `runTestFromGutter`
+#   takes its `refusal.len > 0` branch, unwinds the spinner and calls
+#   `self.api.errorMessage($refusal)`.
+#
+# So the product refuses CORRECTLY and tells the user why, and emits NO
+# `codetracer-noir-build:` line at all. That is the blind spot: a probe reading
+# refusals from the console alone sees `refusedLine=''` and cannot distinguish
+# this — a control that refused and explained itself — from the reported defect,
+# a control that took the click and said nothing.
+#
+# It is also the state the `viewmodel-tests` job runs in for real. That job
+# declares no wasm modules, and its arm G reads exactly this: `the press started
+# no run (clicked=true, refusal='')`, over a page that IS showing the sentence.
+#
+# NOT THE SAME AS DELETING `assets/noir_wasm*.wasm`, which arm P's comment
+# records as tried and failed: the registry is built from what the DESCRIPTOR
+# declares, not from what the fetch returns, so removing the file leaves
+# `capProcessSpawn` granted and the dispatch still happens. The descriptor is
+# the only shell-reachable seam that reaches the absence path.
+mutate_no_declared_modules() {
+	local dir="$1"
+	grep -q 'id="codetracer-deployment"' "${dir}/index.html" || return 1
+	python3 - "${dir}/index.html" <<'PY2'
+import json, re, sys
+p = sys.argv[1]
+s = open(p).read()
+m = re.search(r'(<script type="application/json" id="codetracer-deployment">)'
+              r'(.*?)(</script>)', s, re.S)
+assert m, "no deployment descriptor in the entry document"
+# Same escape/unescape dance as `configure_language_host`; see its note.
+raw = m.group(2).replace('\\u003c', '<').replace('\\u003e', '>').replace('\\u0026', '&')
+d = json.loads(raw)
+# A mutation that found nothing to mutate must not report success — the arm
+# would measure an UNMUTATED bundle and call its verdict evidence. A deployment
+# that already declares no modules is exactly that case, and it is a REAL state
+# (the `viewmodel-tests` job), so this refuses loudly rather than passing.
+if not d.get("modules"):
+    sys.stderr.write("the descriptor already declares no modules\n")
+    raise SystemExit(1)
+d["modules"] = []
+out = json.dumps(d, separators=(",", ":"))
+out = out.replace('<', '\\u003c').replace('>', '\\u003e').replace('&', '\\u0026')
+open(p, 'w').write(s[:m.start(2)] + out + s[m.end(2):])
+PY2
+}
+
 mutate_covered_surface() {
 	local dir="$1"
 	grep -q '</div>' "${dir}/index.html" || return 1
@@ -1793,6 +1854,13 @@ print(" ".join(r["name"] for r in rows))
 	r_clickerr="$(json route runClick.clickError)"
 	r_started="$(json route runClick.startedLine)"
 	r_refused="$(json route runClick.refusedLine)"
+	# THE SECOND CHANNEL, reported rather than asserted here. This pane's
+	# control refuses through the same `api.errorMessage` path the gutter's
+	# does, so the sentence the user is shown is available — but arm G is where
+	# it is ASSERTED, and adding a second assertion of the same fact here would
+	# inflate the tally without adding power. Carried so a red arm R names what
+	# the user saw instead of guessing.
+	r_refusenotice="$(json route runClick.refusalNotice)"
 	r_headbefore="$(json route runClick.headlineBefore)"
 	r_headafter="$(json route runClick.headlineAfter)"
 	r_results="$(json route runClick.resultsLine)"
@@ -1804,7 +1872,23 @@ print(" ".join(r["name"] for r in rows))
 	if [ -n "${r_started}" ]; then
 		ck ok "arm R: THE CLICK STARTED A RUN — ${r_started}"
 	else
-		ck fail "arm R: the click started nothing. Refusal line: '${r_refused:-none}'; headline went '${r_headbefore}' -> '${r_headafter}'. A control that looks live and runs nothing is the dead affordance in its worst form, because the pane also states no reason"
+		# WHAT THIS SENTENCE USED TO CLAIM WAS FALSE IN THE RUN THAT PRINTS IT.
+		#
+		# It ended "because the pane also states no reason", and on the job where
+		# this check actually fails — `viewmodel-tests`, zero wasm modules — the
+		# pane states one: `webNoModulesLoaded`, "this page was published without
+		# the Noir compiler, so nothing here can be compiled, run or tested",
+		# ninety-seven characters of it. The absence check forty lines above goes
+		# red in the SAME run for carrying exactly that sentence, so the two
+		# failures contradicted each other in one log.
+		#
+		# The clause was true when it was written, about a pane that said nothing.
+		# It was never re-read after the pane learned to explain itself. So the
+		# message now REPORTS the three channels it can actually see — the
+		# console, the pane's absence line, the notification — and lets the
+		# reader see which of them were silent, rather than asserting in prose
+		# that all of them were.
+		ck fail "arm R: the click started nothing. Console refusal: '${r_refused:-none}'; on-screen notice: '${r_refusenotice:-none}'; pane absence line: ${r_absence:-0} character(s); headline went '${r_headbefore}' -> '${r_headafter}'. A control that looks live and runs nothing is the dead affordance — and whether the user was told WHY is the ${r_absence:-0}-character absence line and the notice above, not this sentence's assumption"
 		jsonraw route runClick.newConsole 2>/dev/null | head -3 | sed 's/^/      /'
 	fi
 	# ...AND THE RUN REACHED ITS VERDICTS. `nbpTest-started` proves the worker
@@ -2532,6 +2616,7 @@ if ! run_arm no-worker mutate_no_wasm_worker "/noir"; then
 	ck fail "arm P could not be measured"
 	ck fail "arm P could not be measured (second half)"
 	ck fail "arm P could not be measured (third half)"
+	ck fail "arm P could not be measured (discriminating power)"
 else
 	probe_click_run=""
 	p_runbtn="$(jsonraw no-worker dom.testRunButton.text)"
@@ -2540,6 +2625,31 @@ else
 	p_results="$(json no-worker runClick.resultsLine)"
 	p_headbefore="$(json no-worker runClick.headlineBefore)"
 	p_headafter="$(json no-worker runClick.headlineAfter)"
+	# DID THIS ARM DISCRIMINATE ANYTHING? Read from arm R's own report rather
+	# than from a shell variable set 700 lines earlier, so a reordering cannot
+	# quietly compare against the wrong run.
+	#
+	# THE ARM IT NAMES IS ARM R, AND WHAT IT NAMES IS A DIFFERENCE. Every check
+	# below asserts an ABSOLUTE state — "the click started no run" — and an
+	# absolute state is evidence only when the base run was in a DIFFERENT one.
+	# Measured on `viewmodel-tests` run 34072935418 it was not: that job
+	# declares no wasm modules, arm R's own press started nothing, and this arm
+	# then "killed" arm R's run-start assertion by observing the exact condition
+	# the base was already in. Its `[OK]` line and arm R's `[FAILED]` line
+	# carried the same fact.
+	#
+	# That is the failure this check exists to make impossible. It is not a
+	# statement about the product — it is the arm auditing its own evidence — so
+	# it goes red where the arm is powerless instead of letting the three checks
+	# below report kills they did not earn.
+	p_basestarted="$(json route runClick.startedLine)"
+	if [ -n "${p_basestarted}" ] && [ -z "${p_started}" ]; then
+		ck ok "arm P: the MUTATION is what stopped the run — arm R's base run started (${p_basestarted}) and this one did not, so the three checks below are differences rather than constants"
+	elif [ -n "${p_basestarted}" ]; then
+		ck fail "arm P: arm R's base run started (${p_basestarted}) and so did this one ('${p_started}') — deleting the worker script changed nothing, so this arm is a negative control for nothing"
+	else
+		ck fail "arm P: NO DISCRIMINATING POWER HERE — arm R's base run started nothing either, so removing the worker script produced a state this bundle was ALREADY IN and the checks below cannot tell the mutation from the environment. This is a deployment that declares no wasm modules; the arm needs a bundle that can run a test before it can show what stops one."
+	fi
 	if [ "${p_clicked}" = "true" ] && [ "${p_runbtn}" != "null" ] && [ -n "${p_runbtn}" ]; then
 		ck ok "arm P: the control is still painted (${p_runbtn}) and still takes a real click, so arm R's press check is not what this arm reddens"
 	else
@@ -2613,6 +2723,7 @@ if ! run_arm gutter-run "" "/noir"; then
 	ck fail "arm G could not be measured (third half)"
 	ck fail "arm G could not be measured (fourth half)"
 	ck fail "arm G could not be measured (deadline attribution)"
+	ck fail "arm G could not be measured (the refusal the user is shown)"
 else
 	probe_click_gutter_run=""
 	g_slot="$(python3 -c '
@@ -2657,10 +2768,58 @@ print(" | ".join(l.replace("log: codetracer-noir-build: ", "")
 		ck fail "arm G: the run control is unreachable or shares the breakpoint's hit area — ${g_slot}"
 	fi
 
+	g_refusenotice="$(json gutter-run gutterRunClick.refusalNotice)"
 	if [ "${g_clicked}" = "true" ] && [ -n "${g_started}" ]; then
 		ck ok "arm G: pressing it STARTED a run — ${g_started}"
 	else
-		ck fail "arm G: the press started no run (clicked=${g_clicked}, refusal='${g_refused}') — this is the reported defect: a control that takes the click and reaches no runner"
+		ck fail "arm G: the press started no run (clicked=${g_clicked}, console refusal='${g_refused}', on-screen refusal=${g_refusenotice:-none}) — this is the reported defect: a control that takes the click and reaches no runner"
+	fi
+
+	# THE SECOND CHANNEL: A PRESS MUST EITHER RUN OR SAY WHY, and "why" is read
+	# off the SCREEN and not only off the console.
+	#
+	# The check above is about the run. This one is about the answer, and it
+	# exists because the two refusal channels are different artefacts that this
+	# gate used to conflate. `refusedLine` greps the console for
+	# `codetracer-noir-build: ...refused`; the user reads a `.notification-message`.
+	# Every refusal in `runTestFromGutter` produces the second — it answers with
+	# `self.api.errorMessage(...)` on all three of its paths — and only the
+	# dispatch-level ones produce the first.
+	#
+	# So the console-only read had a hole exactly where the product behaves
+	# BEST: the absence path refuses before dispatching, explains itself in a
+	# sentence, and prints nothing. Run 34072935418's arm G reported
+	# `refusal=''` about a page that was showing the user a reason, and the
+	# failure text it printed — "a control that takes the click and reaches no
+	# runner" — described a defect the product did not have there.
+	#
+	# THE DEAD AFFORDANCE IS THE SUBJECT: silence after a press is the reported
+	# bug, and a sentence after a press is the fix.
+	#
+	# WHAT REDDENS THIS CHECK, STATED EXACTLY, because an earlier draft of this
+	# comment said "arm Z below is the mutation that reddens it" and that is not
+	# how the arms are wired. Every arm reads its OWN probe report, so no
+	# mutation applied in arm Z can move a variable arm G computed from
+	# `gutter-run`'s JSON. Arm Z cannot redden this line and never could.
+	#
+	# This check goes red when a press starts no run AND the console is silent
+	# AND the screen is silent — the reported defect exactly. No mutation in
+	# this gate produces that state, because reaching it means breaking the
+	# notification surface itself, which nothing here mutates. So THIS line is a
+	# monitor rather than a controlled assertion, and that is said out loud
+	# instead of implied away.
+	#
+	# The controlled form of the same assertion is ARM Z's third check. Arm Z
+	# empties the descriptor's `modules[]`, which silences the console channel
+	# outright, and then requires the screen to answer. There the assertion has
+	# somewhere to fail from a cause the gate creates, which is what makes the
+	# second channel load-bearing rather than decorative.
+	if [ -n "${g_started}" ]; then
+		ck ok "arm G: the press started a run, so no refusal was owed — and the product volunteered none (on-screen: ${g_refusenotice:-none})"
+	elif [ -n "${g_refusenotice}" ] || [ -n "${g_refused}" ]; then
+		ck ok "arm G: the press started no run and the product SAID WHY on the surface the user actually reads — on-screen: ${g_refusenotice:-none}; console: '${g_refused}'"
+	else
+		ck fail "arm G: the press started no run and the user was told NOTHING — no console refusal and no notification on screen. Silence after a press is the reported defect in its worst form: the control looks live, does nothing, and states no reason"
 	fi
 
 	# THE VERDICT, and it must name a passing test. `startNoirTestRecording`
@@ -2740,6 +2899,7 @@ if ! run_arm gutter-run-no-worker mutate_no_wasm_worker "/noir"; then
 	ck fail "arm Q could not be measured"
 	ck fail "arm Q could not be measured (second half)"
 	ck fail "arm Q could not be measured (the slot's running state)"
+	ck fail "arm Q could not be measured (discriminating power)"
 else
 	probe_click_gutter_run=""
 	q_clicked="$(json gutter-run-no-worker gutterRunClick.clicked)"
@@ -2754,6 +2914,43 @@ print("yes" if s and s["width"] and s["height"] else "no")
 	q_refused="$(json gutter-run-no-worker gutterRunClick.refusedLine)"
 	q_settlems="$(json gutter-run-no-worker gutterRunClick.settleWaitMs)"
 	q_budget="$(json gutter-run-no-worker gutterRunClick.settleBudgetMs)"
+	# DID THIS ARM DISCRIMINATE ANYTHING? The same audit arm P now carries, for
+	# the same reason and against arm G's base instead of arm R's.
+	#
+	# THIS IS THE ONE THAT WAS CAUGHT. On `viewmodel-tests` run 34072935418 arm
+	# G failed with
+	#
+	#     arm G: the press started no run (clicked=true, refusal='')
+	#
+	# and arm Q passed, three lines later, with
+	#
+	#     arm Q: and the press started no run and reached no verdict ('none'),
+	#            so arm G's run-start and verdict assertions can fail
+	#
+	# The SAME observation, scored as a defect once and as a kill once. A
+	# negative control that agrees with its positive arm has measured nothing —
+	# the worker script it deleted was irrelevant, because that job declares no
+	# wasm modules and nothing was going to start with or without it.
+	#
+	# Its third check was worse, and is the "a zero is not a measurement" case
+	# exactly: "the control did NOT stay spinning — it cleared in 1ms". Nothing
+	# cleared. The slot never span, because no run was ever dispatched, and an
+	# empty read was reported as a clean settle.
+	#
+	# On the deploy job, where the modules ARE declared, the same arm is sound:
+	# run 33983246277 shows arm G starting a run (`nbpTest-started starts=1`),
+	# reaching a verdict and clearing a slot that really span, and arm Q showing
+	# none of it. The arm was never wrong about the product — it was blind to
+	# whether the environment had already answered for it.
+	q_basestarted="$(json gutter-run gutterRunClick.startedLine)"
+	q_baserunning="$(json gutter-run gutterRunClick.runningAfterClick)"
+	if [ -n "${q_basestarted}" ] && [ -z "${q_started}" ]; then
+		ck ok "arm Q: the MUTATION is what stopped the run — arm G's base press started one (${q_basestarted}) and spun ${q_baserunning} slot(s), and this press did neither, so the checks below are differences rather than constants"
+	elif [ -n "${q_basestarted}" ]; then
+		ck fail "arm Q: arm G's base press started a run (${q_basestarted}) and so did this one ('${q_started}') — deleting the worker script changed nothing, so this arm is a negative control for nothing"
+	else
+		ck fail "arm Q: NO DISCRIMINATING POWER HERE — arm G's base press started nothing either (and span ${q_baserunning} slots), so removing the worker script produced a state this bundle was ALREADY IN. The checks below would report the same verdict over an unmutated bundle, which is what makes them unearned rather than merely weak. This is a deployment that declares no wasm modules; see arm Z, which is the arm aimed AT that state instead of tripping over it."
+	fi
 	if [ "${q_present}" = "yes" ] && [ "${q_clicked}" = "true" ]; then
 		ck ok "arm Q: the control is still painted and still takes a real click, so arm G's press check is not what this arm reddens"
 	else
@@ -2780,10 +2977,99 @@ print("yes" if s and s["width"] and s["height"] else "no")
 	# Measured here at ~30s after the press, which is well inside that deadline:
 	# before the fix this read 1, and the only thing that would have cleared it
 	# is a timeout no user waits through.
+	# THE PEAK IS PRINTED, not just the final zero. "It cleared in 1ms" over a
+	# slot that never span at all is not a settle, and on run 34072935418 that
+	# is exactly what this line reported. The pass condition is unchanged —
+	# tightening it to demand a spin would be a guess about timing this arm has
+	# never measured, and the power check above is what actually stops the
+	# vacuous case — but an empty read can no longer be read as a clean one.
+	q_running="$(json gutter-run-no-worker gutterRunClick.runningAfterClick)"
 	if [ "${q_settled}" = "0" ]; then
-		ck ok "arm Q: and the control did NOT stay spinning over the refusal — it cleared in ${q_settlems}ms, against a ${q_budget}ms budget that is itself well inside the product's two-minute deadline"
+		ck ok "arm Q: and the control did NOT stay spinning over the refusal — peak ${q_running} slot(s) at the press, cleared in ${q_settlems}ms, against a ${q_budget}ms budget that is itself well inside the product's two-minute deadline"
 	else
 		ck fail "arm Q: ${q_settled} slot(s) still spinning after ${q_settlems}ms, over a run refused synchronously ('${q_refused}') — the control is showing a run that is not happening, which is the reported defect"
+	fi
+fi
+echo
+
+# ---------------------------------------------------------------------------
+echo "Arm Z: MUTATION — the deployment declares no wasm modules at all"
+echo "    Arm G's SECOND-CHANNEL control. Expect the press to be refused with"
+echo "    NOTHING on the console and a sentence on the screen — the state in"
+echo "    which a console-only probe is blind."
+# ---------------------------------------------------------------------------
+# WHY THIS ARM EXISTS, and it is not another way to break the run.
+#
+# Arms P and Q delete the worker SCRIPT: the registry holds modules, cannot
+# start them, and refuses ON THE CONSOLE. That is one refusal channel and this
+# gate has always read it. This arm empties `modules[]` in the deployment
+# descriptor, which takes `capProcessSpawn` away from the profile
+# (`web_platform.newWebPlatform` — "the profile follows the registry"), so
+# `noirTestRunAbsence()` answers with a sentence and `editorTestRunHook` returns
+# it BEFORE dispatching anything. Nothing reaches the console. The user gets a
+# notification.
+#
+# So this is the arm that makes the second channel load bearing rather than
+# decorative: it is the one state where the console says nothing and the screen
+# says everything, and before the `refusalNotice` field existed the gate could
+# not tell it from a control that took the click and died silently.
+#
+# IT IS ALSO A REAL DEPLOYMENT AND NOT A CONTRIVANCE. The `viewmodel-tests` job
+# runs the whole gate in exactly this state — zero wasm modules declared — which
+# is why 8 of its 89 checks fail there legitimately. Those failures are the
+# product correctly refusing on a bundle that cannot run tests. This arm asserts
+# that the refusal is COMPETENT: not merely that the run did not happen, but
+# that the user was told, on the surface they are looking at.
+#
+# WHERE IT CANNOT BE MEASURED IT SAYS SO. On a deployment that already declares
+# no modules the mutation has nothing to remove and `run_arm` returns non-zero,
+# which is three explicit failures rather than three quiet passes over an
+# unmutated bundle. That is the same audit arms P and Q now carry.
+probe_click_gutter_run=1
+if ! run_arm gutter-run-no-modules mutate_no_declared_modules "/noir"; then
+	probe_click_gutter_run=""
+	ck fail "arm Z could not be measured (the descriptor declares no modules already, so there is nothing to remove — on this deployment the second channel cannot be exercised)"
+	ck fail "arm Z could not be measured (the console channel)"
+	ck fail "arm Z could not be measured (the on-screen channel)"
+else
+	probe_click_gutter_run=""
+	z_clicked="$(json gutter-run-no-modules gutterRunClick.clicked)"
+	z_started="$(json gutter-run-no-modules gutterRunClick.startedLine)"
+	z_refused="$(json gutter-run-no-modules gutterRunClick.refusedLine)"
+	z_notice="$(json gutter-run-no-modules gutterRunClick.refusalNotice)"
+	z_settled="$(json gutter-run-no-modules gutterRunClick.runningAfterSettle)"
+
+	# 1. THE MUTATION LANDED, and it landed on the RUN rather than on the
+	#    control. The press must still be taken — otherwise this is arm B or
+	#    arm V wearing a different label — and no run may start.
+	if [ "${z_clicked}" = "true" ] && [ -z "${z_started}" ]; then
+		ck ok "arm Z: the control still takes a real click and the press started no run, so the refusal is what this arm measures"
+	else
+		ck fail "arm Z: clicked=${z_clicked}, started='${z_started}' — with no modules declared a run must not start, and the control must still be pressable; this arm is measuring something other than the refusal"
+	fi
+
+	# 2. AND THE CONSOLE SAID NOTHING. This is the check that makes the next one
+	#    necessary, and it is the whole reason this arm is separate from arm Q.
+	#    If this ever goes red the blind spot has closed on its own and the
+	#    second channel is redundant — which would be worth knowing, so it is
+	#    asserted rather than assumed.
+	if [ -z "${z_refused}" ]; then
+		ck ok "arm Z: and the CONSOLE carried no refusal at all, which is precisely the state a console-only probe reads as silence — this is the blind spot the second channel exists for"
+	else
+		ck fail "arm Z: the console carried a refusal ('${z_refused}') — the absence path is no longer console-silent, so this arm no longer isolates the on-screen channel and arm G's second-channel check has lost its negative control"
+	fi
+
+	# 3. AND THE USER WAS TOLD, IN A SENTENCE, ON THE SCREEN. The check only the
+	#    new channel can make. `refusalNotice` is recorded by a MutationObserver
+	#    armed before the click, so a notification that is dismissed before the
+	#    read is still counted — an empty string here means the product never
+	#    said anything, not that the probe looked late.
+	if [ -n "${z_notice}" ] && [ "${z_settled}" = "0" ]; then
+		ck ok "arm Z: and the product told the user why, on screen and with no run left spinning — ${z_notice}"
+	elif [ -n "${z_notice}" ]; then
+		ck fail "arm Z: the product explained itself (${z_notice}) but left ${z_settled} slot(s) spinning — a refusal that still shows a running control is the reported defect with a caption"
+	else
+		ck fail "arm Z: the press started no run, the console said nothing, and the screen said nothing either — this is the dead affordance exactly as reported, and it is invisible to every check that reads the console alone"
 	fi
 fi
 echo
@@ -2843,7 +3129,71 @@ echo
 # all. One per address: the neutral root (control), the path (arm R) and the
 # origin (arm O), because a build can get any one of the three right while
 # reading the wrong input for the other two.
-expect_count 89
+# 89 -> 95, and the six are ONE subject: an arm must be able to show that its
+# own verdict was caused by its own mutation.
+#
+#   * ONE in arm P and ONE in arm Q — "did this arm discriminate anything?".
+#     Both arms delete the wasm worker script and then assert an ABSOLUTE state
+#     ("the click started no run"), which is evidence only if the base run was
+#     in a different one. On `viewmodel-tests` run 34072935418 it was not, and
+#     the result was visible in the log and read past for weeks: arm G FAILED
+#     with "the press started no run (clicked=true, refusal='')" and arm Q
+#     PASSED, three lines later, for observing the same thing. A negative
+#     control agreeing with its positive arm has measured nothing. The two new
+#     checks compare against arm R's and arm G's own reports and go red when
+#     the base was already degraded, so the arms can no longer bank a kill the
+#     environment handed them.
+#
+#     THE ARMS ARE NOT WRONG ABOUT THE PRODUCT and were not weakened. On the
+#     deploy job, where the modules are declared, run 33983246277 shows them
+#     working exactly as written — arm G starts a run, reaches a verdict and
+#     clears a slot that really span; arm Q shows none of it. What was missing
+#     was the arm's ability to notice which of those two worlds it was in.
+#
+#   * THREE in arm Z, which is new, and one in arm G that arm Z exists to
+#     redden. Arm G could not see a refusal the user was SHOWN: it greps the
+#     console, and `runTestFromGutter`'s absence path answers with
+#     `api.errorMessage` and never reaches the console at all. So the one state
+#     where the product refuses best — before dispatching, with a sentence —
+#     was indistinguishable from the reported defect, a control that takes the
+#     click and says nothing. Arm G now asserts that a press either runs or
+#     explains itself; arm Z empties the descriptor's `modules[]` to produce a
+#     console-silent refusal and proves that assertion can fail.
+#
+# WHAT THIS DOES TO THE TWO JOBS THAT RUN THIS GATE, said out loud because the
+# numbers move in opposite directions and only one of them is a regression:
+#
+#   * the deploy job (`deploy-web-codetracer.yml`, wasm modules present):
+#     89/0 -> 95/0 expected. Every new check has power there.
+#   * `viewmodel-tests` (zero wasm modules declared): 89/8 -> 95/13 expected,
+#     and the delta is FIVE, itemised rather than rounded:
+#
+#         1  arm P's power audit      — arm R's base run started nothing
+#         1  arm Q's power audit      — arm G's base press started nothing
+#         3  arm Z "could not be measured" — the descriptor already declares
+#            no modules, so the mutation has nothing to remove, and its three
+#            checks fail explicitly rather than passing over an unmutated
+#            bundle
+#         0  arm G's second channel   — expected GREEN, see below
+#
+#     An earlier draft of this paragraph said 95/11 and called the delta
+#     "three". That was wrong by two and wrong in kind: it counted arm Z's
+#     unmeasurable branch as ONE failure when it is three `ck fail` calls, one
+#     per check the arm owns. The tally is reconciled to the code instead —
+#     22 new `ck` call sites across four mutually exclusive branch groups plus
+#     arm Z's three, which is 6 new CHECKS (89 -> 95) and 5 new FAILURES in
+#     the no-modules job. Correcting the sentence to match the code, not the
+#     expectation to match the sentence.
+#
+#     None of the five is a new defect. Arms P and Q go red there because they
+#     genuinely have no power in a bundle that cannot run a test — that is the
+#     limit being NAMED rather than papered over — and arm Z goes red because
+#     its mutation is a no-op on a deployment already in the mutated state.
+#     They join the 8 as the same correct refusal. Arm G's new second-channel
+#     check is expected GREEN there — that
+#     job's product does refuse with a sentence — so the gate now records the
+#     one thing about that environment that was working and unmeasured.
+expect_count 95
 echo "${checks} check(s), ${failures} failure(s)"
 if [ "${failures}" -eq 0 ]; then
 	echo "RESULT: OK — the bundle mounts a product, and each check was shown to be able to fail"

--- a/ci/test/web_renderer_probe.mjs
+++ b/ci/test/web_renderer_probe.mjs
@@ -618,6 +618,68 @@ if (process.env.CT_PROBE_SCREENSHOT) {
 // from any state the page paints before the click. A pane headline is reported
 // beside them because the headline is what the user actually sees, but the
 // started line is the one that cannot be faked by rendering.
+
+// THE SECOND CHANNEL: WHAT THE USER IS TOLD, as distinct from what the console
+// prints. These two are different artefacts and this probe used to read only
+// one of them.
+//
+// Every refusal in `ui/editor.runTestFromGutter` answers the user with
+// `self.api.errorMessage(...)`, which becomes a notification and renders as
+// `.notification-message` (`viewmodel/views/isonim_status_view.nim`). NONE of
+// its three refusal paths emits a `codetracer-noir-build:` console line:
+//
+//   * `selector.len == 0`        "Could not work out which test this is."
+//   * `editorTestRunHook.isNil`  "No host in this build can run the tests."
+//   * `refusal.len > 0`          the hook's own sentence — and for a bundle
+//     with no Noir wasm modules that sentence is `noirTestRunAbsence()`'s,
+//     which is the case the `viewmodel-tests` job actually runs in.
+//
+// So `refusedLine` — a grep over the console — reads EMPTY while the user is
+// looking at a sentence explaining why nothing happened. Measured on run
+// 34072935418: `arm G: the press started no run (clicked=true, refusal='')`.
+// The gate could not see the thing the user sees, and the arm's own diagnostic
+// therefore reported "no reason given" about a product that gave one.
+//
+// RECORDED WITH A MutationObserver RATHER THAN SAMPLED, because a notification
+// can be dismissed — by a timer or by the next redraw — between the press and
+// the read, and a poll that lands after that would report the same empty
+// string for "never shown" and "shown and gone". The observer is installed
+// BEFORE the click, so what it collects is caused by the click. The read also
+// re-scans the live DOM and merges, so a node whose text is filled in after
+// insertion is not missed either.
+const installNoticeRecorder = () => page.evaluate(() => {
+  if (window.__ctNoticeLog) return;
+  const log = [];
+  window.__ctNoticeLog = log;
+  const take = (root) => {
+    if (!root || root.nodeType !== 1) return;
+    const els = root.matches && root.matches('.notification-message')
+      ? [root]
+      : Array.from(root.querySelectorAll
+          ? root.querySelectorAll('.notification-message') : []);
+    for (const e of els) {
+      const t = (e.textContent || '').trim();
+      if (t && !log.includes(t)) log.push(t);
+    }
+  };
+  take(document.body);
+  new MutationObserver((muts) => {
+    for (const m of muts) for (const n of m.addedNodes) take(n);
+  }).observe(document.body, { childList: true, subtree: true });
+});
+const noticeTexts = () => page.evaluate(() => {
+  const log = (window.__ctNoticeLog || []).slice();
+  for (const e of document.querySelectorAll('.notification-message')) {
+    const t = (e.textContent || '').trim();
+    if (t && !log.includes(t)) log.push(t);
+  }
+  return log;
+});
+// The two-minute deadline notice is the product GIVING UP, not a refusal, and
+// `timeoutNotice` already carries it. Kept out of `refusalNotice` so the two
+// cannot be confused for one another.
+const TIMEOUT_NOTICE = 'did not answer within two minutes';
+
 let runClick = null;
 if (process.env.CT_PROBE_CLICK_RUN) {
   const marker = 'codetracer-noir-build:';
@@ -635,6 +697,11 @@ if (process.env.CT_PROBE_CLICK_RUN) {
     headlineAfter: '',
     startedLine: '',
     refusedLine: '',
+    // THE SECOND CHANNEL. See `noticeTexts` below: a refusal the user reads is
+    // a different artefact from a refusal the console prints, and this pane's
+    // control can produce either.
+    notices: [],
+    refusalNotice: '',
     resultsLine: '',
     exitLine: '',
     newConsole: [],
@@ -680,6 +747,8 @@ if (process.env.CT_PROBE_CLICK_RUN) {
     runClick.tabActivated = gestures;
 
     runClick.headlineBefore = await headlineOf();
+    // Installed before the press, so every notice it collects was caused by it.
+    await installNoticeRecorder();
     await page.click('.test-results-run-btn', { timeout: 15000 });
     gestures += 1;
     runClick.gesturesToRun = gestures;
@@ -713,6 +782,10 @@ if (process.env.CT_PROBE_CLICK_RUN) {
         (l) => l.includes(marker) && l.includes('test-results '), 10000);
       runClick.headlineAfter = await headlineOf();
     }
+    // THE SECOND CHANNEL, read last so it covers the whole press.
+    runClick.notices = await noticeTexts();
+    runClick.refusalNotice =
+      runClick.notices.find((t) => !t.includes(TIMEOUT_NOTICE)) || '';
   } catch (e) {
     runClick.clickError = String((e && e.message) || e).slice(0, 300);
   }
@@ -758,6 +831,11 @@ if (process.env.CT_PROBE_CLICK_GUTTER_RUN) {
     clickError: '',
     startedLine: '',
     refusedLine: '',
+    // THE SECOND CHANNEL. `refusedLine` is the console's answer; this is the
+    // user's. For this control they are routinely different — see the comment
+    // on `installNoticeRecorder`.
+    notices: [],
+    refusalNotice: '',
     exitLine: '',
     resultsLine: '',
     runningAfterClick: 0,
@@ -813,6 +891,10 @@ if (process.env.CT_PROBE_CLICK_GUTTER_RUN) {
     });
     if (gutterRunClick.slot) {
       gutterRunClick.headlineBefore = await headlineOf();
+      // Installed before the press. The refusal this control produces is
+      // SYNCHRONOUS with the click, so a recorder armed afterwards could miss
+      // it outright.
+      await installNoticeRecorder();
       await page.mouse.move(
         gutterRunClick.slot.centre.x, gutterRunClick.slot.centre.y);
       await page.waitForTimeout(300);
@@ -914,10 +996,6 @@ if (process.env.CT_PROBE_CLICK_GUTTER_RUN) {
       // decides whether the deadline has fired. Both are now measured.
       gutterRunClick.productDeadlineMs = 120000;
       gutterRunClick.msSinceClick = Date.now() - clickedAt;
-      gutterRunClick.timeoutNotice = await page.evaluate(() =>
-        Array.from(document.querySelectorAll('.notification-message'))
-          .map((e) => (e.textContent || '').trim())
-          .find((t) => t.includes('did not answer within two minutes')) || '');
       gutterRunClick.settleBudgetMs = 60000;
       {
         const started = Date.now();
@@ -940,6 +1018,19 @@ if (process.env.CT_PROBE_CLICK_GUTTER_RUN) {
         gutterRunClick.consoleAtSettle = consoleLines.slice(linesBefore)
           .filter((l) => l.includes(marker)).slice(-6);
       }
+      // THE SECOND CHANNEL, read after the settle so the window it covers is
+      // the whole press. Both notices come out of the SAME recorded log, so
+      // "the product gave up" and "the product refused" are separated by which
+      // sentence was shown rather than by when the probe happened to look.
+      //
+      // This also strengthens `timeoutNotice`, which used to be one sample of
+      // the live DOM taken BEFORE the settle wait — a deadline notice raised
+      // during that wait, or one dismissed before it, both read as absent.
+      gutterRunClick.notices = await noticeTexts();
+      gutterRunClick.timeoutNotice =
+        gutterRunClick.notices.find((t) => t.includes(TIMEOUT_NOTICE)) || '';
+      gutterRunClick.refusalNotice =
+        gutterRunClick.notices.find((t) => !t.includes(TIMEOUT_NOTICE)) || '';
       gutterRunClick.headlineAfter = await headlineOf();
     }
   } catch (e) {

--- a/ci/test/web_renderer_probe.mjs
+++ b/ci/test/web_renderer_probe.mjs
@@ -647,11 +647,35 @@ if (process.env.CT_PROBE_SCREENSHOT) {
 // BEFORE the click, so what it collects is caused by the click. The read also
 // re-scans the live DOM and merges, so a node whose text is filled in after
 // insertion is not missed either.
+// WHAT WAS ALREADY ON SCREEN IS RECORDED SEPARATELY, and this is not a
+// refinement — the first version of this recorder seeded ONE log with
+// `take(document.body)` and then answered `refusalNotice` with the first entry
+// that was not the timeout sentence. The page is never empty of notifications
+// at that moment: `viewmodel/platform/store_durability.nim` raises the storage
+// durability sentence ("Your work is saved in this browser and survives
+// reloads...") when the project loads, long before any control is touched. So
+// the first non-timeout entry was a notice about STORAGE, and run 34160263480
+// duly reported it as the run control's reason:
+//
+//   [OK] arm G: the press started no run and the product SAID WHY ... —
+//        on-screen: Your work is saved in this browser and survives reloads...
+//
+// That check passed while quoting a sentence the click did not cause, about a
+// subject it was not asking about. A green earned by an unrelated notification
+// is worse than a red: the arm claimed to have measured the second channel and
+// had not looked at it.
+//
+// The fix is to keep the two populations apart. `before` is what the page
+// carried at install; the log is what arrived afterwards. `refusalNotice` is
+// then drawn only from notices the press is responsible for, which is what the
+// comment above always claimed and the code did not do.
 const installNoticeRecorder = () => page.evaluate(() => {
   if (window.__ctNoticeLog) return;
+  const before = [];
   const log = [];
+  window.__ctNoticeBefore = before;
   window.__ctNoticeLog = log;
-  const take = (root) => {
+  const take = (root, into) => {
     if (!root || root.nodeType !== 1) return;
     const els = root.matches && root.matches('.notification-message')
       ? [root]
@@ -659,22 +683,37 @@ const installNoticeRecorder = () => page.evaluate(() => {
           ? root.querySelectorAll('.notification-message') : []);
     for (const e of els) {
       const t = (e.textContent || '').trim();
-      if (t && !log.includes(t)) log.push(t);
+      if (t && !into.includes(t)) into.push(t);
     }
   };
-  take(document.body);
+  take(document.body, before);
   new MutationObserver((muts) => {
-    for (const m of muts) for (const n of m.addedNodes) take(n);
+    for (const m of muts) for (const n of m.addedNodes) take(n, log);
   }).observe(document.body, { childList: true, subtree: true });
 });
+// Returns the notices the PRESS caused. The live re-scan is still merged, so a
+// node whose text is filled in after insertion is not missed — but it is
+// filtered by `before` too, otherwise the re-scan would put the durability
+// sentence straight back in by the other door. A notice that was on screen at
+// install and is re-rendered verbatim afterwards stays excluded, which is the
+// right answer: nothing about it tells the user why THIS click did nothing.
 const noticeTexts = () => page.evaluate(() => {
+  const before = window.__ctNoticeBefore || [];
   const log = (window.__ctNoticeLog || []).slice();
   for (const e of document.querySelectorAll('.notification-message')) {
     const t = (e.textContent || '').trim();
     if (t && !log.includes(t)) log.push(t);
   }
-  return log;
+  return log.filter((t) => !before.includes(t));
 });
+// What the page was already showing, reported alongside rather than discarded.
+// An arm that finds no refusal needs to distinguish "the probe saw nothing at
+// all" from "the probe saw notices and none of them was caused by the press",
+// and a filtered-away population that is never reported cannot make that
+// distinction. This is the count that stops a zero being mistaken for a
+// measurement.
+const noticesBeforeTexts = () =>
+  page.evaluate(() => (window.__ctNoticeBefore || []).slice());
 // The two-minute deadline notice is the product GIVING UP, not a refusal, and
 // `timeoutNotice` already carries it. Kept out of `refusalNotice` so the two
 // cannot be confused for one another.
@@ -701,6 +740,7 @@ if (process.env.CT_PROBE_CLICK_RUN) {
     // a different artefact from a refusal the console prints, and this pane's
     // control can produce either.
     notices: [],
+    noticesBefore: [],
     refusalNotice: '',
     resultsLine: '',
     exitLine: '',
@@ -784,6 +824,7 @@ if (process.env.CT_PROBE_CLICK_RUN) {
     }
     // THE SECOND CHANNEL, read last so it covers the whole press.
     runClick.notices = await noticeTexts();
+    runClick.noticesBefore = await noticesBeforeTexts();
     runClick.refusalNotice =
       runClick.notices.find((t) => !t.includes(TIMEOUT_NOTICE)) || '';
   } catch (e) {
@@ -835,6 +876,7 @@ if (process.env.CT_PROBE_CLICK_GUTTER_RUN) {
     // user's. For this control they are routinely different — see the comment
     // on `installNoticeRecorder`.
     notices: [],
+    noticesBefore: [],
     refusalNotice: '',
     exitLine: '',
     resultsLine: '',
@@ -1027,6 +1069,7 @@ if (process.env.CT_PROBE_CLICK_GUTTER_RUN) {
       // the live DOM taken BEFORE the settle wait — a deadline notice raised
       // during that wait, or one dismissed before it, both read as absent.
       gutterRunClick.notices = await noticeTexts();
+      gutterRunClick.noticesBefore = await noticesBeforeTexts();
       gutterRunClick.timeoutNotice =
         gutterRunClick.notices.find((t) => t.includes(TIMEOUT_NOTICE)) || '';
       gutterRunClick.refusalNotice =

--- a/src/frontend/ui/editor.nim
+++ b/src/frontend/ui/editor.nim
@@ -2756,17 +2756,39 @@ proc runTestFromGutter(self: EditorViewComponent; attrLine: int) =
   #
   # Armed first, the same settle finds this editor in the list and clears it,
   # and the refusal path below unwinds what it armed.
+  #
+  # WHAT WAS THERE BEFORE IS REMEMBERED, because the unwind must put back
+  # exactly what this click displaced and no more. The commonest refusal the
+  # host now answers is `already-running`, and in that state there IS a real
+  # run — this editor's or another tab's — whose slot and whose spinner belong
+  # to it. A blanket `settleEditorTestRun()` there would stop the animation on
+  # a run that is still going, so a second click would visibly "finish" the
+  # first. Recorded before the arm, restored after a refusal.
+  let wasSpinning = spinningTestEditors.find(self) >= 0
+  let hadRunningSlot = trace.gutterRunningTest.hasKey(self.name)
+  let previousSlot =
+    if hadRunningSlot: trace.gutterRunningTest[self.name] else: 0
   trace.gutterRunningTest[self.name] = attrLine
-  if spinningTestEditors.find(self) < 0:
+  if not wasSpinning:
     spinningTestEditors.add(self)
   self.updateLineNumbersOnly()
 
   let refusal = editorTestRunHook(self.name, selector, attrLine)
   if refusal.len > 0:
-    # UNWIND, so a refusal by sentence still shows no running state. `settle`
-    # rather than `restoreTestButton` because the list must be emptied too, and
-    # emptying it is what `restoreTestButton` alone does not do.
-    settleEditorTestRun()
+    # UNWIND WHAT THIS CLICK ARMED. When nothing was running, that is the whole
+    # of it — `settle` rather than `restoreTestButton` because the list must be
+    # emptied too, and emptying it is what `restoreTestButton` alone does not
+    # do. When a run WAS in flight, its slot and its place in the list are put
+    # back instead, so the refusal costs the user a sentence and not the
+    # progress they were already watching.
+    if hadRunningSlot:
+      trace.gutterRunningTest[self.name] = previousSlot
+      self.updateLineNumbersOnly()
+    elif wasSpinning:
+      trace.gutterRunningTest.del(self.name)
+      self.updateLineNumbersOnly()
+    else:
+      settleEditorTestRun()
     self.api.errorMessage($refusal)
     return
 

--- a/src/frontend/ui/web_noir_build.nim
+++ b/src/frontend/ui/web_noir_build.nim
@@ -881,8 +881,23 @@ proc noirTestRunAbsence*(): string =
     return degradedBehaviour(platform.profile, capProcessSpawn)
   ""
 
-proc startNoirTests*(saved: seq[string] = @[]; only: seq[string] = @[]) =
+proc startNoirTests*(saved: seq[string] = @[];
+                     only: seq[string] = @[]): string =
   ## TEST — run the open project's `#[test]` functions and report each verdict.
+  ##
+  ## RETURNS "" WHEN THE RUN WAS DISPATCHED, and otherwise the sentence saying
+  ## why it was not. The type is the fix: every refusal below used to
+  ## `report(...)` and return `void`, which put the reason in the browser
+  ## console and nowhere else. `test_results_vm.canRun` is TRUE in all three of
+  ## those states — none of them is `runAbsence`, none is the pane's own
+  ## `inFlight` — so the ▶ was painted live, took the click, and left the pane
+  ## exactly as it was. `openRetainedTestRecording` in this same module already
+  ## answers a sentence for precisely this reason; this proc now does too.
+  ##
+  ## The `report` calls are KEPT beside the sentences rather than replaced by
+  ## them. They are two different readers: the console line is what a gate
+  ## greps for (`ci/test/web_renderer_probe.mjs` reads `test-refused` /
+  ## `test-ignored` off it), and the sentence is what the user is owed.
   ##
   ## ONE DISPATCH, not a compile followed by anything: `nv_test_vfs` resolves
   ## the tree, elaborates the crate, discovers the tests with
@@ -897,15 +912,17 @@ proc startNoirTests*(saved: seq[string] = @[]; only: seq[string] = @[]) =
   ## is the single outcome this whole path exists to avoid.
   if activeInFlight:
     report("test-ignored", "reason=already-running")
-    return
+    return "a build or test run is already going in this tab; wait for it " &
+           "to finish, or stop it, and press ▶ again"
   let tmpl = currentProject()
   if not tmpl.hasFiles:
     report("test-refused", "reason=no-project")
-    return
+    return "no project is open, so there is nothing to test"
   let producer = producerFor(tmpl)
   if producer.isNil:
     report("test-refused", "reason=no-build-vm")
-    return
+    return "this tab has no build view-model, so a run cannot be reported " &
+           "anywhere; reload the page"
   activeIntent = nriTest
   if not noirTestRunStarted.isNil:
     noirTestRunStarted()
@@ -1019,8 +1036,24 @@ proc openRetainedTestRecording*(selector: string;
 
 proc startNoirTestRecording*(selector: string;
                              newSessionTab: bool = false;
-                             openWhenDone: bool = true) =
+                             openWhenDone: bool = true): string =
   ## RUN ONE TEST IN THE DEBUGGER — the editor's Run-test control.
+  ##
+  ## RETURNS "" WHEN THE RUN WAS DISPATCHED, and otherwise the sentence saying
+  ## why it was not — `startNoirTests`' change, for a worse version of the same
+  ## defect. This proc is what the GUTTER's run control reaches, and
+  ## `editor.runTestFromGutter` does not merely fail to show these refusals: it
+  ## ARMS THE SPINNER, calls this, reads back a `void` it takes for consent,
+  ## and then sets a two-minute deadline and posts `"<selector>" started`.
+  ##
+  ## So the five refusals below produced, verbatim, the reported defect — "it
+  ## just hanged in the browser without the ability to run the actual test":
+  ## a slot spinning over a dispatch that was declined before the click
+  ## finished, under an info message claiming it had begun, for two minutes,
+  ## with the actual reason on the console.
+  ##
+  ## `runTestFromGutter` has carried the branch that unwinds and shows the
+  ## sentence since the `pkCancelled` fix; it had no sentence to receive.
   ##
   ## "Running a test" in this product means recording it and replaying it: the
   ## test executes, its execution is captured, and the user lands in a
@@ -1034,24 +1067,27 @@ proc startNoirTestRecording*(selector: string;
   ## against the compile options a developer's own terminal uses.
   if activeInFlight:
     report("test-record-ignored", "reason=already-running")
-    return
+    return "a build or test run is already going in this tab; wait for it " &
+           "to finish, or stop it, and press this again"
   if selector.len == 0:
     report("test-record-refused", "reason=no-selector")
-    return
+    return "this line's run control names no test"
   let tmpl = currentProject()
   if not tmpl.hasFiles:
     report("test-record-refused", "reason=no-project")
-    return
+    return "no project is open, so there is nothing to run"
   let producer = producerFor(tmpl)
   if producer.isNil:
     report("test-record-refused", "reason=no-build-vm")
-    return
+    return "this tab has no build view-model, so a run cannot be reported " &
+           "anywhere; reload the page"
   if newSessionTab and not canRecordTestInNewSessionTab():
     # REFUSED BEFORE ANYTHING RUNS. Compiling, running and tracing a test and
     # only then discovering the session cannot be opened where it was asked for
     # would spend seconds to reach a refusal that was knowable at the click.
     report("test-record-refused", "reason=no-second-session")
-    return
+    return "this build holds one live session at a time, so the test was " &
+           "not run in a new tab"
   activeIntent = nriTestRecord
   activeRecordSelector = selector
   activeRecordInNewTab = newSessionTab
@@ -1067,7 +1103,7 @@ proc startNoirTestRecording*(selector: string;
     if not noirTestRunSettled.isNil:
       noirTestRunSettled()
 
-proc startNoirTest*(selector: string) =
+proc startNoirTest*(selector: string): string =
   ## Run ONE test — the editor's Run-test control, and the Test Results pane's
   ## per-row action when it grows one.
   ##
@@ -1078,7 +1114,7 @@ proc startNoirTest*(selector: string) =
   ## the same strings.
   if selector.len == 0:
     report("test-refused", "reason=no-selector")
-    return
+    return "no test was named"
   startNoirTests(only = @[selector])
 
 proc stopNoirBuild*() =

--- a/src/frontend/ui_js.nim
+++ b/src/frontend/ui_js.nim
@@ -6061,8 +6061,14 @@ when defined(ctWeb) and not defined(ctInExtension):
           # introduced to fix. Installation is necessarily against the instance
           # that exists now; only the two callbacks below can defer their read,
           # and they do.
+          # AND THE RUNNER ANSWERS. `RunTestsProc` returns the sentence saying
+          # why a run did not start, and `startRun` files it into the pane's
+          # `.test-results-failure` block. Nothing is discarded here: the three
+          # states `startNoirTests` declines in — a build already running, no
+          # project, no build view-model — are all states in which `canRun` is
+          # TRUE, so the ▶ was live, took the click, and moved nothing.
           test_results.testResultsVMInstance.setRunTests(
-            proc() = web_noir_build.startNoirTests())
+            proc(): string = web_noir_build.startNoirTests())
 
           # THE TWO PER-ROW CONTROLS, pointed at the two things they mean.
           #
@@ -6084,10 +6090,19 @@ when defined(ctWeb) and not defined(ctInExtension):
           # than a flag on the recorder: a flag could be got wrong and still
           # look right, whereas a proc with no `dispatch` in it cannot re-run a
           # test by accident.
+          # THE TWO RECORDING ACTIONS SAY WHY THEY DID NOT RUN, exactly as
+          # `openExisting` below already did. They reach
+          # `startNoirTestRecording`, whose five refusals used to be console
+          # lines — so `⟳` over a project with a Build in flight was a click
+          # that changed nothing on screen.
           test_results.testResultsVMInstance.setRowActions(
             refresh = proc(testId, selector: string) =
-              web_noir_build.startNoirTestRecording(
-                selector, newSessionTab = false, openWhenDone = false),
+              let refusal = web_noir_build.startNoirTestRecording(
+                selector, newSessionTab = false, openWhenDone = false)
+              if refusal.len > 0 and
+                 not test_results.testResultsVMInstance.isNil:
+                test_results.testResultsVMInstance.noteRowActionRefusal(
+                  refusal),
             openExisting = proc(testId, selector: string) =
               let refusal = web_noir_build.openRetainedTestRecording(selector)
               if refusal.len > 0 and
@@ -6103,8 +6118,12 @@ when defined(ctWeb) and not defined(ctInExtension):
                 test_results.testResultsVMInstance.noteRowActionRefusal(
                   refusal),
             recordAndOpen = proc(testId, selector: string) =
-              web_noir_build.startNoirTestRecording(
-                selector, newSessionTab = false, openWhenDone = true))
+              let refusal = web_noir_build.startNoirTestRecording(
+                selector, newSessionTab = false, openWhenDone = true)
+              if refusal.len > 0 and
+                 not test_results.testResultsVMInstance.isNil:
+                test_results.testResultsVMInstance.noteRowActionRefusal(
+                  refusal))
 
           # AND THE PANE IS TOLD WHICH RECORDING NOW EXISTS.
           #
@@ -6280,8 +6299,17 @@ when defined(ctWeb) and not defined(ctInExtension):
             # the test executes, its execution is captured, and the user lands
             # in a time-travel session on it — the verdict arrives first and
             # fills the Test Results pane, the session is what was asked for.
-            web_noir_build.startNoirTestRecording($selector)
-            cstring""
+            #
+            # AND ITS REFUSAL IS THE HOOK'S ANSWER. This used to dispatch and
+            # then return `cstring""` unconditionally — "accepted" — whatever
+            # the host had just decided. `runTestFromGutter` reads that as
+            # consent: it keeps the spinner it armed, sets a two-minute
+            # deadline and posts `"<selector>" started`. So a run declined
+            # inside this call left the slot spinning for two minutes under a
+            # message saying it had begun, which is the reported defect
+            # verbatim. Returning the sentence takes the branch beside it,
+            # which unwinds the spinner and shows the reason.
+            cstring(web_noir_build.startNoirTestRecording($selector))
 
         # AND RE-DERIVE, because the catalog has almost certainly already
         # arrived. `enterTemplateEditMode` above installs the pane host, which

--- a/src/frontend/viewmodel/tests/unit/run-run-control-refusal-mutations.py
+++ b/src/frontend/viewmodel/tests/unit/run-run-control-refusal-mutations.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Mutation arms for `test_run_control_refusal_is_shown.nim`.
+
+Run:
+    direnv exec . python3 \
+      src/frontend/viewmodel/tests/unit/run-run-control-refusal-mutations.py
+
+WHAT THIS PROVES
+================
+
+The suite it drives asserts that a click on a LIVE run control ends in
+something a user can see. Every one of its arms is green today, so the control
+run is fully green and any failure after a mutation is signal — the simple
+shape, unlike `run-edit-mode-toolbar-mutations.py`, whose subject is partly
+unbuilt and which therefore has to subtract a known-red baseline.
+
+Each arm reintroduces one half of the defect the suite was written for and must
+redden THE ASSERTION WRITTEN FOR IT. An arm that leaves the suite green has
+shown that the assertion is not measuring what its name claims, which is worth
+more than the arm passing.
+
+THE ARM THAT FAILED FIRST, AND WHAT IT TAUGHT
+=============================================
+
+The original second arm removed only `noteRunRefusal`'s `if message.len == 0:
+return` and expected the over-firing guard to go red. **It did not.** The suite
+stayed green, and the reason is a real property of the code rather than a hole
+in the test: `runFailureLines` skips diagnostics whose message is empty, so an
+empty diagnostic filed into the summary is filtered one layer down and the pane
+paints nothing either way.
+
+So that arm was WRONG, not the assertion. It is replaced by two:
+
+  * **M2a** expresses the over-firing defect the guard is actually about — a
+    `startRun` that files a sentence on every click, including the accepted
+    ones — and it reddens three arms.
+  * **M2b** removes BOTH empty-message filters at once, which is what it takes
+    to make an empty refusal reach the screen, and reddens the guard alone.
+
+Recording this rather than quietly deleting the arm is the point: the pair now
+says out loud that the two guards are redundant with each other, so a future
+reader removing either one will find out from M2b which of them was load
+bearing.
+"""
+import os
+import subprocess
+import sys
+import tempfile
+
+REPO = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                      capture_output=True, text=True,
+                      check=True).stdout.strip()
+VM = os.path.join(
+    REPO, "src/frontend/viewmodel/viewmodels/test_results_vm.nim")
+TEST = "src/frontend/viewmodel/tests/unit/test_run_control_refusal_is_shown.nim"
+OUT = os.path.join(tempfile.mkdtemp(prefix="run-control-mut-"), "suite")
+
+# name, anchor, replacement, file, [second (anchor, replacement)]
+MUTATIONS = [
+    (
+        "M1 the runner's answer is discarded (THE DEFECT AS IT SHIPPED)",
+        "  vm.noteRunRefusal(runner())",
+        "  discard runner()",
+        VM,
+    ),
+    (
+        "M2a startRun files a sentence on EVERY click (over-firing)",
+        "  vm.noteRunRefusal(runner())",
+        "  discard runner()\n  vm.noteRunRefusal(\"could not start\")",
+        VM,
+    ),
+    (
+        "M2b BOTH empty-message guards removed "
+        "(noteRunRefusal AND runFailureLines)",
+        "  if message.len == 0:\n    return\n  var current = vm.summary.val",
+        "  var current = vm.summary.val",
+        VM,
+        ("    if diagnostic.message.len > 0:\n"
+         "      result.add diagnostic.message",
+         "    result.add diagnostic.message"),
+    ),
+    (
+        "M3 the refusal is filed as a deployment absence instead",
+        "  let runner = vm.runTests.val\n  vm.noteRunRefusal(runner())",
+        "  let runner = vm.runTests.val\n  vm.setRunAbsence(runner())",
+        VM,
+    ),
+    (
+        "M4 startRun stops guarding on canRun",
+        "  ## something a user can see.\n  if not vm.canRun():\n    return",
+        "  ## something a user can see.\n  if false:\n    return",
+        VM,
+    ),
+]
+
+# Which arm each mutation must redden. A mutation that reddens something else
+# INSTEAD is misdirected and is reported as a failure, because it would then be
+# scoring a kill it did not earn.
+KILLS = {
+    "M1": "a host that declines the run says so ON THE PANE",
+    "M2a": "a run the host ACCEPTS leaves no failure line",
+    "M2b": "a run the host ACCEPTS leaves no failure line",
+    "M3": "the refusal is transient",
+    "M4": "a control the pane itself knows is dead is not pressed",
+}
+
+
+def run(cmd):
+    return subprocess.run(cmd, shell=True, capture_output=True, text=True,
+                          cwd=REPO)
+
+
+def measure():
+    compiled = run(
+        f"nim c --hints:off --warnings:off -o:{OUT} {TEST}")
+    if compiled.returncode != 0:
+        return "COMPILE-FAILED", compiled.stdout + compiled.stderr
+    ran = run(OUT)
+    return ("GREEN" if ran.returncode == 0 else "RED"), ran.stdout
+
+
+def failing_arms(output):
+    return [line.strip()[9:] for line in output.splitlines()
+            if line.strip().startswith("[FAILED]")]
+
+
+def main() -> int:
+    print("=== BASELINE (the tree as committed) ===")
+    verdict, out = measure()
+    print(f"  {verdict}")
+    for line in out.splitlines():
+        if line.strip().startswith(("[OK]", "[FAILED]", "[Suite]")):
+            print("   ", line.strip())
+    if verdict != "GREEN":
+        print("baseline is not green; nothing below would mean anything")
+        return 1
+
+    problems = 0
+    for mutation in MUTATIONS:
+        name, anchor, replacement, path = mutation[:4]
+        second = mutation[4] if len(mutation) > 4 else None
+        arm = name.split()[0]
+
+        source = open(path).read()
+        if source.count(anchor) != 1:
+            print(f"\n!!! {name}: anchor matched "
+                  f"{source.count(anchor)} times, not 1")
+            problems += 1
+            continue
+        mutated = source.replace(anchor, replacement)
+        if second is not None:
+            if mutated.count(second[0]) != 1:
+                print(f"\n!!! {name}: second anchor matched "
+                      f"{mutated.count(second[0])} times, not 1")
+                problems += 1
+                continue
+            mutated = mutated.replace(second[0], second[1])
+
+        open(path, "w").write(mutated)
+        try:
+            verdict, out = measure()
+        finally:
+            # RESTORED WHETHER OR NOT THE MEASUREMENT SUCCEEDED. A harness that
+            # leaves a mutation on disk after an exception has edited the
+            # product and told nobody.
+            run(f"git checkout -- {path}")
+
+        reds = failing_arms(out)
+        print(f"\n=== {name} ===")
+        print(f"  {verdict}")
+        for red in reds:
+            print(f"    RED: {red}")
+        if verdict == "GREEN":
+            print("  !!! this mutation changed nothing the suite can see")
+            problems += 1
+        elif not any(KILLS[arm] in red for red in reds):
+            print(f"  !!! MISDIRECTED: expected an arm naming "
+                  f"'{KILLS[arm]}'")
+            problems += 1
+
+    print(f"\nRESULT: {len(MUTATIONS) - problems}/{len(MUTATIONS)} arms "
+          f"killed their own assertion")
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/frontend/viewmodel/tests/unit/test_noir_test_run.nim
+++ b/src/frontend/viewmodel/tests/unit/test_noir_test_run.nim
@@ -524,7 +524,9 @@ fn passes_when_it_should_not() { assert(1 == 1); }
     # No host installed a runner.
     counted not vm.canRun()
     var started = 0
-    vm.setRunTests(proc() = inc started)
+    vm.setRunTests(proc(): string =
+      inc started
+      "")
     counted vm.canRun()
 
     # A deployment that stated a reason.
@@ -569,7 +571,9 @@ fn passes_when_it_should_not() { assert(1 == 1); }
     counted painted[0][1] == "No host in this build can run the tests"
 
     var started = 0
-    vm.setRunTests(proc() = inc started)
+    vm.setRunTests(proc(): string =
+      inc started
+      "")
 
     # The install alone — no other signal written — must have re-rendered.
     counted painted.len == 2

--- a/src/frontend/viewmodel/tests/unit/test_run_control_refusal_is_shown.nim
+++ b/src/frontend/viewmodel/tests/unit/test_run_control_refusal_is_shown.nim
@@ -1,0 +1,337 @@
+## A RUN CONTROL THAT TAKES A CLICK MUST START, OR SAY WHY NOT.
+##
+## LANE: `vm-unit` AND `vm-unit-js`, both by the directory glob.
+##
+## Compile and run:
+##   nim c  -r src/frontend/viewmodel/tests/unit/test_run_control_refusal_is_shown.nim
+##   nim js -r src/frontend/viewmodel/tests/unit/test_run_control_refusal_is_shown.nim
+##
+## ## The defect, as it was on the tree
+##
+## `RunTestsProc` was `proc()`. `ui_js` installed
+## `web_noir_build.startNoirTests` into it, and that proc opens with three
+## refusals:
+##
+##     if activeInFlight:
+##       report("test-ignored", "reason=already-running"); return
+##     if not tmpl.hasFiles:
+##       report("test-refused", "reason=no-project"); return
+##     if producerFor(tmpl).isNil:
+##       report("test-refused", "reason=no-build-vm"); return
+##
+## `report` writes one line to the browser console. Nothing else happened.
+##
+## **And `canRun` is TRUE in all three states.** None of them is `runAbsence`
+## (which is a statement about the deployment, set from
+## `noirTestRunAbsence()`), and none is the pane's own `inFlight` (which only
+## `beginRun` sets, and `beginRun` is never reached on these paths). So the ▶
+## was painted live, correctly titled "Run the tests (nargo test)", took a real
+## pointer click — and the pane did not move by one character.
+##
+## The commonest way in is the ordinary one: press Build, then press ▶ while it
+## is still going. `activeInFlight` is `web_noir_build`'s global and is set by
+## ANY dispatch — a build, a row's `⟳`, the gutter's run control — while the
+## pane's `inFlight` is set only by a run this pane started. The two were never
+## the same flag and the ▶ was gated on the weaker one.
+##
+## ## Why these checks are shaped the way they are
+##
+## **THEY ASSERT PAINTED TEXT.** "The runner returned a sentence" and "the user
+## can read it" are different claims and only the second is the product. The
+## failure block is `hidden` until something is in it, so its class is asserted
+## too — a sentence rendered into a hidden node is the defect with extra steps.
+##
+## **THEY ASSERT THE CONTROL WAS LIVE.** `ck vm.canRun()` before every click.
+## Without it these arms would pass over a build that fixed the symptom by
+## disabling the button, which is a different product and a worse one: a
+## control that vanishes cannot be told apart from a feature that does not
+## exist, and `isonim_test_results_view`'s header argues that at length.
+##
+## **THERE IS AN OVER-FIRING GUARD.** A pane that showed a failure line after
+## every click would satisfy every positive arm here. So a runner that accepts
+## is asserted to leave the block empty and the headline alone.
+##
+## **THE REFUSAL IS ASSERTED NOT TO BECOME A STANDING CLAIM.** `runAbsence` is
+## still empty and `canRun` is still true after the refusal, so the user can
+## press again once the build finishes. Filing a transient refusal into
+## `runAbsence` was the first thing tried when `noteRowActionRefusal` was
+## written, and it greys out the ▶ and every row's `⟳` on the strength of one
+## declined click.
+
+import std/[strutils, tables, unittest]
+
+import isonim/core/[owner, signals, computation]
+import isonim/testing/mock_dom
+
+import ../../../../ct_test/contracts
+import ../../viewmodels/test_results_vm
+import ../../views/isonim_test_results_view
+
+# ---------------------------------------------------------------------------
+# A counted `check` — Verification-Harness-Traps.md §4c.
+# ---------------------------------------------------------------------------
+
+var asserted = 0
+
+template ck(condition: untyped) =
+  inc asserted
+  check condition
+
+template startCount() =
+  asserted = 0
+
+template expectCount(expected: int) =
+  if asserted != expected:
+    checkpoint("assertion count is " & $asserted & ", expected " & $expected)
+  check asserted == expected
+
+# ---------------------------------------------------------------------------
+# Reading the painted pane
+# ---------------------------------------------------------------------------
+
+proc findAllByClass(node: MockNode; className: string;
+                    acc: var seq[MockNode]) =
+  if node.kind == mnkElement and
+      className in node.attributes.getOrDefault("class", ""):
+    acc.add(node)
+  for child in node.children:
+    findAllByClass(child, className, acc)
+
+proc allByClass(node: MockNode; className: string): seq[MockNode] =
+  result = @[]
+  findAllByClass(node, className, result)
+
+proc attr(node: MockNode; name: string): string =
+  node.attributes.getOrDefault(name, "")
+
+proc collectText(node: MockNode; acc: var string) =
+  if node.kind == mnkText:
+    acc.add node.text
+  for child in node.children:
+    collectText(child, acc)
+
+proc textOf(node: MockNode): string =
+  collectText(node, result)
+
+proc firstByClass(panel: MockNode; className: string): MockNode =
+  let nodes = allByClass(panel, className)
+  if nodes.len == 0: MockNode(nil) else: nodes[0]
+
+proc paneText(panel: MockNode; className: string): string =
+  let node = firstByClass(panel, className)
+  if node.isNil: "" else: textOf(node).strip()
+
+proc failureLineCount(panel: MockNode): int =
+  ## The `.test-results-failure-line` children, counted by EXACT class token.
+  ##
+  ## `allByClass` matches by substring and `test-results-failure` is a prefix
+  ## of `test-results-failure-line`, so a substring count here would report the
+  ## container as one of its own children. The same trap the view's header
+  ## names about `test-results-row`, one class over.
+  for node in allByClass(panel, "test-results-failure-line"):
+    if "test-results-failure-line" in node.attr("class").split(' '):
+      inc result
+
+proc runButtonOf(panel: MockNode): MockNode =
+  firstByClass(panel, "test-results-run-btn")
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+const AlreadyRunning =
+  "a build or test run is already going in this tab; wait for it to " &
+  "finish, or stop it, and press ▶ again"
+  ## `web_noir_build.startNoirTests`' `activeInFlight` sentence, spelled here
+  ## rather than imported: `ui/web_noir_build` is a `when defined(js)` renderer
+  ## module that reaches `data`, `ctPlatform` and the DOM, and importing it
+  ## would make this suite uncompilable on the native lane. What is under test
+  ## is that WHATEVER the host answers is carried to the screen intact, which
+  ## is why the arms compare against this value rather than merely asserting
+  ## the block is non-empty.
+
+proc item(id, selector, file: string; line: int): TestItem =
+  TestItem(id: id, providerId: "noir-nargo", language: "noir",
+           framework: "nargo test", name: selector, kind: tikCase,
+           file: file, range: SourceRange(startLine: line, startColumn: 1,
+                                          endLine: line, endColumn: 1),
+           selector: selector, parentId: "", tags: @[],
+           location: LocationProvenance(source: lskParser, detail: "",
+                                        confidence: lcHigh),
+           stale: false, staleReason: "")
+
+proc fiveTests(): seq[TestItem] =
+  @[item("a", "tests::test_main", "src/main.nr", 13),
+    item("b", "tests::test_bounds", "src/main.nr", 20),
+    item("c", "tests::test_fails", "src/main.nr", 27),
+    item("d", "tests::test_expected", "src/main.nr", 34),
+    item("e", "tests::test_skipped", "src/main.nr", 41)]
+
+proc mountedPane(): (TestResultsVM, MockNode) =
+  let vm = createTestResultsVM()
+  vm.setCatalog(TestCatalog(items: fiveTests()))
+  let r = MockRenderer()
+  (vm, renderTestResultsPanel(r, vm))
+
+# ---------------------------------------------------------------------------
+
+suite "a click on a live run control ends in something the user can see":
+
+  test "a host that declines the run says so ON THE PANE, not only on the console":
+    startCount()
+    createRoot proc(dispose: proc()) =
+      let (vm, panel) = mountedPane()
+
+      var asked = 0
+      vm.setRunTests(proc(): string =
+        inc asked
+        AlreadyRunning)
+
+      # THE CONTROL IS LIVE. This is the whole premise: the pane cannot see
+      # `web_noir_build.activeInFlight`, so it correctly believes a run can
+      # start, and the click therefore reaches the host.
+      ck vm.canRun()
+      ck runButtonOf(panel).attr("class") == "test-results-run-btn"
+
+      # BEFORE, spelled out — the string the defect leaves on screen after the
+      # click as well, which is why it is compared by value below.
+      let headlineBefore = paneText(panel, "test-results-headline")
+      ck headlineBefore == "5 tests, not run yet"
+      ck paneText(panel, "test-results-failure") == ""
+      ck "hidden" in firstByClass(panel, "test-results-failure").attr("class")
+
+      fireEvent(runButtonOf(panel), "click")
+      ck asked == 1
+
+      # THE DEFECT, AS ONE ASSERTION: these two were byte-identical.
+      let headlineAfter = paneText(panel, "test-results-headline")
+      ck headlineAfter != headlineBefore
+      ck headlineAfter == "run failed, no tests ran"
+
+      # AND THE REASON IS PAINTED, in the host's own words, in a block that is
+      # no longer hidden.
+      ck "hidden" notin firstByClass(panel, "test-results-failure").attr("class")
+      ck paneText(panel, "test-results-failure") == AlreadyRunning
+      ck failureLineCount(panel) == 1
+
+      # The five tests are still listed. The pane gained a sentence; it did not
+      # lose the project.
+      ck allByClass(panel, "test-results-row").len == 5
+
+      dispose()
+    expectCount(12)
+
+  test "the refusal is transient: the control stays live and can be pressed again":
+    ## `noteRunRefusal` and NOT `setRunAbsence`. A build finishes in seconds and
+    ## the user is entitled to press again; writing the refusal into
+    ## `runAbsence` would grey out the ▶ and every row's `⟳` on the strength of
+    ## one declined click, and would state it as a fact about the deployment.
+    startCount()
+    createRoot proc(dispose: proc()) =
+      let (vm, panel) = mountedPane()
+
+      var answers = @[AlreadyRunning, ""]
+      var asked = 0
+      vm.setRunTests(proc(): string =
+        let reply = answers[asked]
+        inc asked
+        reply)
+
+      fireEvent(runButtonOf(panel), "click")
+      ck paneText(panel, "test-results-failure") == AlreadyRunning
+
+      # NOT A STANDING CLAIM ABOUT THE BUNDLE.
+      ck vm.runAbsence.val == ""
+      ck vm.canRun()
+      ck runButtonOf(panel).attr("class") == "test-results-run-btn"
+
+      # The build finished; the second press is accepted, and the stale
+      # sentence does not outlive it.
+      fireEvent(runButtonOf(panel), "click")
+      ck asked == 2
+      vm.beginRun()
+      ck paneText(panel, "test-results-failure") == ""
+      ck paneText(panel, "test-results-headline") == "running…"
+
+      dispose()
+    expectCount(7)
+
+  test "a run the host ACCEPTS leaves no failure line and does not move the headline":
+    ## The over-firing guard. Without it every arm above would be green over a
+    ## `startRun` that filed a diagnostic on every click, and the pane would
+    ## report a failure for each run it successfully started.
+    startCount()
+    createRoot proc(dispose: proc()) =
+      let (vm, panel) = mountedPane()
+
+      var asked = 0
+      vm.setRunTests(proc(): string =
+        inc asked
+        "")
+
+      fireEvent(runButtonOf(panel), "click")
+      ck asked == 1
+      ck paneText(panel, "test-results-failure") == ""
+      ck "hidden" in firstByClass(panel, "test-results-failure").attr("class")
+      ck failureLineCount(panel) == 0
+      ck paneText(panel, "test-results-headline") == "5 tests, not run yet"
+
+      dispose()
+    expectCount(5)
+
+  test "a control the pane itself knows is dead is not pressed, and states its own reason":
+    ## The seam between the two kinds of "no". `runAbsence` is knowable before
+    ## the click and belongs on the pane as ordinary content; a host refusal is
+    ## only knowable by asking. This arm asserts the first still short-circuits
+    ## — the runner is never called — so the fix did not turn a stated absence
+    ## into a click that has to fail to explain itself.
+    startCount()
+    createRoot proc(dispose: proc()) =
+      let (vm, panel) = mountedPane()
+
+      var asked = 0
+      vm.setRunTests(proc(): string =
+        inc asked
+        AlreadyRunning)
+      vm.setRunAbsence(
+        "this page was published without the Noir compiler, so nothing " &
+        "here can be compiled, run or tested")
+
+      ck not vm.canRun()
+      ck "disabled" in runButtonOf(panel).attr("class")
+      fireEvent(runButtonOf(panel), "click")
+      ck asked == 0
+
+      # The reason is on the pane, in the ABSENCE block and not the failure
+      # block: nothing was attempted, so nothing failed.
+      ck paneText(panel, "test-results-absence").startsWith(
+        "this page was published without the Noir compiler")
+      ck paneText(panel, "test-results-failure") == ""
+      ck paneText(panel, "test-results-headline") == "5 tests, not run"
+
+      dispose()
+    expectCount(6)
+
+  test "a per-row control that is declined uses the same block, in the same words":
+    ## `noteRowActionRefusal` now shares `noteRunRefusal`'s body. The header's ▶
+    ## and a row's `⟳` are different controls with the same obligation, and two
+    ## copies of "file it as a diagnostic" is how one of them would later stop
+    ## doing it.
+    startCount()
+    createRoot proc(dispose: proc()) =
+      let (vm, panel) = mountedPane()
+
+      ck paneText(panel, "test-results-failure") == ""
+      vm.noteRowActionRefusal(AlreadyRunning)
+      ck paneText(panel, "test-results-failure") == AlreadyRunning
+      ck failureLineCount(panel) == 1
+      ck vm.runAbsence.val == ""
+
+      # An empty message files nothing, so a host that answered "" cannot make
+      # the block appear.
+      vm.clearRun()
+      vm.noteRowActionRefusal("")
+      ck paneText(panel, "test-results-failure") == ""
+
+      dispose()
+    expectCount(5)

--- a/src/frontend/viewmodel/viewmodels/test_results_vm.nim
+++ b/src/frontend/viewmodel/viewmodels/test_results_vm.nim
@@ -158,9 +158,27 @@ import test_run_summary_vm
 export test_run_summary_vm
 
 type
-  RunTestsProc* = proc()
+  RunTestsProc* = proc(): string
     ## The host's runner, named so a `Signal` of it can be created carrying
     ## `nil` — an untyped `nil` gives `createSignal` nothing to infer from.
+    ##
+    ## IT ANSWERS A SENTENCE, and the return type is the fix rather than a
+    ## convenience. It was `proc()`, so a host that took the call and then
+    ## declined it had nowhere to say so: `ui_js` installed
+    ## `web_noir_build.startNoirTests`, whose first three lines are
+    ## `report("test-ignored", "reason=already-running")`,
+    ## `report("test-refused", "reason=no-project")` and
+    ## `report("test-refused", "reason=no-build-vm")` — each of which writes one
+    ## line to the browser console and RETURNS. `canRun` is true in all three
+    ## states (they are not `runAbsence`, they are not `inFlight`), so the ▶ was
+    ## enabled, took the click, and produced nothing a user could see.
+    ##
+    ## "" means the run was dispatched. Anything else is why it was not, and
+    ## `startRun` files it where the pane already paints such things.
+    ##
+    ## A `string` and not a `bool`: "it refused" and "it refused BECAUSE" are
+    ## different products, and a bool would have let every caller re-invent a
+    ## sentence the host was already holding.
 
   TestRowActionProc* = proc(testId: string; selector: string)
     ## One row's action, as the host implements it. Named for `RunTestsProc`'s
@@ -474,15 +492,47 @@ proc endRun*(vm: TestResultsVM) =
   ## Called by the host when the run settles, however it settled.
   vm.inFlight.val = false
 
+proc noteRunRefusal*(vm: TestResultsVM; message: string) =
+  ## An attempt was made and the host declined it. Say so, where a user looks.
+  ##
+  ## FILED AS A RUN-LEVEL DIAGNOSTIC, so it renders in the pane's existing
+  ## `.test-results-failure` block — the surface that already exists for "an
+  ## attempt was made and it did not work", and which the view unhides the
+  ## moment `runFailure` is non-empty. Nothing new is painted and no second
+  ## place to look is invented.
+  ##
+  ## SPECIFICALLY NOT `setRunAbsence`. `runAbsence` means "this DEPLOYMENT
+  ## cannot run tests" and greys the ▶ and every row's `⟳`; a transient
+  ## refusal written there would turn one declined click into a standing claim
+  ## about the bundle. See `noteRowActionRefusal`, which files per-row
+  ## refusals here for the same reason and now shares this proc so the two
+  ## cannot drift.
+  if message.len == 0:
+    return
+  var current = vm.summary.val
+  current.diagnostics.add TestRunDiagnostic(
+    severity: "error", message: message)
+  vm.summary.val = current
+
 proc startRun*(vm: TestResultsVM) =
   ## The view's click handler. Guarded here rather than in the view so the mock
   ## and web renderers cannot disagree about when the button is live.
+  ##
+  ## AND THE HOST'S ANSWER IS RENDERED. `canRun` is what this pane knows —
+  ## a runner is installed, the deployment stated no reason, nothing is in
+  ## flight — and it is not everything the HOST knows. `web_noir_build`
+  ## declines a dispatch when a Build is already running, when no project is
+  ## open and when the producer is nil, and `canRun` is true in all three. Those
+  ## refusals used to reach a `console.log` and stop there: the button was
+  ## enabled, the click was taken, and the pane did not move. So the runner's
+  ## sentence is filed rather than discarded, and the click always ends in
+  ## something a user can see.
   if not vm.canRun():
     return
   # Bound first: `vm.runTests.val()` parses as `val(vm.runTests)` and calls
   # nothing.
   let runner = vm.runTests.val
-  runner()
+  vm.noteRunRefusal(runner())
 
 proc clearRun*(vm: TestResultsVM) =
   ## Blank the RUN. Recordings are untouched — see `TestResultsVM.recordings`
@@ -713,12 +763,11 @@ proc noteRowActionRefusal*(vm: TestResultsVM; message: string) =
   ## out the header's ▶ and every row's `⟳` because a `⏵` did not work — a
   ## refusal in one control disabling three others, and a standing claim about
   ## the bundle made out of a transient event.
-  if message.len == 0:
-    return
-  var current = vm.summary.val
-  current.diagnostics.add TestRunDiagnostic(
-    severity: "error", message: message)
-  vm.summary.val = current
+  ##
+  ## ONE BODY, shared with `noteRunRefusal`: the header's ▶ and a row's `⟳`
+  ## are different controls with the same obligation, and two copies of "file
+  ## it as a diagnostic" is how one of them would later stop doing it.
+  vm.noteRunRefusal(message)
 
 proc triggerRefresh*(vm: TestResultsVM; row: TestResultsRow) =
   ## The `⟳` click. Guarded HERE and not in the view, so the mock and web


### PR DESCRIPTION
## Why

Two arms in the web-renderer gate had no discriminating power. Both used `mutate_no_wasm_worker` to produce a degraded state **the base run is already in**, so they "killed" for a reason unrelated to what they name. From `viewmodel-tests` job `101765790355` of run `34072935418` (log fetched via `gh api`, 199,100 bytes — not a placeholder):

```
1634  [FAILED]  arm G: the press started no run (clicked=true, refusal='')
1644  [OK]      arm Q: and the press started no run and reached no verdict ('none'),
                so arm G's run-start and verdict assertions can fail
```

One fact, scored simultaneously as a defect and as a kill. Arm Q's third check compounds it — `cleared in 1ms` over a slot that line 1636 shows never span: an empty read reported as a clean settle.

## What changed

Both arms now compare against another arm's own report and **go red when powerless**, rather than passing quietly. Arm G gains a check that a press must *run or say why*, read from console **and** screen. A new arm Z empties the descriptor's `modules[]`, which strips `capProcessSpawn` and produces a console-silent refusal — the controlled form of arm G's assertion.

Arm G's check is documented honestly as a **monitor**: every arm reads its own probe report, so no arm can redden another's.

## A correction to the finding that prompted this

The probe was **not** blind to `.notification-message` — it queried it, but filtered with `.find(t => t.includes('did not answer within two minutes'))`, so it could only ever see the *timeout* notice. The channel existed; it was filtered to one string. `editorTestRunHook`'s absence path returns before any `report()`, so its refusal was unreadable through either route.

Also corrected: a comment in the inherited work claimed arm Z reddens arm G's check (false), and its reconciliation was off by two — arm Z's unmeasurable branch is three `ck fail` calls, not one.

## Verification

Executed: the arm Z mutation against two fixtures (empties `modules`, preserves `workers`/`languageOrigins`/escaping, returns rc=1 on an already-empty descriptor); the second channel under real Chromium via Playwright — 6 checks, 0 failures, including a **misdirection case** where a page with no notification reads empty; `bash -n`, `node --check`, `shellcheck`, `shfmt`.

Counts reconciled: 244 → 266 `ck` call sites (+22) = +6 checks, 89 → 95. A `grep -c` initially read 267; the extra was a comment containing the literal string.

**Not executed:** the full 21-arm run. A local run needs a full Nim JS assembly against a 10 GB disk floor, and `workflow_dispatch` would activate `origin-dap-windows-nightly` on `eph-win-x64`, an area another session owns. This PR is the only safe trigger, and getting that verdict is why it is open.

No arm was deleted, weakened or skipped. Built on `ct-runcontrols` (`17adda055`), which makes refusals returnable via `RunTestsProc → proc(): string`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)