### PR TITLE
ci: pin codetracer-native-recorder to flake.lock's rev, restoring lint-bash and 12 skipped jobs

### DIFF
--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -3901,6 +3901,45 @@ jobs:
           substituters: ${{ vars.ATTIC_SUBSTITUTER }}
           gh-token: ${{ steps.ci_token.outputs.token }}
 
+      - name: Provision dependency siblings from repro.lock
+        # THIS JOB HAD NO SIBLING PROVISIONING AT ALL, and was green anyway --
+        # by inheriting another job's leftovers off a persistent runner.
+        #
+        # `repro build .#macos-app` compiles Nim OUTSIDE the Nix sandbox, in
+        # this checkout, so the frontend and `ct` targets resolve
+        # `isonim/...` / `nim_everywhere` through codetracer's own
+        # `config.nims`:
+        #
+        #     config.nims:41  addPathIfDir(workspaceRoot / "isonim/src")
+        #     config.nims:50  addPathIfDir(workspaceRoot / "nim-everywhere/src")
+        #
+        # `workspaceRoot` is the checkout's PARENT -- on a self-hosted runner,
+        # the REUSED per-repository work directory that every codetracer job
+        # on that host shares. No step in this job ever put anything there, and
+        # `repro.nim` does not clone either (`siblingPath` only tests
+        # `dirExists`). So every green this job has had was reading siblings
+        # some OTHER job left in that directory, which is state this job
+        # neither creates nor can observe.
+        #
+        # It is not hypothetical that the state varies. Same commit family,
+        # same recipe, different host:
+        #
+        #   run 34066040001  m3-mcl-004  dmg-build  GREEN
+        #   run 34072935418  m3-mcl-003  dmg-build  RED, at the first Nim action:
+        #     src/frontend/ui/auto_hide.nim(61, 20)
+        #       Error: cannot open file: isonim/web/web_renderer
+        #     src/ct/review_session.nim(270, 10)
+        #       Error: cannot open file: nim_everywhere
+        #
+        # Provisioning the siblings here makes the build state its own
+        # dependency rather than inherit it. It is what the other reprobuild /
+        # build-once lanes already do (dev-build, appimage-build, test-non-gui,
+        # test-ui-tests, viewmodel-tests, cross-process-linux).
+        #
+        # After ``Install Nix``: the action reaches ``repro`` through this
+        # repo's own ``devShells.ci``.
+        uses: ./.github/actions/provision-repro-lock-siblings
+
       - name: "Import GPG key for signing commits"
         id: import-gpg
         uses: crazy-max/ghaction-import-gpg@v6
@@ -5118,6 +5157,23 @@ jobs:
           path: ${{ github.workspace }}/../codetracer-trace-format-nim
           gh-token: ${{ steps.ci_token.outputs.token }}
 
+      - name: Clone codetracer-native-recorder (macOS)
+        # The macOS half of the requirement the nixos leg's ``siblings:`` list
+        # carries: this job's ``./ci/test/non-gui.sh`` compiles
+        # ``src/db-backend/build.rs``, which panics at build.rs:170 without
+        # this checkout. This leg provisions siblings with per-repo
+        # ``clone-repo`` steps rather than setup-dev-env, so the entry has to
+        # be spelled here as well as there. Only the CHECKOUT is needed --
+        # build.rs resolves the ``ct_emulator/`` directory; nothing on this
+        # leg builds the recorder.
+        if: matrix.platform == 'macos'
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
+        with:
+          repo: metacraft-labs/codetracer-native-recorder
+          ref: dev
+          path: ${{ github.workspace }}/../codetracer-native-recorder
+          gh-token: ${{ steps.ci_token.outputs.token }}
+
       - name: Clone python-recorder (macOS)
         if: matrix.platform == 'macos'
         uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
@@ -5255,10 +5311,50 @@ jobs:
           # (run 31719867246, job 94513828226). Pinned by the
           # "codetracer-trace-format implies codetracer-trace-format-nim"
           # assertion in ci/test/sibling-provisioning-test.sh.
+          #
+          # codetracer-native-recorder is REQUIRED, not an extra. This job's
+          # `./ci/test/non-gui.sh` runs `just test` -> `just test-rust` ->
+          # `cargo test --bin replay-server`, which compiles
+          # `src/db-backend/build.rs`; that script resolves the Nim MCR
+          # emulator as a sibling of the checkout and PANICS without it
+          # (build.rs:170), because `src/lib.rs` exports `emulator_ffi`,
+          # `emulator_origin`, `emulator_session` and `data_watch`
+          # unconditionally. Run 34072935418, both legs:
+          #
+          #   thread 'main' panicked at build.rs:170:5:
+          #   db-backend requires the sibling `codetracer-native-recorder`
+          #   checkout, and it was not found.
+          #
+          # Zero tests ran on either leg as a result. `ci/test/
+          # sibling-provisioning-test.sh` § 2b states this contract already --
+          # "every job that runs cargo against src/db-backend provisions
+          # codetracer-native-recorder" -- but its scanner only matched call
+          # sites spelled in the YAML (`cd src/db-backend`, `--manifest-path
+          # src/db-backend`, `run-cross-repo-tests.sh`), and this job reaches
+          # the same build.rs through a shell script and a justfile recipe. The
+          # scanner now matches that route too, so this entry is pinned.
+          #
+          # SPELLED BARE, WITHOUT `=dev`, AND THAT IS THE POINT. A bare name is
+          # resolved against the per-commit workspace lock, which is both the
+          # documented form (`.github/sibling-repos`: "ONE REPO NAME PER LINE,
+          # NO REVISIONS") and the reproducible one -- re-running an old
+          # commit's job then clones the revision that commit was built
+          # against. The lock does pin this repo; run 34072935418 shows the
+          # other legs overriding it and being told so:
+          #
+          #   metacraft-labs/codetracer-native-recorder -> dev (override)
+          #     <- UNACKNOWLEDGED; the lock pins de0edc7e897222050c3b0b421a5c0b330a106ce6
+          #
+          # Writing `=dev` here would add a 57th branch-tip pin against a
+          # ceiling of 56 that `ci/test/sibling-provisioning-test.sh` says is
+          # "lowered as blocks are converted and never raised", and would earn
+          # that same warning. The three entries above are pre-existing
+          # overrides and are left alone; converting them is their own change.
           siblings: |
             codetracer-beam-recorder=dev
             codetracer-trace-format=dev
             codetracer-trace-format-nim=dev
+            codetracer-native-recorder
 
       - name: Allow direnv in cloned codetracer-beam-recorder
         # ``elixir_flow_dap_test.rs`` / ``erlang_flow_dap_test.rs``

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -5334,27 +5334,47 @@ jobs:
           # the same build.rs through a shell script and a justfile recipe. The
           # scanner now matches that route too, so this entry is pinned.
           #
-          # SPELLED BARE, WITHOUT `=dev`, AND THAT IS THE POINT. A bare name is
-          # resolved against the per-commit workspace lock, which is both the
+          # SPELLED AS AN EXPLICIT 40-HEX REVISION, and the two alternatives
+          # are both closed. This entry was BARE for one run. Bare is the
           # documented form (`.github/sibling-repos`: "ONE REPO NAME PER LINE,
-          # NO REVISIONS") and the reproducible one -- re-running an old
-          # commit's job then clones the revision that commit was built
-          # against. The lock does pin this repo; run 34072935418 shows the
-          # other legs overriding it and being told so:
+          # NO REVISIONS") and resolves against the per-commit WORKSPACE lock,
+          # which is genuinely the more reproducible answer -- when that lock
+          # exists. On run 34154799274 it did not, and this job died two steps
+          # before any of the above mattered:
           #
-          #   metacraft-labs/codetracer-native-recorder -> dev (override)
-          #     <- UNACKNOWLEDGED; the lock pins de0edc7e897222050c3b0b421a5c0b330a106ce6
+          #   resolve-sibling-rev: no workspace lock found for codetracer
+          #     candidate SHAs: e51cd37c48e8ddd4e705723f48e39ceeb12a3eb8
+          #   ##[error]No workspace lock for codetracer ... in
+          #     metacraft-labs/metacraft-manifests@latest
           #
-          # Writing `=dev` here would add a 57th branch-tip pin against a
-          # ceiling of 56 that `ci/test/sibling-provisioning-test.sh` says is
-          # "lowered as blocks are converted and never raised", and would earn
-          # that same warning. The three entries above are pre-existing
-          # overrides and are left alone; converting them is their own change.
+          # That is not a property of this entry. The lock is written by the
+          # local post-commit gate, and that gate DECLINES whenever any repo in
+          # the developer's workspace is dirty -- "NO lock written: dirty
+          # sibling(s): infra, codetracer-trace-format, grip-stdlib-research".
+          # It had declined on every commit made that day. `dev` itself is 26/40
+          # locked over its last 40 commits, and `workspace-lock-freshness`
+          # fails this run on exactly that assertion. So a bare entry makes this
+          # job's green depend on whether some unrelated repo happened to be
+          # clean when the commit was made, which is not a dependency this job
+          # has.
+          #
+          # `=dev` is closed too: it would be a 57th branch-tip pin against
+          # `ci/test/sibling-provisioning-test.sh`'s ceiling of 56, which that
+          # suite says is "lowered as blocks are converted and never raised".
+          #
+          # An explicit 40-hex revision is the third form that suite names --
+          # "A sibling revision must come from the workspace lock or be an
+          # explicit 40-hex commit SHA" -- and it is the only one that is both
+          # under the ceiling and independent of lock publication. The revision
+          # is `dev`'s tip as of this commit, i.e. exactly what the `=dev`
+          # entries above resolve to today, frozen. The three entries above are
+          # pre-existing overrides and are left alone; converting them is their
+          # own change.
           siblings: |
             codetracer-beam-recorder=dev
             codetracer-trace-format=dev
             codetracer-trace-format-nim=dev
-            codetracer-native-recorder
+            codetracer-native-recorder=b5b8de6eb505dccc42394728b4705c45e0f064ed
 
       - name: Allow direnv in cloned codetracer-beam-recorder
         # ``elixir_flow_dap_test.rs`` / ``erlang_flow_dap_test.rs``
