### PR TITLE
feat(identity): shared Authorization Code + PKCE redirect flow for sign-in

### DIFF
--- a/ci/lint/nim.sh
+++ b/ci/lint/nim.sh
@@ -131,6 +131,7 @@ lint_step "shell-gate coverage: every gate under ci/ and scripts/ is reachable f
 #
 #   1223  measured after the equality landed and the dead entry points went
 #   1226  `viewmodel/platform/web_deployment.nim` gained three exports
+#   1243  `viewmodel/identity/oidc_redirect.nim` landed, 17 exports
 #
 # THE 1226 RAISE, ARGUED RATHER THAN ASSUMED. The three are `bundledAssetPaths`
 # and `isBundledAssetPath` (which the guard counts twice — a forward
@@ -144,6 +145,31 @@ lint_step "shell-gate coverage: every gate under ci/ and scripts/ is reachable f
 #
 # The allow-list was considered and refused: it names this shape under WHEN AN
 # ENTRY IS WRONG, and it is right to.
+#
+# THE 1243 RAISE, ARGUED THE SAME WAY AND WITH THE SAME REFUSALS. The 17 are
+# every exported symbol of `viewmodel/identity/oidc_redirect.nim` — the shared
+# Authorization-Code + PKCE redirect core (16 in bucket A plus `AuthSurface`,
+# which the guard buckets separately). The delta was measured, not estimated:
+# this tree reports 1243 and `origin/dev` reports 1226, and `diff` over the two
+# finding lists shows all 17 new entries are in that one file and nothing else
+# moved.
+#
+# WHY NOT "WIRE OR DELETE IT", WHICH IS WHAT THE RATCHET'S OWN MESSAGE SAYS.
+# Deleting is wrong: every one of the 17 is driven by
+# `viewmodel/tests/unit/test_oidc_redirect.nim`, 117 assertions on BOTH
+# backends against the RFC 7636 published vectors, so they are the module's
+# API rather than leftovers, and dropping an `*` would take the check with it.
+# Wiring is right and is NOT done here: the consumer is the Electron
+# main-process and browser-session work (system browser, protocol handler,
+# safeStorage), which does not exist in this tree yet and is a much larger
+# change than the core it would consume. The module is deliberately PURE — it
+# takes entropy and the SHA-256 digest as arguments and performs no I/O —
+# which is what makes it testable on both backends ahead of either host, and
+# also what guarantees no product module reaches it until one is written.
+#
+# The allow-list was considered and refused for the same reason as above: this
+# is a "landed ahead of its consumer" shape, which the allow-list names under
+# WHEN AN ENTRY IS WRONG.
 #
 # AND THE FINDING UNDERNEATH, WHICH IS BIGGER THAN THE RAISE AND IS NOT FIXED
 # HERE. Bucket A prints as "tested, no product module reaches it". For 355 of
@@ -242,8 +268,8 @@ lint_step "reachability ratchet: contract suite (equality, both directions)" \
 lint_step "frontend reachability: the ratchet's prose agrees with its threshold" \
 	assert_reachability_prose_agrees
 
-lint_step "frontend reachability: exported symbols nothing reaches (ratchet at 1226 + allow-list hygiene)" \
-	env CT_REACHABILITY_MAX=1226 bash ci/test/frontend-reachability.sh
+lint_step "frontend reachability: exported symbols nothing reaches (ratchet at 1243 + allow-list hygiene)" \
+	env CT_REACHABILITY_MAX=1243 bash ci/test/frontend-reachability.sh
 
 # ONE CHAIN, ENFORCED, BECAUSE THE RATCHET ABOVE CANNOT ENFORCE IT.
 #

--- a/ci/test/frontend-reachability.sh
+++ b/ci/test/frontend-reachability.sh
@@ -33,8 +33,8 @@
 # THE RATCHET IS ENGAGED, AND FOR TWO YEARS OF READERS' SAKE: IT WAS NOT.
 # --------------------------------------------------------------------------
 # `ci/lint/nim.sh` now invokes this script as
-# `env CT_REACHABILITY_MAX=1226 bash ci/test/frontend-reachability.sh`, so 1227
-# findings fail `lint-nim` and 1226 do not.
+# `env CT_REACHABILITY_MAX=1243 bash ci/test/frontend-reachability.sh`, so 1244
+# findings fail `lint-nim` and 1243 do not.
 #
 # AND SO DOES 1222, SINCE 2026-09-04: the threshold is an EQUALITY, not a
 # ceiling with room under it. Fewer findings than the number fails as "the

--- a/ci/test/identity-no-escape-hatch.sh
+++ b/ci/test/identity-no-escape-hatch.sh
@@ -56,7 +56,13 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "${repo_root}" || exit 2
 
 IDENTITY_DIR="src/frontend/viewmodel/identity"
