### PR TITLE
editorconfig: declare the shell tab convention that shfmt was enforcing by accident

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,3 +20,47 @@ max_line_length = off
 [{Makefile,go.mod,go.sum,*.go,.gitmodules}]
 indent_style = tab
 indent_size = 4
+
+# SHELL SCRIPTS ARE TAB-INDENTED, AND THIS STANZA IS WHAT SAYS SO.
+#
+# 305 of the 366 tracked *.sh files (excluding the libs/ submodules) are
+# tab-indented. Until this stanza existed, nothing in the repository declared
+# that: the `[*]` block above says `space`/2, and the files disagreed with it.
+#
+# They got away with it by accident. The shfmt pre-commit hook runs
+# `shfmt -w -l -ln auto -s`, and shfmt only consults .editorconfig when it is
+# given NO formatting flags -- `-ln` and `-s` each suppress it on their own
+# (verified against shfmt 3.12.0, the version pinned by the hook). So shfmt has
+# been formatting at its built-in default, `-i 0`, which means tabs. The tab
+# convention held because .editorconfig was never read, not because anyone
+# agreed with it.
+#
+# That is one flag away from a 306-file whitespace commit. Drop `-s`, or drop
+# `-ln auto`, or take an upstream git-hooks.nix bump that rewrites the entry,
+# and shfmt starts honouring `[*]` = space/2 and rewrites 306 files at once.
+# With this stanza the same change is a no-op: .editorconfig now says what
+# shfmt was already doing, so it no longer matters whether shfmt reads it.
+[*.sh]
+indent_style = tab
+
+# ...EXCEPT THESE TWO, WHERE SPACE INDENTATION IS A CONTRACT AND NOT A STYLE.
+#
+# Both are excluded from the formatting hooks in nix/pre-commit.nix -- see the
+# `excludes` list there for the full reasoning -- because each is compared
+# byte-for-byte against a copy that lives somewhere a formatter cannot reach:
+#
+#   ci/runner/sweep-readonly-leftovers.sh  its inline body is pasted verbatim
+#                                          into seven `run:` blocks in
+#                                          .github/workflows/codetracer.yml, and
+#                                          YAML block scalars cannot be indented
+#                                          with tabs at all
+#   tools/check-test-assertions.sh         a byte-for-byte vendored copy of the
+#                                          editable original in codetracer-specs
+#
+# Both are 100% space-indented today (0 tab-indented lines in either). The hook
+# exclusions are what protect them from shfmt; this stanza is what protects them
+# from every OTHER tool that reads .editorconfig -- editors, and any future
+# formatter -- now that `[*.sh]` above would otherwise tell those tools to tab.
+[{ci/runner/sweep-readonly-leftovers.sh,tools/check-test-assertions.sh}]
+indent_style = space
+indent_size = 2

--- a/nix/pre-commit.nix
+++ b/nix/pre-commit.nix
@@ -50,21 +50,36 @@ in
     # to the canonical body with exact string equality (`found[name] != body`),
     # so every byte of leading whitespace is contractual.
     #
-    # WHY IT IS SAFE TODAY, AND WHY THAT IS NOT GOOD ENOUGH. The body is
-    # SPACE-indented at 2. shfmt reads .editorconfig, whose `[*]` stanza says
-    # `indent_style = space` / `indent_size = 2`, so shfmt currently rewrites
-    # NOTHING here (`shfmt -l` does not list it). The file is therefore
-    # protected only by a repo-wide style knob that says nothing about this
-    # file's actual contract.
+    # WHY IT IS SAFE TODAY. This exclusion, and only this exclusion.
     #