@@ -5463,9 +5483,45 @@ jobs:
       # are not available. Stylus flow tests are #[ignore] and need a devnode.
       # Cross-repo tests (rr) run in the separate test-ui-tests-rr job.
       - name: Run tests
+        # ``CODETRACER_DB_BACKEND_SKIP_DIRENV`` / ``CT_EMULATOR_EXTRA_NIM_PATHS``
+        # are the second cause behind the missing-sibling one, and only became
+        # reachable once the sibling was actually provisioned. With the
+        # ``codetracer-native-recorder`` checkout now present, ``just test`` ->
+        # ``just test-rust`` -> ``cargo test --bin replay-server`` gets PAST
+        # build.rs:170 and into ``regenerate_c`` at build.rs:972, which takes
+        # the ``direnv exec <recorder-root>`` path on a clone whose .envrc has
+        # never been allowed (run 34154799274, `test-non-gui (macos)`):
+        #
+        #   db-backend build.rs: generated C stale or missing at
+        #     .../codetracer-native-recorder/ct_emulator/build/native_c_files;
+        #     invoking .../build_native_api.sh
+        #   direnv: error .../codetracer-native-recorder/.envrc is blocked.
+        #     Run `direnv allow` to approve its content
+        #   thread 'main' panicked at build.rs:972:17
+        #
+        # Setting the variable rather than adding a ``direnv allow`` step is
+        # this repo's own documented preference -- scripts/build-once.sh:478:
+        # "CT_EMULATOR_EXTRA_NIM_PATHS below already supplies what the direnv
+        # shell was being entered to provide, so the direnv round-trip buys
+        # nothing here and costs a full nested `nix develop` of the recorder's
+        # flake when it does work."
+        #
+        # The pair is copied verbatim from ``origin-dap-macos``, which reaches
+        # the same build.rs through the same ``nix develop . --command just
+        # <recipe>`` shape and is green on this run. ``just test`` does NOT go
+        # through ``scripts/build-once.sh`` (ci/test/non-gui.sh execs ``just
+        # test`` directly), so that script's identical defaults never apply
+        # here and the job env has to carry them.
+        #
+        # The two must move together: skipping direnv means ``nim c`` no longer
+        # inherits the recorder flake's package store, so the vendored
+        # nim-stew / nim-result paths are what let ``syscall_replay.nim``'s
+        # ``import stew/endians2`` resolve.
         run: ./ci/test/non-gui.sh
         env:
           CODETRACER_CI_PLATFORM: ${{ matrix.platform }}
+          CODETRACER_DB_BACKEND_SKIP_DIRENV: "1"
+          CT_EMULATOR_EXTRA_NIM_PATHS: ${{ github.workspace }}/libs/nim-stew/stew:${{ github.workspace }}/libs/nim-stew:${{ github.workspace }}/libs/nim-result
 
   test-ui-tests:
     strategy:
@@ -6253,6 +6309,8 @@ jobs:
           siblings: |
             codetracer-trace-format=dev
             codetracer-trace-format-nim=dev
+            codetracer-native-recorder=b5b8de6eb505dccc42394728b4705c45e0f064ed
+            runquota=fee60f486616c3ba5ceb5fc741eb70fcb29f17ec
 
       - name: Stage codetracer-trace-format into libs/
         # The flake override below points at ./libs/codetracer-trace-format;
@@ -6298,6 +6356,44 @@ jobs:
 
       - name: Build CodeTracer
         run: nix build --print-build-logs '.?submodules=1#codetracer' --override-input codetracer-trace-format path:./libs/codetracer-trace-format --override-input codetracer-trace-format-nim path:./libs/codetracer-trace-format-nim
+
+      - name: Provision dependency siblings from repro.lock
+        # The `nix build` above is hermetic and needs none of this. The
+        # PLAYWRIGHT step does: `just test-gui` declares `build-once` as a
+        # just PREREQUISITE (justfile:840), so every run of this job also
+        # performs an out-of-sandbox Nim build, and that build resolves
+        # `isonim/...` / `nim_everywhere` through codetracer's own
+        # `config.nims` against the checkout's PARENT directory.
+        #
+        # Nothing in this job ever populated that directory, so
+        # `scripts/require-siblings.sh` aborted before the first test --
+        # run 34154799274, `test-ui-tests-rr`:
+        #
+        #   Cannot start the CodeTracer build: 7 required sibling repo(s)
+        #   are missing.
+        #     * isonim  * nim-agents  * nim-agent-harbor  * nim-acp
+        #     * nim-everywhere  * codetracer-native-recorder  * runquota
+        #   error: Recipe `build-once` failed on line 5 with exit code 1
+        #
+        # This action supplies the first five, at the 40-hex revisions THIS
+        # commit's own `repro.lock` pins; the two `siblings:` entries added
+        # above supply the rest. Same pairing `test-ui-tests` already
+        # carries -- the closest sibling lane, also Playwright, also on the
+        # GPU host.
+        #
+        # Those two entries are explicit 40-hex revisions rather than `=dev`
+        # or bare, for the reason spelled out at length on `test-non-gui`'s
+        # `siblings:` block: `=dev` would breach the branch-tip ceiling of 56,
+        # and a bare name resolves against a workspace lock that is not
+        # reliably published. A bare entry here would have been strictly worse
+        # than the bug it fixes -- it would move this job's failure from the
+        # Playwright step at the END of the job to `Setup dev env` near the
+        # START, losing every stage in between.
+        #
+        # This failure was invisible until now: the `Setup rr-backend` step
+        # ahead of it used to abort on a flake attribute that never existed,
+        # so no run ever reached the Playwright step to discover it.
+        uses: ./.github/actions/provision-repro-lock-siblings
 
       - name: Setup rr-backend
         # `ci/setup-rr-backend.sh` resolves codetracer-native-backend's revision

--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -1280,7 +1280,7 @@ jobs:
           siblings: |
             codetracer-trace-format=dev
             codetracer-trace-format-nim=dev
-            codetracer-native-recorder=dev
+            codetracer-native-recorder=7e0400b364196ec731967a4dd4a3e931c73732f3
 
       - name: Upload env.ps1 component decomposition
         # env.ps1 writes a per-component breakdown of the bootstrap -- wall
@@ -1535,7 +1535,7 @@ jobs:
           gh-token: ${{ steps.ci_token.outputs.token }}
           env-ps1-path: ./env.ps1
           siblings: |
-            codetracer-native-recorder=dev
+            codetracer-native-recorder=7e0400b364196ec731967a4dd4a3e931c73732f3
             codetracer-trace-format=dev
             codetracer-trace-format-nim=dev
 
@@ -1854,7 +1854,7 @@ jobs:
           siblings: |
             codetracer-trace-format=dev
             codetracer-trace-format-nim=dev
-            codetracer-native-recorder=dev
+            codetracer-native-recorder=7e0400b364196ec731967a4dd4a3e931c73732f3
 
       # MEASURE THE FETCH ENVIRONMENT BEFORE NIX TOUCHES THE NETWORK, and
       # before the FIRST `nix develop` in this job rather than before the
@@ -4147,7 +4147,7 @@ jobs:
           siblings: |
             codetracer-trace-format=dev
             codetracer-trace-format-nim=dev
-            codetracer-native-recorder=dev
+            codetracer-native-recorder=7e0400b364196ec731967a4dd4a3e931c73732f3
 
       - name: Remove WSL bash stub from System32
         # As in the other eph-win-x64 jobs: let CreateProcessW fall through to
@@ -5362,19 +5362,45 @@ jobs:
           # `ci/test/sibling-provisioning-test.sh`'s ceiling of 56, which that
           # suite says is "lowered as blocks are converted and never raised".
           #
-          # An explicit 40-hex revision is the third form that suite names --
-          # "A sibling revision must come from the workspace lock or be an
-          # explicit 40-hex commit SHA" -- and it is the only one that is both
-          # under the ceiling and independent of lock publication. The revision
-          # is `dev`'s tip as of this commit, i.e. exactly what the `=dev`
-          # entries above resolve to today, frozen. The three entries above are
-          # pre-existing overrides and are left alone; converting them is their
-          # own change.
+          # So an explicit 40-hex revision it is -- the third form that suite
+          # names: "A sibling revision must come from the workspace lock or be
+          # an explicit 40-hex commit SHA".
+          #
+          # WHICH SHA IS NOT FREE, and picking the wrong one is what run
+          # 34159391653 did. `ci/test/sibling-input-branch-test.sh` also reads
+          # this list, and for any repo that is a branch-tracking flake input it
+          # requires the workflow's pin to be EXACTLY the rev `flake.lock` locks
+          # -- "the sibling checkout and the shell the Nix lane builds are the
+          # same tree, by construction". That run pinned
+          # b5b8de6eb505dccc42394728b4705c45e0f064ed (`dev`'s tip that day)
+          # while flake.lock locks 7e0400b3, and earned:
+          #
+          #   FAIL codetracer-native-recorder: the workflow pins a different
+          #     commit than flake.lock locks
+          #
+          # That reddened `lint-bash`, which `nix-build`, `dev-build`,
+          # `dmg-build`, `appimage-*`, `push-tag` and `create-release` all
+          # `needs:`, so ONE assertion took 12 green jobs to `skipped`. The pin
+          # has to be flake.lock's rev, not the branch tip.
+          #
+          # The gate compares the SET of spellings this file gives a repo, so a
+          # lone `=dev` anywhere else re-breaks it: the comparison becomes
+          # {7e0400b3, dev} against a single locked rev and cannot match. Every
+          # `codetracer-native-recorder` entry in this file therefore names this
+          # same revision. That also drops the branch-tip count from 56 to 49,
+          # which is the direction that ceiling is allowed to move.
+          #
+          # 7e0400b3 is corroborated, not merely consistent: it is the revision
+          # `nix build '.?submodules=1#codetracer'` already builds green on this
+          # commit, so it is known to compile against this tree. Moving every
+          # lane to `dev`'s tip instead would require bumping flake.lock, which
+          # puts the currently-green Nix lane at risk to serve lanes that are
+          # already red; that is its own change, with its own validation.
           siblings: |
             codetracer-beam-recorder=dev
             codetracer-trace-format=dev
             codetracer-trace-format-nim=dev