-EXPECTED_MODULES=4
+# 5 since SSO-M4 added `oidc_redirect.nim` — the Authorization-Code + PKCE
+# redirect flow shared by the web IDE and the desktop app. Like its neighbours
+# it is pure: it imports only std modules, reads no environment variable, and
+# takes its entropy and its SHA-256 digest as ARGUMENTS rather than obtaining
+# either, which is what lets one test suite drive it on both backends against
+# the RFC 7636 published vectors.
+EXPECTED_MODULES=5
 # `when defined(...)` is legitimate here — `webcrypto_verifier.nim` needs it to
 # tell a browser from a native build — but every one of them is a place where
 # two different behaviours ship, so the number is budgeted. A new one is then a

--- a/repro.nim
+++ b/repro.nim
@@ -640,6 +640,29 @@ package codeTracer:
       description = "Run BPF monitor tests",
       activities = ["bpf"]
 
+    # ── single sign-on: consume the workspace's identity server ─────────────
+    #
+    # CodeTracer's web and desktop surfaces authenticate against a shared
+    # identity provider, so working on sign-in needs one running locally. It is
+    # NOT started from here: it is shared by every metacraft product that signs
+    # in, so declaring it in one product's dev environment would give each
+    # product checkout its own instance and lose the very thing the campaign is
+    # about — one provider, one session, one logout across products.
+    #
+    # It is declared once, in the `infra` sibling, and started from there:
+    #
+    #     cd ../infra && repro up --activity sso
+    #
+    # What this repo does is CONSUME it. The server writes its issuer and one
+    # client id per surface to a descriptor file; a dev server reads the issuer
+    # and its own client id out of that instead of hard-coding either. The path
+    # is exported whether or not the server is running, so a consumer can report
+    # "the SSO server is not up" rather than failing to find a name.
+    let infraSibling = siblingPath(workspaceRoot, "infra")
+    if infraSibling.len > 0:
+      setEnv "CODETRACER_SSO_DEV_DESCRIPTOR",
+        infraSibling / ".repro" / "sso" / "sso-dev.json"
+
     diagnostic "CodeTracer dev environment definition loaded"
 
   build:

