### PR TITLE
fix(ct-test): read a Nim import clause as a statement, not as one line

### DIFF
--- a/.agents/codebase-insights.txt
+++ b/.agents/codebase-insights.txt
@@ -760,6 +760,39 @@ and a correlation marker's counterpart is by definition in another process.
   — which is COMPILABLE, so `nim c -r` on it is an independent ground truth for
   what discovery must report (1 suite + 5 cases).
 
+- 2026-09-08 (ct-test Nim framework detection: a statement is not a line): the
+  framework scan in `frameworks/nim_unittest.nim` read ONE PHYSICAL LINE and
+  called it the `import` statement. A bracketed clause continued on the next
+  line —
+      import std/[os, strutils,
+                  unittest]
+  — therefore never showed `unittest`. That is not a small mis-read: a file
+  whose framework is not detected is never scanned for declarations at all, so
+  it left the catalog whole. Measured on the reprobuild workspace: 46 sources
+  and 200 cases were absent for this reason alone (1,394 -> 1,440 addressable
+  sources, 8,028 -> 8,228 cases), with no file's count moving and no identity
+  changing.
+  The clause extent is now decided by the token stream (`importClauseEnd`): the
+  statement continues while a bracket is open or the line ended on `,`/`/`/`.`,
+  and ends at a line break or a `;`. That also picks up `import` inside a
+  `when …:` branch and two clauses separated by `;`, and makes an `import`
+  written inside a string literal a non-event. STILL NOT COVERED: `include`
+  (the included file's imports are not followed) and `import unittest as u` /
+  `except`, both by design.
+  MIRROR DEFECT, also fixed — and the reason this sat unnoticed: the negative
+  diagnostic was the bare sentence `no Nim unittest imports detected in file`,
+  emitted identically for a file with no test import and for a file whose
+  import the scan failed to read. 206 rows in one workspace report, 46 of them
+  false, indistinguishable. A conclusion with no evidence attached cannot be
+  audited: `noFrameworkMessage` now names the modules the scan actually read,
+  and names any `include` whose imports it did not follow.
+  Regression guards: the `ct-test Nim import clause scanning` and `ct-test Nim
+  unittest detection diagnostics` suites in `nim_unittest_provider_test.nim`
+  (each continuation form paired with a shape that must NOT be swallowed, so
+  neither "join everything" nor "join nothing" passes), plus the fixture
+  `fixtures/nim_unittest_project/tests/test_lexical_edge_cases.nim`, whose
+  import now deliberately spans two lines.
+
 - 2026-08-13 (ct-test silent output truncation): `execCaptured` bounds captured
   child output at `DefaultCaptureLimit` (16 MiB) and used to drop the fact that
   it had cut anything. `CapturedRun` now carries `outputBytes` (the true

--- a/src/ct_test/fixtures/nim_unittest_project/tests/test_lexical_edge_cases.nim
+++ b/src/ct_test/fixtures/nim_unittest_project/tests/test_lexical_edge_cases.nim
@@ -6,8 +6,17 @@
 ## character-literal opener desyncs on numeric type suffixes such as
 ## ``10485760'i64`` and then silently drops every declaration up to the next
 ## apostrophe — the failure this fixture pins.
+##
+## The import below spans two lines ON PURPOSE, and that is a second pin: a
+## framework scan that reads one physical line and calls it the ``import``
+## statement never sees ``unittest`` here, detects no framework, and so never
+## looks at this file for declarations at all — the whole fixture would
+## silently leave the catalog while every assertion about its *contents* kept
+## passing vacuously. Because this file is compilable, ``nim c -r`` on it is
+## the independent ground truth for what discovery must report.
 
-import std/[strutils, unittest]
+import std/[strutils,
+            unittest]
 
 type MyMeters = distinct int
 

--- a/src/ct_test/frameworks/nim_unittest.nim
+++ b/src/ct_test/frameworks/nim_unittest.nim
@@ -119,40 +119,162 @@ proc splitTopLevelImports(raw: string): seq[string] =
       discard
   result.add raw[start .. ^1].strip
 
-proc detectFrameworksInTokens*(content: string;
-    tokens: seq[NimToken]): seq[NimUnitFramework] =
-  ## Which unittest flavours does this source import?
+proc continuesClause(token: NimToken): bool =
+  ## May an import clause carry on past a line break that follows ``token``?
   ##
-  ## The scan is line-oriented (an ``import`` clause is a statement, and the
-  ## overwhelmingly common form is a single line), but it runs over
-  ## ``maskNimNonCode`` rather than the raw text.  That is what keeps a ``#``
-  ## or a quote inside a literal from being read as code — the hand-rolled
-  ## per-line comment stripper this replaced shared the apostrophe bug that
-  ## used to break declaration scanning, and duplicated its logic besides.
+  ## Nim's line-continuation rule for these statements in practice: the clause
+  ## goes on when the line ended on the separator between modules or on one of
+  ## the operators that cannot end a module name.  See the grammar's
+  ## ``importStmt``/``includeStmt`` productions in
+  ## https://nim-lang.org/docs/manual.html#modules — an open bracket also
+  ## continues the clause, and that case is handled by the bracket depth in
+  ## ``importClauseEnd`` rather than here.
+  token.kind == ntkPunct and token.ch in {',', '/', '.'}
+
+proc importClauseEnd(tokens: seq[NimToken]; start: int): int =
+  ## Index one past the last token of the import clause whose module list
+  ## begins at ``start``.
+  ##
+  ## THE STATEMENT, NOT THE LINE, IS THE UNIT.  An ``import`` clause routinely
+  ## spans two lines — ``import std/[os, strutils,`` / ``            unittest]``
+  ## is the house style once the list outgrows a line — and a scan that reads
+  ## one physical line and calls it the statement simply does not see the
+  ## continuation.  When the module it cannot see is ``unittest``, the file is
+  ## not merely mis-imported: no framework is detected, so the file is never
+  ## scanned for declarations at all and drops out of the catalog entirely.
+  ##
+  ## So the clause ends at the first line break that is not held open by an
+  ## unclosed bracket and not invited by a trailing separator, or at a ``;``
+  ## statement separator, whichever comes first.
+  var
+    index = start
+    depth = 0
+    previous = -1
+  while index < tokens.len:
+    let token = tokens[index]
+    # Comments carry no syntax: they may sit anywhere inside the clause
+    # (``import std/[os, # why not\n  unittest]``) without ending or
+    # continuing it, so they are neither a break candidate nor a `previous`.
+    if token.kind == ntkComment:
+      inc index
+      continue
+    if previous >= 0 and token.line > tokens[previous].endLine and
+        depth == 0 and not tokens[previous].continuesClause:
+      break
+    if token.kind == ntkPunct:
+      case token.ch
+      of '[', '(', '{':
+        inc depth
+      of ']', ')', '}':
+        if depth > 0:
+          dec depth
+      of ';':
+        # ``import os; import unittest`` — two statements on one line.
+        if depth == 0:
+          break
+      else:
+        discard
+    previous = index
+    inc index
+  max(start, previous + 1)
+
+type
+  NimImportClause* = object
+    ## One ``import`` / ``from … import`` / ``include`` statement, as read by
+    ## ``scanNimImportClauses``.
+    keyword*: string            ## "import", "from" or "include"
+    modules*: seq[string]       ## module names, ``std/[a, b]`` already expanded
+    line*: int                  ## 1-based line the keyword sits on
+
+proc scanNimImportClauses*(content: string;
+    tokens: seq[NimToken]): seq[NimImportClause] =
+  ## Every module this source names in an import-like statement.
+  ##
+  ## Driven by the token stream rather than by lines, which is what makes the
+  ## scan see a clause that spans lines (``importClauseEnd``), an ``import``
+  ## that is not the first thing on its line (``when defined(x): import …``),
+  ## and two clauses separated by ``;``.  It equally makes an ``import`` that
+  ## is only *mentioned* — in a comment, or inside a string literal holding
+  ## sample source — a non-event, because those are tokens of their own kind.
+  ##
+  ## The module list itself is still read out of the source text, over
+  ## ``maskNimNonCode`` so that a comment inside the clause contributes
+  ## nothing; the clause's extent is what the tokens decide.
   ##
   ## Takes the token stream rather than scanning for itself so a caller that
   ## also needs the declarations pays for exactly one scan of the file.
-  var seen = initTable[NimUnitFramework, bool]()
-  for rawLine in maskNimNonCode(content, tokens).splitLines:
-    let line = rawLine.strip
-    if line.len == 0:
+  let masked = maskNimNonCode(content, tokens)
+  var index = 0
+  while index < tokens.len:
+    let token = tokens[index]
+    if token.kind != ntkIdent:
+      inc index
       continue
-    if line.startsWith("import "):
-      for part in splitTopLevelImports(line["import ".len .. ^1]):
-        for candidate in importCandidates(part):
-          let maybeFramework = frameworkForImport(candidate)
-          if maybeFramework.isSome:
-            seen[maybeFramework.get] = true
-    elif line.startsWith("from "):
-      let tail = line["from ".len .. ^1]
-      let moduleName = tail.split("import", maxsplit = 1)[0]
-      let maybeFramework = frameworkForImport(moduleName)
+    let keyword =
+      if content.identIs(token, "import"): "import"
+      elif content.identIs(token, "from"): "from"
+      elif content.identIs(token, "include"): "include"
+      else: ""
+    if keyword.len == 0:
+      inc index
+      continue
+    # ``import`` is a keyword, so an identifier spelled that way can only be a
+    # backtick-quoted one (a field or routine deliberately named after the
+    # keyword). That is not a statement, and reading a module list out of what
+    # follows it would be reading someone else's expression.
+    if index > 0 and tokens[index - 1].kind == ntkPunct and
+        tokens[index - 1].ch == '`':
+      inc index
+      continue
+
+    let stop = importClauseEnd(tokens, index + 1)
+    if stop <= index + 1:
+      inc index
+      continue
+    let
+      clauseStart = min(token.endOffset, masked.len)
+      clauseEnd = min(tokens[stop - 1].endOffset, masked.len)
+    var clause = NimImportClause(keyword: keyword, line: token.line)
+    if clauseStart < clauseEnd:
+      let text = masked[clauseStart ..< clauseEnd]
+      if keyword == "from":
+        # ``from <module> import <symbols>``: only the module is a dependency
+        # of this file on another module; the symbol list names its contents.
+        clause.modules.add text.split("import", maxsplit = 1)[0].strip
+      else:
+        for part in splitTopLevelImports(text):
+          for candidate in importCandidates(part):
+            clause.modules.add candidate
+    result.add clause
+    index = stop
+
+proc detectFrameworksInClauses*(clauses: seq[NimImportClause]):
+    seq[NimUnitFramework] =
+  ## Which unittest flavours do these clauses import?
+  ##
+  ## ``include`` is deliberately not a detection: the included file's own
+  ## imports are what would matter, and resolving an include path is a
+  ## different (and much larger) job than reading one file's text.  A file that
+  ## reaches ``unittest`` only through an ``include`` is therefore still
+  ## undetected — but ``nimUnittestFileCatalog`` reports the include in the
+  ## diagnostic, so the conclusion carries the evidence it was drawn from.
+  var seen = initTable[NimUnitFramework, bool]()
+  for clause in clauses:
+    if clause.keyword == "include":
+      continue
+    for module in clause.modules:
+      let maybeFramework = frameworkForImport(module)
       if maybeFramework.isSome:
         seen[maybeFramework.get] = true
 
   for framework in NimUnitFramework:
     if seen.getOrDefault(framework, false):
       result.add framework
+
+proc detectFrameworksInTokens*(content: string;
+    tokens: seq[NimToken]): seq[NimUnitFramework] =
+  ## Which unittest flavours does this source import?
+  detectFrameworksInClauses(scanNimImportClauses(content, tokens))
 
 proc detectFrameworksInContent*(content: string): seq[NimUnitFramework] =
   ## Convenience wrapper for callers that only need the framework answer
@@ -374,6 +496,56 @@ proc unsupportedDiagnostics(filePath: string; frameworks: seq[NimUnitFramework])
         "Nim " & framework.frameworkName & " discovery is detected but not implemented in M2; only std/unittest is parsed",
         filePath)
 
+const MaxReportedModules = 12
+  ## How many module names the "no unittest import" diagnostic spells out
+  ## before summarising the rest. Enough to recognise a file at a glance
+  ## without turning one info line into a screenful.
+
+proc noFrameworkMessage*(clauses: seq[NimImportClause]): string =
+  ## The message for "this file imports no unittest flavour I know".
+  ##
+  ## It states what the scan READ, not just what it concluded, and that is the
+  ## whole point.  The bare conclusion — "no Nim unittest imports detected in
+  ## file" — is emitted identically whether the file genuinely imports no test
+  ## framework or whether the scan failed to read the import that is right
+  ## there in the source.  Those two are opposite facts, and a diagnostic that
+  ## renders them the same way is why a scan defect that dropped whole files
+  ## out of the catalog could sit in a workspace report, dozens of rows deep,
+  ## looking exactly like the rows that were correct.
+  ##
+  ## With the module list attached, the reader can check the claim against the
+  ## file: an import the scan missed is an import missing from this list.
+  var
+    imported: seq[string] = @[]
+    included: seq[string] = @[]
+  for clause in clauses:
+    for module in clause.modules:
+      if module.len == 0:
+        continue
+      if clause.keyword == "include":
+        included.add module
+      else:
+        imported.add module
+
+  proc summarise(modules: seq[string]): string =
+    if modules.len <= MaxReportedModules:
+      modules.join(", ")
+    else:
+      modules[0 ..< MaxReportedModules].join(", ") &
+        " and " & $(modules.len - MaxReportedModules) & " more"
+
+  if imported.len == 0:
+    result = "no imports were read from this file at all, so no Nim unittest " &
+      "framework could be detected"
+  else:
+    result = "no Nim unittest imports detected in file; the " & $imported.len &
+      " module(s) it imports are " & summarise(imported)
+  if included.len > 0:
+    # The one blind spot left once the clause scan is statement-oriented:
+    # whatever the included file imports is invisible from here.
+    result.add ". It also has " & $included.len & " `include` clause(s) (" &
+      summarise(included) & ") whose own imports this scan does not follow"
+
 proc nimUnittestFileCatalog*(projectRoot, filePath: string): ProviderResult[TestCatalog] =
   let info = providerInfo()
   if not filePath.endsWith(".nim"):
@@ -386,7 +558,10 @@ proc nimUnittestFileCatalog*(projectRoot, filePath: string): ProviderResult[Test
   # every candidate file in a workspace, and a second scan per file is a
   # second pass over every byte of the project's source for no new information.
   let tokens = scanNimSource(content)
-  let frameworks = detectFrameworksInTokens(content, tokens)
+  # Read the import clauses once: the framework answer and the diagnostic that
+  # explains a negative answer are two readings of the same evidence.
+  let clauses = scanNimImportClauses(content, tokens)
+  let frameworks = detectFrameworksInClauses(clauses)
   var catalogDiagnostics = unsupportedDiagnostics(filePath, frameworks)
   var items: seq[TestItem] = @[]
 
@@ -406,7 +581,7 @@ proc nimUnittestFileCatalog*(projectRoot, filePath: string): ProviderResult[Test
   elif frameworks.len == 0:
     catalogDiagnostics.add diagnostic(
       dsInfo,
-      "no Nim unittest imports detected in file",
+      noFrameworkMessage(clauses),
       filePath)
 
   ProviderResult[TestCatalog](

--- a/src/ct_test/nim_unittest_provider_test.nim
+++ b/src/ct_test/nim_unittest_provider_test.nim
@@ -3,6 +3,7 @@ import std/[json, os, osproc, sequtils, strutils, unittest]
 import ct_test
 import contracts
 import discovery
+import nim_lexer
 import frameworks/nim_unittest
 
 proc fixtureRoot(): string =
@@ -342,6 +343,156 @@ suite "ct-test Nim unittest lexical regressions":
     check detectFrameworksInContent("import std/unittest\n").len == 1
     # A single-line literal is preserved: `import "module"` is legal Nim.
     check detectFrameworksInContent("import \"std/unittest\"\n").len == 1
+
+# ---------------------------------------------------------------------------
+# Import clauses are STATEMENTS, not lines.
+#
+# The defect these pin: the framework scan read one physical line and called it
+# the import statement, so the house-style bracketed clause
+#
+#     import std/[os, strutils,
+#                 unittest]
+#
+# never showed `unittest` — and a file whose framework is not detected is never
+# scanned for declarations at all, so it left the catalog entirely. Every case
+# below therefore comes in a matched pair: a continuation form that MUST be
+# read, and a shape that MUST NOT be swallowed by reading past the end of the
+# statement. A scan that joins everything passes the first half and fails the
+# second; a scan that joins nothing does the reverse.
+# ---------------------------------------------------------------------------
+
+proc clausesOf(source: string): seq[NimImportClause] =
+  scanNimImportClauses(source, scanNimSource(source))
+
+suite "ct-test Nim import clause scanning":
+  test "a bracketed import continued on the next line is read whole":
+    const source = "import std/[os, strutils,\n            unittest]\n"
+    let clauses = clausesOf(source)
+    check clauses.len == 1
+    check clauses[0].keyword == "import"
+    check clauses[0].modules == @["std/os", "std/strutils", "std/unittest"]
+    check detectFrameworksInContent(source) == @[nufStdUnittest]
+
+  test "a comma-continued import is read whole":
+    const source = "import std/os,\n       std/unittest\n"
+    let clauses = clausesOf(source)
+    check clauses.len == 1
+    check clauses[0].modules == @["std/os", "std/unittest"]
+    check detectFrameworksInContent(source) == @[nufStdUnittest]
+
+  test "consecutive imports stay separate statements":
+    # The other direction: reading past the line break when nothing invites it
+    # would fuse two statements and mis-report both module lists.
+    let clauses = clausesOf("import std/os\nimport std/strutils\n")
+    check clauses.len == 2
+    check clauses[0].modules == @["std/os"]
+    check clauses[1].modules == @["std/strutils"]
+
+  test "a statement that ends does not swallow the next line":
+    # `unittest` here is a local identifier on the following line, not an
+    # import. A scan that keeps reading past the end of the clause would
+    # detect a framework this file does not use.
+    const source = "import std/os\nvar unittest = 1\ndiscard unittest\n"
+    let clauses = clausesOf(source)
+    check clauses.len == 1
+    check clauses[0].modules == @["std/os"]
+    check detectFrameworksInContent(source).len == 0
+
+  test "a semicolon separates two import statements on one line":
+    let clauses = clausesOf("import std/os; import std/unittest\n")
+    check clauses.len == 2
+    check clauses[0].modules == @["std/os"]
+    check clauses[1].modules == @["std/unittest"]
+    check detectFrameworksInContent("import std/os; import std/unittest\n") ==
+      @[nufStdUnittest]
+
+  test "a comment inside a bracketed clause neither ends nor joins it":
+    const source =
+      "import std/[os, # the platform bits\n" &
+      "            unittest] # and the framework\n" &
+      "import std/strutils\n"
+    let clauses = clausesOf(source)
+    check clauses.len == 2
+    check clauses[0].modules == @["std/os", "std/unittest"]
+    check clauses[1].modules == @["std/strutils"]
+
+  test "an import inside a conditional branch is still an import":
+    const source = "when defined(posix): import std/unittest\n"
+    check clausesOf(source).len == 1
+    check detectFrameworksInContent(source) == @[nufStdUnittest]
+
+  test "`from` names the module, not the symbols it pulls in":
+    let clauses = clausesOf("from std/unittest import check, suite\n")
+    check clauses.len == 1
+    check clauses[0].keyword == "from"
+    check clauses[0].modules == @["std/unittest"]
+
+  test "an `include` is recorded but is not a framework detection":
+    # Resolving an include path is a different job from reading one file, so
+    # the framework answer stays "no" — but the clause is still recorded, so
+    # the diagnostic can say why the answer might be wrong.
+    const source = "include ./common\n"
+    let clauses = clausesOf(source)
+    check clauses.len == 1
+    check clauses[0].keyword == "include"
+    check clauses[0].modules == @["./common"]
+    check detectFrameworksInContent(source).len == 0
+
+  test "a multi-line clause naming no framework detects nothing":
+    # The negative control for the whole suite: if the fix worked by declaring
+    # everything a detection, this would fail.
+    check detectFrameworksInContent(
+      "import std/[os, strutils,\n            tables]\n").len == 0
+
+  test "an import only quoted in a here-doc is still not an import":
+    check clausesOf(
+      "const doc = \"\"\"\nimport std/[os,\n  unittest]\n\"\"\"\n").len == 0
+
+  test "a multi-line import recovers the file's declarations end to end":
+    # The measurable consequence, at the level the defect was visible: file in,
+    # catalog out. Before the fix this catalog was empty and the file carried
+    # an `info` note claiming it had no unittest import.
+    let catalog = catalogForSource(
+      "import std/[os, strutils,\n            unittest]\n" & declarationTail)
+    check catalog.selectorsOf ==
+      @["round trip::", "round trip::keeps the probe"]
+    check "no Nim unittest imports detected" notin catalog.messagesOf
+
+suite "ct-test Nim unittest detection diagnostics":
+  test "a negative detection reports the imports it actually read":
+    # The bare conclusion "no Nim unittest imports detected in file" reads the
+    # same whether the file imports no framework or the scan failed to see the
+    # one it has. Naming the modules makes the two distinguishable: a missed
+    # import is an import missing from this list.
+    let catalog = catalogForSource(
+      "import std/[os, strutils]\nimport std/tables\n\nechoBanner()\n")
+    let messages = catalog.messagesOf
+    check "no Nim unittest imports detected in file" in messages
+    check "std/os" in messages
+    check "std/strutils" in messages
+    check "std/tables" in messages
+
+  test "a file with no imports at all says so, rather than reporting a scan":
+    let catalog = catalogForSource("echo \"hello\"\n")
+    check "no imports were read from this file at all" in catalog.messagesOf
+
+  test "an unfollowed `include` is named as the reason the answer may be wrong":
+    let catalog = catalogForSource("import std/os\ninclude ./shared_cases\n")
+    let messages = catalog.messagesOf
+    check "`include`" in messages
+    check "./shared_cases" in messages
+    check "does not follow" in messages
+
+  test "a long import list is summarised rather than dumped":
+    var modules: seq[string] = @[]
+    for i in 0 ..< 20:
+      modules.add "mod" & $i
+    let catalog = catalogForSource("import " & modules.join(", ") & "\n")
+    let messages = catalog.messagesOf
+    check "the 20 module(s) it imports are" in messages
+    check "mod0" in messages
+    check "and 8 more" in messages
+    check "mod19" notin messages
 
 suite "ct-test CLI surface":
   test "the usage string documents the scoping escape hatch":


### PR DESCRIPTION
## What was wrong

`ct test discover` decided which test framework a Nim source used by scanning its imports **one physical line at a time**. A bracketed clause that outgrows a line and continues on the next —

```nim
import std/[os, strutils,
            unittest]
```

therefore never showed `unittest`.

The consequence is larger than a mis-read import. A file whose framework is not detected is never scanned for declarations at all, so the whole file drops out of the catalog and every selector in it becomes unaddressable — while the file still looks fine in a report, because the diagnostic it carried was indistinguishable from the one a file with genuinely no test import carries.

## What changed

**The statement, not the line, is now the unit.** The extent of an import clause is decided by the token stream the file already builds: the clause continues while a bracket is open or the line ended on `,`, `/` or `.`, and ends at a line break or a `;`.

The same change also picks up:
- an `import` inside a `when ...:` branch,
- two clauses separated by `;`,
- and makes an `import` written inside a string literal or a comment a non-event.

**Still not covered, by design:** `include` (the included file's own imports are not followed), `import x as y` / `import x except y`, and bracketed groups under a prefix other than `std/`.

**Negative detections now carry their evidence.** The old message was the bare sentence `no Nim unittest imports detected in file`, emitted identically whether the file imports no test framework or the scan failed to read the import that is right there. Those are opposite facts. The diagnostic now names the modules the scan actually read, distinguishes "no imports were read from this file at all" from "read these and none matched", and names any `include` clause whose own imports it does not follow.

## Verification

- `src/ct_test/nim_unittest_provider_test.nim`: 19 → 35 tests, none removed or relaxed. Two new suites pair each continuation form with a shape that must **not** be swallowed, so neither a scan that joins everything nor one that joins nothing passes.
- Confirmed the guards discriminate, by mutation: restoring the one-physical-line clause boundary fails 5 of them; making every file detect `std/unittest` fails 10.
- `src/ct_test/fixtures/nim_unittest_project/tests/test_lexical_edge_cases.nim` now has an import that deliberately spans two lines and stays compilable, so `nim c -r` on it is independent ground truth for what discovery must report. It compiles and runs clean.
- `ci/test/m16-release-gate.sh`: green, 174 OK / 0 failed, on this branch rebased onto current `dev`.

`ci/test/ct-providers.sh` could not be run: it needs the `codetracer-native-recorder` sibling, which does not currently build at its own `dev` tip (`ct_cli/src/ct_cli/extract_gfx_cmd.nim` imports `gfx_stream/ctfs_visual`, a module absent from that repo). That is pre-existing and unrelated to this change. The verification note at the top of `src/ct_test/frameworks/nim_unittest.nim` is therefore left in place, unchanged: the providers gate still has no green run behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