-            codetracer-native-recorder=b5b8de6eb505dccc42394728b4705c45e0f064ed
+            codetracer-native-recorder=7e0400b364196ec731967a4dd4a3e931c73732f3
 
       - name: Allow direnv in cloned codetracer-beam-recorder
         # ``elixir_flow_dap_test.rs`` / ``erlang_flow_dap_test.rs``
@@ -5743,7 +5769,7 @@ jobs:
           siblings: |
             codetracer-trace-format=dev
             codetracer-trace-format-nim=dev
-            codetracer-native-recorder=dev
+            codetracer-native-recorder=7e0400b364196ec731967a4dd4a3e931c73732f3
             nim-stackable-hooks=dev
             codetracer-visual-replay=dev
             codetracer-native-backend=dev
@@ -6309,7 +6335,7 @@ jobs:
           siblings: |
             codetracer-trace-format=dev
             codetracer-trace-format-nim=dev
-            codetracer-native-recorder=b5b8de6eb505dccc42394728b4705c45e0f064ed
+            codetracer-native-recorder=7e0400b364196ec731967a4dd4a3e931c73732f3
             runquota=fee60f486616c3ba5ceb5fc741eb70fcb29f17ec
 
       - name: Stage codetracer-trace-format into libs/
@@ -6385,10 +6411,19 @@ jobs:
         # or bare, for the reason spelled out at length on `test-non-gui`'s
         # `siblings:` block: `=dev` would breach the branch-tip ceiling of 56,
         # and a bare name resolves against a workspace lock that is not
-        # reliably published. A bare entry here would have been strictly worse
-        # than the bug it fixes -- it would move this job's failure from the
-        # Playwright step at the END of the job to `Setup dev env` near the
-        # START, losing every stage in between.
+        # reliably published -- run 34159391653's own clone step says so of
+        # this very repo, "<- the lock does not pin this repo". A bare entry
+        # here would have been strictly worse than the bug it fixes -- it would
+        # move this job's failure from the Playwright step at the END of the
+        # job to `Setup dev env` near the START, losing every stage in between.
+        #
+        # `codetracer-native-recorder` must name the rev `flake.lock` locks,
+        # for the reason that block also records: it is a branch-tracking flake
+        # input, so `ci/test/sibling-input-branch-test.sh` compares this pin
+        # against flake.lock and reddens `lint-bash` on any other value.
+        # `runquota` is exempt from that comparison -- flake.nix pins it to a
+        # commit rather than a branch, so the suite skips it -- and it is
+        # guarded by `scripts/test-flake-pin-alignment.sh` instead.
         #
         # This failure was invisible until now: the `Setup rr-backend` step
         # ahead of it used to abort on a flake attribute that never existed,
@@ -6688,7 +6723,7 @@ jobs:
             nim-stackable-hooks=dev
             codetracer-visual-replay=dev
             codetracer-native-backend=dev
-            codetracer-native-recorder=dev
+            codetracer-native-recorder=7e0400b364196ec731967a4dd4a3e931c73732f3
             codetracer-native-test-programs=dev
             codetracer-visual-replay-fixtures=dev
             runquota=dev
@@ -6982,7 +7017,7 @@ jobs:
             nim-shm-queue=5a8e43b52fa202859658692c9f8432967f3971ea
             nim-shm-gset=360bfc15cadab1ff583e6d1cbc20b389d5d6825f
             nim-stackable-hooks=dev
-            codetracer-native-recorder=dev
+            codetracer-native-recorder=7e0400b364196ec731967a4dd4a3e931c73732f3
             codetracer-js-recorder=dev
             codetracer-ruby-recorder=dev
             codetracer-native-backend=dev

--- a/ci/setup-rr-backend.sh
+++ b/ci/setup-rr-backend.sh
@@ -194,18 +194,59 @@ clone_rr_backend() {
 	)
 }
 
+# THE FLAKE ATTRIBUTE IS `codetracer-rr-support`, NOT `ct-native-replay`.
+#
+# `ct-native-replay` is the CARGO package name and the name of the BINARY the
+# derivation installs (codetracer-native-backend's Cargo.toml: `[package] name
+# = "ct-native-replay"`, `[[bin]] name = "ct-native-replay"`). It has never
+# been a flake output: `nix/packages/default.nix` has exported exactly one
+# attribute, `codetracer-rr-support`, since it was written (5355565b), and
+# `pname` is only derived from Cargo.toml INSIDE that derivation. Asking for
+# `#ct-native-replay` therefore always died with
+#
+#   error: flake '...' does not provide attribute
+#          'packages.x86_64-linux.ct-native-replay',
+#          'legacyPackages.x86_64-linux.ct-native-replay' or 'ct-native-replay'
+#
+# which the `||` below swallowed into the cargo fallback, so the nix build has
+# in fact never run. The `result/bin/ct-native-replay` check further down is
+# unchanged and still correct: that binary is what this attribute installs.
+#
+# EVERY NIX CALL AGAINST THIS CHECKOUT NEEDS `?submodules=1` AND THE OVERRIDES.
+#
+# The native-backend flake declares its two vendored submodules as RELATIVE
+# path inputs -- `rr-soft.url = "path:libs/rr"`, `delve-patched.url =
+# "path:libs/delve"` -- and its flake.lock (version 7) keeps them in the
+# unlocked relative form. Nix resolves a relative path input through the PARENT
+# FLAKE'S SOURCE ACCESSOR, and for a local git checkout that accessor exposes
+# only git-TRACKED files. A submodule contributes exactly ONE tracked entry to
+# its superproject -- the gitlink `libs/delve` (`git ls-files -s libs/delve` ->
+# `160000 174cd263... 0 libs/delve`) -- so `libs/delve/flake.nix` is not a
+# tracked path there and the input cannot be read:
+#
+#   error: Path 'libs/delve/flake.nix' in the repository
+#          ".../codetracer-native-backend" is not tracked by Git.
+#
+# `?submodules=1` is what mounts each submodule's own accessor at its path and
+# makes those files visible. The bare `nix develop "${CLONE_DIR}"` calls below
+# lacked it, so they failed that way even when the build above succeeded --
+# which is the second error in the CI log. The ref and the two absolute-path
+# overrides now travel together on all three invocations.
 build_rr_support() {
 	echo "Building ct-native-replay via nix build..."
 
 	nix build \
-		"${CLONE_DIR}?submodules=1#ct-native-replay" \
+		"${CLONE_DIR}?submodules=1#codetracer-rr-support" \
 		--override-input rr-soft "path:${CLONE_DIR}/libs/rr" \
 		--override-input delve-patched "path:${CLONE_DIR}/libs/delve" \
 		--out-link "${CLONE_DIR}/result" \
 		--print-build-logs ||
 		{
 			echo "nix build failed, falling back to cargo build via nix develop..." >&2
-			nix develop "${CLONE_DIR}" --command \
+			nix develop "${CLONE_DIR}?submodules=1" \
+				--override-input rr-soft "path:${CLONE_DIR}/libs/rr" \
+				--override-input delve-patched "path:${CLONE_DIR}/libs/delve" \
+				--command \
 				bash -c "cd '${CLONE_DIR}' && cargo build"
 		}
 
@@ -231,7 +272,12 @@ resolve_runtime_deps() {
 	# Use markers to extract paths cleanly (nix develop may print banners)
 	local raw
 	# shellcheck disable=SC2016
-	raw="$(nix develop "${CLONE_DIR}" --command bash -c \
+	# Same flakeref + overrides as build_rr_support; see the note there for why
+	# `?submodules=1` is not optional against this checkout.
+	raw="$(nix develop "${CLONE_DIR}?submodules=1" \
+		--override-input rr-soft "path:${CLONE_DIR}/libs/rr" \
+		--override-input delve-patched "path:${CLONE_DIR}/libs/delve" \
+		--command bash -c \
 		'echo "___LD_PATH_START___"; echo "$LD_LIBRARY_PATH"; echo "___LD_PATH_END___";
          echo "___PATH_START___"; echo "$PATH"; echo "___PATH_END___"')"
 

--- a/ci/test/cross-process-gate.sh
+++ b/ci/test/cross-process-gate.sh
@@ -54,9 +54,34 @@ fi
 # missing, and the skip guard fired on every run for as long as it
 # existed. The checks above could not see it: they assert the spec's
 # *shape*, and its shape was correct throughout.
-require_source_line "$EVENT_LOG_SPEC" \
-	'threeTraceRecordingRoot()' \
-	"event-log spec must obtain its recordings from the shared materialiser helper"
+#
+# The contract is about WHERE `fixtureDir` COMES FROM, so this reads the
+# binding rather than the file. The two obvious spellings both fail:
+#
+#   * `threeTraceRecordingRoot()` -- what this used to assert -- only
+#     matches a DIRECT call. It went red the moment the call became a
+#     callback handed to `loadTimePrerequisite`, which defers the same
+#     call so that a throw while recording cannot abort Playwright's
+#     collection of the entire suite. Nothing about the fixture's origin
+#     changed; only the call's syntax did.
+#   * the bare identifier `threeTraceRecordingRoot` matches the import
+#     line, so a spec that imports the helper and then computes its own
+#     path would pass.
+#
+# Joining the `const fixtureDir = ...;` statement and requiring the helper
+# inside it is immune to both: an import cannot satisfy it, and any call
+# shape can.
+fixture_dir_binding="$(awk '
+	/^const fixtureDir[[:space:]]*=/ { capturing = 1 }
+	capturing { printf "%s ", $0 }
+	capturing && /;[[:space:]]*$/ { exit }
+' "$EVENT_LOG_SPEC")"
+[ -n "$fixture_dir_binding" ] ||
+	fail "event-log spec must bind fixtureDir in a top-level 'const fixtureDir = ...;' statement"
+case "$fixture_dir_binding" in
+*threeTraceRecordingRoot*) ;;
+*) fail "event-log spec must obtain its recordings from the shared materialiser helper" ;;
+esac
 # `^[^/*]*` keeps the match off comment lines, so the spec can keep
 # documenting the climb it used to have without tripping its own gate.
 if grep -Eq '^[^/*]*(path\.)?(resolve|join)\([[:space:]]*__dirname' "$EVENT_LOG_SPEC"; then

