### PR TITLE
ci(cla): store signatures on dev — `main` has not existed since the rename

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -46,8 +46,8 @@ jobs:
     # another's.
     #
     # `cancel-in-progress: false` because this action commits the signature
-    # file back to the `main` branch; cancelling mid-commit can leave the
-    # signature store half-written. Queueing is the correct behaviour here.
+    # file back to the `branch` named below; cancelling mid-commit can leave
+    # the signature store half-written. Queueing is the correct behaviour here.
     concurrency:
       group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: false
@@ -62,9 +62,42 @@ jobs:
           # PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/metacraft-labs/codetracer/blob/main/docs/cla.md' # e.g. a CLA or a DCO document
-          # branch should not be protected
-          branch: 'main'
+          path-to-document: 'https://github.com/metacraft-labs/codetracer/blob/dev/docs/cla.md' # e.g. a CLA or a DCO document
+
+          # `dev`, not `main`: this repository has NO `main` branch -- the org
+          # renamed its mainlines, and nothing updated these two settings. The
+          # action could therefore never write the signature store, and failed
+          # every run with
+          #
+          #     Error occurred when creating the signed contributors file:
+          #       Branch main not found.
+          #     Committers of pull request N have to sign the CLA
+          #
+          # The second line names the contributor; the cause is the first. The
+          # last signature this store actually recorded is tzanko-matev on
+          # 2025-07-11 (PR #247), while `main` still existed -- so since the
+          # rename NO contributor has been able to sign at all, and every PR
+          # has carried a red CLA check that no action by its author could
+          # clear. `docs/cla.md` and `signatures/version1/cla.json` were on
+          # `dev` the whole time; only these settings pointed elsewhere.
+          #
+          # The action requires an UNPROTECTED branch, because it commits the
+          # signature file directly. Checked against
+          # `GET /repos/metacraft-labs/codetracer/rules/branches/dev`, which
+          # returns `[]` -- the authoritative view, since the legacy
+          # branch-protection endpoint reports 404 for a branch governed only
+          # by a ruleset and would have said "not protected" either way.
+          #
+          # Note what `dev` is NOT: the default branch is `stable`, and the
+          # active ruleset -- named "Protect main", from the same rename --
+          # includes `~DEFAULT_BRANCH`, so it governs `stable` (deletion,
+          # pull_request, required_linear_history), not `dev`. Pointing this
+          # at `stable` would therefore reintroduce the same failure in a new
+          # form: a direct commit into a branch that requires a pull request.
+          #
+          # If `dev` ever becomes protected, move this to a dedicated
+          # signatures branch. Do not point it at a protected branch.
+          branch: 'dev'
           allowlist: 'zah,NGPetrov,Ro6afF,Franz-Fischbach,Madman10K,Aristotelis2002,pxor,SersemPeca,fenix-ov,lispegistus,alehander92'
 
          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken


### PR DESCRIPTION
ci(cla): store signatures on dev — `main` has not existed since the rename

CLAAssistant has failed on every codetracer pull request, and the failure was
never the contributor's to fix:

    Error occurred when creating the signed contributors file:
      Branch main not found.
    Committers of pull request 720 have to sign the CLA

The second line names the committers; the cause is the first. `branch: 'main'`
and a `blob/main/docs/cla.md` link both survived the org's mainline rename, and
this repository has no `main` branch at all.

The store itself was never missing. `docs/cla.md` (6144 bytes) and
`signatures/version1/cla.json` are both on `dev`, and the last signature the
store recorded is tzanko-matev on 2025-07-11 via PR #247 — while `main` still
existed. Since the rename no contributor has been able to sign, because the
action cannot write the file it is asked to append to.

`dev` is the correct target and it was verified as unprotected against
`GET /rules/branches/dev`, which returns `[]`. The legacy branch-protection
endpoint is not sufficient evidence here — it 404s for a ruleset-governed
branch too, so it would have answered "not protected" either way.

`stable` would NOT be correct: it is the default branch, and the active ruleset
(named "Protect main", from the same rename) matches `~DEFAULT_BRANCH` and
imposes `pull_request` on it. Committing a signature file directly into it
would fail again, in a new form.

The `cancel-in-progress: false` rationale above also said "the `main` branch";
it now names the setting instead, so it cannot go stale the same way twice.