-    # That protection is one edit away from gone, and the edit is a reasonable
-    # one: 306 of the 366 tracked *.sh files are tab-indented and do NOT match
-    # that `[*]` stanza (shfmt would rewrite them), so aligning .editorconfig
-    # with reality by adding `[*.sh] indent_style = tab` is a cleanup somebody
-    # will eventually make. The moment it lands, shfmt retabs 78 lines of this
-    # file and breaks the equality against all seven copies at once -- and the
-    # breakage would read as a test bug rather than a formatter bug. Dropping
-    # .editorconfig from shfmt's scope does the same thing.
+    # An earlier note here said the file was safe because "shfmt reads
+    # .editorconfig, whose `[*]` stanza says space/2, so shfmt currently
+    # rewrites NOTHING here (`shfmt -l` does not list it)". That is wrong in a
+    # way worth spelling out, because the mistake is easy to repeat: `shfmt -l`
+    # DOES leave this file alone, but the hook does not run `shfmt -l`. It runs
+    # `shfmt -w -l -ln auto -s`, and shfmt consults .editorconfig only when it
+    # is given NO formatting flags -- `-ln` and `-s` each suppress it on their
+    # own. So the hook formats at shfmt's built-in default of `-i 0`, i.e.
+    # TABS, and `shfmt -l -ln auto -s` on this file lists it and wants to
+    # rewrite 84 lines. Reproduce with shfmt 3.12.0, the pinned version:
+    #
+    #     shfmt -l ci/runner/sweep-readonly-leftovers.sh                 # quiet
+    #     shfmt -l -ln auto -s ci/runner/sweep-readonly-leftovers.sh     # lists it
+    #
+    # The consequence is the opposite of what that note predicted. Adding
+    # `[*.sh] indent_style = tab` to .editorconfig is NOT the edit that breaks
+    # the seven copies -- it is a no-op for this hook, which never reads the
+    # file. (It has since been added, for the separate reason documented
+    # there.) The edit that breaks them is deleting the exclusion below.
+    #
+    # The repo-wide hazard runs the other way. Because .editorconfig is
+    # suppressed, its `[*]` = space/2 has never applied to shell scripts, and
+    # 305 of 366 tracked *.sh files are tab-indented in disagreement with it.
+    # Anything that makes shfmt start reading .editorconfig -- dropping `-s`,
+    # dropping `-ln auto`, or an upstream git-hooks.nix bump that rewrites this
+    # entry -- would have reformatted 306 files in one commit. The `[*.sh]`
+    # stanza in .editorconfig now pins the tab default explicitly, which takes
+    # that from 306 files to none.
     #
     # Nor could that be "resolved" by tabbing both sides: YAML block scalars
     # cannot use tabs for indentation at all. Do not fix a future breakage here
@@ -109,7 +124,43 @@ in
       pass_filenames = false;
     };
 
-    # Shell hooks
+    # Shell hooks.
+    #
+    # THESE TWO DISAGREE WITH EACH OTHER ON REAL FILES, AND ONLY ONE OF THEM
+    # RUNS IN CI. shellcheck is enforced by ci/lint/bash.sh (`shellcheck
+    # ci/**/*.sh` and the per-directory steps below it). shfmt is NOT invoked
+    # anywhere in ci/ or .github/ -- pre-commit is its only enforcement, and
+    # pre-commit only ever sees the files a commit touches. So an unformatted
+    # script can sit on dev indefinitely: as of 37fe0a75, 34 of the 366 tracked
+    # *.sh files are listed by `shfmt -l -ln auto -s`.
+    #
+    # That matters because of how the two tools interact. `-s` rewrites an
+    # escaped double-quoted string into a single-quoted one:
+    #
+    #     echo "a \`b\` c"   ->   echo 'a `b` c'
+    #
+    # and if the string also contains a `$`, shellcheck then reports SC2016
+    # ("expressions don't expand in single quotes"). shellcheck exits 1 on a
+    # note, so CI fails. Of the 34 files above, 9 are clean under shellcheck
+    # today and acquire SC2016 the moment shfmt formats them:
+    #
+    #     ci/test/backend-manager-check-phase-test.sh    ci/test/web-bundle-assets.sh
+    #     ci/test/grep-q-pipefail-gate.sh                ci/verdict/workspace-lock-freshness-test.sh
+    #     ci/test/shell-gate-coverage.sh                 scripts/build-desktop-component.sh
+    #     ci/test/shell-gate-coverage-test.sh            scripts/require-runtime-assets.sh
+    #     scripts/test-python-version-alignment.sh
+    #
+    # Each is a trap for whoever next edits one: pre-commit's `shfmt -w`
+    # reformats the file they touched, and CI then fails on an SC2016 they did
+    # not write, in a line they did not change. The fix is per-file and is
+    # already the established pattern here -- accept shfmt's form and add an
+    # explicit `# shellcheck disable=SC2016` with a sentence saying why, as
+    # ci/test/nimsuggest-check.sh, ci/test/windows-install-root-test.sh,
+    # ci/test/stale-artefact-guards-test.sh and ci/test/vm-js-lane-test.sh all
+    # do. Do NOT resolve it by widening an exclusion or lowering shellcheck's
+    # severity; the nine are listed here so the work can be done file by file,
+    # in the change that touches each file anyway, rather than as one
+    # unreviewable whitespace commit.
     shellcheck.enable = true;
     shfmt.enable = true;
 