--- a/ci/test/sibling-provisioning-test.sh
+++ b/ci/test/sibling-provisioning-test.sh
@@ -915,6 +915,12 @@ echo "db-backend cargo legs provision codetracer-native-recorder"
 # anchor turns "nothing forbidden was found" into a FAILURE instead of a
 # vacuous pass. Two vacuous greens have already been paid for in this file.
 readonly DB_BACKEND_ANCHOR='cross-repo-tests.yml:shell-recorder-tests'
+# The indirect route needs its own anchor for exactly the same reason. The
+# direct-form anchor above cannot detect a regression in the wrapper pattern:
+# it would keep matching `shell-recorder-tests` and report "ok" while
+# `test-non-gui` -- the only job that reaches build.rs through a script --
+# silently left the population again. One anchor per detection route.
+readonly DB_BACKEND_ANCHOR_INDIRECT='codetracer.yml:test-non-gui'
 
 # A job satisfies this contract by naming the composite instead of the repo --
 # which is the shape this contract WANTS, and also a way to launder the defect
@@ -1002,15 +1008,35 @@ for wf in "${SIBLING_SOURCE_FILES[@]}"; do
 		case "$stripped_line" in
 		"- '"* | '- "'*) continue ;;
 		esac
+		# A comment naming a script is PROSE, not a call site -- the mirror of
+		# the rule two blocks up, which already refuses to let a comment naming
+		# the recorder count as provisioning it. Without this the two rules
+		# disagree: prose cannot satisfy the contract but could impose it, so
+		# the paragraph EXPLAINING why a job needs the sibling registers as a
+		# fourth call site, attributed to whatever job the comment sits in and
+		# to the line the comment is on rather than the line that builds
+		# anything. Documenting the contract must not be what violates it.
+		case "$stripped_line" in
+		'#'*) continue ;;
+		esac
 		# The cargo invocations that compile `src/db-backend/build.rs`: a `run:`
 		# step that `cd`s in, an out-of-tree invocation naming the manifest, and
 		# the cross-repo driver, whose `run_db_backend_test` does
 		# `cd "$REPO_ROOT/src/db-backend"; cargo test` (scripts/
 		# run-cross-repo-tests.sh:446).
+		# `ci/test/non-gui.sh` reaches the SAME build.rs without naming it:
+		# it runs `just test` -> `just test-rust` -> `cargo test --bin
+		# replay-server`, with the manifest resolved inside the recipe. That
+		# indirection is why `codetracer.yml:test-non-gui` sat outside this
+		# contract while panicking at build.rs:170 on both legs for months
+		# (run 34072935418, and every sampled run back to 32963460652) -- the
+		# job was never counted as a call site, so "no missing sites" was true
+		# and meaningless. A wrapper that compiles the crate IS a call site;
+		# what varies is only how many layers down the cargo line is written.
 		case "$stripped_line" in
 		'cd src/db-backend' | 'cd src/db-backend '* | "cd 'src/db-backend'"* | \
 			*'--manifest-path src/db-backend'* | *'--manifest-path=src/db-backend'* | \
-			*'run-cross-repo-tests.sh'*)
+			*'run-cross-repo-tests.sh'* | *'ci/test/non-gui.sh'*)
 			db_backend_sites+=("$wf_name:$job")
 			if [ "$seen_recorder" -eq 0 ]; then
 				db_backend_missing+=("$wf_name:$line_no: job '$job' builds src/db-backend with no codetracer-native-recorder sibling before it")
@@ -1021,10 +1047,26 @@ for wf in "${SIBLING_SOURCE_FILES[@]}"; do
 done
 
 _anchor_found=0
+_anchor_indirect_found=0
 for _s in "${db_backend_sites[@]}"; do
 	[ "$_s" = "$DB_BACKEND_ANCHOR" ] && _anchor_found=1
+	[ "$_s" = "$DB_BACKEND_ANCHOR_INDIRECT" ] && _anchor_indirect_found=1
 done
 unset _s
+
+if [ "$_anchor_indirect_found" -eq 1 ]; then
+	ok "the db-backend scanner still matches its INDIRECT anchor ($DB_BACKEND_ANCHOR_INDIRECT)"
+else
+	fail "the db-backend scanner still matches its INDIRECT anchor" \
+		"expected a db-backend call site at '$DB_BACKEND_ANCHOR_INDIRECT', reached" \
+		"through ci/test/non-gui.sh rather than a cargo line in the YAML, and did not" \
+		"find one. Either that job was removed, or the wrapper pattern stopped" \
+		"matching -- which would silently drop every script-mediated call site from" \
+		"this contract, the exact hole that let test-non-gui panic in build.rs on" \
+		"every run for months." \
+		"found: ${db_backend_sites[*]:-<none>}"
+fi
+unset _anchor_indirect_found
 
 if [ "$_anchor_found" -eq 1 ]; then
 	ok "the db-backend cargo scanner still matches its anchor (${#db_backend_sites[@]} call site(s))"
@@ -1546,7 +1588,9 @@ echo
 # four about the lock and the action that reads it (the action still runs the
 # command, it hand-writes no set or revision, the lock declares the set, and
 # every member is pinned to a 40-hex SHA).
-readonly EXPECTED_ASSERTIONS=27
+# 27 + the indirect-route anchor added with the `ci/test/non-gui.sh` call-site
+# pattern (one anchor per detection route; see DB_BACKEND_ANCHOR_INDIRECT).
+readonly EXPECTED_ASSERTIONS=28
 if [ "$assertions" -ne "$EXPECTED_ASSERTIONS" ]; then
 	printf 'FAIL: ran %d assertions, expected %d\n' "$assertions" "$EXPECTED_ASSERTIONS"
 	failures=$((failures + 1))

--- a/ci/test/stale-artefact-guards-test.sh
+++ b/ci/test/stale-artefact-guards-test.sh
@@ -122,7 +122,9 @@ VERSION_NIM="${SUITE_ROOT}/src/ct/version.nim"
 # Every contract this suite claims to check. A suite that silently runs fewer
 # assertions than it advertises is a suite that stops protecting anything, so
 # the count is asserted at the end and has to be changed deliberately.
-EXPECTED_ASSERTIONS=107
+# 107 + the 5 in "the freshness check survives a build system that discards
+# mtimes", added with that section.
+EXPECTED_ASSERTIONS=112
 
 ASSERTIONS=0
 FAILURES=0
@@ -1346,6 +1348,80 @@ else
 	bad "all five contrast specs resolve their stylesheet through the shared helper" \
 		"${CSS_NOT_DELEGATING[@]}"
 fi
+
+section "the freshness check survives a build system that discards mtimes"
+
+# THE GUARD ABOVE WAS UNCONDITIONALLY RED ON THE ONE LEG THAT RUNS IT MOST.
+# Nix sets every store file's mtime to 1970-01-01T00:00:01Z by design, so for a
+# `nix build` artefact the mtime is not old, it is ABSENT -- and "is the built
+# CSS newer than the .styl" then always answers no, for every tree, forever.
+#
+# `test-ui-tests (nixos)` resolves its stylesheet through
+# `CODETRACER_E2E_CT_PATH=$GITHUB_WORKSPACE/result/bin/ct` -> `result/frontend/
+# styles/`, so it hit exactly that. Run 34026517513, job 101563733984: 23
+# failures, all "(built 1980-01-01T00:00:01.000Z)". The "Run TypeScript
+# Playwright UI tests (DB-based only)" step carries no `if:`, so a red
+# Stylesheet-guards step SKIPS it -- one impossible comparison cost that leg the
+# whole 711-test suite.
+#
+# The answer is not to stop asking. `nix build` rewrites the `result` symlink
+# on every build, that symlink is on an ordinary filesystem, and its mtime is
+# precisely "when this artefact was produced". So the same question is asked
+# where this build system records it. All four directions are pinned below,
+# because a check that accepted the nix case by ceasing to check would pass the
+# first assertion and none of the others.
+
+NIXTREE="${TEST_ROOT}/nixcss"
+mkdir -p "${NIXTREE}/repo/src/frontend/styles/components" \
+	"${NIXTREE}/store/out/frontend/styles"
+printf '.x { color: red }\n' >"${NIXTREE}/repo/src/frontend/styles/components/status_bar.styl"
+printf '.x{color:red}\n' >"${NIXTREE}/store/out/frontend/styles/theme.css"
+# What nix actually writes: epoch + 1s.
+touch -t 197001010000.01 "${NIXTREE}/store/out/frontend/styles/theme.css"
+ln -sfn "${NIXTREE}/store/out" "${NIXTREE}/repo/result"
+
+resolve_nix_css() {
+	CODETRACER_BUILD_DIR= CODETRACER_E2E_CT_PATH="${NIXTREE}/repo/result/bin/ct" node -e '
+		const { resolveBuiltThemeCss } = require(process.argv[1]);
+		try {
+			process.stdout.write(resolveBuiltThemeCss(process.argv[2], process.argv[3]));
+		} catch (e) {
+			process.stdout.write("REFUSED: " + e.message);
+		}
+	' "${CSS_LIB}" "${NIXTREE}/repo" theme.css 2>&1
+}
+
+# `-h` matters: without it `touch` follows the symlink and dates the store.
+touch -t 202601010000 "${NIXTREE}/repo/src/frontend/styles/components/status_bar.styl"
+touch -h -t 202602010000 "${NIXTREE}/repo/result"
+assert_contains "$(resolve_nix_css)" "result/frontend/styles/theme.css" \
+	"a nix-built stylesheet whose build postdates the .styl is ACCEPTED, despite its 1970 mtime"
+
+touch -t 202603010000 "${NIXTREE}/repo/src/frontend/styles/components/status_bar.styl"
+NIX_STALE="$(resolve_nix_css)"
+assert_contains "${NIX_STALE}" "is STALE" \
+	"...and one whose .styl was edited after that build is still REFUSED"
+assert_contains "${NIX_STALE}" "components/status_bar.styl" \
+	"...naming the source that outdates it, as in the non-nix case"
+
+touch -h -t 202604010000 "${NIXTREE}/repo/result"
+assert_contains "$(resolve_nix_css)" "result/frontend/styles/theme.css" \
+	"...and a re-run of \`nix build\` clears it again"
+
+# The remaining direction: a store path reached WITHOUT the symlink cannot be
+# dated at all. Answering "fresh" there would be the silent hole this whole
+# section exists to close, so it refuses and says why.
+rm "${NIXTREE}/repo/result"
+UNDATABLE="$(CODETRACER_BUILD_DIR= CODETRACER_E2E_CT_PATH="${NIXTREE}/store/out/bin/ct" node -e '
+	const { resolveBuiltThemeCss } = require(process.argv[1]);
+	try {
+		process.stdout.write(resolveBuiltThemeCss(process.argv[2], process.argv[3]));
+	} catch (e) {
+		process.stdout.write("REFUSED: " + e.message);
+	}
+' "${CSS_LIB}" "${NIXTREE}/repo" theme.css 2>&1)"
+assert_contains "${UNDATABLE}" "cannot be dated" \
+	"a timestamp-normalized stylesheet with no build-output symlink is refused, not assumed fresh"
 
 # ---------------------------------------------------------------------------
 # THE DB-BACKEND WASM REPLAY ENGINE.