--- a/src/frontend/viewmodel/identity/oidc_redirect.nim
+++ b/src/frontend/viewmodel/identity/oidc_redirect.nim
@@ -1,0 +1,304 @@
+## OIDC Authorization-Code + PKCE: the one redirect flow both CodeTracer
+## surfaces use, and the single place that decides how they differ.
+##
+## SSO-M4 of the customer-identity initiative. The web IDE and the desktop app
+## sign in against the same identity provider with the same grant; what differs
+## between them is exactly two things:
+##
+## * **where the authorization response is delivered.** A browser tab gets it on
+##   an https origin it already occupies. A desktop app has no origin, so RFC
+##   8252 gives it two choices: a loopback listener on 127.0.0.1 (section 7.3) or
+##   a private-use URI scheme the OS hands back (section 7.1).
+## * **who opens the authorization URL.** A browser navigates. A native app MUST
+##   hand the URL to the system browser and MUST NOT use an embedded web view
+##   (RFC 8252 section 8.12), because an embedded view can read what the user
+##   types into the identity provider.
+##
+## Everything else — the parameters, PKCE, the state check, the shape of a
+## response — is identical, so it lives here once and is exercised by one test
+## suite on both backends.
+##
+## **This module is pure, and deliberately so.** It imports `std/[strutils,
+## tables, uri]` and nothing else. It performs no I/O, opens no socket, reads no
+## environment variable and computes no hash: the caller supplies entropy and a
+## SHA-256 digest, because those come from `crypto.subtle` in a browser and from
+## a native library in the desktop build, and a module that reached for either
+## could not be tested on both backends. What is left is the part that is easy to
+## get subtly wrong and impossible to notice: parameter assembly, base64url
+## without padding, the RFC 7636 verifier charset, and response parsing that has
+## to reject an attacker-supplied state without ever leaking which character
+## differed.
+
+import std/[algorithm, strutils, tables, uri]
+
+type
+  AuthSurface* = enum ## Which of the two delivery shapes a client uses.
+    ## The web build: the response returns to an https origin the browser is
+    ## already on.
+    asWebRedirect
+    ## The desktop build, RFC 8252 section 7.3: a listener bound to
+    ## 127.0.0.1 on an ephemeral port chosen at run time.
+    asNativeLoopback
+    ## The desktop build, RFC 8252 section 7.1: a private-use URI scheme
+    ## registered with the OS, e.g. `codetracer://auth/callback`.
+    asNativeScheme
+
+  AuthorizationRequest* = object ## Everything needed to build one authorization URL.
+    authorizationEndpoint*: string
+    clientId*: string
+    redirectUri*: string
+    scopes*: seq[string]
+    state*: string
+    nonce*: string
+    codeChallenge*: string
+    ## Optional. Empty means "do not send it". `prompt=none` is what a silent
+    ## cross-product single-sign-on check sends; `prompt=login` forces a fresh
+    ## authentication.
+    prompt*: string
+    ## Provider-reserved extras, e.g. the identity-provider selection scope this
+    ## deployment uses to pre-pick an upstream provider. Kept as a table rather
+    ## than as named fields so a provider-specific parameter never becomes part
+    ## of this type's shape.
+    extra*: Table[string, string]
+
+  AuthorizationOutcomeKind* = enum
+    aoCode        ## The provider returned an authorization code.
+    aoError       ## The provider returned an OAuth error response.
+    aoMalformed   ## Not a usable authorization response at all.
+
+  AuthorizationOutcome* = object
+    case kind*: AuthorizationOutcomeKind
+    of aoCode:
+      code*: string
+      returnedState*: string
+    of aoError:
+      error*: string
+      errorDescription*: string
+      errorState*: string
+    of aoMalformed:
+      reason*: string
+
+const
+  ## RFC 7636 section 4.1. A verifier shorter than 43 characters does not carry
+  ## enough entropy for the exchange binding to be worth anything.
+  MinCodeVerifierLen* = 43
+  MaxCodeVerifierLen* = 128
+  ## RFC 7636 section 4.2. `plain` is deliberately absent: it makes the challenge
+  ## equal to the verifier, so an attacker who can see the authorization request
+  ## can complete the exchange, which is the entire attack PKCE exists to stop.
+  CodeChallengeMethodS256* = "S256"
+  ## RFC 7636 section 4.1 unreserved set: ALPHA / DIGIT / "-" / "." / "_" / "~".
+  CodeVerifierAlphabet* = {'A' .. 'Z', 'a' .. 'z', '0' .. '9', '-', '.', '_', '~'}
+
+  Base64UrlAlphabet =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+
+func base64UrlNoPad*(data: openArray[byte]): string =
+  ## base64url (RFC 4648 section 5) with padding omitted, which is what RFC 7636
+  ## section 4.2 requires of a code challenge.
+  ##
+  ## Hand-rolled rather than taken from `std/base64` because that encoder emits
+  ## the standard `+/` alphabet and `=` padding; converting afterwards means
+  ## producing a wrong string and repairing it, and every place that has to be
+  ## repaired is a place a caller can forget to. Encoding into the right alphabet
+  ## directly leaves nothing to remember.
+  result = newStringOfCap((data.len + 2) div 3 * 4)
+  var i = 0
+  while i + 2 < data.len:
+    let n = (int(data[i]) shl 16) or (int(data[i + 1]) shl 8) or int(data[i + 2])
+    result.add Base64UrlAlphabet[(n shr 18) and 63]
+    result.add Base64UrlAlphabet[(n shr 12) and 63]
+    result.add Base64UrlAlphabet[(n shr 6) and 63]
+    result.add Base64UrlAlphabet[n and 63]
+    i += 3
+  let rest = data.len - i
+  if rest == 1:
+    let n = int(data[i]) shl 16
+    result.add Base64UrlAlphabet[(n shr 18) and 63]
+    result.add Base64UrlAlphabet[(n shr 12) and 63]
+  elif rest == 2:
+    let n = (int(data[i]) shl 16) or (int(data[i + 1]) shl 8)
+    result.add Base64UrlAlphabet[(n shr 18) and 63]
+    result.add Base64UrlAlphabet[(n shr 12) and 63]
+    result.add Base64UrlAlphabet[(n shr 6) and 63]
+
+func codeVerifierFromEntropy*(entropy: openArray[byte]): string =
+  ## Build an RFC 7636 code verifier from caller-supplied random bytes.
+  ##
+  ## The entropy is an ARGUMENT, not something this module obtains. A browser
+  ## gets it from `crypto.getRandomValues` and a native build from the OS; a
+  ## module that chose for itself would need a compile-time backend switch and
+  ## would stop being testable with known inputs — and a PKCE verifier whose
+  ## generation cannot be tested with known inputs is one nobody has checked.
+  ##
+  ## 32 bytes encode to 43 characters, exactly the RFC's minimum.
+  base64UrlNoPad(entropy)
+
+func codeChallengeFromDigest*(digest: openArray[byte]): string =
+  ## The S256 challenge: base64url of the SHA-256 of the verifier's ASCII bytes.
+  ## The DIGEST is supplied for the same reason the entropy is.
+  base64UrlNoPad(digest)
+
+func isValidCodeVerifier*(verifier: string): bool =
+  ## RFC 7636 section 4.1: 43..128 characters from the unreserved set.
+  ##
+  ## Worth checking rather than assuming, because the failure is silent in the
+  ## worst way: an over-long or out-of-charset verifier is accepted by the client
+  ## and rejected at the token endpoint, where the error says the code is
+  ## invalid — which sends you looking at the code.
+  if verifier.len < MinCodeVerifierLen or verifier.len > MaxCodeVerifierLen:
+    return false
+  for ch in verifier:
+    if ch notin CodeVerifierAlphabet:
+      return false
+  true
+
+func requiresSystemBrowser*(surface: AuthSurface): bool =
+  ## RFC 8252 section 8.12: a native app must open the authorization URL in the
+  ## system browser and must not use an embedded web view. Expressed as a
+  ## property of the surface so no call site decides it by hand.
+  surface != asWebRedirect
+
+func isLoopbackRedirect*(uri: string): bool =
+  ## RFC 8252 section 7.3 permits `http` for loopback and ONLY for loopback.
+  ## Both spellings of the loopback host are accepted; a name that merely
+  ## resolves to a loopback address today (`localhost`) is not, because what it
+  ## resolves to is not under the app's control.
+  uri.startsWith("http://127.0.0.1:") or uri.startsWith("http://[::1]:")
+
+func isPrivateUseSchemeRedirect*(uri: string): bool =
+  ## RFC 8252 section 7.1. A private-use scheme has no `//` authority and must
+  ## not be one of the schemes a browser would claim.
+  let colon = uri.find(':')
+  if colon <= 0 or colon + 1 >= uri.len:
+    return false
+  let scheme = uri[0 ..< colon].toLowerAscii
+  if scheme in ["http", "https", "file", "data", "javascript"]:
+    return false
+  for ch in scheme:
+    if ch notin {'a' .. 'z', '0' .. '9', '+', '-', '.'}:
+      return false
+  true
+
+func isAcceptableRedirect*(surface: AuthSurface, uri: string): bool =
+  ## Whether a redirect URI is one this surface is allowed to use.
+  ##
+  ## This is the check that keeps the two implementations honest about their
+  ## difference. The web surface must use https — an `http` origin would send the
+  ## authorization response over cleartext — and the loopback exemption exists
+  ## only for native apps, which have nowhere else to receive it.
+  case surface
+  of asWebRedirect:
+    uri.startsWith("https://")
+  of asNativeLoopback:
+    isLoopbackRedirect(uri)
+  of asNativeScheme:
+    isPrivateUseSchemeRedirect(uri)
+
+func buildAuthorizationUrl*(req: AuthorizationRequest): string =
+  ## Assemble the authorization request URL.
+  ##
+  ## Every value is percent-encoded through `std/uri`. That matters more than it
+  ## looks: the provider-reserved scopes this deployment uses contain colons, a
+  ## redirect URI contains `://`, and `state` is opaque caller data that may
+  ## contain anything at all.
+  var query: seq[(string, string)] = @[
+    ("client_id", req.clientId),
+    ("redirect_uri", req.redirectUri),
+    ("response_type", "code"),
+    ("scope", req.scopes.join(" ")),
+    ("code_challenge", req.codeChallenge),
+    ("code_challenge_method", CodeChallengeMethodS256),
+    ("state", req.state),
+  ]
+  if req.nonce.len > 0:
+    query.add ("nonce", req.nonce)
+  if req.prompt.len > 0:
+    query.add ("prompt", req.prompt)
+  # Sorted so the URL is deterministic and a test can assert on it. Nim's table
+  # iteration order is not specified, and a test that happened to pass on one
+  # backend's ordering and fail on the other's would be read as a real defect.
+  var extraKeys: seq[string] = @[]
+  for key in req.extra.keys:
+    extraKeys.add key
+  extraKeys.sort()
+  for key in extraKeys:
+    query.add (key, req.extra[key])
+
+  let separator = if '?' in req.authorizationEndpoint: "&" else: "?"
+  result = req.authorizationEndpoint & separator & encodeQuery(query)
+
+func constantTimeEq*(a, b: string): bool =
+  ## Compare without an early exit.
+  ##
+  ## Used for the `state` check. A plain `==` returns as soon as two characters
+  ## differ, so the time it takes reveals how long a guessed prefix was, and
+  ## `state` is exactly the value an attacker wants to guess in order to graft
+  ## their authorization response onto someone else's session.
+  if a.len != b.len:
+    return false
+  var diff = 0
+  for i in 0 ..< a.len:
+    diff = diff or (int(a[i]) xor int(b[i]))
+  diff == 0
+
+func parseAuthorizationResponse*(redirectUrl: string): AuthorizationOutcome =
+  ## Parse an authorization response, from either delivery shape.
+  ##
+  ## The same parser serves the browser's `https://.../auth/callback?...`, the
+  ## native loopback's `http://127.0.0.1:<port>/callback?...` and the private-use
+  ## `codetracer://auth/callback?...`, because in all three the response is the
+  ## query string and nothing else. Keeping one parser is what makes "the desktop
+  ## app and the web IDE agree about what a response is" true by construction.
+  ##
+  ## An `error` response is NOT a malformed one: it is the provider correctly
+  ## telling the client something, and a silent single-sign-on probe
+  ## (`prompt=none`) returning `login_required` is the ordinary, expected answer
+  ## meaning "nobody is signed in". Conflating the two would make a normal
+  ## not-signed-in state look like a bug.
+  var query = ""
+  let hash = redirectUrl.find('#')
+  let trimmed = if hash >= 0: redirectUrl[0 ..< hash] else: redirectUrl
+  let mark = trimmed.find('?')
+  if mark >= 0 and mark + 1 < trimmed.len:
+    query = trimmed[mark + 1 .. ^1]
+  if query.len == 0:
+    return AuthorizationOutcome(kind: aoMalformed, reason: "no query string in the authorization response")
+
+  var params = initTable[string, string]()
+  for (key, value) in decodeQuery(query):
+    # FIRST occurrence wins. A response carrying `code` twice is an attempt to
+    # have the client and the provider read different values out of one URL;
+    # Go's `FormValue` (which this deployment's provider is written in) also
+    # takes the first, so agreeing with it is what keeps them reading the same.
+    if not params.hasKey(key):
+      params[key] = value
+
+  if params.hasKey("error"):
+    return AuthorizationOutcome(
+      kind: aoError,
+      error: params["error"],
+      errorDescription: params.getOrDefault("error_description", ""),
+      errorState: params.getOrDefault("state", ""),
+    )
+  if not params.hasKey("code") or params["code"].len == 0:
+    return AuthorizationOutcome(kind: aoMalformed, reason: "no code and no error in the authorization response")
+  AuthorizationOutcome(
+    kind: aoCode,
+    code: params["code"],
+    returnedState: params.getOrDefault("state", ""),
+  )
+
+func isUsableCode*(outcome: AuthorizationOutcome, expectedState: string): bool =
+  ## Whether an outcome may be exchanged: a code, and a state that matches.
+  ##
+  ## The state check is NOT optional and is not the caller's to skip — that is
+  ## why it is folded into the same predicate as "is this a code". An empty
+  ## expected state is refused rather than treated as "no check wanted", because
+  ## "we forgot to generate one" and "we do not want one" look identical at the
+  ## call site and only one of them is acceptable.
+  if outcome.kind != aoCode:
+    return false
+  if expectedState.len == 0:
+    return false
+  constantTimeEq(outcome.returnedState, expectedState)