### PR DESCRIPTION
## What this is

A formatting hazard was filed as *"shfmt would retab a file whose byte-identity with seven workflow copies is asserted."* An earlier pass found it did not reproduce and recorded the reasoning in `nix/pre-commit.nix`. **That recorded reasoning is wrong**, and the real hazard is a different, larger one.

## The mechanism

The shfmt pre-commit hook runs `shfmt -w -l -ln auto -s`. shfmt consults `.editorconfig` **only when given no formatting flags** — `-ln` and `-s` each suppress it on their own. Verified against shfmt 3.12.0, the pinned version:

```
shfmt -d tabbed.sh              # honours .editorconfig -> converts tab to 2 spaces
shfmt -d -ln auto tabbed.sh     # quiet
shfmt -d -s tabbed.sh           # quiet
```

So `.editorconfig`'s `[*]` = space/2 has **never** applied to shell scripts. shfmt has been formatting at its built-in default `-i 0`, i.e. tabs.

## The numbers (366 tracked `*.sh`, excluding `libs/` submodules)

| | |
|---|---|
| tab-indented | 305 |
| space-indented | 58 |
| listed by `shfmt -l` if `.editorconfig` were honoured — **before** | **306** |
| listed by `shfmt -l` if `.editorconfig` were honoured — **after this PR** | **26** |
| listed by the hook's real flags `shfmt -l -ln auto -s`, before and after | **36 (unchanged)** |

The 26 remaining are already in today's dirty set, so this PR **reformats nothing**. It converts a 306-file latent whitespace commit into a no-op.

## What changed

**`.editorconfig`** — `[*.sh] indent_style = tab` declares what shfmt was already doing, so it no longer matters whether shfmt reads the file. Plus an explicit space/2 pin for the two files whose byte-identity is contractual (`ci/runner/sweep-readonly-leftovers.sh`, `tools/check-test-assertions.sh`), both 100% space-indented today — the hook exclusions protect them from shfmt, the pin protects them from editors and any future tool now that `[*.sh]` would otherwise say tab.

**`nix/pre-commit.nix`** — comment-only. Corrects the note that had the causation backwards, and records the live conflict below.

## Corrections to the original framing

- The sweep file is protected **by its hook exclusion**, not by `.editorconfig`. The old note's test (`shfmt -l`) was not the command the hook runs.
- Adding `[*.sh] indent_style = tab` was predicted to retab that file and break all seven copies. It is a **no-op** there — the hook never reads `.editorconfig`.
- The byte-identity gate **does** already name which copy diverged (`f"{name}: the pasted body has DIVERGED from {canon}"`) and prints population counts. No fix needed.

## Live conflict, recorded but deliberately not fixed here

shfmt is **not invoked anywhere** in `ci/` or `.github/` — pre-commit is its only enforcement, and pre-commit only sees files a commit touches. Hence 34 unformatted `*.sh` on dev.

Nine are shellcheck-clean today and acquire **SC2016** the moment shfmt's `-s` rewrites `"a \`b\` c"` into `'a \`b\` c'`. CI's shellcheck exits 1 on a note, so each is a trap: pre-commit reformats the file you touched, CI then fails on a finding you did not write.

```
ci/test/backend-manager-check-phase-test.sh    ci/test/web-bundle-assets.sh
ci/test/grep-q-pipefail-gate.sh                ci/verdict/workspace-lock-freshness-test.sh
ci/test/shell-gate-coverage.sh                 scripts/build-desktop-component.sh
ci/test/shell-gate-coverage-test.sh            scripts/require-runtime-assets.sh
scripts/test-python-version-alignment.sh
```

Listed by name in `nix/pre-commit.nix` to be fixed file by file with an explicit `# shellcheck disable=SC2016` and a stated reason — the pattern four other scripts already use — rather than as one unreviewable commit that would collide with the branches currently in flight.

## Verification executed

- shfmt 3.12.0 flag-suppression behaviour, and all counts above, measured on `origin/dev` @ `37fe0a75`
- `ci/test/readonly-leftovers-sweep-test.sh` — **PASSED 20/20**, with the drift check running against a real population (7 jobs expected, 7 carrying the step, 0 diverged)
- Real pre-commit hooks via the dev shell's config: nixfmt-rfc-style, end-of-file-fixer, trim-trailing-whitespace, check-added-large-files, check-merge-conflict all **Passed**; no `--no-verify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)