--- a/ci/test/stale-artefact-guards-test.sh
+++ b/ci/test/stale-artefact-guards-test.sh
@@ -123,8 +123,10 @@ VERSION_NIM="${SUITE_ROOT}/src/ct/version.nim"
 # assertions than it advertises is a suite that stops protecting anything, so
 # the count is asserted at the end and has to be changed deliberately.
 # 107 + the 5 in "the freshness check survives a build system that discards
-# mtimes", added with that section.
-EXPECTED_ASSERTIONS=112
+# mtimes", added with that section, + 1 pinning that section's fixture to the
+# exact mtime nix writes (the assertions around it are only meaningful at that
+# value, so the value itself is asserted rather than assumed).
+EXPECTED_ASSERTIONS=113
 
 ASSERTIONS=0
 FAILURES=0
@@ -1359,7 +1361,7 @@ section "the freshness check survives a build system that discards mtimes"
 # `test-ui-tests (nixos)` resolves its stylesheet through
 # `CODETRACER_E2E_CT_PATH=$GITHUB_WORKSPACE/result/bin/ct` -> `result/frontend/
 # styles/`, so it hit exactly that. Run 34026517513, job 101563733984: 23
-# failures, all "(built 1980-01-01T00:00:01.000Z)". The "Run TypeScript
+# failures, all "(built 1970-01-01T00:00:01.000Z)". The "Run TypeScript
 # Playwright UI tests (DB-based only)" step carries no `if:`, so a red
 # Stylesheet-guards step SKIPS it -- one impossible comparison cost that leg the
 # whole 711-test suite.
@@ -1377,11 +1379,37 @@ mkdir -p "${NIXTREE}/repo/src/frontend/styles/components" \
 printf '.x { color: red }\n' >"${NIXTREE}/repo/src/frontend/styles/components/status_bar.styl"
 printf '.x{color:red}\n' >"${NIXTREE}/store/out/frontend/styles/theme.css"
 # What nix actually writes: epoch + 1s.
-touch -t 197001010000.01 "${NIXTREE}/store/out/frontend/styles/theme.css"
+#
+# TZ=UTC IS LOAD-BEARING. `touch -t` reads its stamp in LOCAL time, so the bare
+# form encodes epoch+1s only for a host already on UTC. Measured, same file,
+# same command, four zones:
+#
+#     UTC                  mtimeMs=1000        <- the value nix writes
+#     Europe/Sofia         mtimeMs=-7199000
+#     America/New_York     mtimeMs=18001000
+#     America/Los_Angeles  mtimeMs=28801000
+#
+# `artefactBuiltAt` treats "> 1000" as a real timestamp, so on any host WEST of
+# UTC the fixture is not a normalized artefact at all, the symlink branch never
+# runs, and the four assertions below fail on a developer's machine while
+# passing on the UTC runners -- the check would be measuring the tester's
+# timezone rather than the code. The zone-independent `touch -d @1` is GNU-only;
+# `TZ=UTC` with `-t` is POSIX and holds for BSD touch too.
+TZ=UTC touch -t 197001010000.01 "${NIXTREE}/store/out/frontend/styles/theme.css"
 ln -sfn "${NIXTREE}/store/out" "${NIXTREE}/repo/result"
 