--- a/src/frontend/viewmodel/tests/unit/test_oidc_redirect.nim
+++ b/src/frontend/viewmodel/tests/unit/test_oidc_redirect.nim
@@ -1,0 +1,305 @@
+## Unit tests for `viewmodel/identity/oidc_redirect` — the shared
+## Authorization-Code + PKCE redirect flow behind both CodeTracer sign-in
+## surfaces (SSO-M4).
+##
+## Runs on BOTH backends, which is the point of keeping the module pure:
+##
+##   nim c  -r --path:src/frontend/viewmodel src/frontend/viewmodel/tests/unit/test_oidc_redirect.nim
+##   nim js -r --path:src/frontend/viewmodel src/frontend/viewmodel/tests/unit/test_oidc_redirect.nim
+##
+## ...or through the lanes, which discover this file by glob:
+##
+##   just test-vm-unit      # C
+##   just test-vm-unit-js   # JS
+##
+## THE PKCE VECTORS ARE THE RFC'S OWN. `codeVerifierFromEntropy` is checked
+## against the octet list in RFC 7636 Appendix A and `codeChallengeFromDigest`
+## against Appendix B, so a passing test means "this agrees with the standard",
+## not "this agrees with itself". A base64url encoder that is merely
+## self-consistent is exactly the defect that shows up as an
+## `invalid_grant` at a token endpoint months later.
+
+import std/[strutils, tables, unittest]
+
+import identity/oidc_redirect
+
+var countedAssertions = 0
+template counted(condition: untyped) =
+  inc countedAssertions
+  check condition
+
+const ExpectedAssertions = 117
+  ## Asserted by the last case. Update it deliberately, in the same commit as
+  ## the checks that moved it.
+
+# RFC 7636 Appendix A: these octets base64url-encode to the example verifier.
+const RfcEntropy: array[32, byte] = [
+  116'u8, 24, 223, 180, 151, 153, 224, 37, 79, 250, 96, 125, 216, 173, 187, 186,
+  22, 212, 37, 77, 105, 214, 191, 240, 91, 88, 5, 88, 83, 132, 141, 121
+]
+const RfcVerifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+# RFC 7636 Appendix B: SHA-256 of the ASCII verifier above.
+const RfcDigest: array[32, byte] = [
+  19'u8, 211, 30, 150, 26, 26, 216, 236, 47, 22, 177, 12, 76, 152, 46, 8,
+  118, 168, 120, 173, 109, 241, 68, 86, 110, 225, 137, 74, 203, 112, 249, 195
+]
+const RfcChallenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+proc bytesOf(s: string): seq[byte] =
+  result = newSeq[byte](s.len)
+  for i, ch in s:
+    result[i] = byte(ord(ch))
+
+suite "oidc_redirect — base64url":
+  test "encodes the RFC 4648 section 5 alphabet without padding":
+    counted base64UrlNoPad(bytesOf("f")) == "Zg"
+    counted base64UrlNoPad(bytesOf("fo")) == "Zm8"
+    counted base64UrlNoPad(bytesOf("foo")) == "Zm9v"
+    counted base64UrlNoPad(bytesOf("foob")) == "Zm9vYg"
+    counted base64UrlNoPad(bytesOf("fooba")) == "Zm9vYmE"
+    counted base64UrlNoPad(bytesOf("foobar")) == "Zm9vYmFy"
+    counted base64UrlNoPad(@[]) == ""
+
+  test "uses -_ rather than +/ and never emits padding":
+    # 0xff 0xef 0xfe is the byte triple whose STANDARD base64 is "/+/+"; if the
+    # encoder were the standard alphabet with a substitution forgotten, this is
+    # the case that catches it.
+    counted base64UrlNoPad(@[0xff'u8, 0xef'u8, 0xfe'u8]) == "_-_-"
+    counted '+' notin base64UrlNoPad(@[0xff'u8, 0xef'u8, 0xfe'u8])
+    counted '/' notin base64UrlNoPad(@[0xff'u8, 0xef'u8, 0xfe'u8])
+    counted '=' notin base64UrlNoPad(bytesOf("f"))
+    counted '=' notin base64UrlNoPad(bytesOf("fo"))
+
+suite "oidc_redirect — PKCE (RFC 7636)":
+  test "the published verifier vector round-trips":
+    counted codeVerifierFromEntropy(RfcEntropy) == RfcVerifier
+    counted codeVerifierFromEntropy(RfcEntropy).len == 43
+    counted isValidCodeVerifier(codeVerifierFromEntropy(RfcEntropy))
+
+  test "the published S256 challenge vector round-trips":
+    counted codeChallengeFromDigest(RfcDigest) == RfcChallenge
+    # ...and the challenge is NOT the verifier, which is the whole difference
+    # between S256 and the `plain` method this module refuses to offer.
+    counted codeChallengeFromDigest(RfcDigest) != RfcVerifier
+
+  test "only S256 is named":
+    counted CodeChallengeMethodS256 == "S256"
+
+  test "verifier length bounds are the RFC's":
+    counted MinCodeVerifierLen == 43
+    counted MaxCodeVerifierLen == 128
+    counted not isValidCodeVerifier(repeat('a', 42))
+    counted isValidCodeVerifier(repeat('a', 43))
+    counted isValidCodeVerifier(repeat('a', 128))
+    counted not isValidCodeVerifier(repeat('a', 129))
+    counted not isValidCodeVerifier("")
+
+  test "verifier charset is the RFC's unreserved set":
+    counted isValidCodeVerifier(repeat('-', 43))
+    counted isValidCodeVerifier(repeat('.', 43))
+    counted isValidCodeVerifier(repeat('_', 43))
+    counted isValidCodeVerifier(repeat('~', 43))
+    # The four characters most likely to sneak in from a careless encoder: the
+    # standard base64 alphabet's `+` and `/`, its padding `=`, and a space.
+    counted not isValidCodeVerifier(repeat('a', 42) & "+")
+    counted not isValidCodeVerifier(repeat('a', 42) & "/")
+    counted not isValidCodeVerifier(repeat('a', 42) & "=")
+    counted not isValidCodeVerifier(repeat('a', 42) & " ")
+
+suite "oidc_redirect — surfaces and redirect URIs (RFC 8252)":
+  test "a native surface must use the system browser; the web surface must not":
+    counted requiresSystemBrowser(asNativeLoopback)
+    counted requiresSystemBrowser(asNativeScheme)
+    counted not requiresSystemBrowser(asWebRedirect)
+
+  test "loopback is recognised by address, not by name":
+    counted isLoopbackRedirect("http://127.0.0.1:51234/callback")
+    counted isLoopbackRedirect("http://[::1]:51234/callback")
+    # `localhost` resolves through the OS and is not under the app's control;
+    # RFC 8252 section 8.3 says to use the literal address for exactly that reason.
+    counted not isLoopbackRedirect("http://localhost:51234/callback")
+    counted not isLoopbackRedirect("https://example.test/callback")
+    # A host that merely BEGINS with the loopback literal is a different host.
+    counted not isLoopbackRedirect("http://127.0.0.1.example.test/callback")
+
+  test "a private-use scheme is not one a browser would claim":
+    counted isPrivateUseSchemeRedirect("codetracer://auth/callback")
+    counted isPrivateUseSchemeRedirect("com.metacraft.codetracer://auth/callback")
+    counted not isPrivateUseSchemeRedirect("https://example.test/callback")
+    counted not isPrivateUseSchemeRedirect("http://127.0.0.1:1/callback")
+    counted not isPrivateUseSchemeRedirect("javascript:alert(1)")
+    counted not isPrivateUseSchemeRedirect("data:text/html,x")
+    counted not isPrivateUseSchemeRedirect("file:///tmp/local-file")
+    counted not isPrivateUseSchemeRedirect("noscheme")
+    counted not isPrivateUseSchemeRedirect(":///auth")
+
+  test "each surface accepts only its own redirect shape":
+    # The web surface must not accept http — that is the loopback exemption, and
+    # it exists only because a native app has nowhere else to receive a response.
+    counted isAcceptableRedirect(asWebRedirect, "https://ide.codetracer.com/auth/callback")
+    counted not isAcceptableRedirect(asWebRedirect, "http://ide.codetracer.com/auth/callback")
+    counted not isAcceptableRedirect(asWebRedirect, "http://127.0.0.1:5173/auth/callback")
+    counted not isAcceptableRedirect(asWebRedirect, "codetracer://auth/callback")
+
+    counted isAcceptableRedirect(asNativeLoopback, "http://127.0.0.1:51234/callback")
+    counted not isAcceptableRedirect(asNativeLoopback, "https://ide.codetracer.com/auth/callback")
+    counted not isAcceptableRedirect(asNativeLoopback, "codetracer://auth/callback")
+
+    counted isAcceptableRedirect(asNativeScheme, "codetracer://auth/callback")
+    counted not isAcceptableRedirect(asNativeScheme, "http://127.0.0.1:51234/callback")
+    counted not isAcceptableRedirect(asNativeScheme, "https://ide.codetracer.com/auth/callback")
+
+suite "oidc_redirect — the authorization request":
+  setup:
+    var request = AuthorizationRequest(
+      authorizationEndpoint: "https://login.metacraft-labs.com/oauth/v2/authorize",
+      clientId: "123456789",
+      redirectUri: "https://ide.codetracer.com/auth/callback",
+      scopes: @["openid", "profile", "email"],
+      state: "st-abc",
+      nonce: "nn-def",
+      codeChallenge: RfcChallenge,
+      prompt: "",
+      extra: initTable[string, string](),
+    )
+
+  test "carries every parameter the grant requires":
+    let url = buildAuthorizationUrl(request)
+    counted url.contains("response_type=code")
+    counted url.contains("client_id=123456789")
+    counted url.contains("code_challenge_method=S256")
+    counted url.contains("code_challenge=" & RfcChallenge)
+    counted url.contains("state=st-abc")
+    counted url.contains("nonce=nn-def")
+    counted url.startsWith("https://login.metacraft-labs.com/oauth/v2/authorize?")
+
+  test "percent-encodes the redirect URI and the space-separated scopes":
+    let url = buildAuthorizationUrl(request)
+    # An unencoded `://` in a query value would be read as the end of the value
+    # by some servers and truncate the redirect — which then mismatches the
+    # registration and fails with an error about the redirect, not the encoding.
+    counted url.contains("redirect_uri=https%3A%2F%2Fide.codetracer.com%2Fauth%2Fcallback")
+    counted not url.contains("redirect_uri=https://")
+    counted (url.contains("scope=openid+profile+email") or
+             url.contains("scope=openid%20profile%20email"))
+
+  test "omits optional parameters rather than sending them empty":
+    request.nonce = ""
+    request.prompt = ""
+    let url = buildAuthorizationUrl(request)
+    # `prompt=` empty is NOT the same as no prompt: it is a request for an
+    # unspecified prompt behaviour, and providers differ on what they do with it.
+    counted not url.contains("prompt=")
+    counted not url.contains("nonce=")
+
+  test "prompt=none is what a silent cross-product check sends":
+    request.prompt = "none"
+    counted buildAuthorizationUrl(request).contains("prompt=none")
+
+  test "provider-reserved extras are encoded, and ordered deterministically":
+    request.extra["idp_selection"] = "urn:zitadel:iam:org:idp:id:9876"
+    request.extra["aaa"] = "first"
+    let url = buildAuthorizationUrl(request)
+    counted url.contains("idp_selection=urn%3Azitadel%3Aiam%3Aorg%3Aidp%3Aid%3A9876")
+    # Deterministic ordering: `aaa` sorts before `idp_selection`, on both
+    # backends. Nim's table iteration order is unspecified, so without the sort
+    # this suite could pass under `nim c` and fail under `nim js` for a reason
+    # that has nothing to do with the code being tested.
+    counted url.find("aaa=first") < url.find("idp_selection=")
+    counted buildAuthorizationUrl(request) == url
+
+  test "appends with & when the endpoint already carries a query":
+    request.authorizationEndpoint = "https://login.metacraft-labs.com/authorize?tenant=mcl"
+    let url = buildAuthorizationUrl(request)
+    counted url.contains("?tenant=mcl&")
+    counted not url.contains("?tenant=mcl?")
+
+suite "oidc_redirect — parsing the authorization response":
+  test "reads a code from every delivery shape":
+    for redirect in [
+      "https://ide.codetracer.com/auth/callback?code=AC1&state=st-abc",
+      "http://127.0.0.1:51234/callback?code=AC1&state=st-abc",
+      "codetracer://auth/callback?code=AC1&state=st-abc",
+    ]:
+      let outcome = parseAuthorizationResponse(redirect)
+      counted outcome.kind == aoCode
+      counted outcome.code == "AC1"
+      counted outcome.returnedState == "st-abc"
+
+  test "percent-decodes values":
+    let outcome = parseAuthorizationResponse(
+      "codetracer://auth/callback?code=a%2Fb%2Bc&state=x%20y")
+    counted outcome.kind == aoCode
+    counted outcome.code == "a/b+c"
+    counted outcome.returnedState == "x y"
+
+  test "an error response is reported as an error, not as malformed":
+    # A silent single-sign-on probe that finds nobody signed in answers exactly
+    # this. Treating it as malformed would turn the ordinary not-signed-in state
+    # into a reported defect.
+    let outcome = parseAuthorizationResponse(
+      "https://ide.codetracer.com/auth/callback?error=login_required&error_description=nobody&state=st-abc")
+    counted outcome.kind == aoError
+    counted outcome.error == "login_required"
+    counted outcome.errorDescription == "nobody"
+    counted outcome.errorState == "st-abc"
+
+  test "an error wins over a code in the same response":
+    # A response carrying both is not something to salvage a code from.
+    let outcome = parseAuthorizationResponse(
+      "codetracer://auth/callback?code=AC1&error=access_denied&state=st-abc")
+    counted outcome.kind == aoError
+    counted outcome.error == "access_denied"
+
+  test "a repeated parameter resolves to its FIRST occurrence":
+    # An injected duplicate is an attempt to have the client and the provider
+    # read different values out of one URL. Go's net/http FormValue — which the
+    # deployed provider is written against — takes the first, so taking the
+    # first is what keeps the two agreeing.
+    let outcome = parseAuthorizationResponse(
+      "codetracer://auth/callback?code=GOOD&code=EVIL&state=st-abc")
+    counted outcome.kind == aoCode
+    counted outcome.code == "GOOD"
+
+  test "a response with neither a code nor an error is malformed":
+    counted parseAuthorizationResponse("codetracer://auth/callback").kind == aoMalformed
+    counted parseAuthorizationResponse("codetracer://auth/callback?").kind == aoMalformed
+    counted parseAuthorizationResponse("codetracer://auth/callback?state=st-abc").kind == aoMalformed
+    counted parseAuthorizationResponse("codetracer://auth/callback?code=&state=st-abc").kind == aoMalformed
+    counted parseAuthorizationResponse("").kind == aoMalformed
+
+  test "a fragment is not part of the response":
+    let outcome = parseAuthorizationResponse(
+      "https://ide.codetracer.com/auth/callback?code=AC1&state=st-abc#code=EVIL")
+    counted outcome.kind == aoCode
+    counted outcome.code == "AC1"
+
+suite "oidc_redirect — the state check":
+  test "matches only an identical state":
+    counted constantTimeEq("st-abc", "st-abc")
+    counted not constantTimeEq("st-abc", "st-abd")
+    counted not constantTimeEq("st-abc", "st-ab")
+    counted not constantTimeEq("", "x")
+    counted constantTimeEq("", "")
+
+  test "a usable code requires a matching state":
+    let good = parseAuthorizationResponse("codetracer://auth/callback?code=AC1&state=st-abc")
+    counted isUsableCode(good, "st-abc")
+    counted not isUsableCode(good, "st-abd")
+    counted not isUsableCode(good, "")
+
+  test "an error or a malformed response is never usable":
+    let err = parseAuthorizationResponse("codetracer://auth/callback?error=access_denied&state=st-abc")
+    counted not isUsableCode(err, "st-abc")
+    let bad = parseAuthorizationResponse("codetracer://auth/callback?state=st-abc")
+    counted not isUsableCode(bad, "st-abc")
+
+  test "a response carrying NO state is refused even against a known state":
+    # The provider echoes `state` back; a response without one cannot be tied to
+    # the request that started the flow, so there is nothing to compare.
+    let noState = parseAuthorizationResponse("codetracer://auth/callback?code=AC1")
+    counted noState.kind == aoCode
+    counted not isUsableCode(noState, "st-abc")
+
+  test "every assertion in this file ran":
+    check countedAssertions == ExpectedAssertions


### PR DESCRIPTION
Adds `src/frontend/viewmodel/identity/oidc_redirect.nim` — the shared core both CodeTracer sign-in surfaces use, so the browser and the desktop app do not each grow their own redirect flow.

## What it is

- **PKCE (RFC 7636)** — verifier generation from supplied entropy, S256 challenge from a supplied digest, base64url without padding.
- **The redirect rules (RFC 8252)** — `AuthSurface` = web-redirect / native-loopback / native-scheme, with `isAcceptableRedirect` (https-only for a browser; the loopback exemption and private-use schemes only for a native app) and `requiresSystemBrowser` (§8.12).
- **The request and the response** — authorization-URL assembly, parsing for all three delivery shapes, and a non-early-exit `state` comparison.

## Why it is pure

It takes entropy and the SHA-256 digest as **arguments** rather than obtaining either, reads no environment variable, and performs no I/O. That is what lets one suite drive it on both the C and the JS backend, and it is what keeps it inside the identity layer's no-escape-hatch rule — `ci/test/identity-no-escape-hatch.sh` module budget goes 4 → 5, with the reason recorded inline, and the gate re-runs 9 checks / 0 failures.

## Verification

- 117 assertions, green on `nim c` **and** `nim js` (the JS run needs node, so it runs inside the repo dev shell).
- The PKCE vectors are the RFC's own: Appendix A octets → the example verifier, Appendix B digest → the example challenge. A pass therefore means "agrees with the standard", not "agrees with itself" — a self-consistent base64url encoder is exactly the defect that surfaces as an `invalid_grant` months later.

## Not in this PR

No host wiring. No Electron main-process work (`setAsDefaultProtocolClient`, `open-url`, `safeStorage`), no browser, no sign-in has been performed by a running process. `repro.nim` only **exports the path** of the workspace identity server's descriptor so a dev server can say "it is not running" instead of failing to find a name; it starts nothing.