### PR TITLE
Gate lane->job coverage: 16 of 30 test lanes run in no CI job

### DIFF
--- a/ci/lib/ci-reachability.sh
+++ b/ci/lib/ci-reachability.sh
@@ -1,0 +1,704 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# ci-reachability.sh — "can a CI lane actually reach this?", answered once.
+#
+# WHY THIS EXISTS
+# ---------------
+# Two guards ask the same question about different subjects.
+# `ci/test/shell-gate-coverage.sh` asks it about shell scripts under ci/ and
+# scripts/; `ci/test/test-lane-job-coverage.sh` asks it about the test LANES
+# declared in ci/lib/test-lane-files.sh. Both need the identical answer to
+# "which `just` recipes, and which scripts, can a GitHub workflow actually get
+# to?", and that answer is 600 lines of hard-won reference parsing: command
+# position vs. a mere mention, variables that hold script paths, `just`
+# dependency lists, script-to-script calls, and the equal-length-basename trap
+# that credited `ci/test/rust.sh` for years because `ci/lint/rust.sh` is the
+# same length.
+#
+# The second guard was written after the first. Re-deriving the walk for it
+# would have produced two engines that agree today and drift by the first
+# bugfix applied to only one -- which is precisely the failure mode
+# `ci/lib/test-lane-files.sh` exists to have ended for lane FILE selection.
+# This file ends it for lane REACHABILITY. Everything below was moved here
+# VERBATIM from shell-gate-coverage.sh; that guard's 22-check contract suite
+# (ci/test/shell-gate-coverage-test.sh) is what proves the move changed no
+# behaviour, and it must keep passing.
+#
+# CONTRACT
+#   The caller creates `tmp` (a mktemp -d it owns), sets `gates` to the
+#   newline-separated universe of script paths to resolve references against,
+#   and defines a `note` function for the one progress line `ci_reach_walk`
+#   does not emit. Then:
+#
+#     source ci/lib/ci-reachability.sh
+#     roots="$(ci_reach_roots)"
+#     ci_reach_parse_justfile     # sets `recipe_count`; fills ${tmp}/bodies,deps
+#     ci_reach_walk              # fills ${tmp}/reached, rreached, recipe-names
+#
+#   Outputs, all under ${tmp}:
+#     reached          script paths a CI lane can reach
+#     rreached         `just` recipe names a CI lane can reach
+#     recipe-names     every recipe the justfile defines
+#     missing-recipes  `just <name>` for a recipe the justfile does not define
+#
+#   `ci_reach_walk` reports nothing itself; the caller owns all output, because
+#   the two guards word their findings differently and neither should have to
+#   inherit the other's phrasing.
+
+# `ci_reach_roots` — the files a CI lane can START from, and nothing else.
+#
+# ---------------------------------------------------------------------------
+# THE WORKFLOWS, AND NOTHING ELSE. THIS IS THE OTHER HALF OF THE FIX.
+#
+# This list used to include the justfile and the `ci/lint/*.sh` dispatchers as
+# roots in their own right, and the justfile is the one that made the number a
+# fiction: EVERY gate any `just` recipe mentioned was seeded as reachable,
+# whether or not any lane runs that recipe. `just` is a developer entry point.
+# Most of its 200-odd recipes are things a person types; a handful are things CI
+# types. Seeding from the file rather than from the recipes CI actually calls
+# credited fourteen gates — the `noir-*` family, the `desktop-*` family,
+# `cli-record-smoke.sh`, `python-recorder-smoke.sh` and the rest — as covered
+# while they ran in no lane at all.
+#
+# The dispatchers do not need to be roots either, and making them roots hid the
+# same class of error one level down. `ci/lint/nim.sh` IS reachable — four
+# workflow steps name it — so the walk below reaches it the ordinary way, and if
+# a day comes when no workflow names it, this guard should say so rather than
+# assume it.
+#
+# NOT A ROOT, DELIBERATELY: `.gitlab-ci.yml`. It exists, it is 120 lines, and it
+# names `just test` and `ci/test/ui-tests.sh`. Counting it would credit
+# `ui-tests.sh` and everything under `just test` — and this repository's CI is
+# GitHub Actions: the inventory beside this file has recorded `ui-tests.sh` as
+# dark since 2026-09-01 with `ui-tests-db.sh is wired and this is not` as the
+# reason, which is a statement about the GitHub lanes. Treating the GitLab file
+# as a lane would silently retire that finding and five more. If somebody
+# revives that pipeline, add it here and watch six entries evict themselves.
+ci_reach_roots() {
+	find .github/workflows -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null | sort
+}
+
+# `refs_in` — reads file paths on STDIN, prints one reference per line:
+#
+#     S <token>     a `*.sh` path or basename this file INVOKES
+#     J <recipe>    a `just <recipe>` this file CALLS
+#
+# AN INVOCATION IS A POSITION, NOT A MENTION — AND THAT IS THE WHOLE RULE.
+#
+# This used to extract EVERY `*.sh`/`*.mjs`/`*.py` token on every non-comment
+# line and call each one a reference. That reads a filename and calls it a wire,
+# and it was wrong in three shapes that all look identical to a regex:
+#
+#     grep -q wasm_engine_assert_fresh "${WORKER_E2E}"   # a READ
+#     cat "${WORKER_E2E}"                                # a READ
+#     WORKER_E2E="${SUITE_ROOT}/ci/test/worker-...-e2e.sh"  # a NAME
+#
+# 295f36835 added exactly those three lines to `stale-artefact-guards-test.sh`.
+# Nothing in that commit builds the WASM engine and nothing executes the gate —
+# it is read as text, twice — and this guard nevertheless reported
+# `ci/test/worker-backend-wasm-e2e.sh` RESURRECTED and demanded its line be
+# deleted from the recorded-dark inventory. A truthfully recorded blocker, about
+# to be retired because a meta-test `cat`ted the file.
+#
+# The old rule needed a BLACKLIST to stay standing — `shellcheck` and `shfmt`
+# lines were dropped wholesale, because `ci/lint/bash.sh` shellchecks eleven
+# scripts it never runs. That blacklist is the same shape as a sweep that names
+# a symptom: it stops the readers somebody remembered, and `grep`, `cat`, `head`,
+# `cp`, `echo`, `diff` and a Python docstring went on counting. Enumerating them
+# is unbounded, and every miss is silent and green.
+#
+# So the test is now STRUCTURAL, and it is the one the shell itself applies. A
+# path is INVOKED when it stands where a command goes:
+#
+#   * COMMAND POSITION — the first word of a command. Start of a line, or after
+#     `|`, `||`, `&&`, `;`, `&`, `$(`, a backtick, a justfile `@`/`-` prefix, a
+#     workflow `run:`, or a keyword that opens a command (`if`, `then`, `do`,
+#     `exec`, `env`, `timeout 60`).
+#   * INTERPRETER ARGUMENT — the first non-flag word after `bash`, `sh`,
+#     `source`, `.`, `node`, `python3` and their relatives, WHEREVER that word
+#     stands. This one clause is what makes the wrappers work without a list of
+#     wrappers: `lint_step "name" bash ci/x.sh`, `nix develop -c ./ci/x.sh`,
+#     `timeout 900 bash ci/x.sh` and `xargs bash ci/x.sh` are all just `bash`
+#     followed by a path.
+#
+# Everything else is an argument, and an argument is a read. `shellcheck x.sh`
+# needs no special case any more: `shellcheck` takes command position and `x.sh`
+# is its argument. The blacklist is GONE, and eleven shellchecked-never-run
+# scripts stay dark for a reason that is now stated once instead of enumerated.
+#
+# AND THE ONE THING A POSITION RULE ALONE GETS WRONG: `bash "${GUARD}"`.
+#
+# Twenty-nine contract suites in this tree are written
+#
+#     GUARD="$REPO_ROOT/ci/verdict/job-timeouts.py"
+#     python3 "${GUARD}" --root "${TMP}"
+#
+# and the path never appears in command position at all. Dropping assignments
+# outright would have invented dark gates by the dozen — the failure mode that
+# gets a guard switched off. So the extractor makes TWO PASSES over the file: the
+# first records what each variable was ASSIGNED, the second resolves a variable
+# standing in an invoking position back to the paths it holds.
+#
+# That is also precisely what tells the two cases apart. `WASM_FRESHNESS_LIB` is
+# `source`d, so `ci/lib/wasm-engine-freshness.sh` is reachable and stays
+# reachable. `WORKER_E2E` is only ever `grep`ped and `cat`ted, so it confers
+# nothing — which is the truth 295f36835 wrote into the file.
+#
+# LINE CONTINUATIONS ARE JOINED FIRST, and that is load-bearing for both rules:
+# `ci/lint/bash.sh` writes every step as `lint_step "..." \` with the command on
+# the next physical line, so reading them separately would put `bash` at the
+# start of a line and make the interpreter clause fire on nothing.
+#
+# NOT DROPPED, DELIBERATELY: `source` and `.`. Sourcing EXECUTES the file in the
+# current shell, so it is an invocation and this guard has always counted it —
+# `ci/lib/published-asset.sh` and `visual-replay-gate-lib.sh` are reachable only
+# that way, and the transitivity note above depends on it.
+refs_in() {
+	# Reads paths on STDIN, one per line, so the caller need not expand a list
+	# into positional arguments — bash 3.2 has no array to expand.
+	#
+	# COMMENT LINES ARE DROPPED BEFORE NAMES ARE EXTRACTED, and this file is the
+	# reason. Its own header lists the gates it found dark. Once it was wired
+	# into `ci/lint/nim.sh` it became reachable, the transitive walk followed it,
+	# and every gate NAMED IN ITS PROSE was credited as reachable — so the guard
+	# reported 63 of 63 covered while four of them were referenced by nothing at
+	# all. A scanner that reads its own documentation is satisfied by anything
+	# that documentation says.
+	#
+	# Verification-Harness-Traps.md §4d, and the third instance found in this
+	# session: `ci-coverage.sh` in the sibling repository read a step's doc
+	# comment instead of the step, and its selftest's mutation arms rewrote a
+	# comment about a trigger instead of the trigger. Each time a control caught
+	# it; none of the three would have been visible in the transcript.
+	local f
+	while read -r f; do
+		[ -n "${f}" ] || continue
+		[ -f "${f}" ] || continue
+		refs_of_text <"${f}"
+	done | grep -v '^$' | sort -u || true
+}
+
+# The extractor itself, over one file's text on stdin. `awk`, because joining
+# continuations and then walking command positions is a multi-state job and
+# `grep` has one state.
+#
+# POSIX awk only: no `gensub`, no `asort`, no `[[:space:]]` outside brackets.
+# AND NO APOSTROPHE ANYWHERE IN THIS PROGRAM, comments included: it is
+# single-quoted from bash, and one apostrophe closes it — producing a bash
+# syntax error a hundred lines further down, in code that is not wrong. Where
+# the character itself is needed it is built with `sprintf("%c", 39)`.
+#
+# THE WHOLE FILE IS BUFFERED because the rule needs two passes: pass 1 records
+# variable assignments, pass 2 resolves them in invoking positions. See the
+# `bash "${GUARD}"` note in the header above for why that is not optional.
+refs_of_text() {
+	awk '
+	BEGIN {
+		SQ = sprintf("%c", 39)
+		# Quotes and parens are noise around a token, never part of a path.
+		STRIP = "[\"" SQ "()]"
+		# Words after which the NEXT non-flag word is a file this runs.
+		INTERP = " bash sh zsh dash ksh source . node nodejs python python2 python3 deno bun npx tsx ts-node ruby perl "
+		# Words that KEEP command position rather than consuming it: shell
+		# keywords, transparent prefixes, the justfile line prefixes, and the
+		# workflow `run:` key whose value is a shell script.
+		OPEN = " if while until then else elif do done fi ! exec command sudo nohup env eval builtin nice ionice stdbuf setsid time timeout xargs run: - @ @- -@ { } "
+		# Flags whose VALUE is a command line: `nix develop -c ./ci/lint/bash.sh`.
+		CMDARG = " -c --command --run --exec -exec "
+		# Declaration keywords: what follows is an assignment, not a command.
+		DECL = " local readonly export declare typeset "
+		# The JavaScript module-execution positions. `new Worker(x)`, `import(x)`
+		# and `require(x)` LOAD AND RUN x; they are the `.mjs` spelling of
+		# `bash x.sh`, and `ci/test/noir-wasm-worker/compare.mjs` reaches
+		# `worker.mjs` through nothing else.
+		JSEXEC = "(^|[^A-Za-z0-9_$.])(new[ \t]+Worker|require|import)[ \t]*\\("
+		nl = 0
+	}
+	{
+		cur = cur $0
+		if (cur ~ /\\$/) { sub(/\\$/, " ", cur); next }
+		lines[++nl] = cur; cur = ""
+	}
+	END {
+		if (cur != "") lines[++nl] = cur
+		# PASS 1 RUNS TWICE, and the second time is not superstition. It learns
+		# which parameter of each local function is EXECUTED rather than read
+		# (see `runsarg`), and functions call each other: `expect_leak` hands its
+		# `$1` to `leak_scan`, so whether `$1` is executed depends on what
+		# `leak_scan` was found to do. One iteration answers that only when the
+		# callee is defined first. Two covers a call to a helper defined later,
+		# which is the whole of the nesting this tree actually has.
+		for (pass = 1; pass <= 2; pass++) {
+			curfn = ""
+			for (k = 1; k <= nl; k++) scan(lines[k], 1)
+		}
+		curfn = ""
+		for (k = 1; k <= nl; k++) scan(lines[k], 2)
+	}
+
+	# A line that carries no wire at all, whatever it names.
+	function dropped(line) {
+		# COMMENT MARKERS FOR ALL THREE LANGUAGES, not just `#`. Widening the
+		# subject to `.mjs` and `.py` without widening this would re-create the
+		# exact defect the comment rule exists for, in the new files: a probe
+		# named in a `//` doc comment would be credited as wired.
+		if (line ~ /^[ \t]*#/) return 1
+		if (line ~ /^[ \t]*\/\//) return 1
+		if (line ~ /^[ \t]*\*/) return 1
+		# A `paths:` TRIGGER FILTER NAMES A FILE TO WATCH, NOT ONE TO RUN. It is
+		# the read rule one more step along: `grep x.sh` at least opens the file,
+		# while `- x.sh` under `on: push: paths:` only decides whether the
+		# workflow starts. Measured: `beam-flow.yml` lists
+		# `ci/test/elixir-flow-cross-repo.sh` in two `paths:` blocks and runs
+		# `beam-flow-cross-repo.sh` instead, so the ONLY reference to that shim
+		# in the entire repository was a trigger condition, and it counted as
+		# coverage.
+		#
+		# The shape matched is a YAML sequence item whose whole content is one
+		# unbroken token ending in `.sh`, optionally quoted. A real step is
+		# `- run: bash x.sh` or `- uses: ...` and always carries a space before
+		# the path, so it cannot match this.
+		if (line ~ /^[ \t]*-[ \t]*[^ \t]*\.(sh|mjs|py)[^ \t]*[ \t]*$/) return 1
+		return 0
+	}
+
+	function haspath(s) { return (s ~ /[A-Za-z0-9_-]\.(sh|mjs|py)/) }
+
+	function putpaths(s,   rest) {
+		rest = s
+		while (match(rest, /[A-Za-z0-9_.\/-]*[A-Za-z0-9_-]\.(sh|mjs|py)/)) {
+			print "S " substr(rest, RSTART, RLENGTH)
+			rest = substr(rest, RSTART + RLENGTH)
+		}
+	}
+
+	# The first ${NAME} or $NAME in a token, so `"${GUARD}"` resolves.
+	function varname(s) {
+		if (match(s, /\$\{[A-Za-z_][A-Za-z0-9_]*/)) return substr(s, RSTART + 2, RLENGTH - 2)
+		if (match(s, /\$[A-Za-z_][A-Za-z0-9_]*/)) return substr(s, RSTART + 1, RLENGTH - 1)
+		return ""
+	}
+
+	# `$1`, `${2}`, `$@` — a POSITIONAL PARAMETER standing where a command goes.
+	# Returns the index, or 0.
+	function posref(s) {
+		if (s ~ /^\$\{?[@*]\}?$/) return 1
+		if (match(s, /^\$\{?[0-9]+/)) {
+			if (match(s, /[0-9]+/)) return substr(s, RSTART, RLENGTH) + 0
+		}
+		return 0
+	}
+
+	# A token that stands where a command goes.
+	#
+	# Phase 2 prints the paths it holds — literally, or through the variable it
+	# names. Phase 1 prints nothing and instead LEARNS: a positional parameter in
+	# this position means the enclosing function EXECUTES that argument, which is
+	# what makes `probe chords ci/test/chord_double_fire_probe.mjs` a wire and
+	# `expect_leak leaky.sh REPO_ROOT` a read.
+	function invoke(tok, phase,   v, p) {
+		p = posref(tok)
+		if (p > 0) {
+			posmode = 1
+			if (phase == 1 && curfn != "") runsarg[curfn, p] = 1
+			return
+		}
+		v = varname(tok)
+		if (phase == 1) {
+			if (v != "" && curfn != "" && ((curfn, v) in frompos))
+				runsarg[curfn, frompos[curfn, v]] = 1
+			return
+		}
+		if (haspath(tok)) { putpaths(tok); return }
+		if (v != "" && (v in assigned)) putpaths(assigned[v])
+	}
+
+	function record(tok,   name, val) {
+		name = substr(tok, 1, index(tok, "=") - 1)
+		val = substr(tok, index(tok, "=") + 1)
+		# `local script="$2"` inside a function: remember the binding, so that a
+		# later `node "${script}"` is understood as executing parameter 2.
+		if (curfn != "" && match(val, /^\$\{?[0-9]+/)) {
+			if (match(val, /[0-9]+/)) frompos[curfn, name] = substr(val, RSTART, RLENGTH) + 0
+		}
+		if (!haspath(val)) return
+		# A variable assigned twice holds either value, so both are recorded —
+		# but pass 1 itself runs twice, so an unconditional append would store
+		# every value twice over.
+		if (!(name in assigned)) assigned[name] = val
+		else if (index(" " assigned[name] " ", " " val " ") == 0)
+			assigned[name] = assigned[name] " " val
+	}
+
+	# `bash`, `/usr/bin/python3`, and the two indirect spellings this tree uses
+	# for an interpreter it had to locate first:
+	#
+	#     cargo_lock_pin_guard_python="$(type -P python3)"
+	#     "$cargo_lock_pin_guard_python" -I "$PREFLIGHT_DIR/cargo-lock-pin-guard.py"
+	#     "$(visual_replay_gate_python)" -I "$VISUAL_REPLAY_GATE_REPORT_VALIDATOR"
+	#
+	# Both of those RUN a python guard, and a rule that only knows the literal
+	# word `python3` calls both of those guards dark. The LAST word of the name
+	# is the test — `..._python` and `${BASH:-bash}` are interpreters,
+	# `${SUITE_ROOT}` and `${WORKER_E2E}` are not — and it is the last word
+	# rather than any word for exactly that reason: `${SH_LIB}` would otherwise
+	# read as `sh`.
+	# A FILENAME IS NEVER THE INTERPRETER, and this guard is not decorative.
+	# Without it `scripts/docs/deep-review-capture-lib.sh` splits to a last word
+	# of `sh`, reads as an interpreter, and credits whatever `shellcheck` was
+	# handed next on the same line — which put `capture-deep-review-screenshots.sh`
+	# back on the reachable list while it declares NOT-A-CI-GATE in its own header.
+	function isinterp(s,   b, nb, ba, q, last) {
+		if (haspath(s)) return 0
+		if (index(INTERP, " " s " ") > 0) return 1
+		b = s
+		sub(/.*\//, "", b)
+		if (index(INTERP, " " b " ") > 0) return 1
+		gsub(/[^A-Za-z0-9]/, " ", b)
+		nb = split(b, ba, / +/)
+		last = ""
+		for (q = 1; q <= nb; q++) if (ba[q] != "") last = ba[q]
+		if (last != "" && index(INTERP, " " tolower(last) " ") > 0) return 1
+		return 0
+	}
+
+	function scan(line, phase,   work, n, arr, i, t, core, cmdpos, want, infn, argn) {
+		if (dropped(line)) return
+		if (phase == 2) justrefs(line)
+
+		# FUNCTION BOUNDARIES, tracked so that `$1` can be attributed to the
+		# function whose parameter it is. Closing brace at column 0 is how every
+		# function in this tree ends, and a stricter parser buys nothing here.
+		if (match(line, /^[ \t]*(function[ \t]+)?[A-Za-z_][A-Za-z0-9_-]*[ \t]*\(\)/)) {
+			curfn = line
+			sub(/^[ \t]*/, "", curfn)
+			sub(/^function[ \t]+/, "", curfn)
+			sub(/[ \t]*\(\).*$/, "", curfn)
+			isfn[curfn] = 1
+		} else if (line ~ /^\}/) {
+			curfn = ""
+		}
+
+		# The operators that END one command and start the next. Turned into
+		# free-standing tokens so the walk below needs no separate lexer.
+		# NOT SPLIT ON: `{`, because `${VAR}` would then put the rest of the
+		# path in command position and credit every `X="${ROOT}/ci/y.sh"` line
+		# this rule exists to stop.
+		#
+		# A BACKTICK IS NOT COMMAND SUBSTITUTION HERE, IT IS A QUOTATION MARK.
+		# This did split on it, and that put a path in command position every
+		# time a Python docstring or a `.mjs` block comment quoted one the way
+		# this repository quotes everything:
+		#
+		#     suppresses everything, so `ci/test/known-failures-gate.sh` drives
+		#     `ci/test/desktop-bundle-self-contained.sh` asks "does every path...
+		#
+		# Both read as an invocation, in files that only mention the name. The
+		# invariant that makes dropping the split safe is enforced, not assumed:
+		# `shellcheck` runs over all of ci/ and scripts/ in the `lint-bash` lane
+		# and SC2006 flags legacy backtick substitution, of which this tree has
+		# exactly zero. So the token rule below can treat a leading backtick as
+		# prose outright.
+		work = line
+		gsub(/\$\(/, " @@CMD@@ ", work)
+		gsub(/\|\|/, " @@CMD@@ ", work)
+		gsub(/&&/, " @@CMD@@ ", work)
+		gsub(/\|/, " @@CMD@@ ", work)
+		gsub(/;/, " @@CMD@@ ", work)
+		gsub(/&/, " @@CMD@@ ", work)
+
+		posmode = 0
+		n = split(work, arr, /[ \t]+/)
+		cmdpos = 1
+		want = 0
+		infn = ""
+		argn = 0
+		for (i = 1; i <= n; i++) {
+			t = arr[i]
+			if (t == "") continue
+			if (t == "@@CMD@@") { cmdpos = 1; want = 0; infn = ""; continue }
+			# A backtick-quoted word is prose. See the note above the splitter.
+			if (t ~ /^`/) { cmdpos = 0; want = 0; continue }
+			core = t
+			gsub(STRIP, "", core)
+			if (core == "") continue
+
+			# `VAR=value`. The path in it is a NAME. Command position survives,
+			# because `FOO=1 bash x.sh` is an environment prefix.
+			if (core ~ /^[A-Za-z_][A-Za-z0-9_]*=/) {
+				if (phase == 1) record(core)
+				cmdpos = 1; want = 0; continue
+			}
+			if (index(DECL, " " core " ") > 0) { cmdpos = 1; want = 0; continue }
+
+			if (want) {
+				if (core ~ /^-/) {
+					# `bash -lc PROGRAM` / `python3 -c PROGRAM`: what follows is
+					# not a path but a SCRIPT, so the walk restarts in command
+					# position inside it rather than eating the next word.
+					if (core ~ /^-[A-Za-z]*c$/ || index(CMDARG, " " core " ") > 0) {
+						want = 0; cmdpos = 1
+					}
+					continue
+				}
+				invoke(core, phase)
+				want = 0; cmdpos = 0; continue
+			}
+			if (cmdpos) {
+				if (index(OPEN, " " core " ") > 0) continue
+				# `timeout 900 bash x.sh`, `sleep 5` — a bare duration.
+				if (core ~ /^[0-9]+[smhd]?$/) continue
+				if (haspath(core)) { invoke(core, phase); cmdpos = 0; continue }
+				if (isinterp(core)) { want = 1; cmdpos = 0; continue }
+				# A LOCALLY DEFINED FUNCTION. Its arguments are invoking
+				# positions exactly where its body executes the matching `$N`.
+				if (core in isfn) { infn = core; argn = 0; cmdpos = 0; continue }
+				cmdpos = 0; continue
+			}
+			# Argument position. An argument is a READ — with three exceptions,
+			# each of which is still "something executes this".
+			if (infn != "") {
+				argn++
+				if ((infn, argn) in runsarg) { invoke(core, phase); continue }
+			}
+			if (index(CMDARG, " " core " ") > 0) { cmdpos = 1; continue }
+			if (isinterp(core)) { want = 1; continue }
+		}
+
+		# A POSITIONAL PARAMETER STOOD WHERE A COMMAND GOES, and the program it
+		# stood in is a quoted string this walk cannot see inside:
+		#
+		#     bash -c "source \"$1\"; newest_executable \"$@\"" _ "${NEWEST_LIB}"
+		#
+		# `ci/lib/newest-build.sh` is reached by that line and by nothing else in
+		# ci/ or scripts/. Rather than parse an embedded shell program, the line
+		# that proves it runs one is credited whole. Deliberately the widening
+		# direction: it over-credits a line that already declared it executes an
+		# argument, and it fires on nothing that does not.
+		if (posmode && phase == 2)
+			for (i = 1; i <= n; i++) {
+				core = arr[i]
+				gsub(STRIP, "", core)
+				if (core == "") continue
+				if (core ~ /^[A-Za-z_][A-Za-z0-9_]*=/) continue
+				if (haspath(core)) { putpaths(core); continue }
+				t = varname(core)
+				if (t != "" && (t in assigned)) putpaths(assigned[t])
+			}
+
+		# THE JAVASCRIPT MODULE-EXECUTION POSITIONS, which have no command
+		# position to stand in. See JSEXEC.
+		if (phase == 2 && line ~ JSEXEC) putpaths(line)
+	}
+
+	# `just <recipe>`, unchanged: a recipe name is not a path and the position
+	# rule above does not apply to it.
+	function justrefs(line,   n, i, j, t, u, arr) {
+		n = split(line, arr, /[ \t]+/)
+		for (i = 1; i <= n; i++) {
+			t = arr[i]
+			gsub(/^[^A-Za-z0-9_.\/-]+/, "", t)
+			gsub(/[^A-Za-z0-9_.\/-]+$/, "", t)
+			if (t != "just") continue
+			# Skip flags, and the VALUE of a flag that takes one — otherwise
+			# `just --justfile X recipe` reports the recipe as `--justfile`.
+			j = i + 1
+			while (j <= n) {
+				u = arr[j]
+				gsub(/^[^A-Za-z0-9_.\/=-]+/, "", u)
+				gsub(/[^A-Za-z0-9_.\/=-]+$/, "", u)
+				if (u !~ /^-/) break
+				if (u == "-f" || u == "--justfile" || u == "-d" ||
+					u == "--working-directory" || u == "--set") j++
+				j++
+			}
+			if (j > n) continue
+			u = arr[j]
+			gsub(/^[^A-Za-z0-9_-]+/, "", u)
+			gsub(/[^A-Za-z0-9_-]+$/, "", u)
+			if (u ~ /^[A-Za-z0-9_][A-Za-z0-9_-]*$/) print "J " u
+		}
+	}
+	'
+}
+
+# `ci_reach_parse_justfile` — fill ${tmp}/bodies and ${tmp}/deps, set recipe_count.
+# ---------------------------------------------------------------------------
+# The justfile, read as a GRAPH rather than as a root.
+# ---------------------------------------------------------------------------
+# A recipe is reached when a workflow calls it, or when a reached recipe depends
+# on it, or when a reached script calls it. Only THEN does what it invokes count.
+#
+# Emitted as two flat, tab-separated tables rather than shell variables, because
+# bash 3.2 has no associative array and `just` has 208 recipes here.
+#
+#     ${tmp}/bodies   NAME <tab> one body line
+#     ${tmp}/deps     NAME <tab> one dependency name
+#
+# The header grammar this reads: an unindented line whose first token is the
+# recipe name, optional parameters, then `:` and optional dependencies. `:=` is
+# an assignment, not a recipe, and dependencies may carry `(args)` or be joined
+# by `&&` for post-dependencies — all stripped. The body is every following line
+# that is indented or blank, up to the next unindented non-blank line.
+ci_reach_parse_justfile() {
+	: >"${tmp}/bodies"
+	: >"${tmp}/deps"
+	justfile=""
+	[ -f justfile ] && justfile="justfile"
+	[ -z "${justfile}" ] && [ -f Justfile ] && justfile="Justfile"
+	recipe_count=0
+	if [ -n "${justfile}" ]; then
+		awk -v bodies="${tmp}/bodies" -v deps="${tmp}/deps" '
+		/^[ \t]/  { if (name != "") print name "\t" $0 >> bodies; next }
+		/^[ \t]*$/ { next }
+		{
+			name = ""
+			if ($0 !~ /:=/ && $0 ~ /^@?[A-Za-z0-9_][A-Za-z0-9_-]*([ \t][^:]*)?:/) {
+				hdr = $0
+				sub(/^@/, "", hdr)
+				split(hdr, h, ":")
+				split(h[1], hn, /[ \t]/)
+				name = hn[1]
+				if (name == "set" || name == "alias" || name == "export" ||
+					name == "import" || name == "mod") { name = ""; next }
+				d = substr(hdr, index(hdr, ":") + 1)
+				gsub(/\(/, " ", d); gsub(/\)/, " ", d); gsub(/&&/, " ", d)
+				gsub(/{{[^}]*}}/, " ", d)
+				nd = split(d, da, /[ \t]+/)
+				for (i = 1; i <= nd; i++)
+					if (da[i] ~ /^[A-Za-z0-9_][A-Za-z0-9_-]*$/)
+						print name "\t" da[i] >> deps
+				print name "\t" >> bodies
+			}
+		}
+		' "${justfile}"
+		recipe_count="$(cut -f1 "${tmp}/bodies" | sort -u | grep -c . || true)"
+	fi
+}
+
+# `resolve` — reference tokens on stdin, universe paths on stdout.
+#
+# A token carrying a directory wins over a bare basename: `ci/lint/nix.sh`
+# resolves to that file alone, while a bare `nix.sh` cannot tell `ci/build/nix.sh`
+# from `ci/lint/nix.sh` and credits both. That is the false-POSITIVE direction
+# for exactly two basenames in this tree, and it is the safe one — a guard that
+# invents dark gates gets switched off.
+resolve() {
+	awk -F'\t' '
+	NR == FNR { n[$1]++; p[$1, n[$1]] = $2; next }
+	{
+		tok = $0; sub(/^\.\//, "", tok)
+		b = tok; sub(/.*\//, "", b)
+		if (!(b in n)) next
+		found = 0
+		if (tok ~ /\//)
+			for (i = 1; i <= n[b]; i++) {
+				q = p[b, i]
+				# `index()` RETURNS 0 FOR "NOT FOUND", AND 0 IS ALSO A LEGITIMATE
+				# VALUE OF `length(q) - length(tok)` — WHENEVER THE TWO PATHS ARE
+				# THE SAME LENGTH. Without the `> 0` guard the suffix test reads
+				# `0 == 0` and every equal-length sibling of a basename is
+				# credited by its twin. Measured on this tree: `ci/lint/rust.sh`
+				# (15 chars) is invoked by `codetracer.yml`, and that invocation
+				# silently credited `ci/test/rust.sh` (15 chars), which is
+				# referenced by NOTHING in the repository — an orphan from the
+				# initial open-source release, superseded by the `test-rust`
+				# recipe and still naming `--bin db-backend`, a binary since
+				# renamed. The guard reported it covered for as long as it existed.
+				#
+				# `ci/build/nix.sh` (15) and `ci/lint/nix.sh` (14) differ in
+				# length, which is the only reason that pair never showed the bug.
+				if (q == tok ||
+					(index(q, "/" tok) > 0 &&
+						index(q, "/" tok) == length(q) - length(tok))) {
+					print q; found = 1
+				}
+			}
+		if (!found) for (i = 1; i <= n[b]; i++) print p[b, i]
+	}
+	' "${tmp}/index" -
+}
+
+# `body_of RECIPE` / `deps_of RECIPE` — the two tables, read back.
+body_of() { awk -F'\t' -v r="$1" '$1 == r { print substr($0, length(r) + 2) }' "${tmp}/bodies"; }
+deps_of() { awk -F'\t' -v r="$1" '$1 == r { print $2 }' "${tmp}/deps"; }
+
+# `absorb` — reference lines (`S tok` / `J recipe`) on stdin; enqueue what is new.
+# One `resolve` per CALLER, not per token: resolving token-at-a-time made this a
+# few thousand awk processes and thirty seconds.
+absorb() {
+	local r
+	cat >"${tmp}/refs"
+	grep '^S ' "${tmp}/refs" | cut -c3- | resolve | sort -u >"${tmp}/refs.s"
+	grep '^J ' "${tmp}/refs" | cut -c3- | sort -u >"${tmp}/refs.j"
+	while read -r r; do
+		[ -n "${r}" ] || continue
+		grep -Fxq -- "${r}" "${tmp}/reached" && continue
+		printf '%s\n' "${r}" >>"${tmp}/reached"
+		printf '%s\n' "${r}" >>"${tmp}/fq"
+	done <"${tmp}/refs.s"
+	while read -r r; do
+		[ -n "${r}" ] || continue
+		if grep -Fxq -- "${r}" "${tmp}/recipe-names"; then
+			grep -Fxq -- "${r}" "${tmp}/rreached" && continue
+			printf '%s\n' "${r}" >>"${tmp}/rreached"
+			printf '%s\n' "${r}" >>"${tmp}/rq"
+		else
+			# `just <name>` for a recipe THIS justfile does not define. Recorded
+			# but not reported: see step 4 for why it cannot be treated as rot.
+			# What matters here is that it confers no reachability.
+			printf '%s\n' "${r}" >>"${tmp}/missing-recipes"
+		fi
+	done <"${tmp}/refs.j"
+}
+
+# `ci_reach_walk` — seed from the roots, then alternate the two worklists.
+ci_reach_walk() {
+	printf '%s\n' "${gates}" >"${tmp}/universe"
+	# basename <tab> path, so a reference can be resolved without an assoc array.
+	awk -F/ '{ print $NF "\t" $0 }' "${tmp}/universe" >"${tmp}/index"
+
+	# TWO WORKLISTS, because the graph has two kinds of node. Files and recipes are
+	# not interchangeable: a recipe's outgoing edges come from its body AND its
+	# dependency list, a file's only from its text.
+	: >"${tmp}/reached"
+	: >"${tmp}/rreached"
+	: >"${tmp}/fq"
+	: >"${tmp}/rq"
+
+	: >"${tmp}/missing-recipes"
+	cut -f1 "${tmp}/bodies" | sort -u >"${tmp}/recipe-names"
+
+	printf '%s\n' "${roots}" | grep -v '^$' | refs_in | absorb
+
+	# THE SEED COUNTS ARE SNAPSHOTTED HERE, BEFORE THE TRANSITIVE LOOP RUNS.
+	#
+	# When the seed and the loop lived in the caller, it read these two numbers
+	# off `${tmp}/reached` between the two stages and got "what the workflows
+	# name DIRECTLY". Folding both stages into this one function silently
+	# changed that line's meaning to "everything reachable at all": the first
+	# refactor of this file reported `197 script(s) and 66 recipe(s) directly`
+	# where the truth is 62 and 41. The gate's verdict was unaffected -- the
+	# same 238/197/30/1 came out either way -- which is exactly why it would
+	# have shipped. A number that is only ever printed is the easiest kind to
+	# corrupt without failing anything.
+	grep -c . "${tmp}/reached" >"${tmp}/seeded-scripts" || true
+	grep -c . "${tmp}/rreached" >"${tmp}/seeded-recipes" || true
+
+	# Alternate between the two queues until both are empty.
+	while [ -s "${tmp}/fq" ] || [ -s "${tmp}/rq" ]; do
+		if [ -s "${tmp}/fq" ]; then
+			cur="$(head -1 "${tmp}/fq")"
+			tail -n +2 "${tmp}/fq" >"${tmp}/fq.next" && mv "${tmp}/fq.next" "${tmp}/fq"
+			printf '%s\n' "${cur}" | refs_in | absorb
+		else
+			cur="$(head -1 "${tmp}/rq")"
+			tail -n +2 "${tmp}/rq" >"${tmp}/rq.next" && mv "${tmp}/rq.next" "${tmp}/rq"
+			{
+				body_of "${cur}" | refs_of_text
+				deps_of "${cur}" | sed 's/^/J /'
+			} | absorb
+		fi
+	done
+}

--- a/ci/lib/test-lane-files.sh
+++ b/ci/lib/test-lane-files.sh
@@ -271,6 +271,91 @@ test_lane_parity_partner() {
 	esac
 }
 
+# test_lane_entrypoint ID — the ONE command that runs this lane, as either
+# `just:<recipe>` or `script:<path>`.
+#
+# WHY THIS EXISTS
+# ---------------
+# `ci/test/test-lane-coverage.sh` proves FILE -> LANE: every test-shaped Nim
+# file is claimed by some lane. Nothing proved LANE -> JOB. Those are different
+# questions, and the gap between them is not theoretical: measured on this tree
+# on 2026-09-08, 16 of the 30 lanes below were invoked by NO CI job at all, and
+# every one of them looked covered, because `test-lane-coverage.sh` was happy
+# and `ci/test/test-lane-report-test.sh` asserts only that a lane is
+# WELL-FORMED, never that anything runs it. A new test file could therefore be
+# correctly assigned to a lane, pass every gate in the repository, and be
+# executed by nothing. `just test-vm-unit` was in exactly that state: zero hits
+# across all twelve files in .github/workflows.
+#
+# So this accessor is the missing edge, written down where the other lane facts
+# live. `ci/test/test-lane-job-coverage.sh` reads it and fails, BY NAME, on any
+# lane whose entrypoint no workflow can reach.
+#
+# WHY IT IS DECLARED AND ALSO DERIVED
+# -----------------------------------
+# For 21 of the 30 lanes the answer is already discoverable: the recipe body
+# contains `run-nim-test-lane.sh <id>` or `test_lane_files <id>`, and the gate
+# derives it from the justfile. For those, this table is CROSS-CHECKED against
+# the derivation and a disagreement is a hard failure -- so the declaration
+# cannot quietly rot into naming a recipe that stopped running the lane.
+#
+# The remaining nine lanes are the ones whose runners predate the lane library
+# and do not consume it (`test-bpf` shells out to its own scripts,
+# `agentic-headless` is a bare script with no recipe at all, `m16-release-gate`
+# and `ct-providers` are ct-test binaries). Nothing can derive those, so they
+# are declared -- and the gate still proves the declared entrypoint EXISTS and
+# is reachable, which is the half that matters. A declaration can be wrong
+# about which recipe corresponds to a lane; it cannot make an unreachable
+# recipe look reachable.
+#
+# EVERY LANE MUST HAVE ONE. The `*)` arm returns empty and the gate treats an
+# empty answer as a failure, naming the lane. That is deliberate: a new lane
+# added without an entrypoint is precisely the state this file exists to stop,
+# and defaulting to something plausible would recreate it.
+test_lane_entrypoint() {
+	case "$1" in
+	# --- derived and cross-checked (recipe body names the lane id) ---------
+	common-units) echo "just:test-common-units" ;;
+	ct-cli-units) echo "just:test-ct-cli-units" ;;
+	ct-trace-units) echo "just:test-ct-trace-units" ;;
+	mcr-enrichment-units) echo "just:test-mcr-enrichment-units" ;;
+	online-sharing-live) echo "just:test-online-sharing-compile" ;;
+	host-instantiations) echo "just:test-host-instantiations" ;;
+	# Both renderer lanes are compiled by the one recipe; it runs
+	# `run-nim-test-lane.sh renderer-electron` and `... renderer-web` back to
+	# back, which is why two lanes share an entrypoint here.
+	renderer-electron) echo "just:test-renderer-browser" ;;
+	renderer-web) echo "just:test-renderer-browser" ;;
+	frontend-native-units) echo "just:test-frontend-units" ;;
+	vm-unit) echo "just:test-vm-unit" ;;
+	vm-unit-js) echo "just:test-vm-unit-js" ;;
+	vm-collab-units) echo "just:test-vm-collab-units" ;;
+	vm-collab-integration) echo "just:test-vm-collab-integration" ;;
+	vm-native) echo "just:test-vm-native" ;;
+	vm-js) echo "just:test-vm-js" ;;
+	vm-gui-headless) echo "just:test-vm-gui-headless" ;;
+	cli-record) echo "just:test-cli-record" ;;
+	ct-test-incremental) echo "just:test-ct-test-incremental" ;;
+	ct-test-incremental-e2e) echo "just:test-ct-test-incremental-e2e" ;;
+	ct-test-certificates) echo "just:test-ct-test-certificates" ;;
+	vm-recorder-gated) echo "just:test-vm-recorder-gated" ;;
+
+	# --- declared only (runner does not consume this library) --------------
+	frontend-js) echo "just:test-frontend-js" ;;
+	no-sidecar-manifests) echo "just:test-no-sidecar-manifests" ;;
+	m16-release-gate) echo "just:test-m16-release-gate" ;;
+	ct-providers) echo "just:test-ct-providers" ;;
+	visual-replay-gate) echo "just:test-visual-replay-gate" ;;
+	agent-api-contract) echo "just:test-agent-api-contract" ;;
+	bpf) echo "just:test-bpf" ;;
+	book-isonim) echo "just:test-book-isonim" ;;
+	# The only lane with no recipe at all: a bare script, invoked directly.
+	agentic-headless) echo "script:scripts/test-codetracer-agentic-headless.sh" ;;
+
+	*) echo "" ;;
+	esac
+}
+
 # test_lane_extra_flags ID — extra `nim` flags the lane's files need. Each
 # non-empty answer must say what breaks without it.
 test_lane_extra_flags() {

--- a/ci/lint/nim.sh
+++ b/ci/lint/nim.sh
@@ -43,6 +43,23 @@ lint_step "test-lane coverage guard: contract suite" \
 lint_step "test-lane coverage: every test-shaped file runs somewhere" \
 	bash ci/test/test-lane-coverage.sh
 
+# THE SAME QUESTION, ONE EDGE FURTHER ALONG. The guard above proves FILE ->
+# LANE: no test-shaped Nim file is missed by every lane. It says nothing about
+# whether a LANE is run by a JOB, and those are different questions with a real
+# gap between them — measured on 2026-09-08, 16 of the 30 declared lanes were
+# invoked by no CI job at all, while passing the guard above on every file they
+# claim. `just test-vm-unit`, 62 cases of ViewModel unit pyramid, had zero hits
+# across all fourteen workflow files.
+#
+# That is why a correctly-assigned test file could pass every gate in this
+# repository and still be executed by nothing, and it is the specific hole this
+# pair closes. Contract suite first, same reason as every other pair here.
+lint_step "test-lane job-coverage guard: contract suite" \
+	bash ci/test/test-lane-job-coverage-test.sh
+
+lint_step "test-lane job coverage: every declared lane is invoked by a CI job" \
+	bash ci/test/test-lane-job-coverage.sh
+
 # THE SAME QUESTION, ONE FILE EXTENSION OVER. `test-lane-coverage.sh` is scoped
 # in its own first line to "any test-shaped **Nim** file", and `ci/test/` holds
 # sixty-three SHELL gates that nothing measured. Twelve of them were reachable

--- a/ci/test/shell-gate-coverage.sh
+++ b/ci/test/shell-gate-coverage.sh
@@ -91,6 +91,18 @@
 set -uo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# WHERE THE LIBRARY IS, AS OPPOSED TO WHAT IS BEING SCANNED. `root` is the tree
+# under examination and `--root` moves it; this is the checkout THIS SCRIPT
+# lives in, and nothing moves it. They are the same path in CI and different
+# whenever ci/test/shell-gate-coverage-test.sh drives the guard against one of
+# its synthetic fixture trees -- which contain a `.github/workflows` and some
+# `ci/*.sh` decoys and no `ci/lib` at all. Sourcing the library through `root`
+# worked in the repo and made every one of the 22 mutation arms abort with
+# `found 0 CI root(s)`, because the failed `source` left `ci_reach_roots`
+# undefined and the guard carried on with an empty root list.
+gate_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
 while [ $# -gt 0 ]; do
 	case "$1" in
 	--root)
@@ -262,35 +274,43 @@ fi
 echo
 
 # ---------------------------------------------------------------------------
-# The roots: what CI can start from.
+# The roots, the reference scanner and the reachability walk: ci/lib/ci-reachability.sh
 # ---------------------------------------------------------------------------
-# THE WORKFLOWS, AND NOTHING ELSE. THIS IS THE OTHER HALF OF THE FIX.
+# They used to be 600 lines of THIS file. They moved out when
+# ci/test/test-lane-job-coverage.sh started asking the same question about test
+# LANES that this guard asks about shell scripts -- "can a CI lane actually
+# reach it?" -- because a second copy of this walk would have agreed with this
+# one on the day it was written and drifted from it by the first bugfix applied
+# to only one of the two. That is the same failure mode ci/lib/test-lane-files.sh
+# exists to have ended for lane FILE selection, one question over.
 #
-# This list used to include the justfile and the `ci/lint/*.sh` dispatchers as
-# roots in their own right, and the justfile is the one that made the number a
-# fiction: EVERY gate any `just` recipe mentioned was seeded as reachable,
-# whether or not any lane runs that recipe. `just` is a developer entry point.
-# Most of its 200-odd recipes are things a person types; a handful are things CI
-# types. Seeding from the file rather than from the recipes CI actually calls
-# credited fourteen gates — the `noir-*` family, the `desktop-*` family,
-# `cli-record-smoke.sh`, `python-recorder-smoke.sh` and the rest — as covered
-# while they ran in no lane at all.
+# Nothing about the walk changed in the move, INCLUDING the doctrine that used
+# to be written here at length: the workflow files are the only roots, the
+# justfile is not a root (seeding from it credited fourteen gates that run in no
+# lane), and the ci/lint/*.sh dispatchers are not roots either (they are
+# reachable the ordinary way, and if a day comes when no workflow names one,
+# this guard should say so rather than assume it). That text moved with the
+# code it governs. The 22 checks in ci/test/shell-gate-coverage-test.sh are what
+# hold the move honest.
+# ---------------------------------------------------------------------------
+# Spelled `"${gate_repo_root}/ci/lib/ci-reachability.sh"`, matching the idiom
+# ci/lib/run-nim-test-lane.sh already uses, and BOTH halves of that are
+# load-bearing.
 #
-# The dispatchers do not need to be roots either, and making them roots hid the
-# same class of error one level down. `ci/lint/nim.sh` IS reachable — four
-# workflow steps name it — so the walk below reaches it the ordinary way, and if
-# a day comes when no workflow names it, this guard should say so rather than
-# assume it.
+#   * The variable, not `cd`-relative: `--root` repoints the scan at a synthetic
+#     tree that has no ci/lib (see gate_repo_root above).
 #
-# NOT A ROOT, DELIBERATELY: `.gitlab-ci.yml`. It exists, it is 120 lines, and it
-# names `just test` and `ci/test/ui-tests.sh`. Counting it would credit
-# `ui-tests.sh` and everything under `just test` — and this repository's CI is
-# GitHub Actions: the inventory beside this file has recorded `ui-tests.sh` as
-# dark since 2026-09-01 with `ui-tests-db.sh is wired and this is not` as the
-# reason, which is a statement about the GitHub lanes. Treating the GitLab file
-# as a lane would silently retire that finding and five more. If somebody
-# revives that pipeline, add it here and watch six entries evict themselves.
-roots="$(find .github/workflows -type f \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null | sort)"
+#   * The literal `ci/lib/...` tail, not `$(dirname "${BASH_SOURCE[0]}")/../lib/`:
+#     this guard's OWN reference scanner resolves a token by basename plus
+#     directory suffix, and `../lib/ci-reachability.sh` is not a suffix of
+#     `ci/lib/ci-reachability.sh`. Written that way, the refactor's first run
+#     reported the new library as a gate reachable from nothing — this guard
+#     failing on the file it had just been split into.
+# shellcheck source=ci/lib/ci-reachability.sh
+# shellcheck disable=SC1091 # resolved at runtime through gate_repo_root
+source "${gate_repo_root}/ci/lib/ci-reachability.sh"
+
+roots="$(ci_reach_roots)"
 root_count="$(printf '%s\n' "${roots}" | grep -c . || true)"
 
 echo "Step 1: the CI roots are readable"
@@ -304,623 +324,26 @@ else
 fi
 echo
 
-# `refs_in` — reads file paths on STDIN, prints one reference per line:
-#
-#     S <token>     a `*.sh` path or basename this file INVOKES
-#     J <recipe>    a `just <recipe>` this file CALLS
-#
-# AN INVOCATION IS A POSITION, NOT A MENTION — AND THAT IS THE WHOLE RULE.
-#
-# This used to extract EVERY `*.sh`/`*.mjs`/`*.py` token on every non-comment
-# line and call each one a reference. That reads a filename and calls it a wire,
-# and it was wrong in three shapes that all look identical to a regex:
-#
-#     grep -q wasm_engine_assert_fresh "${WORKER_E2E}"   # a READ
-#     cat "${WORKER_E2E}"                                # a READ
-#     WORKER_E2E="${SUITE_ROOT}/ci/test/worker-...-e2e.sh"  # a NAME
-#
-# 295f36835 added exactly those three lines to `stale-artefact-guards-test.sh`.
-# Nothing in that commit builds the WASM engine and nothing executes the gate —
-# it is read as text, twice — and this guard nevertheless reported
-# `ci/test/worker-backend-wasm-e2e.sh` RESURRECTED and demanded its line be
-# deleted from the recorded-dark inventory. A truthfully recorded blocker, about
-# to be retired because a meta-test `cat`ted the file.
-#
-# The old rule needed a BLACKLIST to stay standing — `shellcheck` and `shfmt`
-# lines were dropped wholesale, because `ci/lint/bash.sh` shellchecks eleven
-# scripts it never runs. That blacklist is the same shape as a sweep that names
-# a symptom: it stops the readers somebody remembered, and `grep`, `cat`, `head`,
-# `cp`, `echo`, `diff` and a Python docstring went on counting. Enumerating them
-# is unbounded, and every miss is silent and green.
-#
-# So the test is now STRUCTURAL, and it is the one the shell itself applies. A
-# path is INVOKED when it stands where a command goes:
-#
-#   * COMMAND POSITION — the first word of a command. Start of a line, or after
-#     `|`, `||`, `&&`, `;`, `&`, `$(`, a backtick, a justfile `@`/`-` prefix, a
-#     workflow `run:`, or a keyword that opens a command (`if`, `then`, `do`,
-#     `exec`, `env`, `timeout 60`).
-#   * INTERPRETER ARGUMENT — the first non-flag word after `bash`, `sh`,
-#     `source`, `.`, `node`, `python3` and their relatives, WHEREVER that word
-#     stands. This one clause is what makes the wrappers work without a list of
-#     wrappers: `lint_step "name" bash ci/x.sh`, `nix develop -c ./ci/x.sh`,
-#     `timeout 900 bash ci/x.sh` and `xargs bash ci/x.sh` are all just `bash`
-#     followed by a path.
-#
-# Everything else is an argument, and an argument is a read. `shellcheck x.sh`
-# needs no special case any more: `shellcheck` takes command position and `x.sh`
-# is its argument. The blacklist is GONE, and eleven shellchecked-never-run
-# scripts stay dark for a reason that is now stated once instead of enumerated.
-#
-# AND THE ONE THING A POSITION RULE ALONE GETS WRONG: `bash "${GUARD}"`.
-#
-# Twenty-nine contract suites in this tree are written
-#
-#     GUARD="$REPO_ROOT/ci/verdict/job-timeouts.py"
-#     python3 "${GUARD}" --root "${TMP}"
-#
-# and the path never appears in command position at all. Dropping assignments
-# outright would have invented dark gates by the dozen — the failure mode that
-# gets a guard switched off. So the extractor makes TWO PASSES over the file: the
-# first records what each variable was ASSIGNED, the second resolves a variable
-# standing in an invoking position back to the paths it holds.
-#
-# That is also precisely what tells the two cases apart. `WASM_FRESHNESS_LIB` is
-# `source`d, so `ci/lib/wasm-engine-freshness.sh` is reachable and stays
-# reachable. `WORKER_E2E` is only ever `grep`ped and `cat`ted, so it confers
-# nothing — which is the truth 295f36835 wrote into the file.
-#
-# LINE CONTINUATIONS ARE JOINED FIRST, and that is load-bearing for both rules:
-# `ci/lint/bash.sh` writes every step as `lint_step "..." \` with the command on
-# the next physical line, so reading them separately would put `bash` at the
-# start of a line and make the interpreter clause fire on nothing.
-#
-# NOT DROPPED, DELIBERATELY: `source` and `.`. Sourcing EXECUTES the file in the
-# current shell, so it is an invocation and this guard has always counted it —
-# `ci/lib/published-asset.sh` and `visual-replay-gate-lib.sh` are reachable only
-# that way, and the transitivity note above depends on it.
-refs_in() {
-	# Reads paths on STDIN, one per line, so the caller need not expand a list
-	# into positional arguments — bash 3.2 has no array to expand.
-	#
-	# COMMENT LINES ARE DROPPED BEFORE NAMES ARE EXTRACTED, and this file is the
-	# reason. Its own header lists the gates it found dark. Once it was wired
-	# into `ci/lint/nim.sh` it became reachable, the transitive walk followed it,
-	# and every gate NAMED IN ITS PROSE was credited as reachable — so the guard
-	# reported 63 of 63 covered while four of them were referenced by nothing at
-	# all. A scanner that reads its own documentation is satisfied by anything
-	# that documentation says.
-	#
-	# Verification-Harness-Traps.md §4d, and the third instance found in this
-	# session: `ci-coverage.sh` in the sibling repository read a step's doc
-	# comment instead of the step, and its selftest's mutation arms rewrote a
-	# comment about a trigger instead of the trigger. Each time a control caught
-	# it; none of the three would have been visible in the transcript.
-	local f
-	while read -r f; do
-		[ -n "${f}" ] || continue
-		[ -f "${f}" ] || continue
-		refs_of_text <"${f}"
-	done | grep -v '^$' | sort -u || true
-}
-
-# The extractor itself, over one file's text on stdin. `awk`, because joining
-# continuations and then walking command positions is a multi-state job and
-# `grep` has one state.
-#
-# POSIX awk only: no `gensub`, no `asort`, no `[[:space:]]` outside brackets.
-# AND NO APOSTROPHE ANYWHERE IN THIS PROGRAM, comments included: it is
-# single-quoted from bash, and one apostrophe closes it — producing a bash
-# syntax error a hundred lines further down, in code that is not wrong. Where
-# the character itself is needed it is built with `sprintf("%c", 39)`.
-#
-# THE WHOLE FILE IS BUFFERED because the rule needs two passes: pass 1 records
-# variable assignments, pass 2 resolves them in invoking positions. See the
-# `bash "${GUARD}"` note in the header above for why that is not optional.
-refs_of_text() {
-	awk '
-	BEGIN {
-		SQ = sprintf("%c", 39)
-		# Quotes and parens are noise around a token, never part of a path.
-		STRIP = "[\"" SQ "()]"
-		# Words after which the NEXT non-flag word is a file this runs.
-		INTERP = " bash sh zsh dash ksh source . node nodejs python python2 python3 deno bun npx tsx ts-node ruby perl "
-		# Words that KEEP command position rather than consuming it: shell
-		# keywords, transparent prefixes, the justfile line prefixes, and the
-		# workflow `run:` key whose value is a shell script.
-		OPEN = " if while until then else elif do done fi ! exec command sudo nohup env eval builtin nice ionice stdbuf setsid time timeout xargs run: - @ @- -@ { } "
-		# Flags whose VALUE is a command line: `nix develop -c ./ci/lint/bash.sh`.
-		CMDARG = " -c --command --run --exec -exec "
-		# Declaration keywords: what follows is an assignment, not a command.
-		DECL = " local readonly export declare typeset "
-		# The JavaScript module-execution positions. `new Worker(x)`, `import(x)`
-		# and `require(x)` LOAD AND RUN x; they are the `.mjs` spelling of
-		# `bash x.sh`, and `ci/test/noir-wasm-worker/compare.mjs` reaches
-		# `worker.mjs` through nothing else.
-		JSEXEC = "(^|[^A-Za-z0-9_$.])(new[ \t]+Worker|require|import)[ \t]*\\("
-		nl = 0
-	}
-	{
-		cur = cur $0
-		if (cur ~ /\\$/) { sub(/\\$/, " ", cur); next }
-		lines[++nl] = cur; cur = ""
-	}
-	END {
-		if (cur != "") lines[++nl] = cur
-		# PASS 1 RUNS TWICE, and the second time is not superstition. It learns
-		# which parameter of each local function is EXECUTED rather than read
-		# (see `runsarg`), and functions call each other: `expect_leak` hands its
-		# `$1` to `leak_scan`, so whether `$1` is executed depends on what
-		# `leak_scan` was found to do. One iteration answers that only when the
-		# callee is defined first. Two covers a call to a helper defined later,
-		# which is the whole of the nesting this tree actually has.
-		for (pass = 1; pass <= 2; pass++) {
-			curfn = ""
-			for (k = 1; k <= nl; k++) scan(lines[k], 1)
-		}
-		curfn = ""
-		for (k = 1; k <= nl; k++) scan(lines[k], 2)
-	}
-
-	# A line that carries no wire at all, whatever it names.
-	function dropped(line) {
-		# COMMENT MARKERS FOR ALL THREE LANGUAGES, not just `#`. Widening the
-		# subject to `.mjs` and `.py` without widening this would re-create the
-		# exact defect the comment rule exists for, in the new files: a probe
-		# named in a `//` doc comment would be credited as wired.
-		if (line ~ /^[ \t]*#/) return 1
-		if (line ~ /^[ \t]*\/\//) return 1
-		if (line ~ /^[ \t]*\*/) return 1
-		# A `paths:` TRIGGER FILTER NAMES A FILE TO WATCH, NOT ONE TO RUN. It is
-		# the read rule one more step along: `grep x.sh` at least opens the file,
-		# while `- x.sh` under `on: push: paths:` only decides whether the
-		# workflow starts. Measured: `beam-flow.yml` lists
-		# `ci/test/elixir-flow-cross-repo.sh` in two `paths:` blocks and runs
-		# `beam-flow-cross-repo.sh` instead, so the ONLY reference to that shim
-		# in the entire repository was a trigger condition, and it counted as
-		# coverage.
-		#
-		# The shape matched is a YAML sequence item whose whole content is one
-		# unbroken token ending in `.sh`, optionally quoted. A real step is
-		# `- run: bash x.sh` or `- uses: ...` and always carries a space before
-		# the path, so it cannot match this.
-		if (line ~ /^[ \t]*-[ \t]*[^ \t]*\.(sh|mjs|py)[^ \t]*[ \t]*$/) return 1
-		return 0
-	}
-
-	function haspath(s) { return (s ~ /[A-Za-z0-9_-]\.(sh|mjs|py)/) }
-
-	function putpaths(s,   rest) {
-		rest = s
-		while (match(rest, /[A-Za-z0-9_.\/-]*[A-Za-z0-9_-]\.(sh|mjs|py)/)) {
-			print "S " substr(rest, RSTART, RLENGTH)
-			rest = substr(rest, RSTART + RLENGTH)
-		}
-	}
-
-	# The first ${NAME} or $NAME in a token, so `"${GUARD}"` resolves.
-	function varname(s) {
-		if (match(s, /\$\{[A-Za-z_][A-Za-z0-9_]*/)) return substr(s, RSTART + 2, RLENGTH - 2)
-		if (match(s, /\$[A-Za-z_][A-Za-z0-9_]*/)) return substr(s, RSTART + 1, RLENGTH - 1)
-		return ""
-	}
-
-	# `$1`, `${2}`, `$@` — a POSITIONAL PARAMETER standing where a command goes.
-	# Returns the index, or 0.
-	function posref(s) {
-		if (s ~ /^\$\{?[@*]\}?$/) return 1
-		if (match(s, /^\$\{?[0-9]+/)) {
-			if (match(s, /[0-9]+/)) return substr(s, RSTART, RLENGTH) + 0
-		}
-		return 0
-	}
-
-	# A token that stands where a command goes.
-	#
-	# Phase 2 prints the paths it holds — literally, or through the variable it
-	# names. Phase 1 prints nothing and instead LEARNS: a positional parameter in
-	# this position means the enclosing function EXECUTES that argument, which is
-	# what makes `probe chords ci/test/chord_double_fire_probe.mjs` a wire and
-	# `expect_leak leaky.sh REPO_ROOT` a read.
-	function invoke(tok, phase,   v, p) {
-		p = posref(tok)
-		if (p > 0) {
-			posmode = 1
-			if (phase == 1 && curfn != "") runsarg[curfn, p] = 1
-			return
-		}
-		v = varname(tok)
-		if (phase == 1) {
-			if (v != "" && curfn != "" && ((curfn, v) in frompos))
-				runsarg[curfn, frompos[curfn, v]] = 1
-			return
-		}
-		if (haspath(tok)) { putpaths(tok); return }
-		if (v != "" && (v in assigned)) putpaths(assigned[v])
-	}
-
-	function record(tok,   name, val) {
-		name = substr(tok, 1, index(tok, "=") - 1)
-		val = substr(tok, index(tok, "=") + 1)
-		# `local script="$2"` inside a function: remember the binding, so that a
-		# later `node "${script}"` is understood as executing parameter 2.
-		if (curfn != "" && match(val, /^\$\{?[0-9]+/)) {
-			if (match(val, /[0-9]+/)) frompos[curfn, name] = substr(val, RSTART, RLENGTH) + 0
-		}
-		if (!haspath(val)) return
-		# A variable assigned twice holds either value, so both are recorded —
-		# but pass 1 itself runs twice, so an unconditional append would store
-		# every value twice over.
-		if (!(name in assigned)) assigned[name] = val
-		else if (index(" " assigned[name] " ", " " val " ") == 0)
-			assigned[name] = assigned[name] " " val
-	}
-
-	# `bash`, `/usr/bin/python3`, and the two indirect spellings this tree uses
-	# for an interpreter it had to locate first:
-	#
-	#     cargo_lock_pin_guard_python="$(type -P python3)"
-	#     "$cargo_lock_pin_guard_python" -I "$PREFLIGHT_DIR/cargo-lock-pin-guard.py"
-	#     "$(visual_replay_gate_python)" -I "$VISUAL_REPLAY_GATE_REPORT_VALIDATOR"
-	#
-	# Both of those RUN a python guard, and a rule that only knows the literal
-	# word `python3` calls both of those guards dark. The LAST word of the name
-	# is the test — `..._python` and `${BASH:-bash}` are interpreters,
-	# `${SUITE_ROOT}` and `${WORKER_E2E}` are not — and it is the last word
-	# rather than any word for exactly that reason: `${SH_LIB}` would otherwise
-	# read as `sh`.
-	# A FILENAME IS NEVER THE INTERPRETER, and this guard is not decorative.
-	# Without it `scripts/docs/deep-review-capture-lib.sh` splits to a last word
-	# of `sh`, reads as an interpreter, and credits whatever `shellcheck` was
-	# handed next on the same line — which put `capture-deep-review-screenshots.sh`
-	# back on the reachable list while it declares NOT-A-CI-GATE in its own header.
-	function isinterp(s,   b, nb, ba, q, last) {
-		if (haspath(s)) return 0
-		if (index(INTERP, " " s " ") > 0) return 1
-		b = s
-		sub(/.*\//, "", b)
-		if (index(INTERP, " " b " ") > 0) return 1
-		gsub(/[^A-Za-z0-9]/, " ", b)
-		nb = split(b, ba, / +/)
-		last = ""
-		for (q = 1; q <= nb; q++) if (ba[q] != "") last = ba[q]
-		if (last != "" && index(INTERP, " " tolower(last) " ") > 0) return 1
-		return 0
-	}
-
-	function scan(line, phase,   work, n, arr, i, t, core, cmdpos, want, infn, argn) {
-		if (dropped(line)) return
-		if (phase == 2) justrefs(line)
-
-		# FUNCTION BOUNDARIES, tracked so that `$1` can be attributed to the
-		# function whose parameter it is. Closing brace at column 0 is how every
-		# function in this tree ends, and a stricter parser buys nothing here.
-		if (match(line, /^[ \t]*(function[ \t]+)?[A-Za-z_][A-Za-z0-9_-]*[ \t]*\(\)/)) {
-			curfn = line
-			sub(/^[ \t]*/, "", curfn)
-			sub(/^function[ \t]+/, "", curfn)
-			sub(/[ \t]*\(\).*$/, "", curfn)
-			isfn[curfn] = 1
-		} else if (line ~ /^\}/) {
-			curfn = ""
-		}
-
-		# The operators that END one command and start the next. Turned into
-		# free-standing tokens so the walk below needs no separate lexer.
-		# NOT SPLIT ON: `{`, because `${VAR}` would then put the rest of the
-		# path in command position and credit every `X="${ROOT}/ci/y.sh"` line
-		# this rule exists to stop.
-		#
-		# A BACKTICK IS NOT COMMAND SUBSTITUTION HERE, IT IS A QUOTATION MARK.
-		# This did split on it, and that put a path in command position every
-		# time a Python docstring or a `.mjs` block comment quoted one the way
-		# this repository quotes everything:
-		#
-		#     suppresses everything, so `ci/test/known-failures-gate.sh` drives
-		#     `ci/test/desktop-bundle-self-contained.sh` asks "does every path...
-		#
-		# Both read as an invocation, in files that only mention the name. The
-		# invariant that makes dropping the split safe is enforced, not assumed:
-		# `shellcheck` runs over all of ci/ and scripts/ in the `lint-bash` lane
-		# and SC2006 flags legacy backtick substitution, of which this tree has
-		# exactly zero. So the token rule below can treat a leading backtick as
-		# prose outright.
-		work = line
-		gsub(/\$\(/, " @@CMD@@ ", work)
-		gsub(/\|\|/, " @@CMD@@ ", work)
-		gsub(/&&/, " @@CMD@@ ", work)
-		gsub(/\|/, " @@CMD@@ ", work)
-		gsub(/;/, " @@CMD@@ ", work)
-		gsub(/&/, " @@CMD@@ ", work)
-
-		posmode = 0
-		n = split(work, arr, /[ \t]+/)
-		cmdpos = 1
-		want = 0
-		infn = ""
-		argn = 0
-		for (i = 1; i <= n; i++) {
-			t = arr[i]
-			if (t == "") continue
-			if (t == "@@CMD@@") { cmdpos = 1; want = 0; infn = ""; continue }
-			# A backtick-quoted word is prose. See the note above the splitter.
-			if (t ~ /^`/) { cmdpos = 0; want = 0; continue }
-			core = t
-			gsub(STRIP, "", core)
-			if (core == "") continue
-
-			# `VAR=value`. The path in it is a NAME. Command position survives,
-			# because `FOO=1 bash x.sh` is an environment prefix.
-			if (core ~ /^[A-Za-z_][A-Za-z0-9_]*=/) {
-				if (phase == 1) record(core)
-				cmdpos = 1; want = 0; continue
-			}
-			if (index(DECL, " " core " ") > 0) { cmdpos = 1; want = 0; continue }
-
-			if (want) {
-				if (core ~ /^-/) {
-					# `bash -lc PROGRAM` / `python3 -c PROGRAM`: what follows is
-					# not a path but a SCRIPT, so the walk restarts in command
-					# position inside it rather than eating the next word.
-					if (core ~ /^-[A-Za-z]*c$/ || index(CMDARG, " " core " ") > 0) {
-						want = 0; cmdpos = 1
-					}
-					continue
-				}
-				invoke(core, phase)
-				want = 0; cmdpos = 0; continue
-			}
-			if (cmdpos) {
-				if (index(OPEN, " " core " ") > 0) continue
-				# `timeout 900 bash x.sh`, `sleep 5` — a bare duration.
-				if (core ~ /^[0-9]+[smhd]?$/) continue
-				if (haspath(core)) { invoke(core, phase); cmdpos = 0; continue }
-				if (isinterp(core)) { want = 1; cmdpos = 0; continue }
-				# A LOCALLY DEFINED FUNCTION. Its arguments are invoking
-				# positions exactly where its body executes the matching `$N`.
-				if (core in isfn) { infn = core; argn = 0; cmdpos = 0; continue }
-				cmdpos = 0; continue
-			}
-			# Argument position. An argument is a READ — with three exceptions,
-			# each of which is still "something executes this".
-			if (infn != "") {
-				argn++
-				if ((infn, argn) in runsarg) { invoke(core, phase); continue }
-			}
-			if (index(CMDARG, " " core " ") > 0) { cmdpos = 1; continue }
-			if (isinterp(core)) { want = 1; continue }
-		}
-
-		# A POSITIONAL PARAMETER STOOD WHERE A COMMAND GOES, and the program it
-		# stood in is a quoted string this walk cannot see inside:
-		#
-		#     bash -c "source \"$1\"; newest_executable \"$@\"" _ "${NEWEST_LIB}"
-		#
-		# `ci/lib/newest-build.sh` is reached by that line and by nothing else in
-		# ci/ or scripts/. Rather than parse an embedded shell program, the line
-		# that proves it runs one is credited whole. Deliberately the widening
-		# direction: it over-credits a line that already declared it executes an
-		# argument, and it fires on nothing that does not.
-		if (posmode && phase == 2)
-			for (i = 1; i <= n; i++) {
-				core = arr[i]
-				gsub(STRIP, "", core)
-				if (core == "") continue
-				if (core ~ /^[A-Za-z_][A-Za-z0-9_]*=/) continue
-				if (haspath(core)) { putpaths(core); continue }
-				t = varname(core)
-				if (t != "" && (t in assigned)) putpaths(assigned[t])
-			}
-
-		# THE JAVASCRIPT MODULE-EXECUTION POSITIONS, which have no command
-		# position to stand in. See JSEXEC.
-		if (phase == 2 && line ~ JSEXEC) putpaths(line)
-	}
-
-	# `just <recipe>`, unchanged: a recipe name is not a path and the position
-	# rule above does not apply to it.
-	function justrefs(line,   n, i, j, t, u, arr) {
-		n = split(line, arr, /[ \t]+/)
-		for (i = 1; i <= n; i++) {
-			t = arr[i]
-			gsub(/^[^A-Za-z0-9_.\/-]+/, "", t)
-			gsub(/[^A-Za-z0-9_.\/-]+$/, "", t)
-			if (t != "just") continue
-			# Skip flags, and the VALUE of a flag that takes one — otherwise
-			# `just --justfile X recipe` reports the recipe as `--justfile`.
-			j = i + 1
-			while (j <= n) {
-				u = arr[j]
-				gsub(/^[^A-Za-z0-9_.\/=-]+/, "", u)
-				gsub(/[^A-Za-z0-9_.\/=-]+$/, "", u)
-				if (u !~ /^-/) break
-				if (u == "-f" || u == "--justfile" || u == "-d" ||
-					u == "--working-directory" || u == "--set") j++
-				j++
-			}
-			if (j > n) continue
-			u = arr[j]
-			gsub(/^[^A-Za-z0-9_-]+/, "", u)
-			gsub(/[^A-Za-z0-9_-]+$/, "", u)
-			if (u ~ /^[A-Za-z0-9_][A-Za-z0-9_-]*$/) print "J " u
-		}
-	}
-	'
-}
-
-# ---------------------------------------------------------------------------
-# The justfile, read as a GRAPH rather than as a root.
-# ---------------------------------------------------------------------------
-# A recipe is reached when a workflow calls it, or when a reached recipe depends
-# on it, or when a reached script calls it. Only THEN does what it invokes count.
-#
-# Emitted as two flat, tab-separated tables rather than shell variables, because
-# bash 3.2 has no associative array and `just` has 208 recipes here.
-#
-#     ${tmp}/bodies   NAME <tab> one body line
-#     ${tmp}/deps     NAME <tab> one dependency name
-#
-# The header grammar this reads: an unindented line whose first token is the
-# recipe name, optional parameters, then `:` and optional dependencies. `:=` is
-# an assignment, not a recipe, and dependencies may carry `(args)` or be joined
-# by `&&` for post-dependencies — all stripped. The body is every following line
-# that is indented or blank, up to the next unindented non-blank line.
 tmp="$(mktemp -d)"
 trap 'rm -rf "${tmp}"' EXIT
-: >"${tmp}/bodies"
-: >"${tmp}/deps"
-justfile=""
-[ -f justfile ] && justfile="justfile"
-[ -z "${justfile}" ] && [ -f Justfile ] && justfile="Justfile"
-recipe_count=0
-if [ -n "${justfile}" ]; then
-	awk -v bodies="${tmp}/bodies" -v deps="${tmp}/deps" '
-	/^[ \t]/  { if (name != "") print name "\t" $0 >> bodies; next }
-	/^[ \t]*$/ { next }
-	{
-		name = ""
-		if ($0 !~ /:=/ && $0 ~ /^@?[A-Za-z0-9_][A-Za-z0-9_-]*([ \t][^:]*)?:/) {
-			hdr = $0
-			sub(/^@/, "", hdr)
-			split(hdr, h, ":")
-			split(h[1], hn, /[ \t]/)
-			name = hn[1]
-			if (name == "set" || name == "alias" || name == "export" ||
-				name == "import" || name == "mod") { name = ""; next }
-			d = substr(hdr, index(hdr, ":") + 1)
-			gsub(/\(/, " ", d); gsub(/\)/, " ", d); gsub(/&&/, " ", d)
-			gsub(/{{[^}]*}}/, " ", d)
-			nd = split(d, da, /[ \t]+/)
-			for (i = 1; i <= nd; i++)
-				if (da[i] ~ /^[A-Za-z0-9_][A-Za-z0-9_-]*$/)
-					print name "\t" da[i] >> deps
-			print name "\t" >> bodies
-		}
-	}
-	' "${justfile}"
-	recipe_count="$(cut -f1 "${tmp}/bodies" | sort -u | grep -c . || true)"
-fi
+ci_reach_parse_justfile
 
 # ---------------------------------------------------------------------------
 echo "Step 2: reachability from the roots, through recipes and script-to-script"
 # ---------------------------------------------------------------------------
 note "the justfile defines ${recipe_count} recipe(s); a recipe counts only once a lane calls it"
-printf '%s\n' "${gates}" >"${tmp}/universe"
-# basename <tab> path, so a reference can be resolved without an assoc array.
-awk -F/ '{ print $NF "\t" $0 }' "${tmp}/universe" >"${tmp}/index"
-
-# `resolve` — reference tokens on stdin, universe paths on stdout.
-#
-# A token carrying a directory wins over a bare basename: `ci/lint/nix.sh`
-# resolves to that file alone, while a bare `nix.sh` cannot tell `ci/build/nix.sh`
-# from `ci/lint/nix.sh` and credits both. That is the false-POSITIVE direction
-# for exactly two basenames in this tree, and it is the safe one — a guard that
-# invents dark gates gets switched off.
-resolve() {
-	awk -F'\t' '
-	NR == FNR { n[$1]++; p[$1, n[$1]] = $2; next }
-	{
-		tok = $0; sub(/^\.\//, "", tok)
-		b = tok; sub(/.*\//, "", b)
-		if (!(b in n)) next
-		found = 0
-		if (tok ~ /\//)
-			for (i = 1; i <= n[b]; i++) {
-				q = p[b, i]
-				# `index()` RETURNS 0 FOR "NOT FOUND", AND 0 IS ALSO A LEGITIMATE
-				# VALUE OF `length(q) - length(tok)` — WHENEVER THE TWO PATHS ARE
-				# THE SAME LENGTH. Without the `> 0` guard the suffix test reads
-				# `0 == 0` and every equal-length sibling of a basename is
-				# credited by its twin. Measured on this tree: `ci/lint/rust.sh`
-				# (15 chars) is invoked by `codetracer.yml`, and that invocation
-				# silently credited `ci/test/rust.sh` (15 chars), which is
-				# referenced by NOTHING in the repository — an orphan from the
-				# initial open-source release, superseded by the `test-rust`
-				# recipe and still naming `--bin db-backend`, a binary since
-				# renamed. The guard reported it covered for as long as it existed.
-				#
-				# `ci/build/nix.sh` (15) and `ci/lint/nix.sh` (14) differ in
-				# length, which is the only reason that pair never showed the bug.
-				if (q == tok ||
-					(index(q, "/" tok) > 0 &&
-						index(q, "/" tok) == length(q) - length(tok))) {
-					print q; found = 1
-				}
-			}
-		if (!found) for (i = 1; i <= n[b]; i++) print p[b, i]
-	}
-	' "${tmp}/index" -
-}
-
-# `body_of RECIPE` / `deps_of RECIPE` — the two tables, read back.
-body_of() { awk -F'\t' -v r="$1" '$1 == r { print substr($0, length(r) + 2) }' "${tmp}/bodies"; }
-deps_of() { awk -F'\t' -v r="$1" '$1 == r { print $2 }' "${tmp}/deps"; }
-
-# TWO WORKLISTS, because the graph has two kinds of node. Files and recipes are
-# not interchangeable: a recipe's outgoing edges come from its body AND its
-# dependency list, a file's only from its text.
-: >"${tmp}/reached"
-: >"${tmp}/rreached"
-: >"${tmp}/fq"
-: >"${tmp}/rq"
-
-: >"${tmp}/missing-recipes"
-cut -f1 "${tmp}/bodies" | sort -u >"${tmp}/recipe-names"
-
-# `absorb` — reference lines (`S tok` / `J recipe`) on stdin; enqueue what is new.
-# One `resolve` per CALLER, not per token: resolving token-at-a-time made this a
-# few thousand awk processes and thirty seconds.
-absorb() {
-	local r
-	cat >"${tmp}/refs"
-	grep '^S ' "${tmp}/refs" | cut -c3- | resolve | sort -u >"${tmp}/refs.s"
-	grep '^J ' "${tmp}/refs" | cut -c3- | sort -u >"${tmp}/refs.j"
-	while read -r r; do
-		[ -n "${r}" ] || continue
-		grep -Fxq -- "${r}" "${tmp}/reached" && continue
-		printf '%s\n' "${r}" >>"${tmp}/reached"
-		printf '%s\n' "${r}" >>"${tmp}/fq"
-	done <"${tmp}/refs.s"
-	while read -r r; do
-		[ -n "${r}" ] || continue
-		if grep -Fxq -- "${r}" "${tmp}/recipe-names"; then
-			grep -Fxq -- "${r}" "${tmp}/rreached" && continue
-			printf '%s\n' "${r}" >>"${tmp}/rreached"
-			printf '%s\n' "${r}" >>"${tmp}/rq"
-		else
-			# `just <name>` for a recipe THIS justfile does not define. Recorded
-			# but not reported: see step 4 for why it cannot be treated as rot.
-			# What matters here is that it confers no reachability.
-			printf '%s\n' "${r}" >>"${tmp}/missing-recipes"
-		fi
-	done <"${tmp}/refs.j"
-}
-
-printf '%s\n' "${roots}" | grep -v '^$' | refs_in | absorb
-seeded="$(grep -c . "${tmp}/reached" || true)"
-seeded_recipes="$(grep -c . "${tmp}/rreached" || true)"
+ci_reach_walk
+# What the workflows name DIRECTLY, snapshotted by `ci_reach_walk` between its
+# seed and its transitive loop. Reading `${tmp}/reached` here instead would now
+# report the post-walk totals, because the seed and the loop are one call.
+seeded="$(cat "${tmp}/seeded-scripts")"
+seeded_recipes="$(cat "${tmp}/seeded-recipes")"
 
 if [ "${seeded}" -ge 1 ]; then
 	ok "the workflows name ${seeded} script(s) and ${seeded_recipes} recipe(s) directly"
 else
 	bad "no workflow names any script under ${gate_dirs} — either CI runs none of them, or this scan cannot see them"
 fi
-
-# Alternate between the two queues until both are empty.
-while [ -s "${tmp}/fq" ] || [ -s "${tmp}/rq" ]; do
-	if [ -s "${tmp}/fq" ]; then
-		cur="$(head -1 "${tmp}/fq")"
-		tail -n +2 "${tmp}/fq" >"${tmp}/fq.next" && mv "${tmp}/fq.next" "${tmp}/fq"
-		printf '%s\n' "${cur}" | refs_in | absorb
-	else
-		cur="$(head -1 "${tmp}/rq")"
-		tail -n +2 "${tmp}/rq" >"${tmp}/rq.next" && mv "${tmp}/rq.next" "${tmp}/rq"
-		{
-			body_of "${cur}" | refs_of_text
-			deps_of "${cur}" | sed 's/^/J /'
-		} | absorb
-	fi
-done
 
 reachable="$(sort -u "${tmp}/reached")"
 reachable_count="$(printf '%s\n' "${reachable}" | grep -c . || true)"
@@ -1087,7 +510,7 @@ echo
 # ---------------------------------------------------------------------------
 echo "Step 4: nothing CI reaches names a script or a recipe that does not exist"
 echo "    A step invoking a missing script fails loudly — but only if that"
-echo "    workflow runs, and a step behind an \`if:\` may not for months."
+echo '    workflow runs, and a step behind an `if:` may not for months.'
 # ---------------------------------------------------------------------------
 # THE SUBJECT IS THE WORKFLOWS AND THE LINT DISPATCHERS, AND NOT EVERY REACHABLE
 # SCRIPT. Widening it to the whole reachable set was tried and produced five
@@ -1153,6 +576,6 @@ echo "  Every shell script under ci/ and scripts/ is reached by a workflow lane,
 echo "  declares in its own header that it is not a gate, or is recorded as dark"
 echo "  with a reason, in a list that can only shrink."
 echo "  NOT claimed: that any of them passes, or that a reachable gate is actually"
-echo "  RUN — a step behind a false \`if:\` is reachable and never executes. This"
+echo '  RUN — a step behind a false `if:` is reachable and never executes. This'
 echo "  guard measures the graph, which is strictly less than the schedule."
 echo "RESULT: OK"

--- a/ci/test/test-lane-job-coverage-test.sh
+++ b/ci/test/test-lane-job-coverage-test.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+#
+# test-lane-job-coverage-test.sh — contract suite for ci/test/test-lane-job-coverage.sh.
+#
+# WHY THIS EXISTS
+# ---------------
+# The guard next door reports that every test lane is invoked by a CI job. The
+# only thing that makes that report worth reading is evidence it can say NO —
+# and a coverage guard is the specific kind of instrument that fails silently in
+# the passing direction, because every one of its checks is a "must not contain"
+# over a list it builds itself. Hand it an empty lane list, a justfile it cannot
+# parse, or a workflow scan that matches nothing, and it prints a perfect score.
+# That is not hypothetical for this family of guards: the shell-gate guard next
+# door shipped exactly that bug, reporting `0 found, 0 reachable, RESULT: OK`.
+#
+# So every arm below is a MUTATION. Each builds a synthetic tree the guard
+# should pass, changes ONE thing that ought to make it fail, and asserts it
+# does. An arm that cannot kill its mutation is reported as a failure of THIS
+# suite, and the CONTROL arm — the unmutated tree must be GREEN — is what keeps
+# the other arms from passing for the wrong reason. Without the control, a
+# synthetic tree that is red for an unrelated reason makes every mutation look
+# killed while proving nothing.
+#
+# The synthetic trees are deliberately tiny: a justfile, a .github/workflows,
+# and a ci/lib/test-lane-files.sh defining just enough of the lane library's
+# interface. The guard is driven against them with `--root`, which is the only
+# reason that flag exists.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GUARD="${repo_root}/ci/test/test-lane-job-coverage.sh"
+
+checks=0
+failures=0
+ok() {
+	checks=$((checks + 1))
+	printf '  [OK]     %s\n' "$*"
+}
+bad() {
+	checks=$((checks + 1))
+	failures=$((failures + 1))
+	printf '  [FAILED] %s\n' "$*"
+	if [ -n "${2:-}" ]; then
+		printf '%s\n' "${2}" | sed 's/^/             /'
+	fi
+}
+
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+# ---------------------------------------------------------------------------
+# make_tree DIR — a synthetic repo the guard should pass.
+# ---------------------------------------------------------------------------
+# Two lanes, both wired: `alpha` is reached because a workflow names its recipe
+# directly; `beta` is reached only THROUGH a dependency of a recipe a workflow
+# names, which is the transitive edge the guard must follow.
+make_tree() {
+	local d="$1"
+	mkdir -p "${d}/.github/workflows" "${d}/ci/lib" "${d}/ci/test" "${d}/scripts"
+
+	cat >"${d}/ci/lib/test-lane-files.sh" <<'EOF'
+#!/usr/bin/env bash
+test_lane_ids() {
+	printf '%s\n' alpha beta
+}
+test_lane_entrypoint() {
+	case "$1" in
+	alpha) echo "just:test-alpha" ;;
+	beta) echo "just:test-beta" ;;
+	*) echo "" ;;
+	esac
+}
+test_lane_files() { echo ""; }
+test_lane_description() { echo "synthetic"; }
+EOF
+
+	cat >"${d}/justfile" <<'EOF'
+test-alpha:
+  bash ci/lib/run-nim-test-lane.sh alpha
+
+test-beta:
+  bash ci/lib/run-nim-test-lane.sh beta
+
+test-aggregate: test-beta
+  echo aggregate
+EOF
+
+	cat >"${d}/.github/workflows/ci.yml" <<'EOF'
+name: ci
+on: [push]
+jobs:
+  a:
+    steps:
+      - run: just test-alpha
+  b:
+    steps:
+      - run: just test-aggregate
+EOF
+}
+
+# `--min-lanes 1` because these fixtures carry two or three lanes on purpose.
+# Arm 7 still proves an EMPTY list fails: zero is below one.
+run_guard() { bash "${GUARD}" --root "$1" --min-lanes 1 2>&1; }
+
+echo "=== test-lane-job-coverage selftest — mutation arms ==="
+echo
+
+# ---------------------------------------------------------------------------
+# CONTROL
+# ---------------------------------------------------------------------------
+ctl="${work}/control"
+make_tree "${ctl}"
+ctl_out="$(run_guard "${ctl}")"
+ctl_rc=$?
+if [ "${ctl_rc}" -eq 0 ]; then
+	ok "CONTROL: the unmutated synthetic tree is GREEN — the arms below can mean something"
+else
+	bad "CONTROL: the synthetic tree is already red — no arm can demonstrate anything" \
+		"$(printf '%s\n' "${ctl_out}" | grep -E '^\s*\[FAILED\]|^ERROR' | head -5)"
+	echo
+	echo "${checks} check(s), ${failures} failure(s)"
+	echo "RESULT: FAILED"
+	exit 1
+fi
+
+# The control must also prove it MEASURED both lanes, not that it found none.
+# `lanes: 2 declared, 2 reachable` is the line that separates "everything is
+# covered" from "there was nothing to cover".
+if printf '%s\n' "${ctl_out}" | grep -q 'lanes: 2 declared, 2 reachable'; then
+	ok "CONTROL: reports 2 declared and 2 reachable — a real population, not an empty one"
+else
+	bad "CONTROL: did not report 2 declared / 2 reachable" \
+		"$(printf '%s\n' "${ctl_out}" | grep -i 'lanes:')"
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 1 — a lane no workflow reaches is reported, BY NAME.
+# ---------------------------------------------------------------------------
+# THE ARM THE WHOLE GUARD EXISTS FOR. `gamma` is a well-formed lane with a
+# well-formed recipe that no workflow calls and no reached recipe depends on —
+# exactly the state 16 real lanes were in when this guard was written.
+t="${work}/orphan"
+make_tree "${t}"
+sed -i.bak "s/printf '%s\\\\n' alpha beta/printf '%s\\\\n' alpha beta gamma/" "${t}/ci/lib/test-lane-files.sh"
+sed -i.bak 's|\tbeta) echo "just:test-beta" ;;|\tbeta) echo "just:test-beta" ;;\n\tgamma) echo "just:test-gamma" ;;|' "${t}/ci/lib/test-lane-files.sh"
+cat >>"${t}/justfile" <<'EOF'
+
+test-gamma:
+  bash ci/lib/run-nim-test-lane.sh gamma
+EOF
+out="$(run_guard "${t}")"
+rc=$?
+if [ "${rc}" -ne 0 ] && printf '%s\n' "${out}" | grep -q 'gamma'; then
+	ok "1/a lane no workflow reaches is reported by name: killed"
+else
+	bad "1/a lane no workflow reaches is reported by name: SURVIVED (rc=${rc})" \
+		"$(printf '%s\n' "${out}" | tail -6)"
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 2 — deleting the workflow step that reaches a lane makes it an orphan.
+# ---------------------------------------------------------------------------
+# The complement of arm 1: the lane list is untouched and CI loses a step. This
+# is the change that actually happens in practice — nobody adds an orphan lane,
+# somebody removes or renames the step that ran one.
+t="${work}/unwired"
+make_tree "${t}"
+sed -i.bak '/just test-alpha/d' "${t}/.github/workflows/ci.yml"
+out="$(run_guard "${t}")"
+rc=$?
+if [ "${rc}" -ne 0 ] && printf '%s\n' "${out}" | grep -q 'alpha'; then
+	ok "2/removing the workflow step that ran a lane makes it a named orphan: killed"
+else
+	bad "2/removing the workflow step that ran a lane makes it a named orphan: SURVIVED (rc=${rc})" \
+		"$(printf '%s\n' "${out}" | tail -6)"
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 3 — the TRANSITIVE edge is real, not decoration.
+# ---------------------------------------------------------------------------
+# `beta` is reached only via `test-aggregate: test-beta`. Break that dependency
+# and beta must go dark. Without this arm, a guard that credited every recipe in
+# the justfile regardless of reachability would still pass arms 1 and 2 — that
+# over-crediting is the precise bug the shell-gate guard had, where seeding from
+# the justfile marked fourteen unreachable gates as covered.
+t="${work}/nodep"
+make_tree "${t}"
+sed -i.bak 's/^test-aggregate: test-beta$/test-aggregate:/' "${t}/justfile"
+out="$(run_guard "${t}")"
+rc=$?
+if [ "${rc}" -ne 0 ] && printf '%s\n' "${out}" | grep -q 'beta'; then
+	ok "3/a lane reached only through a recipe dependency goes dark when the dependency is cut: killed"
+else
+	bad "3/a lane reached only through a recipe dependency goes dark when the dependency is cut: SURVIVED (rc=${rc})" \
+		"$(printf '%s\n' "${out}" | tail -6)"
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 4 — a lane with no declared entrypoint fails, rather than defaulting.
+# ---------------------------------------------------------------------------
+t="${work}/noentry"
+make_tree "${t}"
+sed -i.bak "s/printf '%s\\\\n' alpha beta/printf '%s\\\\n' alpha beta delta/" "${t}/ci/lib/test-lane-files.sh"
+out="$(run_guard "${t}")"
+rc=$?
+if [ "${rc}" -ne 0 ] && printf '%s\n' "${out}" | grep -q 'delta'; then
+	ok "4/a lane declaring no entrypoint is named, not silently skipped: killed"
+else
+	bad "4/a lane declaring no entrypoint is named, not silently skipped: SURVIVED (rc=${rc})" \
+		"$(printf '%s\n' "${out}" | tail -6)"
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 5 — an entrypoint naming a recipe that does not exist is ROT.
+# ---------------------------------------------------------------------------
+# The failure mode a pure declaration always has: the recipe is renamed and the
+# table still names the old one. Reachability alone would report this lane as an
+# orphan; the guard must say the entrypoint does not EXIST, which is a different
+# and more actionable finding.
+t="${work}/rot"
+make_tree "${t}"
+sed -i.bak 's|alpha) echo "just:test-alpha" ;;|alpha) echo "just:test-alpha-renamed-away" ;;|' "${t}/ci/lib/test-lane-files.sh"
+out="$(run_guard "${t}")"
+rc=$?
+if [ "${rc}" -ne 0 ] && printf '%s\n' "${out}" | grep -q 'no such recipe'; then
+	ok "5/an entrypoint naming a recipe the justfile does not define is reported as rot: killed"
+else
+	bad "5/an entrypoint naming a recipe the justfile does not define is reported as rot: SURVIVED (rc=${rc})" \
+		"$(printf '%s\n' "${out}" | tail -6)"
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 6 — a declaration that disagrees with the justfile is caught.
+# ---------------------------------------------------------------------------
+# `alpha`'s declaration is pointed at `test-beta`, a recipe that exists and IS
+# reachable — so checks 2 and 4 both pass and only the derivation arm can catch
+# it. This is what stops the table from rotting into a plausible lie.
+t="${work}/disagree"
+make_tree "${t}"
+sed -i.bak 's|alpha) echo "just:test-alpha" ;;|alpha) echo "just:test-beta" ;;|' "${t}/ci/lib/test-lane-files.sh"
+out="$(run_guard "${t}")"
+rc=$?
+if [ "${rc}" -ne 0 ] && printf '%s\n' "${out}" | grep -qi 'while the justfile runs them from another'; then
+	ok "6/a declared entrypoint that disagrees with the recipe actually running the lane: killed"
+else
+	bad "6/a declared entrypoint that disagrees with the recipe actually running the lane: SURVIVED (rc=${rc})" \
+		"$(printf '%s\n' "${out}" | tail -6)"
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 7 — an empty lane list must not read as full coverage.
+# ---------------------------------------------------------------------------
+# The vacuous-pass trap, and the reason Step 0 is a hard exit. A guard that
+# reports "0 declared, 0 reachable, RESULT: OK" has measured nothing and said
+# everything is fine.
+t="${work}/empty"
+make_tree "${t}"
+sed -i.bak "s/printf '%s\\\\n' alpha beta/printf '%s\\\\n'/" "${t}/ci/lib/test-lane-files.sh"
+out="$(run_guard "${t}")"
+rc=$?
+if [ "${rc}" -ne 0 ]; then
+	ok "7/an empty lane list is a hard failure, not a perfect score: killed"
+else
+	bad "7/an empty lane list is a hard failure, not a perfect score: SURVIVED (rc=${rc})" \
+		"$(printf '%s\n' "${out}" | tail -6)"
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 8 — a lane library with no test_lane_entrypoint refuses to run.
+# ---------------------------------------------------------------------------
+# The accessor could be deleted in a refactor. The guard must then STOP, not
+# skip its checks and print OK — a skipped check that still reports success is
+# how the condition it guards comes back.
+t="${work}/noaccessor"
+make_tree "${t}"
+python3 - "${t}/ci/lib/test-lane-files.sh" <<'PY'
+import re,sys
+p=sys.argv[1]; s=open(p).read()
+s=re.sub(r'test_lane_entrypoint\(\) \{.*?\n\}\n', '', s, flags=re.S)
+open(p,'w').write(s)
+PY
+out="$(run_guard "${t}")"
+rc=$?
+if [ "${rc}" -ne 0 ] && printf '%s\n' "${out}" | grep -q 'defines no test_lane_entrypoint'; then
+	ok "8/a lane library missing test_lane_entrypoint stops the guard: killed"
+else
+	bad "8/a lane library missing test_lane_entrypoint stops the guard: SURVIVED (rc=${rc})" \
+		"$(printf '%s\n' "${out}" | tail -6)"
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 9 — recording an orphan without moving the ceiling is an error.
+# ---------------------------------------------------------------------------
+# The inventory's whole safety property. Appending a line is the cheapest way to
+# make this guard green; the equality is what forces that diff to also change a
+# number a reviewer is looking at.
+t="${work}/ceiling"
+make_tree "${t}"
+sed -i.bak "s/printf '%s\\\\n' alpha beta/printf '%s\\\\n' alpha beta gamma/" "${t}/ci/lib/test-lane-files.sh"
+sed -i.bak 's|\tbeta) echo "just:test-beta" ;;|\tbeta) echo "just:test-beta" ;;\n\tgamma) echo "just:test-gamma" ;;|' "${t}/ci/lib/test-lane-files.sh"
+cat >>"${t}/justfile" <<'EOF'
+
+test-gamma:
+  bash ci/lib/run-nim-test-lane.sh gamma
+EOF
+# Record the orphan, but declare a ceiling that does not match.
+cat >"${t}/ci/test/test-lane-job-coverage.known-orphan.txt" <<'EOF'
+# RECORDED-ORPHAN-CEILING: 0
+gamma
+EOF
+out="$(run_guard "${t}")"
+rc=$?
+if [ "${rc}" -ne 0 ] && printf '%s\n' "${out}" | grep -q 'ceiling says'; then
+	ok "9/recording an orphan without raising the ceiling is an error: killed"
+else
+	bad "9/recording an orphan without raising the ceiling is an error: SURVIVED (rc=${rc})" \
+		"$(printf '%s\n' "${out}" | tail -6)"
+fi
+
+# ---------------------------------------------------------------------------
+# ARM 10 — a correctly recorded orphan is GREEN, but still printed.
+# ---------------------------------------------------------------------------
+# The other half of arm 9. If recording an orphan did not make the guard green,
+# nobody could land it; if it made the orphan invisible, recording would be
+# exempting. Both must hold: exit 0 AND the lane still named in the output.
+t="${work}/recorded"
+make_tree "${t}"
+sed -i.bak "s/printf '%s\\\\n' alpha beta/printf '%s\\\\n' alpha beta gamma/" "${t}/ci/lib/test-lane-files.sh"
+sed -i.bak 's|\tbeta) echo "just:test-beta" ;;|\tbeta) echo "just:test-beta" ;;\n\tgamma) echo "just:test-gamma" ;;|' "${t}/ci/lib/test-lane-files.sh"
+cat >>"${t}/justfile" <<'EOF'
+
+test-gamma:
+  bash ci/lib/run-nim-test-lane.sh gamma
+EOF
+cat >"${t}/ci/test/test-lane-job-coverage.known-orphan.txt" <<'EOF'
+# RECORDED-ORPHAN-CEILING: 1
+gamma
+EOF
+out="$(run_guard "${t}")"
+rc=$?
+if [ "${rc}" -eq 0 ] && printf '%s\n' "${out}" | grep -q 'gamma'; then
+	ok "10/a correctly recorded orphan is green AND still named in the report"
+else
+	bad "10/a correctly recorded orphan is green AND still named in the report (rc=${rc})" \
+		"$(printf '%s\n' "${out}" | tail -8)"
+fi
+
+echo
+echo "${checks} check(s), ${failures} failure(s)"
+if [ "${failures}" -eq 0 ]; then
+	echo "  A lane that runs nowhere is named, and recording one costs a ceiling."
+	echo "RESULT: OK"
+	exit 0
+fi
+echo "RESULT: FAILED"
+exit 1

--- a/ci/test/test-lane-job-coverage.known-orphan.txt
+++ b/ci/test/test-lane-job-coverage.known-orphan.txt
@@ -1,0 +1,132 @@
+# Test lanes that ci/test/test-lane-job-coverage.sh has found to be invoked by
+# NO CI job, and that are RECORDED rather than fixed today.
+#
+# RECORDED-ORPHAN-CEILING: 16
+#
+# WHAT THIS FILE IS, AND WHAT IT IS NOT
+# -------------------------------------
+# It is NOT an exemption list. Every lane named here is still printed on every
+# run of the guard, still counted in its summary, and still darkness: its tests
+# compile assertions that cannot fail a build. Recording one changes exactly one
+# thing — whether the guard's exit status distinguishes "a lane we know about
+# and have written down" from "a lane that appeared and nobody noticed". The
+# second is the condition the guard exists to catch, and it cannot catch it if
+# the first keeps it permanently red.
+#
+# THE CEILING ABOVE IS AN EQUALITY, checked by the guard. Adding a line here
+# without moving the number is an error, and so is removing one. That is the
+# point: the cheapest way to silence this guard is to append a lane, and the
+# equality makes that a diff which also changes a number a reviewer is looking
+# at. Wiring a lane up means DELETING its entry and LOWERING the ceiling in the
+# same commit.
+#
+# WHY SIXTEEN AND NOT TWELVE. The hand count that prompted this work found 12.
+# The guard finds 16. The four it missed are `frontend-js`, `bpf`,
+# `book-isonim` and `agentic-headless` — and two of those were already recorded
+# as dark in ci/test/shell-gate-coverage.known-dark.txt, as the SCRIPTS
+# `ci/test/frontend-js.sh` and `scripts/test-codetracer-agentic-headless.sh`.
+# The darkness was written down; nobody had connected it to the LANES those
+# scripts run. That is the argument for asking this question in lane terms as
+# well as in script terms, and it is why the number here was measured rather
+# than copied.
+#
+# THE DECISION, PER LANE, IS "WIRE" FOR ALL SIXTEEN. None of them should be
+# deleted, and that is not a dodge — it was checked. Deleting a lane does not
+# delete its test files; it makes them dark, and `ci/test/test-lane-coverage.sh`
+# would immediately fail by name on every one of them. Each lane below runs real
+# suites that somebody wrote and that assert real things. So the question is
+# never "wire or delete", it is "wire now or name what blocks it", and the
+# blocker is named on every line.
+#
+# NOT WIRED IN THE COMMIT THAT ADDED THIS FILE, and the reason is worth stating
+# plainly rather than leaving to be inferred: the author could not measure these
+# lanes in CI's environment. They were measured on macOS/aarch64 against a
+# nix-profile Nim, not inside `nix develop .#devShells.x86_64-linux.default`,
+# and two lanes the justfile currently certifies as "GREEN today and could be
+# promoted as-is" were RED there (`common-units` 2 passed / 3 failed;
+# `ct-cli-units` 1 passed / 4 failed, two of them COMPILE ERRORs). That
+# disagreement is unresolved: it is either a real regression the justfile's note
+# has outlived, or an artefact of building outside the dev shell. Wiring a lane
+# into CI on the strength of a claim that the only available measurement
+# contradicts is how a red lane gets into a required job and breaks every build
+# for everybody — which is the exact thing the justfile's own deferral note
+# warns about. The lanes are recorded, the disagreement is recorded with them,
+# and the next person to run one inside the dev shell can settle it.
+#
+# Format: one lane id per line. Comments and blank lines ignored.
+
+# --- claimed green by justfile, CONTRADICTED by an out-of-shell measurement ---
+# Retire by: running the lane inside the dev shell. If green there, wire it and
+# delete the line. If red, the justfile's "promotable" note is stale and should
+# be corrected in the same commit.
+common-units
+ct-cli-units
+
+# `book-isonim` is in the same justfile "promotable" list and was not measured
+# here at all; it needs docs/book-isonim's own toolchain.
+book-isonim
+
+# Compile-only by design — a live round-trip against the production sharing
+# service must not run in CI. The justfile records it as green since AS-2.
+# Retire by: adding the compile step to a lint or build job; it needs no
+# recorder, no sibling and no display, so it is the cheapest of the sixteen.
+online-sharing-live
+
+# --- red for reasons that are not the lane's, per the justfile's own notes ---
+# Wiring any of these into a required job breaks every build until the named
+# blocker is cleared. Each retires when its blocker does.
+#
+# cross_process_origin_vm_test needs an uncommitted rr/MCR cross-process
+# recording.
+frontend-native-units
+# The collab signal registry has drifted from the ViewModels (30 unclassified,
+# 1 stale) — a real, pre-existing red.
+vm-collab-units
+# test_collab_m8_cross_frontend needs libgpui_nim_shim.so.
+vm-collab-integration
+# test_io_mon_readfiles_materialized asserts an insertion order the
+# implementation returns sorted.
+ct-test-incremental
+# Needs a buildable Python recorder sibling.
+ct-test-incremental-e2e
+# noir_space_ship_test: recorded traces come back "unrecognized format";
+# real_backend_test needs the Python recorder installed.
+vm-gui-headless
+
+# --- red on a small, diagnosed number of checks -------------------------------
+# Both left the justfile's promotable list on 2026-09-01 and are still red on 3
+# checks between them, every one a DEFECTIVE ASSERTION rather than missing
+# product code, each diagnosed at the line in
+# codetracer-specs/Testing/Known-Test-Failures.md. They must NOT be made green
+# by relaxing the assertions; all three are registered in release_gate.nim's
+# CoreViewModelGateTests precisely so that trying fails the m16 lane.
+#
+# These two are the costliest of the sixteen to leave dark: between them they
+# are 117 cases (62 + 55) over the ViewModel unit pyramid, on both backends,
+# including the Embed SDK's own conformance suite.
+# Retire by: correcting the three assertions, then wiring both lanes together —
+# they are a declared parity pair and wiring one without the other reopens the
+# single-backend gap that `test-vm-unit-js` was created to close.
+vm-unit
+vm-unit-js
+
+# --- no documented blocker; needs an owner to look --------------------------
+# Nothing in the justfile or the lane library explains why these run nowhere.
+# That absence is itself the finding — they are not deferred, they were simply
+# never wired, and no note anywhere says so.
+#
+# Runs through ci/test/frontend-js.sh, which shell-gate-coverage.known-dark.txt
+# already records as a dark script. Needs npm-installed jsdom, which exists
+# after a tup build and not in a bare nix shell — that is the likely reason, and
+# it is a guess, not a record.
+frontend-js
+# ct-test test-certificate issuance, verification and conformance vectors.
+ct-test-certificates
+# `just test-bpf` fans out to four recipes; BPF needs privileges CI may not
+# grant, which would be a legitimate reason to keep it out of the default
+# pipeline — but it should then be recorded as such, not left silent.
+bpf
+# The only lane with no `just` recipe at all: a bare script, invoked from
+# `just test-codetracer-agentic-headless-matrix` / `-regression`, neither of
+# which any workflow calls.
+agentic-headless

--- a/ci/test/test-lane-job-coverage.sh
+++ b/ci/test/test-lane-job-coverage.sh
@@ -1,0 +1,456 @@
+#!/usr/bin/env bash
+#
+# test-lane-job-coverage.sh — fail, BY NAME, on any test lane that no CI job runs.
+#
+# WHY THIS EXISTS
+# ---------------
+# `ci/test/test-lane-coverage.sh` proves FILE -> LANE. This proves LANE -> JOB.
+# Nothing proved the second, and the gap is where sixteen lanes were living.
+#
+# Measured on this tree on 2026-09-08 by this guard: 30 lanes declared in
+# ci/lib/test-lane-files.sh, and 16 of them invoked by NO CI job at all.
+# The hand count that prompted this work said 12; it had missed `frontend-js`,
+# `bpf`, `book-isonim` and `agentic-headless`. Two of those four were ALREADY
+# recorded as dark by ci/test/shell-gate-coverage.known-dark.txt -- as SCRIPTS
+# (`ci/test/frontend-js.sh`, `scripts/test-codetracer-agentic-headless.sh`).
+# Nobody had connected that to the LANES those scripts run, which is the whole
+# argument for asking the question in lane terms as well as in script terms. They
+# were not hidden — they were VISIBLE AND LOOKED FINE. `test-lane-coverage.sh`
+# was green on every one, because their files were correctly assigned. And
+# their only other references, in `ci/test/test-lane-report-test.sh`, assert
+# that a lane is WELL-FORMED — that its file list resolves, that its backend is
+# a real backend — never that anything runs it. So a new test file could be
+# written, correctly assigned to a lane, pass every gate in the repository, and
+# be executed by nothing. `just test-vm-unit` was in precisely that state: zero
+# hits across all twelve files in .github/workflows, while the ViewModel unit
+# pyramid it runs was being cited as covered.
+#
+# That is the same defect the whole lane library was built to end, one level up
+# the chain. The library ended "a lane forgets a FILE". This ends "CI forgets a
+# LANE".
+#
+# WHAT "RUN BY A JOB" MEANS HERE
+# ------------------------------
+# A lane is COVERED when its entrypoint — `test_lane_entrypoint <id>`, a `just`
+# recipe or a script — is reachable from a GitHub workflow: named directly by a
+# `run:` step, or reached from one through recipe dependencies and
+# script-to-script calls. That walk is ci/lib/ci-reachability.sh, the same
+# engine ci/test/shell-gate-coverage.sh uses to answer the identical question
+# about shell gates. Sharing it is deliberate: two copies would agree on the
+# day the second was written and drift by the first bugfix applied to one.
+#
+# WHAT THIS DOES NOT CLAIM
+# ------------------------
+# Not that a lane PASSES. Not that a reachable lane actually EXECUTES — a step
+# behind a false `if:` is reachable and never runs. This measures the graph,
+# which is strictly less than the schedule, and saying so is the difference
+# between a guard and a reassurance.
+#
+# THE FOUR CHECKS
+# ---------------
+#   1. EVERY LANE DECLARES AN ENTRYPOINT. `test_lane_entrypoint` returns empty
+#      for anything it does not know, and empty is a failure naming the lane.
+#      A lane added without one is the exact state this file exists to stop.
+#
+#   2. THE ENTRYPOINT EXISTS. A declared recipe must be defined in the
+#      justfile; a declared script must be on disk. This is the anti-rot arm,
+#      and it is not hypothetical: `scripts/test-codetracer-agentic-headless.sh`
+#      named a test file for months after that file was renamed.
+#
+#   3. THE DECLARATION AGREES WITH THE DERIVATION. For the 21 lanes whose
+#      recipe body names the lane id (`run-nim-test-lane.sh <id>` or
+#      `test_lane_files <id>`), the entrypoint is ALSO derived from the
+#      justfile, and a disagreement is a hard failure. This is what stops the
+#      table in test-lane-files.sh from rotting into naming a recipe that
+#      stopped running the lane — the failure mode a pure declaration always
+#      has, and the reason this gate does not simply trust one.
+#
+#   4. THE ENTRYPOINT IS REACHABLE FROM A WORKFLOW. The finding itself.
+#
+# THE RECORDED-ORPHAN INVENTORY
+# -----------------------------
+# Sixteen lanes cannot be wired the day this guard lands. Six of them are RED
+# for reasons that are not theirs (a missing recorder sibling, an uncommitted
+# cross-process recording, a drifted collab registry), and wiring a red lane
+# into a required job breaks every build for everybody. So they are RECORDED,
+# in test-lane-job-coverage.known-orphan.txt, each with a reason and a
+# retirement condition, under a CEILING that is an equality: the count must
+# match exactly, so adding a line to make this guard green is a diff that
+# changes a number a reviewer is looking at. Recording an orphan is not
+# exempting it — a recorded orphan is still printed on every run, still counted,
+# and still darkness. It is the difference between a debt that is written down
+# and a debt that is invisible.
+#
+# Usage:
+#   ci/test/test-lane-job-coverage.sh
+#   ci/test/test-lane-job-coverage.sh --root DIR    # drive a synthetic tree
+#
+# `--root` exists so ci/test/test-lane-job-coverage-test.sh can prove this
+# guard RED on a deliberately-orphaned lane before trusting it green here.
+
+set -uo pipefail
+
+# The tree under examination. `--root` moves it.
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# The checkout THIS SCRIPT lives in, which nothing moves. The reachability
+# library is loaded from here, not from `root`: the contract suite points
+# `--root` at synthetic fixture trees that carry a justfile and a
+# .github/workflows and no ci/lib/ci-reachability.sh at all.
+gate_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# The floor Step 0 enforces on the lane population. FIVE for a real run: this
+# repository has thirty lanes and a scan that resolved fewer than five has
+# broken its enumeration, which would make every "must not contain" check below
+# vacuously true. `--min-lanes` lowers it ONLY for
+# ci/test/test-lane-job-coverage-test.sh, whose synthetic trees carry two or
+# three lanes on purpose — an arm has to be small enough to reason about. It is
+# not passed in CI, and lowering it there would switch off the vacuity guard
+# that Step 0 exists to be.
+min_lanes=5
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--root)
+		root="$(cd "$2" && pwd)"
+		shift 2
+		;;
+	--min-lanes)
+		min_lanes="$2"
+		shift 2
+		;;
+	-h | --help)
+		sed -n '2,60p' "${BASH_SOURCE[0]}"
+		exit 0
+		;;
+	*)
+		echo "test-lane-job-coverage.sh: unknown argument '$1'" >&2
+		exit 2
+		;;
+	esac
+done
+cd "${root}" || exit 2
+
+checks=0
+failures=0
+note() { printf '  %s\n' "$*"; }
+ok() {
+	checks=$((checks + 1))
+	printf '  [OK]     %s\n' "$*"
+}
+bad() {
+	checks=$((checks + 1))
+	failures=$((failures + 1))
+	printf '  [FAILED] %s\n' "$*"
+}
+
+echo "=== test lane -> CI job coverage ==="
+echo
+
+# ---------------------------------------------------------------------------
+# The lane library of the tree under scan.
+# ---------------------------------------------------------------------------
+if [ ! -f "${root}/ci/lib/test-lane-files.sh" ]; then
+	echo "ERROR: ${root}/ci/lib/test-lane-files.sh does not exist — there is no" >&2
+	echo "  lane declaration to check. Refusing to report coverage of nothing." >&2
+	exit 2
+fi
+# shellcheck source=ci/lib/test-lane-files.sh
+# shellcheck disable=SC1091 # resolved at runtime, through the tree under scan
+source "${root}/ci/lib/test-lane-files.sh"
+
+if ! command -v test_lane_entrypoint >/dev/null 2>&1; then
+	echo "ERROR: ci/lib/test-lane-files.sh defines no test_lane_entrypoint." >&2
+	echo "  Without it this guard cannot tell which command runs a lane, so it" >&2
+	echo "  would have to skip every check below — and a skipped check that" >&2
+	echo "  still prints OK is how the thing it guards comes back." >&2
+	exit 2
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+test_lane_ids >"${tmp}/lanes"
+lane_count="$(grep -c . <"${tmp}/lanes" || true)"
+
+# ---------------------------------------------------------------------------
+# Step 0: the population is real.
+# ---------------------------------------------------------------------------
+# Every "must not contain" check below is vacuously true over an empty lane
+# list, and would print a perfect score. Same trap as Step 0 of
+# shell-gate-coverage.sh, and it is kept for the same reason: a guard that can
+# report on nothing will eventually be handed nothing.
+echo "Step 0: there are lanes to check"
+if [ "${lane_count}" -ge "${min_lanes}" ]; then
+	ok "ci/lib/test-lane-files.sh declares ${lane_count} lane(s)"
+else
+	bad "only ${lane_count} lane(s) declared (floor is ${min_lanes}) — the enumeration is broken, and every check below would be vacuous"
+	echo
+	echo "RESULT: FAILED"
+	exit 1
+fi
+echo
+
+# ---------------------------------------------------------------------------
+# The reachability walk, shared with ci/test/shell-gate-coverage.sh.
+# ---------------------------------------------------------------------------
+# `gates` is the universe references are resolved against. It is the same
+# ci/ + scripts/ script inventory the shell-gate guard uses, because a lane's
+# entrypoint can be reached THROUGH a script (`codetracer.yml` ->
+# `ci/test/non-gui.sh` -> `just test`), and a walk that could not follow a
+# script edge would report reachable lanes as orphans.
+# shellcheck source=ci/lib/ci-reachability.sh
+# shellcheck disable=SC1091 # resolved at runtime through gate_repo_root
+source "${gate_repo_root}/ci/lib/ci-reachability.sh"
+
+gates="$(find ci scripts \( -name node_modules -o -name .git \) -prune -o \
+	-type f -print 2>/dev/null |
+	sed 's#^\./##' | grep -E '\.(sh|bash|mjs|js|py|ps1)$' | sort)"
+
+roots="$(ci_reach_roots)"
+root_count="$(printf '%s\n' "${roots}" | grep -c . || true)"
+
+echo "Step 1: the CI roots are readable"
+if [ "${root_count}" -ge 1 ]; then
+	ok "${root_count} workflow file(s) to walk from"
+else
+	bad "found ${root_count} workflow file(s) — reachability below would be measured from nothing"
+	echo
+	echo "RESULT: FAILED"
+	exit 1
+fi
+echo
+
+ci_reach_parse_justfile
+ci_reach_walk
+
+# ---------------------------------------------------------------------------
+# The derivation: which recipe's body names each lane id.
+# ---------------------------------------------------------------------------
+# `${tmp}/bodies` is NAME <tab> one body line, filled by ci_reach_parse_justfile.
+# A recipe DERIVES a lane when its body invokes the lane runner on that id, or
+# asks the lane library for that id's files. Matched with a trailing boundary so
+# `vm-unit` does not claim `vm-unit-js`'s recipe — without it the derivation
+# credits the wrong recipe for every lane whose id is a prefix of another's.
+derive_recipe_for_lane() {
+	awk -F'\t' -v lane="$1" '
+	{
+		body = substr($0, length($1) + 2)
+		if (body ~ ("run-nim-test-lane\\.sh[ \t]+" lane "([ \t]|$)") ||
+			body ~ ("test_lane_files[ \t]+" lane "([ \t)]|$)"))
+			print $1
+	}
+	' "${tmp}/bodies" | sort -u
+}
+
+# ---------------------------------------------------------------------------
+# Steps 2-4, one pass over the lanes.
+# ---------------------------------------------------------------------------
+: >"${tmp}/no-entrypoint"
+: >"${tmp}/rot"
+: >"${tmp}/disagree"
+: >"${tmp}/orphan"
+: >"${tmp}/covered"
+
+while read -r lane; do
+	[ -n "${lane}" ] || continue
+	entry="$(test_lane_entrypoint "${lane}")"
+
+	if [ -z "${entry}" ]; then
+		printf '%s\n' "${lane}" >>"${tmp}/no-entrypoint"
+		continue
+	fi
+
+	kind="${entry%%:*}"
+	target="${entry#*:}"
+
+	# --- check 2: the entrypoint exists ---------------------------------
+	case "${kind}" in
+	just)
+		if ! grep -Fxq -- "${target}" "${tmp}/recipe-names"; then
+			printf '%s\t%s\tno such recipe in the justfile\n' \
+				"${lane}" "${entry}" >>"${tmp}/rot"
+			continue
+		fi
+		;;
+	script)
+		if [ ! -f "${target}" ]; then
+			printf '%s\t%s\tno such file\n' \
+				"${lane}" "${entry}" >>"${tmp}/rot"
+			continue
+		fi
+		;;
+	*)
+		printf '%s\t%s\tentrypoint must be just:<recipe> or script:<path>\n' \
+			"${lane}" "${entry}" >>"${tmp}/rot"
+		continue
+		;;
+	esac
+
+	# --- check 3: declaration agrees with derivation --------------------
+	# Only for lanes the justfile can be asked about. A lane with no derived
+	# recipe is one whose runner does not consume the lane library; silence
+	# there is expected and is not a disagreement.
+	derived="$(derive_recipe_for_lane "${lane}")"
+	if [ -n "${derived}" ] && [ "${kind}" = "just" ]; then
+		if ! grep -Fxq -- "${target}" <<<"${derived}"; then
+			printf '%s\t%s\t%s\n' "${lane}" "${entry}" \
+				"$(printf '%s' "${derived}" | tr '\n' ' ')" >>"${tmp}/disagree"
+			continue
+		fi
+	fi
+
+	# --- check 4: reachable from a workflow -----------------------------
+	reached=1
+	case "${kind}" in
+	just) grep -Fxq -- "${target}" "${tmp}/rreached" || reached=0 ;;
+	script) grep -Fxq -- "${target}" "${tmp}/reached" || reached=0 ;;
+	esac
+
+	if [ "${reached}" -eq 1 ]; then
+		printf '%s\t%s\n' "${lane}" "${entry}" >>"${tmp}/covered"
+	else
+		printf '%s\t%s\n' "${lane}" "${entry}" >>"${tmp}/orphan"
+	fi
+done <"${tmp}/lanes"
+
+no_entry_n="$(grep -c . <"${tmp}/no-entrypoint" || true)"
+rot_n="$(grep -c . <"${tmp}/rot" || true)"
+disagree_n="$(grep -c . <"${tmp}/disagree" || true)"
+orphan_n="$(grep -c . <"${tmp}/orphan" || true)"
+covered_n="$(grep -c . <"${tmp}/covered" || true)"
+
+echo "Step 2: every lane declares an entrypoint"
+if [ "${no_entry_n}" -eq 0 ]; then
+	ok "all ${lane_count} lane(s) name the command that runs them"
+else
+	bad "${no_entry_n} lane(s) declare NO entrypoint:"
+	sed 's/^/             /' <"${tmp}/no-entrypoint"
+	cat <<'EOF'
+
+    Add an arm to `test_lane_entrypoint` in ci/lib/test-lane-files.sh saying
+    which `just` recipe or script runs the lane. If nothing runs it, that is
+    the finding — wire it up or delete the lane.
+EOF
+fi
+echo
+
+echo "Step 3: every declared entrypoint exists, and matches what the justfile does"
+if [ "${rot_n}" -eq 0 ]; then
+	ok "every declared recipe is defined and every declared script is on disk"
+else
+	bad "${rot_n} lane(s) name an entrypoint that does not exist:"
+	while IFS=$'\t' read -r lane entry why; do
+		printf '             %-24s %-40s %s\n' "${lane}" "${entry}" "${why}"
+	done <"${tmp}/rot"
+fi
+if [ "${disagree_n}" -eq 0 ]; then
+	ok "every derivable lane's declaration matches the recipe that runs it"
+else
+	bad "${disagree_n} lane(s) declare one entrypoint while the justfile runs them from another:"
+	while IFS=$'\t' read -r lane entry derived; do
+		printf '             %-24s declared %-32s justfile: %s\n' \
+			"${lane}" "${entry}" "${derived}"
+	done <"${tmp}/disagree"
+	cat <<'EOF'
+
+    One of the two is wrong. Either the recipe stopped running the lane, or
+    the declaration was not updated when the lane moved.
+EOF
+fi
+echo
+
+# ---------------------------------------------------------------------------
+# Step 4: the finding.
+# ---------------------------------------------------------------------------
+inventory="${root}/ci/test/test-lane-job-coverage.known-orphan.txt"
+recorded=""
+if [ -f "${inventory}" ]; then
+	recorded="$(grep -vE '^[[:space:]]*(#|$)' "${inventory}" || true)"
+fi
+recorded_n="$(printf '%s\n' "${recorded}" | grep -c . || true)"
+
+echo "Step 4: every lane is invoked by at least one CI job"
+: >"${tmp}/unrecorded"
+: >"${tmp}/recorded-hit"
+while IFS=$'\t' read -r lane entry; do
+	[ -n "${lane}" ] || continue
+	if printf '%s\n' "${recorded}" | grep -Fxq -- "${lane}"; then
+		printf '%s\t%s\n' "${lane}" "${entry}" >>"${tmp}/recorded-hit"
+	else
+		printf '%s\t%s\n' "${lane}" "${entry}" >>"${tmp}/unrecorded"
+	fi
+done <"${tmp}/orphan"
+unrecorded_n="$(grep -c . <"${tmp}/unrecorded" || true)"
+recorded_hit_n="$(grep -c . <"${tmp}/recorded-hit" || true)"
+
+if [ "${recorded_hit_n}" -gt 0 ]; then
+	note "recorded orphans — declared in test-lane-job-coverage.known-orphan.txt,"
+	note "still dark, still counted:"
+	while IFS=$'\t' read -r lane entry; do
+		printf '      %-24s %s\n' "${lane}" "${entry}"
+	done <"${tmp}/recorded-hit"
+	echo
+fi
+
+if [ "${unrecorded_n}" -eq 0 ]; then
+	ok "${covered_n} of ${lane_count} lane(s) reachable; ${recorded_hit_n} recorded orphan(s), 0 unrecorded"
+else
+	bad "${unrecorded_n} lane(s) are invoked by NO workflow, NO recipe a workflow calls, and NO reachable script:"
+	while IFS=$'\t' read -r lane entry; do
+		printf '             %-24s %s\n' "${lane}" "${entry}"
+	done <"${tmp}/unrecorded"
+	cat <<'EOF'
+
+    Each of these compiles and asserts nothing that can fail a build. Fix by
+    either:
+      * invoking its entrypoint from a workflow step (and adding the job to
+        ci/verdict/required-jobs.txt, so a run that skips it reports lost
+        coverage rather than a pass); or
+      * deleting the lane, if it should not exist; or
+      * recording it in ci/test/test-lane-job-coverage.known-orphan.txt with a
+        reason and a retirement condition, AND raising that file's ceiling in
+        the same diff.
+
+EOF
+fi
+
+# THE CEILING, AND WHY IT IS AN EQUALITY.
+#
+# The inventory is an exception list, and an exception list that can grow
+# quietly stops being read: the cheapest way to make this guard green is to
+# append a line. An equality means the number in the file has to move too, in
+# the same diff, where a reviewer is looking at it — and it means REMOVING an
+# orphan without lowering the ceiling is also an error, so the debt cannot be
+# quietly paid off and then silently re-borrowed against.
+ceiling=""
+if [ -f "${inventory}" ]; then
+	ceiling="$(grep -E '^[[:space:]]*#[[:space:]]*RECORDED-ORPHAN-CEILING:' "${inventory}" |
+		head -1 | sed 's/.*://; s/[^0-9]//g')"
+fi
+if [ -n "${recorded}" ] || [ -f "${inventory}" ]; then
+	if [ -z "${ceiling}" ]; then
+		bad "${inventory##*/} carries no '# RECORDED-ORPHAN-CEILING: <n>' line"
+	elif [ "${recorded_n}" -eq "${ceiling}" ]; then
+		ok "recorded-orphan inventory holds exactly its declared ceiling of ${ceiling}"
+	else
+		bad "recorded-orphan inventory holds ${recorded_n} entries, ceiling says ${ceiling} — move the ceiling in the same diff"
+	fi
+fi
+echo
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+echo "${checks} check(s), ${failures} failure(s)"
+printf '  lanes: %d declared, %d reachable, %d recorded orphan(s), %d UNRECORDED orphan(s)\n' \
+	"${lane_count}" "${covered_n}" "${recorded_hit_n}" "${unrecorded_n}"
+echo "  NOT claimed: that any lane passes, or that a reachable lane executes —"
+echo '  a step behind a false `if:` is reachable and never runs.'
+
+if [ "${failures}" -eq 0 ]; then
+	echo "RESULT: OK"
+	exit 0
+fi
+echo "RESULT: FAILED — ${failures} check(s)"
+exit 1

--- a/justfile
+++ b/justfile
@@ -2759,7 +2759,94 @@ test-vm-js: vm-test-prereqs
   bash ci/lib/run-nim-test-lane.sh vm-js
 
 # Run ViewModel headless tests on both native and JS backends.
-test-vm: test-vm-native test-vm-js
+#
+# WHY THIS IS A BODY AND NOT `test-vm: test-vm-native test-vm-js`.
+#
+# It was that dependency list until 2026-09-08, and for as long as it was, THIS
+# LANE REPORTED ONE BACKEND OF THE TWO. `just` runs dependencies in order and
+# STOPS AT THE FIRST ONE THAT FAILS, so `test-vm-js` never started on any run
+# where `test-vm-native` was red — and `test-vm-native` has been red for the
+# whole time the `viewmodel-tests` job has been able to report at all. The
+# first CI measurement of it (2026-09-08, the run that un-darkened this job)
+# was 95 of 100 files passing, 5 failing. Five red files were therefore enough
+# to produce ZERO OUTPUT from the JS backend, on every push, invisibly: the
+# step said "ViewModel headless tests (native + JS backends)" and the log
+# contained only native.
+#
+# That is the worst possible one to lose. The JS backend is what BlockTracer
+# ships; `nim js` is the compiler whose output reaches a browser. The lane
+# closest to the product was dark, one level below a job that had just been
+# un-darkened, and the dependency list is the entire reason.
+#
+# THE FIX IS "RUN BOTH, THEN DECIDE", NOT "IGNORE A FAILURE". `status` starts
+# at 0 and each lane can only ever raise it, so this recipe fails whenever
+# EITHER backend fails — exactly as the dependency list did. What changes is
+# that both have run and both have printed by the time it does. Neither lane is
+# weakened, skipped, or made `continue-on-error`; the native lane's five reds
+# still fail this recipe.
+#
+# `set -e` is deliberately ABSENT and must stay absent. With it, `just
+# test-vm-native` returning non-zero would kill this shell before the JS lane
+# ran, which is the identical defect wearing different syntax. `-u` and
+# `pipefail` are kept; only the exit-on-error is dropped, and every command
+# whose failure matters is checked explicitly.
+#
+# Both lanes are invoked as nested `just` recipes rather than by inlining their
+# `run-nim-test-lane.sh` calls, so there is still exactly ONE definition of
+# what each lane runs and where it logs. Inlining them here would have made
+# this recipe a second copy to drift from — the same mistake `ci/lib/test-lane-
+# files.sh` exists to have stopped.
+#
+# NOTE: the same defect, with a wider blast radius, is still open one level up
+# in the `test` recipe (~line 771): seven `just test-*` lanes under `set -e`,
+# where a red first lane darkens the six behind it. That is the `test-non-gui`
+# job. It is left alone here only because this change is scoped to the
+# ViewModel lanes; it is the same class and wants the same fix.
+test-vm:
+  #!/usr/bin/env bash
+  set -uo pipefail
+
+  status=0
+
+  echo "=== ViewModel backend 1 of 2: native (nim c) ==="
+  just test-vm-native || status=1
+
+  echo ""
+  echo "=== ViewModel backend 2 of 2: JS (nim js + node) ==="
+  # Runs whether or not the native lane above passed. That is the point of
+  # this recipe; see the header.
+  just test-vm-js || status=1
+
+  # A closing summary naming BOTH backends, so a reader of the CI log can see
+  # at a glance which of the two failed rather than inferring it from which
+  # section the log happens to end in. `test-logs/test-vm-native.log` and
+  # `test-logs/test-vm-js.log` hold the full per-file detail either way.
+  echo ""
+  echo "=== ViewModel lane summary ==="
+  # `run-nim-test-lane.sh` closes each lane with an UNINDENTED line
+  #     <lane>: N file(s) passed, M failed, K case(s)
+  # while every per-file verdict it prints is indented by two spaces. Anchoring
+  # on `^<lane>:` is what tells those apart; an earlier draft of this loop
+  # grepped for `^OK|^FAILED|^PARTIAL`, matched neither shape, and would have
+  # printed an empty verdict for both backends — a summary that always agrees
+  # with itself and says nothing.
+  for lane in vm-native vm-js; do
+    log="test-logs/test-${lane}.log"
+    line=""
+    [ -f "${log}" ] && line="$(grep -E "^${lane}: .*file\(s\) passed" "${log}" | tail -1)"
+    if [ -n "${line}" ]; then
+      printf '  %s\n' "${line}"
+    elif [ -f "${log}" ]; then
+      # The log exists but carries no summary line: the lane died before
+      # finishing (compile hang, timeout, signal). Distinct from "ran and
+      # failed", and the distinction is the whole reason this branch exists.
+      printf '  %s: NO SUMMARY LINE — lane started but did not finish (see %s)\n' "${lane}" "${log}"
+    else
+      printf '  %s: NO LOG — lane never started\n' "${lane}"
+    fi
+  done
+
+  exit "${status}"
 
 # ====
 # Lanes converted from hand-maintained path lists to DISCOVERY.


### PR DESCRIPTION
Two structural defects in the test wiring. Both are about a test that exists and never runs.

## 1. `vm-js` was dark one level below the job

`just test-vm` was `test-vm: test-vm-native test-vm-js`. `just` runs dependencies in order and **stops at the first one that fails**, and `test-vm-native` has been red for the whole time the `viewmodel-tests` job has been able to report. So `test-vm-js` produced **no output at all** on every push, while the step called itself "ViewModel headless tests (native + JS backends)".

`test-vm` is now a body that runs both lanes and fails if either failed. `status` starts at 0 and each lane can only raise it, so the recipe fails exactly when the dependency list did — nothing is skipped, weakened, or made `continue-on-error`. Proven on a fixture: the dependency-list shape runs one lane, the new shape runs both and still exits 1.

### What vm-js reveals, now that it can report

Measured on macOS/aarch64 outside `nix develop` (the CI dev shell is x86_64-linux and was not reproducible here — treat as indicative):

```
vm-js: 81 file(s) passed, 4 failed, 2052 case(s)
```

5 red files; `isonim_views_test`'s 2 are registered known failures, so 81 + 4 = 85 reconciles.

| file | JS | native (same machine) |
|---|---|---|
| `event_log_vm_test` | 2 FAILED — `key not found: rrTicks [KeyError]` | also red in CI |
| `review_layout_test` | 1 FAILED | **passes** |
| `debugging_scenarios_test` | 1 FAILED — same `rrTicks` KeyError | also red in CI |
| `feature_scenarios_test` | 3 FAILED — `mock.findCommand("ct/event-load").isSome` | also red in CI |
| `layout_config_roundtrip_test` | passes | **fails** |
| `mode_layout_test` | passes | **asserts nothing** |

**The backends disagree in both directions.** The decisive one: `review_layout_test`'s failing case `test_the_e2e_fixture_is_what_edit_mode_actually_writes` sits inside a `when defined(js):` block — it **cannot** run on the native backend. That whole block ran nowhere. The committed e2e fixture is missing `tabOverlapAllowance` and `tabControlOffset`, which edit mode does write.

The native-only reds reproduce CI's reported native failures on this machine, which is the cross-check that the instrument agrees with CI where the two overlap.

## 2. The structural one: nothing proved lane -> job

`ci/test/test-lane-coverage.sh` proves **file -> lane**. Nothing proved **lane -> job**. A test file could be correctly assigned to a lane, pass every gate in the repository, and be executed by nothing — `just test-vm-unit` was in exactly that state.

`ci/test/test-lane-job-coverage.sh` closes it. Four checks: every lane declares an entrypoint; the entrypoint exists; the declaration is **cross-checked against what the justfile actually does** for the 21 derivable lanes; and the entrypoint is reachable from a workflow.

**Measured: 30 lanes, 14 reachable, 16 invoked by no CI job.** The hand count that prompted this was 12 — it missed `frontend-js`, `bpf`, `book-isonim` and `agentic-headless`. Two of those four were *already* recorded as dark in `shell-gate-coverage.known-dark.txt` — as **scripts**. Nobody had connected that to the **lanes** those scripts run, which is the argument for asking the question in lane terms too.

### Proof it can fail

`ci/test/test-lane-job-coverage-test.sh`: 12 arms, all mutations, all killed. Arm 1 is a deliberately-orphaned lane and the guard goes red naming it. The CONTROL arm asserts the unmutated fixture is green *and* reports a real population (`2 declared, 2 reachable`), so no arm can pass because the fixture was already broken. Arm 7 proves an empty lane list is a hard failure, not a perfect score.

### Per-orphan decisions

**WIRE for all 16; delete none.** That was checked, not assumed: deleting a lane does not delete its test files, it makes them dark, and `test-lane-coverage.sh` would immediately fail by name on every one. Each of the 16 is recorded in `test-lane-job-coverage.known-orphan.txt` with its blocker (`vm-collab-integration` needs `libgpui_nim_shim.so`, `ct-test-incremental-e2e` needs a buildable Python recorder sibling, and so on), under a ceiling that is an **equality** — appending a lane to silence the guard also has to move a number a reviewer is looking at.

**None were wired in this PR, and the reason is recorded rather than left to be inferred:** these lanes could not be measured in CI's environment, and two lanes the justfile currently certifies as "GREEN today and could be promoted as-is" were **red** when measured outside the dev shell (`common-units` 2 passed / 3 failed; `ct-cli-units` 1 passed / 4 failed, two COMPILE ERRORs). That disagreement is unresolved — either the justfile's note is stale or it is an out-of-shell artefact — and wiring a lane into CI on the strength of a claim the only available measurement contradicts is how a red lane gets into a required job.

## Shared reachability engine

The walk moved verbatim from `shell-gate-coverage.sh` to `ci/lib/ci-reachability.sh` and is now shared rather than copied. Non-regression: that guard's **22 mutation arms still pass** and its output is **byte-identical** to pre-refactor. The refactor did briefly corrupt one reported number (seed counts became post-walk totals); that is fixed and commented, and it is why the byte-identical diff was taken rather than trusted.

## Also found, not fixed

`just test` (~line 771) has the **same defect with a wider blast radius**: seven `just test-*` lanes under `set -e`, where a red first lane darkens the six behind it. That is the `test-non-gui` job. `test-bpf` is a third instance. Noted in the justfile; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)