+# Verify the INSTRUMENT before trusting anything it reports. Every assertion in
+# this section is about behaviour that only occurs at nix's normalized mtime, so
+# a fixture that drifted off that value would be testing the ordinary path under
+# a nix-shaped name. Pin the number itself, not just the behaviour it produces.
+# Bracketed so this is an EQUALITY, not a substring: bare "1000" would also be
+# satisfied by 18001000, which is precisely the wrong value this guards against.
+assert_contains "[$(node -e 'process.stdout.write(String(require("fs").statSync(process.argv[1]).mtimeMs))' \
+	"${NIXTREE}/store/out/frontend/styles/theme.css")]" "[1000]" \
+	"the nix fixture carries the exact mtime nix normalizes store files to (epoch + 1s)"
+
 resolve_nix_css() {
-	CODETRACER_BUILD_DIR= CODETRACER_E2E_CT_PATH="${NIXTREE}/repo/result/bin/ct" node -e '
+	CODETRACER_BUILD_DIR='' CODETRACER_E2E_CT_PATH="${NIXTREE}/repo/result/bin/ct" node -e '
 		const { resolveBuiltThemeCss } = require(process.argv[1]);
 		try {
 			process.stdout.write(resolveBuiltThemeCss(process.argv[2], process.argv[3]));
@@ -1406,13 +1434,13 @@ assert_contains "${NIX_STALE}" "components/status_bar.styl" \
 
 touch -h -t 202604010000 "${NIXTREE}/repo/result"
 assert_contains "$(resolve_nix_css)" "result/frontend/styles/theme.css" \
-	"...and a re-run of \`nix build\` clears it again"
+	"...and a re-run of nix build clears it again"
 
 # The remaining direction: a store path reached WITHOUT the symlink cannot be
 # dated at all. Answering "fresh" there would be the silent hole this whole
 # section exists to close, so it refuses and says why.
 rm "${NIXTREE}/repo/result"
-UNDATABLE="$(CODETRACER_BUILD_DIR= CODETRACER_E2E_CT_PATH="${NIXTREE}/store/out/bin/ct" node -e '
+UNDATABLE="$(CODETRACER_BUILD_DIR='' CODETRACER_E2E_CT_PATH="${NIXTREE}/store/out/bin/ct" node -e '
 	const { resolveBuiltThemeCss } = require(process.argv[1]);
 	try {
 		process.stdout.write(resolveBuiltThemeCss(process.argv[2], process.argv[3]));

--- a/justfile
+++ b/justfile
@@ -650,7 +650,22 @@ ensure-storybook-static *args:
   done
 
   if [ "$needs_storybook" -eq 1 ]; then
-    just storybook-build
+    # NOT FATAL, and this is the whole point of the recipe's placement.
+    # `just test-e2e` calls this under `set -e` BEFORE `npx playwright test`,
+    # so for as long as a failed storybook build aborted here, a broken
+    # storybook cost the run EVERY test -- 776 of them across 153 spec files
+    # -- rather than the four `*storybook*.spec.ts` that need the artefact.
+    # That is how the nixos leg reported a red Playwright step having
+    # executed nothing at all.
+    #
+    # Nothing is softened by continuing. Each of those four specs already
+    # asserts the artefact in its own `beforeAll`
+    # ("Missing StoryBook static build. Run `just storybook-build` first.")
+    # so they go red, by name, with a diagnostic that says what to run --
+    # and the other 772 tests get to answer for themselves.
+    if ! just storybook-build; then
+      echo "::error::just storybook-build failed; the *storybook*.spec.ts specs will fail on the missing storybook-static. Continuing so the rest of the suite still runs." >&2
+    fi
   fi
 
 serve-docs hostname="localhost" port="3000":

--- a/scripts/build-once.sh
+++ b/scripts/build-once.sh
@@ -213,9 +213,11 @@ if [ -n "$ct_reprobuild_host" ]; then
 	if [ "$ct_reprobuild_host" != "windows" ]; then
 		export CODETRACER_DB_BACKEND_SKIP_DIRENV="${CODETRACER_DB_BACKEND_SKIP_DIRENV:-1}"
 		export CODETRACER_TRACE_FORMAT_NIM_SKIP_NIMBLE_INSTALL="${CODETRACER_TRACE_FORMAT_NIM_SKIP_NIMBLE_INSTALL:-1}"
-		if [ -z "${CT_EMULATOR_EXTRA_NIM_PATHS:-}" ] && [ -d "$PWD/libs/nim-stew/stew" ]; then
+		# ONE GUARD PER VARIABLE. See the long note on the copy of this block
+		# further down (the tup branch) for the failure a shared guard caused.
+		if [ -d "$PWD/libs/nim-stew/stew" ]; then
 			ct_nim_paths_lib="$PWD/libs/nim-stew/stew:$PWD/libs/nim-stew"
-			export CT_EMULATOR_EXTRA_NIM_PATHS="$ct_nim_paths_lib"
+			export CT_EMULATOR_EXTRA_NIM_PATHS="${CT_EMULATOR_EXTRA_NIM_PATHS:-$ct_nim_paths_lib}"
 			export CODETRACER_TRACE_FORMAT_NIM_EXTRA_PATHS="${CODETRACER_TRACE_FORMAT_NIM_EXTRA_PATHS:-$ct_nim_paths_lib}"
 		fi
 	fi
@@ -479,9 +481,29 @@ ct_publish_build_env "" "$ct_tup_config" "$ct_tup_variant" "src/$ct_tup_variant"
 # costs a full nested `nix develop` of the recorder's flake when it does work.
 export CODETRACER_DB_BACKEND_SKIP_DIRENV="${CODETRACER_DB_BACKEND_SKIP_DIRENV:-1}"
 export CODETRACER_TRACE_FORMAT_NIM_SKIP_NIMBLE_INSTALL="${CODETRACER_TRACE_FORMAT_NIM_SKIP_NIMBLE_INSTALL:-1}"
-if [ -z "${CT_EMULATOR_EXTRA_NIM_PATHS:-}" ] && [ -d "$PWD/libs/nim-stew/stew" ]; then
+# ONE GUARD PER VARIABLE, and the previous shape is why.
+#
+# This block used to open `if [ -z "${CT_EMULATOR_EXTRA_NIM_PATHS:-}" ] && ...`,
+# so a caller that set ONLY the emulator variable skipped the whole body --
+# including the export of CODETRACER_TRACE_FORMAT_NIM_EXTRA_PATHS, which is a
+# DIFFERENT variable consumed by a DIFFERENT build script. The line above still
+# ran, so `codetracer_trace_writer_nim`'s build.rs was told not to
+# `nimble install` AND given no substitute path:
+#
+#   .../codetracer-trace-format-nim/src/codetracer_trace_writer.nim(17, 8)
+#     Error: cannot open file: results
+#   nim static-library build failed
+#   error: Recipe `build-once` failed on line 5 with exit code 1
+#
+# That is exactly the job env `cross-process-linux` carries
+# (.github/workflows/codetracer.yml: CT_EMULATOR_EXTRA_NIM_PATHS, and no
+# CODETRACER_TRACE_FORMAT_NIM_EXTRA_PATHS), and the shell supplies no fallback:
+# nix/shells/ci-base.nix sets the pair only as derivation attributes of the
+# Python-recorder package, not as dev-shell exports. Each variable now defaults
+# independently, so setting one never silences the other.
+if [ -d "$PWD/libs/nim-stew/stew" ]; then
 	ct_nim_paths_lib="$PWD/libs/nim-stew/stew:$PWD/libs/nim-stew:$PWD/libs/nim-result"
-	export CT_EMULATOR_EXTRA_NIM_PATHS="$ct_nim_paths_lib"
+	export CT_EMULATOR_EXTRA_NIM_PATHS="${CT_EMULATOR_EXTRA_NIM_PATHS:-$ct_nim_paths_lib}"
 	export CODETRACER_TRACE_FORMAT_NIM_EXTRA_PATHS="${CODETRACER_TRACE_FORMAT_NIM_EXTRA_PATHS:-$ct_nim_paths_lib}"
 fi
 

--- a/src/Tuprules.tup
+++ b/src/Tuprules.tup
@@ -462,6 +462,57 @@ export CODETRACER_TRACE_FORMAT_NIM_SKIP_NIMBLE_INSTALL
 export CT_EMULATOR_EXTRA_NIM_PATHS
 export CODETRACER_TRACE_FORMAT_NIM_EXTRA_PATHS
 
+# The io-mon family reaches `ct` through src/ct_test/incremental: the
+# `-d:ctTest` build compiles `io_mon_capture.nim`, which opens with
+#
+#   src/ct_test/incremental/io_mon_capture.nim:83  import io_mon/depfile
+#   src/ct_test/incremental/io_mon_capture.nim:91  import stackable_hooks/propagation
+#
+# NEITHER REPO IS ON `NIM_REPO_PATH_FLAGS` ABOVE, and neither is in
+# `repro.lock`, so `.github/actions/provision-repro-lock-siblings` does not
+# clone them either. The only thing that resolves them on a CI runner is the
+# env fallback in the repo-root `config.nims`:
+#
+#   config.nims:69  addPathIfDir(getEnv("IO_MON_SRC"))
+#   config.nims:79  addPathIfDir(getEnv("NIM_STACKABLE_HOOKS_SRC"))
+#
+# whose values `nix/shells/main.nix:259-264` exports from this repo's own
+# flake inputs. config.nims IS read under tup (it is an ancestor of every
+# project file), but tup sanitizes the environment down to THIS list, so
+# `getEnv` came back empty and the dev shell's export could not reach the
+# compiler. That is the exact shape of the RUNQUOTA_SRC problem documented at
+# the top of this file, and it is why `cross-process-linux` died ~2000 lines
+# into `just build-once` with
+#
+#   src/ct_test/incremental/io_mon_capture.nim(83, 14)
+#     Error: cannot open file: io_mon/depfile
+#
+# in every run it has ever had. Exporting the two variables lets the value the
+# shell already computed survive into the tup rules. An adjacent `../io-mon`
+# checkout still wins where one exists: config.nims lists the workspace
+# sibling AFTER the env var, and Nim resolves later `--path` entries first, so
+# `visual-replay-regression-gate` -- which DOES clone the io-mon family -- is
+# unaffected by this.
+#
+# WHY THE ENV VAR HERE AND A CHECKOUT FOR RUNQUOTA. The runquota entry above
+# argues, correctly, that accepting RUNQUOTA_SRC would let a lane green a
+# workspace check the tup driver cannot satisfy. That argument turns on there
+# being NO WELL-DEFINED PIN to fall back to -- runquota is not a flake input of
+# this repo, so the variable's value is whatever the caller's shell happened to
+# contain. io-mon and nim-stackable-hooks are the opposite case: both are
+# `flake.nix` inputs (flake.nix:257, flake.nix:261), so the value the dev shell
+# exports is a revision flake.lock pins, checked in next to this file.
+#
+# The checkout route is additionally NOT AVAILABLE for nim-stackable-hooks
+# today: flake.lock locks it at two different revisions under two nodes
+# (`nim-stackable-hooks` and `nim-stackable-hooks-src`), so a sibling entry
+# could only be `=dev` -- a branch tip -- and
+# ci/test/sibling-provisioning-test.sh's branch-tip ceiling is already at its
+# limit and may only shrink. Threading the flake input is the pin, not a
+# workaround for the absence of one.
+export IO_MON_SRC
+export NIM_STACKABLE_HOOKS_SRC
+
 # Keep linker selection in Cargo config/env instead of inline --config args.
 # This avoids shell-quoting differences between Windows environments.
 RUST_WINDOWS_LINKER_CONFIG =

--- a/src/tests/gui/lib/built-theme-css.cjs
+++ b/src/tests/gui/lib/built-theme-css.cjs
@@ -99,6 +99,93 @@ function candidateStyleDirs(repoRoot) {
   return dirs;
 }
 
+/**
+ * Nix sets EVERY file it puts in the store to mtime 1970-01-01T00:00:01Z, on
+ * purpose: a build output must not vary with when it was built. So for a
+ * `result/` artefact the file's own mtime is not "old", it is ABSENT, and
+ * comparing it to a source mtime is not a freshness test — it is a test that
+ * always says STALE.
+ *
+ * That is not a hypothetical. On `test-ui-tests (nixos)` the ct binary is
+ * `nix build .#codetracer` output, `CODETRACER_E2E_CT_PATH` points at
+ * `result/bin/ct`, and the last candidate below therefore resolves to
+ * `result/frontend/styles/…`. Run 34026517513, job 101563733984:
+ *
+ *     the built stylesheet `default_dark_theme_electron.css` is STALE — it is
+ *     older than src/frontend/styles/generated/index.styl
+ *       stylesheet: …/result/frontend/styles/default_dark_theme_electron.css
+ *                   (built 1980-01-01T00:00:01.000Z)
+ *       source:     …/src/frontend/styles/generated/index.styl
+ *                   (edited 2026-09-06T21:43:24.887Z)
+ *
+ * 23 failures, all of that shape, all unfixable by any rebuild. And because
+ * the "Run TypeScript Playwright UI tests (DB-based only)" step carries no
+ * `if:`, a red Stylesheet-guards step SKIPS it — so this one comparison cost
+ * the nixos leg the entire Playwright suite. Only the trailing Event Log step,
+ * which is `if: always()` and names a single file, ran at all: 2 tests.
+ */
+const TIMESTAMP_NORMALIZED_MS = 1000;
+
+/**
+ * When the artefact at `candidate` was actually produced, or null if that
+ * cannot be established.
+ *
+ * The ordinary answer is its own mtime. For a timestamp-normalized artefact
+ * the answer is the mtime of the SYMLINK THROUGH WHICH IT WAS REACHED --
+ * `nix build` rewrites `result` on every build, and that symlink lives on the
+ * ordinary filesystem and carries a real timestamp. That is the same question
+ * the mtime asked ("when was this built"), answered where the build system
+ * actually records it.
+ *
+ * The symlink must be one the artefact was reached THROUGH (its target is a
+ * prefix of the artefact's real path) and must not also contain the checkout:
+ * on macOS `/var -> /private/var` satisfies the first test for every path on
+ * the machine, and its mtime means nothing about any build.
+ */
+function artefactBuiltAt(candidate, repoRoot) {
+  const abs = path.resolve(candidate);
+  const direct = fs.statSync(abs).mtimeMs;
+  if (direct > TIMESTAMP_NORMALIZED_MS) {
+    return { mtimeMs: direct, evidence: null };
+  }
+
+  const real = fs.realpathSync(abs);
+  let repoRootReal;
+  try {
+    repoRootReal = fs.realpathSync(path.resolve(repoRoot));
+  } catch {
+    repoRootReal = path.resolve(repoRoot);
+  }
+
+  let dir = abs;
+  for (;;) {
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+
+    let link;
+    try {
+      link = fs.lstatSync(dir);
+    } catch {
+      return null;
+    }
+    if (!link.isSymbolicLink()) continue;
+
+    let target;
+    try {
+      target = fs.realpathSync(dir);
+    } catch {
+      continue;
+    }
+    // Reached through it?
+    if (real !== target && !real.startsWith(target + path.sep)) continue;
+    // A build-output symlink sits inside or at the tree, never above it.
+    if (repoRootReal === target || repoRootReal.startsWith(target + path.sep)) continue;
+
+    return { mtimeMs: link.mtimeMs, evidence: dir };
+  }
+}
+
 /** The newest mtime among the stylus sources, and which file carried it. */
 function newestStylSource(repoRoot) {
   const root = path.join(repoRoot, "src", "frontend", "styles");
@@ -143,15 +230,37 @@ function newestStylSource(repoRoot) {
 function resolveBuiltThemeCss(repoRoot, theme) {
   const tried = [];
   let best = null;
+  const undatable = [];
 
   for (const dir of candidateStyleDirs(repoRoot)) {
     const candidate = path.join(dir, theme);
     tried.push(candidate);
     if (!fs.existsSync(candidate)) continue;
-    const { mtimeMs } = fs.statSync(candidate);
-    if (best === null || mtimeMs > best.mtimeMs) {
-      best = { file: candidate, mtimeMs };
+    const builtAt = artefactBuiltAt(candidate, repoRoot);
+    if (builtAt === null) {
+      // Present, but there is no honest answer to "when was this built".
+      // Recorded rather than dropped: a candidate that silently vanishes here
+      // would surface as the misleading "not found" below.
+      undatable.push(candidate);
+      continue;
     }
+    if (best === null || builtAt.mtimeMs > best.mtimeMs) {
+      best = { file: candidate, mtimeMs: builtAt.mtimeMs, evidence: builtAt.evidence };
+    }
+  }
+
+  if (best === null && undatable.length > 0) {
+    throw new Error(
+      `built theme stylesheet \`${theme}\` cannot be dated, so its freshness ` +
+        `cannot be checked and this spec would measure an artefact of unknown ` +
+        `provenance.\n` +
+        `  found: ${undatable.join("\n         ")}\n` +
+        `Its mtime is the timestamp nix normalizes store files to ` +
+        `(1970-01-01T00:00:01Z), and it was not reached through a build-output ` +
+        `symlink whose own mtime could answer instead. Build with ` +
+        `\`nix build .#codetracer\` so \`result\` exists, or point ` +
+        `CODETRACER_BUILD_DIR at a tup/reprobuild output.`,
+    );
   }
 
   if (best === null) {
@@ -172,7 +281,8 @@ function resolveBuiltThemeCss(repoRoot, theme) {
         `measure the previous build and report green on a change that never ` +
         `reached a browser.\n` +
         `  stylesheet: ${best.file}\n` +
-        `              (built ${new Date(best.mtimeMs).toISOString()})\n` +
+        `              (built ${new Date(best.mtimeMs).toISOString()}` +
+        `${best.evidence ? `, dated from ${best.evidence}` : ""})\n` +
         `  source:     ${newestSource.file}\n` +
         `              (edited ${new Date(newestSource.mtimeMs).toISOString()})\n` +
         `Run \`just build-once\`.`,

--- a/src/tests/gui/lib/built-theme-css.cjs
+++ b/src/tests/gui/lib/built-theme-css.cjs
@@ -114,7 +114,7 @@ function candidateStyleDirs(repoRoot) {
  *     the built stylesheet `default_dark_theme_electron.css` is STALE — it is
  *     older than src/frontend/styles/generated/index.styl
  *       stylesheet: …/result/frontend/styles/default_dark_theme_electron.css
- *                   (built 1980-01-01T00:00:01.000Z)
+ *                   (built 1970-01-01T00:00:01.000Z)
  *       source:     …/src/frontend/styles/generated/index.styl
  *                   (edited 2026-09-06T21:43:24.887Z)
  *

--- a/src/tests/gui/lib/load-time-prerequisite.ts
+++ b/src/tests/gui/lib/load-time-prerequisite.ts
@@ -1,0 +1,82 @@
+/**
+ * Resolve a prerequisite AT MODULE LOAD without letting its failure
+ * delete the entire suite.
+ *
+ * WHAT THIS EXISTS TO STOP. Playwright collects a run by importing every
+ * spec file. If any one of those imports THROWS, the run is not "that
+ * file minus its tests" -- collection aborts and Playwright reports
+ *
+ *     Total: 0 tests in 0 files
+ *
+ * for the whole `testDir`. Five spec files resolved a heavy prerequisite
+ * at top level -- `resolveRealVisualTracePath()`, which requires a built
+ * `ct_gfx_player`, and `threeTraceRecordingRoot()`, which RECORDS the
+ * cross-process demo through the real recorders -- so on any leg where
+ * one of those was unavailable, all 152 spec files discovered zero tests
+ * and the job's Playwright step executed nothing. Measured on
+ * `origin/dev` 009ac5d9f: scoped to `tests/event-log` the suite lists 2
+ * tests; unscoped it lists 0.
+ *
+ * That failure mode is silent in exactly the wrong way: a step that
+ * exits non-zero having run nothing looks the same in a log as a step
+ * that ran the suite and hit one red. The CI comment on the macOS-only
+ * "Build ct_gfx_player" step already says these specs
+ * `requireExecutable(...)` "at module-load time" -- the coupling was
+ * known; what was not known is that the cost is the OTHER 147 files.
+ *
+ * WHAT THIS DOES NOT DO. It does not skip, soften or hide the failure.
+ * The original error is re-thrown from a `beforeAll` registered on the
+ * calling file's own `test` object, so every test in THAT file fails,
+ * loudly, with the original message and stack as `cause`. The only thing
+ * that changes is the blast radius: one unbuilt binary now costs the
+ * tests that need it, not the run.
+ *
+ * A file that wants to SKIP rather than fail when a fixture is
+ * unavailable already has a way to say so -- `threeTraceFixtureSkipReason()`
+ * in `beforeAll`, which three of these five files already call. That path
+ * was simply unreachable, because the throw happened first.
+ */
+
+/**
+ * The subset of Playwright's `test` object this needs. Passed in rather
+ * than imported so the helper cannot introduce an import cycle with
+ * `lib/fixtures.ts`, and so the hook is registered on the SAME extended
+ * `test` instance the calling file uses -- Playwright rejects hooks
+ * mixed across test instances.
+ */
+export interface HookRegistrar {
+  beforeAll(fn: () => void | Promise<void>): void;
+}
+
+/**
+ * @param test        the spec file's own `test` object (from `lib/fixtures`)
+ * @param description what is being resolved, for the deferred message
+ * @param resolve     the load-time resolution that may throw
+ * @param fallback    a value of the right shape for `test.use()` etc. to
+ *                    hold until the deferred `beforeAll` fails the file
+ */
+export function loadTimePrerequisite<T>(
+  test: HookRegistrar,
+  description: string,
+  resolve: () => T,
+  fallback: T,
+): T {
+  try {
+    return resolve();
+  } catch (ex) {
+    const original = ex instanceof Error ? ex : new Error(String(ex));
+    test.beforeAll(() => {
+      throw new Error(
+        `unavailable at load time: ${description}\n`
+          + `\n`
+          + `${original.message}\n`
+          + `\n`
+          + `This was raised while the spec file was being imported. It is `
+          + `re-thrown here so it fails the tests that need it instead of `
+          + `aborting Playwright's collection of every other spec file.`,
+        { cause: original },
+      );
+    });
+    return fallback;
+  }
+}

--- a/src/tests/gui/tests/docs/visual-recording-book-screenshots.spec.ts
+++ b/src/tests/gui/tests/docs/visual-recording-book-screenshots.spec.ts
@@ -3,9 +3,18 @@ import * as path from "node:path";
 
 import { test, expect } from "../../lib/fixtures";
 import { resolveRealVisualTracePath } from "../../lib/real-visual-trace";
+import { loadTimePrerequisite } from "../../lib/load-time-prerequisite";
 import type { Locator, Page } from "@playwright/test";
 
-const visualTracePath = resolveRealVisualTracePath();
+// Wrapped because those binary prerequisites are resolved AT IMPORT, and a
+// throw during import aborts Playwright's collection of the whole suite
+// rather than this file (see `lib/load-time-prerequisite.ts`).
+const visualTracePath = loadTimePrerequisite(
+  test,
+  "a recorded GL trace and the ct_gfx_player binaries behind it",
+  resolveRealVisualTracePath,
+  "",
+);
 const repoRoot = path.resolve(__dirname, "..", "..", "..", "..", "..");
 const outputDir = process.env.CODETRACER_BOOK_SCREENSHOT_DIR
   ?? path.join(repoRoot, "docs", "book", "src", "generated", "visual_recordings");

--- a/src/tests/gui/tests/frame-viewer/visual-replay-real-recording.spec.ts
+++ b/src/tests/gui/tests/frame-viewer/visual-replay-real-recording.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "../../lib/fixtures";
 import { resolveRealVisualTracePath } from "../../lib/real-visual-trace";
+import { loadTimePrerequisite } from "../../lib/load-time-prerequisite";
 
 /**
  * Real-recording end-to-end smoke test for the M3+ Video Player chrome.
@@ -33,7 +34,17 @@ import { resolveRealVisualTracePath } from "../../lib/real-visual-trace";
  * ``lib/real-visual-trace.ts``.
  */
 
-const visualTracePath = resolveRealVisualTracePath();
+// Wrapped because those binary prerequisites are resolved AT IMPORT, and a
+// throw during import aborts Playwright's collection of the whole suite
+// rather than this file (see `lib/load-time-prerequisite.ts`). `ct_gfx_player`
+// is built by a macOS-only CI step, so on the nixos leg this throw alone
+// discovered 0 tests in 0 files across all 152 spec files.
+const visualTracePath = loadTimePrerequisite(
+  test,
+  "a recorded GL trace and the ct_gfx_player binaries behind it",
+  resolveRealVisualTracePath,
+  "",
+);
 
 test.describe("MCR visual replay real recording GUI integration", () => {
   test.describe.configure({ mode: "serial" });

--- a/src/tests/gui/tests/value-origin/cross-tracer-process-tree.spec.ts
+++ b/src/tests/gui/tests/value-origin/cross-tracer-process-tree.spec.ts
@@ -38,10 +38,21 @@ import {
   threeTraceFixtureSkipReason,
   threeTraceRecordingRoot,
 } from "../../lib/value-origin-fixtures";
+import { loadTimePrerequisite } from "../../lib/load-time-prerequisite";
 
 // Produced from this tree rather than read from a committed copy — see
 // `scripts/materialize-recording.sh`.
-const recordingRoot = threeTraceRecordingRoot();
+//
+// Wrapped because this RECORDS, at import time, and a throw during import
+// aborts Playwright's collection of the whole suite rather than this file
+// (see `lib/load-time-prerequisite.ts`). A failure still fails every test
+// below, with the recorder's own diagnostic.
+const recordingRoot = loadTimePrerequisite(
+  test,
+  "the cross-process three-trace recording",
+  threeTraceRecordingRoot,
+  "",
+);
 
 test.use({ sourcePath: recordingRoot, launchMode: "trace-folder" });
 test.setTimeout(240_000);

--- a/src/tests/gui/tests/value-origin/cross-tracer-three-recording.spec.ts
+++ b/src/tests/gui/tests/value-origin/cross-tracer-three-recording.spec.ts
@@ -45,6 +45,7 @@ import {
   threeTraceRecordingRoot,
   threeTraceSourceRoot,
 } from "../../lib/value-origin-fixtures";
+import { loadTimePrerequisite } from "../../lib/load-time-prerequisite";
 
 /**
  * The recordings, produced from this tree when the spec loads. The
@@ -56,8 +57,18 @@ import {
  * here that the recordings are the current pipeline's: a committed copy
  * would let the whole chain keep rendering after the recorder that
  * produced it had been replaced.
+ *
+ * Wrapped because it records DURING IMPORT, and a throw during import
+ * aborts Playwright's collection of the whole suite rather than this file
+ * (see `lib/load-time-prerequisite.ts`). A failure still fails every test
+ * below, with the recorder's own diagnostic.
  */
-const recordingRoot = threeTraceRecordingRoot();
+const recordingRoot = loadTimePrerequisite(
+  test,
+  "the cross-process three-trace recording",
+  threeTraceRecordingRoot,
+  "",
+);
 
 /** The demo's sources, which stay in the repository. */
 const sourceRoot = threeTraceSourceRoot();

--- a/src/tests/gui/tests/value-origin/event-log-correlation-markers-three-trace.spec.ts
+++ b/src/tests/gui/tests/value-origin/event-log-correlation-markers-three-trace.spec.ts
@@ -31,6 +31,7 @@ import {
   threeTraceFixtureSkipReason,
   threeTraceRecordingRoot,
 } from "../../lib/value-origin-fixtures";
+import { loadTimePrerequisite } from "../../lib/load-time-prerequisite";
 
 // Shared with the sibling TCT-M5 spec rather than recomputed here. The
 // local `path.resolve(__dirname, "..", "..", "..", "..")` this replaces
@@ -43,7 +44,16 @@ import {
 // through the real recorders and returns the cache directory they landed
 // in, so the marker rows asserted below are the ones today's browser
 // recorder emits rather than the ones some earlier build emitted.
-const fixtureDir = threeTraceRecordingRoot();
+//
+// Wrapped because that call RECORDS at import time, and a throw during
+// import aborts Playwright's collection of the whole suite rather than
+// this file (see `lib/load-time-prerequisite.ts`).
+const fixtureDir = loadTimePrerequisite(
+  test,
+  "the cross-process three-trace recording",
+  threeTraceRecordingRoot,
+  "",
+);
 
 // The HTTP boundary token the fixture's `frontend/app.js` passes to
 // `__ct.markCorrelation` (`const BOUNDARY_HTTP = "account-balance";`),

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -1,11 +1,57 @@
 import type { StorybookConfig } from "@storybook/html-webpack5";
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { relative, resolve } from "node:path";
 
 const repoRoot = resolve(__dirname, "../..");
-const buildDir = existsSync(resolve(repoRoot, "src/build-debug-repro/frontend"))
-  ? "build-debug-repro"
-  : "build-debug";
+
+/**
+ * Where the built frontend + public trees live, in preference order.
+ *
+ * THE THIRD ENTRY IS WHY THIS IS A LIST. The two tup roots are what a
+ * developer machine and the macOS CI leg produce (`just build-once` ->
+ * `src/build-debug-repro`, plain tup -> `src/build-debug`). The NIXOS CI
+ * leg produces NEITHER: its "Build CodeTracer (nix)" step runs
+ * `nix build .#codetracer` and the artefacts land in `result/`, whose
+ * `installPhase` (nix/packages/default.nix) creates exactly the two
+ * directories wanted here -- `$out/frontend/styles` and `$out/public`.
+ *
+ * The previous form asked ONE question -- does `src/build-debug-repro/
+ * frontend` exist? -- and fell through to `src/build-debug` without
+ * checking it. `src/build-debug/` always exists, because `tup.config` is
+ * COMMITTED there, but on the nixos leg `src/build-debug/frontend` does
+ * not. Storybook treats a `staticDirs` entry pointing at a missing
+ * directory as fatal, so `just storybook-build` died, and because
+ * `just test-e2e` routes through `ensure-storybook-static` under `set -e`,
+ * `npx playwright test` was never reached at all. A missing static
+ * directory therefore cost the nixos leg the ENTIRE Playwright suite,
+ * not the four `*storybook*.spec.ts` files that need it.
+ */
+const BUILD_ROOTS = ["src/build-debug-repro", "src/build-debug", "result"];
+
+function resolveBuildRoot(): string {
+  for (const candidate of BUILD_ROOTS) {
+    const root = resolve(repoRoot, candidate);
+    // BOTH, because both are served below and either one missing is fatal
+    // to storybook. Checking only `frontend` is what let the fall-through
+    // above select a root that could not satisfy the second entry.
+    if (existsSync(resolve(root, "frontend")) && existsSync(resolve(root, "public"))) {
+      return root;
+    }
+  }
+  throw new Error(
+    `storybook: no built frontend found. Looked for a "frontend" and a `
+      + `"public" directory under, in order: `
+      + `${BUILD_ROOTS.map((c) => resolve(repoRoot, c)).join(", ")}.\n`
+      + `Build CodeTracer first -- "just build-once" (tup/reprobuild) or `
+      + `"nix build .#codetracer" (produces ./result).`,
+  );
+}
+
+const buildRoot = resolveBuildRoot();
+// `staticDirs` entries are resolved relative to this config file, so keep
+// them relative rather than absolute to stay consistent with the two
+// entries above them.
+const buildRootRelative = relative(__dirname, buildRoot);
 
 const config: StorybookConfig = {
   stories: ["../stories/**/*.stories.@(js|ts)"],
@@ -17,8 +63,8 @@ const config: StorybookConfig = {
   staticDirs: [
     { from: "../dist", to: "/dist" },
     { from: "../../src/frontend/index.html", to: "/codetracer-app-index.html" },
-    { from: `../../src/${buildDir}/frontend`, to: "/frontend" },
-    { from: `../../src/${buildDir}/public`, to: "/public" },
+    { from: `${buildRootRelative}/frontend`, to: "/frontend" },
+    { from: `${buildRootRelative}/public`, to: "/public" },
   ],
 };
 


### PR DESCRIPTION
## What this fixes

Run [34159391653](https://github.com/metacraft-labs/codetracer/actions/runs/34159391653) (`ci/green-sweep-diag`) lost **13 successes** and gained **15 skipped** against run [34154799274](https://github.com/metacraft-labs/codetracer/actions/runs/34154799274) (`ci/green-sweep`). The whole delta traces to one assertion.

`lint-bash` went green → red on `ci/test/sibling-input-branch-test.sh`:

```
FAIL  codetracer-native-recorder: the workflow pins a different commit than flake.lock locks
      the workflow says 'b5b8de6eb505dccc42394728b4705c45e0f064ed
dev', flake.lock locks '7e0400b364196ec731967a4dd4a3e931c73732f3' (flake.nix tracks 'dev')
```

`nix-build`, `dev-build`, `dmg-build`, `dmg-lib-check`, `appimage-build`, `appimage-lib-check`, the five `appimage-cross-distro` legs, `push-tag` and `create-release` all reach `lint-bash` through `needs:`. One red assertion took **12 jobs that were green the run before** to `skipped`; `lint-bash` itself is the 13th lost success.

## Why this spelling

The gate accepts a 40-hex pin for a branch-tracking flake input **only when it equals the rev `flake.lock` locks** — deliberately, so that "pin it to a commit" cannot become a way to opt out of the contract. `b5b8de6e` was `dev`'s tip, not the locked rev.

Two properties of the gate were measured, not assumed, by re-running the suite over each candidate spelling:

| spelling | branch-tip ceiling | sibling-input-branch |
|---|---|---|
| `=b5b8de6e` (as-is) | 56 ≤ 56 ok | **FAIL** |
| `=7e0400b3` on the 2 new entries only | 56 ≤ 56 ok | **FAIL** — set is `{7e0400b3, dev}` |
| bare (previous run's spelling) | 56 ≤ 56 ok | PASS |
| `=dev` | **FAIL 58 > 56** | PASS |
| **`=7e0400b3` on all 9 entries** | **49 ≤ 56 ok** | **PASS** |

The gate compares the *set* of spellings the workflow gives a repo, so a lone `=dev` anywhere re-breaks it. Reverting to bare also passes, but bare is what killed `test-non-gui` at `Setup dev env` on `No workspace lock for codetracer` — it trades 12 skipped jobs for two lanes that die at step 14 of 19.

`7e0400b3` is corroborated rather than merely consistent: it is what `nix build '.?submodules=1#codetracer'` already builds green on this commit. Bumping `flake.lock` to `dev`'s tip instead would risk the currently-green Nix lane to serve lanes that are already red — its own change, with its own validation.

## Kept, because they are real progress

- `test-non-gui (nixos)`: step 14/19 → reaches `Run tests`
- `test-ui-tests-rr`: aborted before any compilation → full tup build, later recipe
- `cross-process value-origin`: stale syntactic false positive removed; lane now reports its real missing-prerequisite blocker

## Verified locally

Against GNU awk and bash 5 — macOS `awk` mis-parses the extractor's regex and silently matches nothing, so the control run on the unmodified tree was used to confirm the harness reproduces CI's `10 passed, 1 failed` exactly.

```
sibling-input-branch-test.sh   10 passed, 1 failed  ->  11 passed, 0 failed
sibling-provisioning-test.sh   all 28 assertions passed, ceiling 49 <= 56
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)