### PR TITLE
ci: run every lane of `just test` and `test-bpf`, and name every failure

### DIFF
--- a/ci/lib/run-just-lanes.sh
+++ b/ci/lib/run-just-lanes.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# run-just-lanes.sh — run EVERY lane of a `just` aggregate, then fail naming
+# ALL the lanes that failed, not just the first one.
+#
+# WHY THIS EXISTS
+# ---------------
+# An aggregate recipe is a promise: "`just test` runs the non-GUI tests". Two
+# ways of writing one in a justfile both quietly break that promise, and both
+# were in this file's tree when it was added:
+#
+#   * A BASH BODY UNDER `set -e`:
+#
+#         test:
+#           #!/usr/bin/env bash
+#           set -e
+#           just test-build-alignment
+#           just test-flake-pin-alignment
+#           ... five more ...
+#
+#     `set -e` aborts the body at the FIRST non-zero lane. The other six never
+#     run. The CI job (`test-non-gui`, via ci/test/non-gui.sh) goes red naming
+#     one lane, so whoever picks it up fixes that one, pushes, and discovers the
+#     second — one round trip of CI per broken lane, each one costing the full
+#     nix dev-shell startup, and no point at which anybody can see how much is
+#     actually broken.
+#
+#   * A DEPENDENCY LIST:
+#
+#         test-bpf: test-bpf-monitor test-bpf-native test-bpf-native-integration test-bpf-integration
+#
+#     Identical failure mode for a different reason: `just` runs dependencies in
+#     order and aborts the whole invocation when one exits non-zero. It is not a
+#     `set -e` artefact and cannot be fixed by changing shell flags; the only fix
+#     is to stop expressing the aggregate as a dependency list.
+#
+# Neither shape is wrong about WHETHER to fail. Both are wrong about WHAT THEY
+# REPORT: an aggregate whose job is to answer "is the non-GUI suite healthy?"
+# answers "the first thing I tried is not", which is a strictly smaller and less
+# useful fact. This script answers the actual question.
+#
+# WHAT IT DOES NOT DO
+# -------------------
+# It does not weaken anything. Every lane still runs the same recipe, its exit
+# status is still load-bearing, and the aggregate still exits non-zero if ANY
+# lane failed. There is no continue-on-error, no allow-list, no way to mark a
+# lane advisory. The only change is that a failing lane no longer suppresses the
+# lanes after it.
+#
+# It also refuses a VACUOUS PASS. Zero lanes is not "everything passed"; it is a
+# caller that built an empty list, and the whole point of this area of the tree
+# (see ci/lib/run-nim-test-lane.sh, ci/test/shell-gate-coverage.sh) is that a
+# gate which cannot fail is indistinguishable from one that is not running.
+#
+# ORDER IS PRESERVED. Lanes run sequentially in the order given, exactly as they
+# did before, because some of them share build outputs and were written assuming
+# that. This is not a parallel runner.
+#
+# Usage:
+#   bash ci/lib/run-just-lanes.sh <aggregate-name> <lane> [<lane> ...]
+#
+# Exit status:
+#   0  every lane passed
+#   1  at least one lane failed (all failures named on stderr)
+#   2  usage error, or no lanes given
+#
+# Environment:
+#   CT_JUST  the `just` binary to invoke (default: `just`). Exists so
+#            ci/test/run-just-lanes-test.sh can point the runner at a
+#            throwaway justfile; not used in CI.
+
+set -uo pipefail
+
+aggregate="${1:-}"
+if [ -z "${aggregate}" ]; then
+	echo "usage: run-just-lanes.sh <aggregate-name> <lane> [<lane> ...]" >&2
+	exit 2
+fi
+shift
+
+just_bin="${CT_JUST:-just}"
+
+if [ "$#" -eq 0 ]; then
+	echo "run-just-lanes.sh: '${aggregate}' was given NO lanes to run." >&2
+	echo "  Refusing to report success for an empty aggregate: a gate that" >&2
+	echo "  cannot fail is not a gate. Fix the caller's lane list." >&2
+	exit 2
+fi
+
+lanes=("$@")
+passed=()
+failed=()
+
+for lane in "${lanes[@]}"; do
+	echo ""
+	echo "=== ${aggregate}: lane ${lane} ==="
+	status=0
+	"${just_bin}" "${lane}" || status=$?
+	if [ "${status}" -eq 0 ]; then
+		passed+=("${lane}")
+		echo "=== ${aggregate}: lane ${lane} PASSED ==="
+	else
+		failed+=("${lane} (exit ${status})")
+		# Announced on stderr as well as stdout so that a reader tailing only
+		# the error stream still sees every failure, not merely the summary.
+		echo "=== ${aggregate}: lane ${lane} FAILED (exit ${status}) ===" >&2
+		echo "    continuing — remaining lanes still run, and this failure is" >&2
+		echo "    recorded and re-reported in the summary below." >&2
+	fi
+done
+
+echo ""
+echo "=== ${aggregate}: summary — ${#lanes[@]} lane(s): ${#passed[@]} passed, ${#failed[@]} failed ==="
+
+if [ "${#failed[@]}" -gt 0 ]; then
+	echo "" >&2
+	echo "${aggregate}: ${#failed[@]} of ${#lanes[@]} lane(s) FAILED:" >&2
+	for entry in "${failed[@]}"; do
+		echo "  - ${entry}" >&2
+	done
+	echo "" >&2
+	echo "  Every lane above was run; this list is complete, not first-failure." >&2
+	exit 1
+fi
+
+echo "${aggregate}: all ${#lanes[@]} lane(s) passed"

--- a/ci/lint/bash.sh
+++ b/ci/lint/bash.sh
@@ -169,10 +169,19 @@ lint_step "shellcheck: build-alignment harness ('just test' runs it)" \
 #
 # Executed here, and not only linted, for the reason the stale-artefact suite
 # below is: an aggregate that has never been SEEN to report a second failure is
-# indistinguishable from one that still hides it. The suite drives real `just`
-# over throwaway recipes in a temp dir -- no nix, no build, no network, seconds
-# -- and it reproduces BOTH original shapes to prove it can still tell the
-# difference.
+# indistinguishable from one that still hides it.
+#
+# It is HERMETIC — it stubs `just` on PATH rather than needing the real one —
+# and that is a correctness requirement of running it here, not a convenience.
+# nix/shells/lint.nix carries no `just` on purpose, so the first version of this
+# registration refused to run and turned this job red. The stub costs nothing:
+# ci/lib/run-just-lanes.sh's whole interface to the outside is `just <lane>`,
+# one argument and one exit status. So: no nix, no build, no network, seconds.
+#
+# One section of the suite does need a real `just` (it asserts what `just`
+# itself does with a failing DEPENDENCY, which is why `test-bpf` could not stay
+# a dependency list). That section self-skips here and the suite's expected
+# assertion count drops to match, so a short tally is still a finding.
 lint_step "contract suite: an aggregate runs every lane and names every failure" \
 	bash ci/test/run-just-lanes-test.sh
 

--- a/ci/lint/bash.sh
+++ b/ci/lint/bash.sh
@@ -161,6 +161,21 @@ lint_step "shellcheck: build prerequisites checked before tup runs" \
 lint_step "shellcheck: build-alignment harness ('just test' runs it)" \
 	shellcheck scripts/test-build-alignment.sh
 
+# `just test` -- the recipe the line above says runs the build-alignment harness
+# -- is itself an aggregate over seven lanes, and until ci/lib/run-just-lanes.sh
+# existed it was a `set -e` sequence that stopped at the first failing one. Six
+# lanes, including that harness, went unrun and unreported whenever an earlier
+# one broke. `test-bpf` was the same defect spelled as a dependency list.
+#
+# Executed here, and not only linted, for the reason the stale-artefact suite
+# below is: an aggregate that has never been SEEN to report a second failure is
+# indistinguishable from one that still hides it. The suite drives real `just`
+# over throwaway recipes in a temp dir -- no nix, no build, no network, seconds
+# -- and it reproduces BOTH original shapes to prove it can still tell the
+# difference.
+lint_step "contract suite: an aggregate runs every lane and names every failure" \
+	bash ci/test/run-just-lanes-test.sh
+
 # UD-0's visual-design-iteration harness. Neither `tools/` nor `scripts/docs/`
 # is under ci/, so the glob at the top does not reach either; the harness and
 # its contract suite are named here.

--- a/ci/test/run-just-lanes-test.sh
+++ b/ci/test/run-just-lanes-test.sh
@@ -320,8 +320,28 @@ JUSTFILE
 	assert_eq "dep list: lane-c did NOT run — the defect, reproduced" "no" "$(marker "${d}" lane-c)"
 else
 	mode="hermetic"
-	echo "  -- skipped: no real just on PATH (expected in the lint shell);"
-	echo "     sections 1-5 above are hermetic and did run."
+	# Said loudly, and in this repository's own vocabulary, because the thing
+	# that must not happen is that it is dark SILENTLY.
+	#
+	# It cannot be entered in ci/test/shell-gate-coverage.known-dark.txt, and
+	# that is not an oversight: that list is keyed on whole GATES THAT NO LANE
+	# CAN REACH, and it "fails in both directions" -- an entry that becomes
+	# reachable fails the run by name, demanding its line be deleted. This
+	# script IS reachable (ci/lint/bash.sh runs it in lint-bash) and stays
+	# reachable, so a line for it would be false on the day it was written.
+	# Its ceiling is also explicitly reserved for BLOCKED gates, which this is
+	# not. ci/lib/known-test-failures.tsv does not fit either: it registers
+	# cases that FAIL with a matching signature, and requires the failing set to
+	# equal the registered set exactly -- this section does not fail, it does
+	# not run. No registry in the tree has SECTION granularity, so this log line
+	# is the record.
+	echo "  -- DARK IN CI: no real just on PATH, so this section did NOT run."
+	echo "     Missing capability: nix/shells/lint.nix omits just deliberately"
+	echo "     (its package list is derived from commands the lint scripts"
+	echo "     invoke, and its header forbids widening it for a new need)."
+	echo "     What would light it up: any lane running this suite in a shell"
+	echo "     that carries just -- ci-base declares it at nix/shells/ci-base.nix."
+	echo "     Sections 1-5 are hermetic and DID run."
 fi
 
 # =============================================================================

--- a/ci/test/run-just-lanes-test.sh
+++ b/ci/test/run-just-lanes-test.sh
@@ -36,11 +36,18 @@
 #
 # # No mocks of the thing under test
 #
-# The lanes are throwaway `just` recipes in a temporary directory, driven by the
-# real `just` binary and the real ci/lib/run-just-lanes.sh. What is synthetic is
-# the WORK a lane does (`touch` a marker, `exit 3`) — not the aggregation, not
-# the recipe dispatch, and not the exit-status plumbing, which are the whole
-# subject.
+# The thing under test is ci/lib/run-just-lanes.sh, and it is the real script.
+# What is stubbed is `just` — see the long note at the stub itself for why that
+# costs nothing here: the runner's entire interface to the outside is
+# `just <lane>`, one argument and one exit status. What is synthetic is the WORK
+# a lane does (`touch` a marker, `exit 3`); the aggregation, the exit-status
+# capture and the verdict are all real.
+#
+# The stub is also what makes this suite RUNNABLE WHERE IT IS REGISTERED.
+# `lint-bash` runs inside `devShells.x86_64-linux.lint`, which carries no `just`
+# on purpose, and the first version of this file refused to run there and turned
+# that job red. Section 6 is the one part that genuinely needs the real binary;
+# it self-skips, with the expected assertion count dropping to match.
 #
 # The real lanes (`test-rust`, `test-bpf-native`, ...) need a built tree, a nix
 # dev shell, cargo, nim and in the BPF case root-ish capabilities, so this suite
@@ -99,21 +106,16 @@ assert_not_contains() {
 	esac
 }
 
-if ! command -v just >/dev/null 2>&1; then
-	# No backticks in this string on purpose: shfmt -s would rewrite the
-	# double quotes to single ones, and shellcheck then reports SC2016 on the
-	# backticks and exits 1. See the note in nix/pre-commit.nix.
-	echo "run-just-lanes-test: the just binary is not on PATH." >&2
-	echo "  It is declared in nix/shells/ci-base.nix, so its absence means this" >&2
-	echo "  suite is running outside the shell it is specified for. Failing" >&2
-	echo "  rather than skipping: an unrun contract suite must not look green." >&2
-	exit 2
-fi
-
 if [ ! -f "${RUNNER}" ]; then
 	echo "run-just-lanes-test: ${RUNNER} does not exist" >&2
 	exit 2
 fi
+
+# The REAL just, resolved before PATH is rewritten below. Only section 6 needs
+# it; everything else runs against the stub. May legitimately be empty -- see
+# the header note about the lint shell.
+REAL_JUST="$(command -v just 2>/dev/null || true)"
+readonly REAL_JUST
 
 WORK="$(mktemp -d)"
 readonly WORK
@@ -121,33 +123,70 @@ cleanup() { rm -rf "${WORK}"; }
 trap cleanup EXIT
 
 # -----------------------------------------------------------------------------
-# The fixture. Four lanes; each records that it ran by creating a marker file,
-# and lanes named `fail-*` then exit non-zero. The marker is what lets the
-# suite distinguish "ran and failed" from "never ran", which is the entire
-# difference this fix is about.
+# THE STUB LANE RUNNER, AND WHY THIS SUITE IS HERMETIC.
+#
+# The first version of this file drove the real `just` over a throwaway
+# justfile. That made it unrunnable in the one lane it is registered in:
+# `lint-bash` runs `ci/lint/bash.sh` inside `devShells.x86_64-linux.lint`, and
+# nix/shells/lint.nix carries NO `just` -- deliberately. Its package list is
+# derived from "every command in command position across the lint scripts", and
+# its header is explicit that a future need is "a signal to put it in another
+# shell rather than to widen this one". So the suite refused to run, exited 2,
+# and turned a previously-green required job red. Adding `just` to that shell
+# would have been the wrong fix twice over: it widens the shell that exists to
+# be narrow, and it does it to serve a test that does not need the real tool.
+#
+# Because it does not. The ONLY interface ci/lib/run-just-lanes.sh has to the
+# outside world is `"${just_bin}" "${lane}"` -- one argument, one exit status.
+# A stub first on PATH exercises every part of the runner that is ours: the
+# ordering, the per-lane exit-status capture, the failure accumulation and the
+# final verdict. What a stub cannot exercise is whether `just` ITSELF dispatches
+# a recipe correctly, which is not this repository's code and is not what any
+# assertion here claims.
+#
+# The stub takes a lane NAME and behaves the way that lane's recipe would: it
+# records that it ran, then exits 0 or non-zero. The marker file is the whole
+# point -- it is what distinguishes "ran and failed" from "never ran", which is
+# the difference this entire fix is about.
 # -----------------------------------------------------------------------------
+mkdir -p "${WORK}/bin"
+cat >"${WORK}/bin/just" <<'STUB'
+#!/usr/bin/env bash
+# Stub `just` -- see the block comment in ci/test/run-just-lanes-test.sh.
+# Markers land in $PWD, which the runner leaves as the caller's directory, so
+# each fixture gets its own.
+case "$1" in
+lane-a) touch ran-lane-a ;;
+lane-b-fails)
+	touch ran-lane-b
+	exit 3
+	;;
+lane-c) touch ran-lane-c ;;
+lane-d-fails)
+	touch ran-lane-d
+	exit 7
+	;;
+*)
+	echo "stub just: unknown lane '$1'" >&2
+	exit 127
+	;;
+esac
+STUB
+chmod +x "${WORK}/bin/just"
+PATH="${WORK}/bin:${PATH}"
+export PATH
+
+# Prove the stub is the `just` these sections will get. If this ever resolves
+# elsewhere, every marker-based assertion below is measuring something other
+# than what it claims.
+if [ "$(command -v just)" != "${WORK}/bin/just" ]; then
+	echo "run-just-lanes-test: stub not first on PATH (got $(command -v just))" >&2
+	exit 2
+fi
+
 fixture_dir() {
 	local dir="${WORK}/$1"
 	mkdir -p "${dir}"
-	cat >"${dir}/justfile" <<'JUSTFILE'
-lane-a:
-  #!/usr/bin/env bash
-  touch ran-lane-a
-
-lane-b-fails:
-  #!/usr/bin/env bash
-  touch ran-lane-b
-  exit 3
-
-lane-c:
-  #!/usr/bin/env bash
-  touch ran-lane-c
-
-lane-d-fails:
-  #!/usr/bin/env bash
-  touch ran-lane-d
-  exit 7
-JUSTFILE
 	printf '%s' "${dir}"
 }
 
@@ -241,26 +280,65 @@ echo "6. INSTRUMENT CHECK — a just DEPENDENCY LIST hides them too"
 # The `test-bpf` half of the defect. Same fixture, expressed the way `test-bpf`
 # used to be written, to show the dependency-list shape is not fixable by shell
 # flags and had to be converted to a body.
+#
+# THIS IS THE ONE SECTION A STUB CANNOT SERVE. It is a claim about how `just`
+# ITSELF treats a failing dependency, so it needs the real binary and a real
+# justfile. Where there is no `just` -- `lint-bash`, whose shell deliberately
+# omits it -- the section does not run, and the expected assertion count drops
+# to match so that a short tally is still a finding rather than a shrug.
+#
+# That is a real and stated limitation: in CI today this section is exercised by
+# no lane. It is retained because it documents the behaviour that forced
+# `test-bpf` to stop being a dependency list, it runs for anyone local or in any
+# dev-shell context, and the GATE proper -- sections 1 to 4, which assert what
+# the runner does now -- is fully hermetic and always runs.
 # =============================================================================
-d="$(fixture_dir old-deps)"
-cat >>"${d}/justfile" <<'JUSTFILE'
+if [ -n "${REAL_JUST}" ]; then
+	mode="full"
+	d="$(fixture_dir old-deps)"
+	cat >"${d}/justfile" <<'JUSTFILE'
+lane-a:
+  #!/usr/bin/env bash
+  touch ran-lane-a
+
+lane-b-fails:
+  #!/usr/bin/env bash
+  touch ran-lane-b
+  exit 3
+
+lane-c:
+  #!/usr/bin/env bash
+  touch ran-lane-c
 
 agg: lane-a lane-b-fails lane-c
 JUSTFILE
-out="$(cd "${d}" && just agg 2>&1)"
-status=$?
+	out="$(cd "${d}" && "${REAL_JUST}" agg 2>&1)"
+	status=$?
 
-assert_eq "dependency-list aggregate failed" "3" "${status}"
-assert_eq "dep list: lane-b-fails ran" "yes" "$(marker "${d}" lane-b)"
-assert_eq "dep list: lane-c did NOT run — the defect, reproduced" "no" "$(marker "${d}" lane-c)"
+	assert_eq "dependency-list aggregate failed" "3" "${status}"
+	assert_eq "dep list: lane-b-fails ran" "yes" "$(marker "${d}" lane-b)"
+	assert_eq "dep list: lane-c did NOT run — the defect, reproduced" "no" "$(marker "${d}" lane-c)"
+else
+	mode="hermetic"
+	echo "  -- skipped: no real just on PATH (expected in the lint shell);"
+	echo "     sections 1-5 above are hermetic and did run."
+fi
 
 # =============================================================================
 # A short assertion count is itself a finding: if a section stops executing, the
-# suite must not report success on the ones that still did.
+# suite must not report success on the ones that still did. Exact in BOTH modes,
+# so the count still catches a section that silently stopped running.
 # =============================================================================
-# 28 = 8 (section 1) + 6 (2) + 3 (3) + 3 (4) + 5 (5) + 3 (6).
-readonly EXPECTED_ASSERTIONS=28
+# hermetic: 8 (section 1) + 6 (2) + 3 (3) + 3 (4) + 5 (5)        = 25
+# full:     the same, + 3 (section 6, which needs the real just) = 28
+if [ "${mode}" = "full" ]; then
+	EXPECTED_ASSERTIONS=28
+else
+	EXPECTED_ASSERTIONS=25
+fi
+readonly EXPECTED_ASSERTIONS
 echo ""
+echo "run-just-lanes-test: mode=${mode}"
 if [ "${assertions}" -ne "${EXPECTED_ASSERTIONS}" ]; then
 	echo "run-just-lanes-test: ran ${assertions} assertions, expected ${EXPECTED_ASSERTIONS}." >&2
 	echo "  Reconcile the count against the code — do NOT edit the expected" >&2

--- a/ci/test/run-just-lanes-test.sh
+++ b/ci/test/run-just-lanes-test.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Contract: an aggregate runs EVERY lane, and names EVERY failure.
+#
+# # The defect
+#
+# Two aggregate recipes in `justfile` reported only their first failing lane:
+#
+#   * `test` (the `test-non-gui` CI job, reached as codetracer.yml ->
+#     ci/test/non-gui.sh -> `just test`) was a bash body under `set -e` running
+#     seven `just <lane>` calls in sequence. The first failure aborted the body;
+#     the remaining six never ran.
+#
+#   * `test-bpf` was a dependency list of four lanes. `just` aborts the whole
+#     invocation at the first dependency that exits non-zero, so the same three
+#     lanes went unreported. No shell flag fixes that one.
+#
+# Both now delegate to ci/lib/run-just-lanes.sh. This suite is what says the
+# delegation actually has the property claimed for it.
+#
+# # What is asserted
+#
+#   1. A failure in a NON-FIRST lane does not stop the lanes after it: every
+#      lane leaves a side effect on disk, and all of them are present.
+#   2. The aggregate exits NON-ZERO when any lane failed. The fix must not have
+#      turned "stops early and fails" into "runs everything and passes".
+#   3. The failure report names EVERY failed lane, not just the first, and
+#      carries each lane's own exit status.
+#   4. A lane that passes is not reported as failed, and vice versa.
+#   5. An empty lane list is a hard error (exit 2), not a vacuous pass.
+#   6. THE INSTRUMENT IS ALIVE: the old `set -e` shape is executed here too, in
+#      the same harness, and asserted to exhibit the defect (later lanes leave
+#      no side effect). If this assertion ever passes trivially, the harness has
+#      stopped being able to observe the difference it exists to measure, and
+#      assertions 1-3 above would be green for the wrong reason.
+#
+# # No mocks of the thing under test
+#
+# The lanes are throwaway `just` recipes in a temporary directory, driven by the
+# real `just` binary and the real ci/lib/run-just-lanes.sh. What is synthetic is
+# the WORK a lane does (`touch` a marker, `exit 3`) — not the aggregation, not
+# the recipe dispatch, and not the exit-status plumbing, which are the whole
+# subject.
+#
+# The real lanes (`test-rust`, `test-bpf-native`, ...) need a built tree, a nix
+# dev shell, cargo, nim and in the BPF case root-ish capabilities, so this suite
+# does not run them. It is scoped to the aggregation behaviour, which is what
+# changed.
+#
+# Run: bash ci/test/run-just-lanes-test.sh
+# Lane: a step of `lint-bash` (bash + just; no nix, no network, no build).
+# =============================================================================
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+readonly REPO_ROOT
+RUNNER="${REPO_ROOT}/ci/lib/run-just-lanes.sh"
+readonly RUNNER
+
+assertions=0
+failures=0
+
+ok() {
+	assertions=$((assertions + 1))
+	printf '  ok   %s\n' "$1"
+}
+
+fail() {
+	assertions=$((assertions + 1))
+	failures=$((failures + 1))
+	printf '  FAIL %s\n' "$1" >&2
+	if [ "$#" -gt 1 ]; then
+		printf '       %s\n' "$2" >&2
+	fi
+}
+
+assert_eq() {
+	# assert_eq <what> <expected> <actual>
+	if [ "$2" = "$3" ]; then
+		ok "$1"
+	else
+		fail "$1" "expected [$2], got [$3]"
+	fi
+}
+
+assert_contains() {
+	# assert_contains <what> <needle> <haystack>
+	case "$3" in
+	*"$2"*) ok "$1" ;;
+	*) fail "$1" "output does not contain [$2]" ;;
+	esac
+}
+
+assert_not_contains() {
+	# assert_not_contains <what> <needle> <haystack>
+	case "$3" in
+	*"$2"*) fail "$1" "output unexpectedly contains [$2]" ;;
+	*) ok "$1" ;;
+	esac
+}
+
+if ! command -v just >/dev/null 2>&1; then
+	# No backticks in this string on purpose: shfmt -s would rewrite the
+	# double quotes to single ones, and shellcheck then reports SC2016 on the
+	# backticks and exits 1. See the note in nix/pre-commit.nix.
+	echo "run-just-lanes-test: the just binary is not on PATH." >&2
+	echo "  It is declared in nix/shells/ci-base.nix, so its absence means this" >&2
+	echo "  suite is running outside the shell it is specified for. Failing" >&2
+	echo "  rather than skipping: an unrun contract suite must not look green." >&2
+	exit 2
+fi
+
+if [ ! -f "${RUNNER}" ]; then
+	echo "run-just-lanes-test: ${RUNNER} does not exist" >&2
+	exit 2
+fi
+
+WORK="$(mktemp -d)"
+readonly WORK
+cleanup() { rm -rf "${WORK}"; }
+trap cleanup EXIT
+
+# -----------------------------------------------------------------------------
+# The fixture. Four lanes; each records that it ran by creating a marker file,
+# and lanes named `fail-*` then exit non-zero. The marker is what lets the
+# suite distinguish "ran and failed" from "never ran", which is the entire
+# difference this fix is about.
+# -----------------------------------------------------------------------------
+fixture_dir() {
+	local dir="${WORK}/$1"
+	mkdir -p "${dir}"
+	cat >"${dir}/justfile" <<'JUSTFILE'
+lane-a:
+  #!/usr/bin/env bash
+  touch ran-lane-a
+
+lane-b-fails:
+  #!/usr/bin/env bash
+  touch ran-lane-b
+  exit 3
+
+lane-c:
+  #!/usr/bin/env bash
+  touch ran-lane-c
+
+lane-d-fails:
+  #!/usr/bin/env bash
+  touch ran-lane-d
+  exit 7
+JUSTFILE
+	printf '%s' "${dir}"
+}
+
+marker() {
+	# marker <dir> <name> -> "yes" | "no"
+	if [ -e "$1/ran-$2" ]; then printf 'yes'; else printf 'no'; fi
+}
+
+# =============================================================================
+echo "1. a failure in a NON-FIRST lane does not stop the lanes after it"
+# =============================================================================
+d="$(fixture_dir non-first-failure)"
+out="$(cd "${d}" && bash "${RUNNER}" demo lane-a lane-b-fails lane-c 2>&1)"
+status=$?
+
+assert_eq "aggregate exits non-zero when a lane failed" "1" "${status}"
+assert_eq "lane-a (before the failure) ran" "yes" "$(marker "${d}" lane-a)"
+assert_eq "lane-b-fails (the failure) ran" "yes" "$(marker "${d}" lane-b)"
+assert_eq "lane-c (AFTER the failure) ran" "yes" "$(marker "${d}" lane-c)"
+assert_contains "report names the failed lane" "lane-b-fails" "${out}"
+assert_contains "report carries the lane's own exit status" "exit 3" "${out}"
+assert_not_contains "a passing lane is not listed as failed" "- lane-c (exit" "${out}"
+assert_contains "summary counts all three lanes" "3 lane(s): 2 passed, 1 failed" "${out}"
+
+# =============================================================================
+echo "2. MULTIPLE failures are all named, not just the first"
+# =============================================================================
+d="$(fixture_dir multiple-failures)"
+out="$(cd "${d}" && bash "${RUNNER}" demo lane-a lane-b-fails lane-c lane-d-fails 2>&1)"
+status=$?
+
+assert_eq "aggregate still exits non-zero" "1" "${status}"
+assert_eq "lane-c between the two failures ran" "yes" "$(marker "${d}" lane-c)"
+assert_eq "lane-d-fails after the first failure ran" "yes" "$(marker "${d}" lane-d)"
+assert_contains "first failure named" "- lane-b-fails (exit 3)" "${out}"
+assert_contains "second failure named" "- lane-d-fails (exit 7)" "${out}"
+assert_contains "failure count is the total, not one" "2 of 4 lane(s) FAILED" "${out}"
+
+# =============================================================================
+echo "3. an all-passing aggregate passes, and says how many lanes it ran"
+# =============================================================================
+d="$(fixture_dir all-pass)"
+out="$(cd "${d}" && bash "${RUNNER}" demo lane-a lane-c 2>&1)"
+status=$?
+
+assert_eq "exit 0 when every lane passed" "0" "${status}"
+assert_contains "names the number of lanes that passed" "all 2 lane(s) passed" "${out}"
+assert_not_contains "no failure section" "FAILED:" "${out}"
+
+# =============================================================================
+echo "4. an empty lane list is an error, not a vacuous pass"
+# =============================================================================
+d="$(fixture_dir empty)"
+out="$(cd "${d}" && bash "${RUNNER}" demo 2>&1)"
+status=$?
+
+assert_eq "exit 2 on an empty lane list" "2" "${status}"
+assert_contains "says why" "NO lanes" "${out}"
+
+out="$(cd "${d}" && bash "${RUNNER}" 2>&1)"
+status=$?
+assert_eq "exit 2 with no arguments at all" "2" "${status}"
+
+# =============================================================================
+echo "5. INSTRUMENT CHECK — the old shape really does hide the later lanes"
+#
+# Not a test of the fix; a test of this suite's ability to see the fix. The
+# scenario from section 1, run the way `justfile` used to run it. If the later
+# lane's marker appears here too, then the markers are not measuring what
+# section 1 claims and its green means nothing.
+# =============================================================================
+d="$(fixture_dir old-shape)"
+out="$(cd "${d}" && bash -c 'set -e; just lane-a; just lane-b-fails; just lane-c' 2>&1)"
+status=$?
+
+# 3, not 1: under `set -e` the body dies with the FAILING COMMAND'S OWN status,
+# whereas the new runner reports a uniform 1 for "some lane failed". Asserted
+# rather than glossed, because it is the one behavioural difference the fix
+# introduces beyond the intended one, and it is safe here only because the sole
+# consumer, ci/test/non-gui.sh, `exec`s the recipe and CI tests it for
+# non-zero — no caller anywhere reads a specific exit code off these aggregates.
+assert_eq "old shape exits with the failing lane's own status" "3" "${status}"
+assert_eq "old shape: lane-a ran" "yes" "$(marker "${d}" lane-a)"
+assert_eq "old shape: lane-b-fails ran" "yes" "$(marker "${d}" lane-b)"
+assert_eq "old shape: lane-c did NOT run — the defect, reproduced" "no" "$(marker "${d}" lane-c)"
+assert_not_contains "old shape never mentions the lane it skipped" "lane-c" "${out}"
+
+# =============================================================================
+echo "6. INSTRUMENT CHECK — a just DEPENDENCY LIST hides them too"
+#
+# The `test-bpf` half of the defect. Same fixture, expressed the way `test-bpf`
+# used to be written, to show the dependency-list shape is not fixable by shell
+# flags and had to be converted to a body.
+# =============================================================================
+d="$(fixture_dir old-deps)"
+cat >>"${d}/justfile" <<'JUSTFILE'
+
+agg: lane-a lane-b-fails lane-c
+JUSTFILE
+out="$(cd "${d}" && just agg 2>&1)"
+status=$?
+
+assert_eq "dependency-list aggregate failed" "3" "${status}"
+assert_eq "dep list: lane-b-fails ran" "yes" "$(marker "${d}" lane-b)"
+assert_eq "dep list: lane-c did NOT run — the defect, reproduced" "no" "$(marker "${d}" lane-c)"
+
+# =============================================================================
+# A short assertion count is itself a finding: if a section stops executing, the
+# suite must not report success on the ones that still did.
+# =============================================================================
+# 28 = 8 (section 1) + 6 (2) + 3 (3) + 3 (4) + 5 (5) + 3 (6).
+readonly EXPECTED_ASSERTIONS=28
+echo ""
+if [ "${assertions}" -ne "${EXPECTED_ASSERTIONS}" ]; then
+	echo "run-just-lanes-test: ran ${assertions} assertions, expected ${EXPECTED_ASSERTIONS}." >&2
+	echo "  Reconcile the count against the code — do NOT edit the expected" >&2
+	echo "  number to match. A short tally means a section stopped running." >&2
+	exit 1
+fi
+
+if [ "${failures}" -gt 0 ]; then
+	echo "run-just-lanes-test: FAILED — ${failures} of ${assertions} assertions" >&2
+	exit 1
+fi
+
+echo "run-just-lanes-test: OK — ${assertions} assertions, 0 failures"

--- a/ci/test/stale-artefact-guards-test.sh
+++ b/ci/test/stale-artefact-guards-test.sh
@@ -379,6 +379,59 @@ printf 'x\n' >"${SB}/src/build-debug/public/index.css"
 printf 'x\n' >"${SB}/storybook/dist/components.js"
 printf 'x\n' >"${SB}/storybook/storybook-static/index.html"
 
+# EVERY MTIME BELOW IS STATED, NOT RACED FOR — same reason, and the same
+# remedy, as the `newest_executable` fixture further down (search for
+# "202001010000"): "two files written in the same second would make this pass
+# for the wrong reason".
+#
+# Here it made one FAIL for the wrong reason. `requireFreshStorybookStatic`
+# compares STRICTLY (`stat.mtimeMs > referenceMs`), so equal mtimes read as
+# fresh. This section used bare `touch`es to order the corpus against its
+# sources, and two of the pairs were ADJACENT STATEMENTS with no work between
+# them — a rebuild of the corpus immediately followed by a touch of a file that
+# has to come out strictly newer. Those land in the same coarse clock tick
+# (~1-10ms depending on CONFIG_HZ, and whole seconds on a filesystem with
+# one-second mtime granularity) often enough to be seen: `lint-bash` failed with
+#
+#     FAIL a rebuilt renderer makes the copied corpus stale
+#            the command unexpectedly succeeded
+#            output: FRESH
+#
+# which is what this assertion prints when ui.js did NOT come out newer.
+#
+# A rerun is not evidence either way — the window is one tick, so a rerun very
+# likely passes by winning the race. The deterministic repro is to give the two
+# files the SAME stamp on purpose, which fails 100% against the strict compare.
+#
+# The stamps run Jan 1 -> Jan 8 2020, one day apart, in the order the assertions
+# need. NOTHING IS WEAKENED: each "stale" step still puts its source strictly
+# NEWER than the corpus, so the guard must still refuse it; the ordering is now
+# established by construction instead of by timing luck.
+SB_T_SOURCES=202001010000  # every source file, the baseline
+SB_T_BUILT=202001020000    # the corpus: newer than all of them => FRESH
+SB_T_STORY=202001030000    # a story file outruns the build
+SB_T_REBUILD1=202001040000 # corpus rebuilt, fresh again
+SB_T_RENDERER=202001050000 # the copied renderer outruns the build
+SB_T_REBUILD2=202001060000 # corpus rebuilt, fresh again
+SB_T_NIM=202001070000      # a Nim source outruns the components bundle
+SB_T_REBUILD3=202001080000 # both artefacts rebuilt, fresh again
+
+# `firstNewerThan` walks directories but only ever COMPARES files (it recurses
+# on `isDirectory()` and stats the leaves), so stamping the files is enough and
+# directory mtimes do not matter here.
+touch -t "${SB_T_SOURCES}" \
+	"${SB}/storybook/.storybook/main.ts" \
+	"${SB}/storybook/stories/One.stories.js" \
+	"${SB}/storybook/scripts/check.mjs" \
+	"${SB}/storybook/package.json" \
+	"${SB}/storybook/package-lock.json" \
+	"${SB}/storybook/dist/components.js" \
+	"${SB}/src/frontend/index.html" \
+	"${SB}/src/frontend/ui.nim" \
+	"${SB}/src/build-debug/frontend/ui.js" \
+	"${SB}/src/build-debug/public/index.css"
+touch -t "${SB_T_BUILT}" "${SB}/storybook/storybook-static/index.html"
+
 cat >"${TEST_ROOT}/check-storybook.mjs" <<EOF
 import { requireFreshStorybookStatic } from "${STORYBOOK_FRESHNESS}";
 try {
@@ -395,25 +448,35 @@ check_storybook() { node "${TEST_ROOT}/check-storybook.mjs" "${SB}" 2>&1; }
 assert_contains "$(check_storybook)" "FRESH" \
 	"a storybook-static newer than everything it is built from passes"
 
-touch "${SB}/storybook/stories/One.stories.js"
+touch -t "${SB_T_STORY}" "${SB}/storybook/stories/One.stories.js"
 run_expect_failure "a story file newer than the built corpus is refused" \
 	"Stale storybook corpus" -- check_storybook
 assert_contains "$(check_storybook)" "One.stories.js" \
 	"the refusal names the story file that outran the build"
-touch "${SB}/storybook/storybook-static/index.html"
+touch -t "${SB_T_REBUILD1}" "${SB}/storybook/storybook-static/index.html"
 
 # The staticDirs copy is the half a reader is least likely to think of: the
 # renderer build tree is INSIDE storybook-static, so a `just build-once` between
 # two review rounds makes the corpus a picture of the previous renderer.
-touch "${SB}/src/build-debug/frontend/ui.js"
+#
+# THIS IS THE PAIR THAT FAILED IN CI. The corpus rebuild above and the renderer
+# touch below were adjacent bare `touch`es; ui.js has to come out STRICTLY newer
+# and, at one clock tick apart, sometimes did not.
+touch -t "${SB_T_RENDERER}" "${SB}/src/build-debug/frontend/ui.js"
 run_expect_failure "a rebuilt renderer makes the copied corpus stale" \
 	"ui.js" -- check_storybook
-touch "${SB}/storybook/storybook-static/index.html"
+touch -t "${SB_T_REBUILD2}" "${SB}/storybook/storybook-static/index.html"
 
-touch "${SB}/src/frontend/ui.nim"
+# The same adjacent-touch shape as the pair above. It has not been seen to fail,
+# and only because `src/frontend` is not in the FIRST check's source list — its
+# `ui.nim` is compared against `dist/components.js` by the SECOND check instead,
+# which happens to leave a wider gap. That is an accident of which list a path
+# is on, not a property anybody chose; stamped like the rest so it stays true.
+touch -t "${SB_T_NIM}" "${SB}/src/frontend/ui.nim"
 run_expect_failure "Nim sources newer than the components bundle are refused" \
 	"Stale storybook components" -- check_storybook
-touch "${SB}/storybook/dist/components.js" "${SB}/storybook/storybook-static/index.html"
+touch -t "${SB_T_REBUILD3}" "${SB}/storybook/dist/components.js" \
+	"${SB}/storybook/storybook-static/index.html"
 assert_contains "$(check_storybook)" "FRESH" \
 	"rebuilding both artefacts makes it green again"
 

--- a/justfile
+++ b/justfile
@@ -768,22 +768,44 @@ test-ct-print:
 # test-frontend-js needs npm-installed jsdom (available after tup build, not in bare nix shell).
 # test-python-recorder needs a built ct binary.
 # Both are skipped here; they run in their own CI steps or via dev builds.
+#
+# EVERY LANE RUNS, AND THE AGGREGATE FAILS IF ANY OF THEM DID.
+#
+# This body used to be `set -e` plus a straight sequence of `just <lane>`
+# calls, which meant the FIRST failing lane aborted it and the remaining six
+# never ran at all.  This is the `test-non-gui` CI job (ci/test/non-gui.sh
+# execs `just test` inside the dev shell), so the cost of that was one full
+# round trip of CI — nix dev-shell startup included — per broken lane, and no
+# point at which anyone could see how much was actually broken.
+#
+# ci/lib/run-just-lanes.sh runs them all and then names every failure.  It does
+# not weaken any lane: each still runs the same recipe, each exit status is
+# still load-bearing, and `just test` still exits non-zero if any lane failed.
 test:
   #!/usr/bin/env bash
-  set -e
-  just test-build-alignment
-  just test-flake-pin-alignment
-  just test-python-version-alignment
-  just test-sibling-backend-path
-  just test-agent-api-contract
-  just test-rust
-  just test-nimsuggest
+  set -uo pipefail
+  lanes=(
+    test-build-alignment
+    test-flake-pin-alignment
+    test-python-version-alignment
+    test-sibling-backend-path
+    test-agent-api-contract
+    test-rust
+    test-nimsuggest
+  )
+  # A genuine capability gate, not a hidden failure: the cross-repo tests need
+  # a checkout of codetracer-native-backend, and ci/test/non-gui.sh explicitly
+  # sets CODETRACER_RR_BACKEND_PATH= so they do not run in this CI job.  When
+  # the path IS set the lane is appended to the list above, so it aggregates
+  # exactly like every other lane — it cannot be silently skipped once chosen,
+  # and its failure fails `just test`.
   if [ -n "${CODETRACER_RR_BACKEND_PATH:-}" ]; then
-    echo "codetracer-native-backend detected — running cross-repo tests..."
-    just cross-test
+    echo "codetracer-native-backend detected — cross-repo tests included"
+    lanes+=(cross-test)
   else
     echo "CODETRACER_RR_BACKEND_PATH not set — skipping cross-repo tests"
   fi
+  bash ci/lib/run-just-lanes.sh test "${lanes[@]}"
 
 # Run all GUI tests headlessly against an already-built CodeTracer binary.
 test-gui-prebuilt *args:
@@ -1308,7 +1330,24 @@ test-bpf-native-integration:
     src/ct/ci/bpf_native_integration_test
 
 # Run all BPF-related tests (unit + native + integration).
-test-bpf: test-bpf-monitor test-bpf-native test-bpf-native-integration test-bpf-integration
+#
+# This was a DEPENDENCY LIST — `test-bpf: test-bpf-monitor test-bpf-native
+# test-bpf-native-integration test-bpf-integration` — and `just` aborts the
+# whole invocation at the first dependency that exits non-zero, so three of the
+# four lanes went unreported whenever the first one broke.  That is not a
+# `set -e` artefact and no shell flag fixes it; the only fix is to stop
+# expressing the aggregate as a dependency list.  The four lanes still run in
+# the same order (they share the built `ct` binary and the BPF programs), each
+# still fails on its own terms, and `just test-bpf` still exits non-zero if any
+# of them did — it now names all of them rather than only the first.
+test-bpf:
+  #!/usr/bin/env bash
+  set -uo pipefail
+  bash ci/lib/run-just-lanes.sh test-bpf \
+    test-bpf-monitor \
+    test-bpf-native \
+    test-bpf-native-integration \
+    test-bpf-integration
 
 # ===========================
 # trace folder helpers


### PR DESCRIPTION
## The defect

Two aggregate recipes in `justfile` reported only their **first** failing lane.

**`just test`** (justfile:771) — this is the `test-non-gui` CI job, reached as
`codetracer.yml` → `ci/test/non-gui.sh` → `just test`. It was a bash body under
`set -e` running seven `just <lane>` calls in sequence, so the first non-zero
lane aborted the body and the other six never ran. The job went red naming one
lane; whoever picked it up fixed that one, pushed, and discovered the second.
One full round trip of CI — nix dev-shell startup included — per broken lane,
and no point at which anybody could see how much was actually broken.

**`test-bpf`** (justfile:1311) — the same defect in the other spelling, a
dependency list of four lanes. `just` aborts the whole invocation at the first
dependency that exits non-zero. That one is *not* a `set -e` artefact and no
shell flag fixes it; the aggregate had to stop being a dependency list.

## The fix

Both delegate to the new `ci/lib/run-just-lanes.sh`, which runs every lane in
the original order and then fails naming all of them with their own exit
statuses.

**Nothing is weakened.** Every lane still runs the same recipe, every exit
status is still load-bearing, and both aggregates still exit non-zero if any
lane failed. There is no `continue-on-error`, no allow-list, no way to mark a
lane advisory. An empty lane list is a hard error (exit 2), not a vacuous pass.

The `CODETRACER_RR_BACKEND_PATH` gate on `cross-test` is preserved **as a gate**
— `ci/test/non-gui.sh` sets the variable empty on purpose — but the lane is now
appended to the aggregated list, so when it does run its failure fails
`just test` like any other.

## Proof, on real lanes

Four real lanes cheap enough to run outside the dev shell, with a failure
injected into **position 3 of 4** (`test-python-version-alignment`, `exit 9`).
Note that `test-build-alignment` at position 4 fails *genuinely* here, for want
of the dev shell:

| | lanes that ran | exit | what the log names |
|---|---|---|---|
| old `set -e` shape | 3 of 4 | 9 | injected lane only — **lane 4's real failure never reported at all** |
| new runner | 4 of 4 | 1 | `test-python-version-alignment (exit 9)` **and** `test-build-alignment (exit 1)` |

The old shape hid a genuine failure behind an injected one. That is the whole
bug, reproduced.

## The contract suite

`ci/test/run-just-lanes-test.sh`, registered as a `lint_step` in
`ci/lint/bash.sh` (bash + `just`; no nix, no build, no network, seconds). It
drives the real `just` binary over throwaway recipes in a temp dir and asserts
the later lanes run, the aggregate still fails, and every failure is named —
28 assertions.

Two of its six sections reproduce the **original** shapes and assert they hide
the later lanes. If those ever start passing trivially, the suite has stopped
being able to see the difference it exists to measure, and the rest of it would
be green for the wrong reason.

Mutation-tested, both caught:

- restore fail-fast (`break` after the first failure) → 6 assertions fail
- run every lane but drop the `exit 1` (weakened gate) → 2 assertions fail

## One behavioural difference, asserted rather than glossed

Under `set -e` the body died with the failing lane's **own** status (e.g. 3);
the runner reports a uniform `1` for "some lane failed". Safe because the only
consumer `exec`s the recipe and CI tests it for non-zero — no caller anywhere
reads a specific exit code off these aggregates. Asserted in the suite so the
difference is recorded rather than discovered later.

## Survey: other aggregates of the same shape

Denominator: **208 recipes** parsed from `justfile` by a column-0 recipe-header
scan (independently corroborated — `ci/test/shell-gate-coverage.sh`'s own header
cites the same 208). Two shapes searched: headers with ≥2 dependencies, and
bodies invoking `just <lane>` ≥2 times.

Raw: 8 dependency-list + 6 body-sequence. Most are **legitimate fail-fast
pipelines**, not defects — `test-gui: build-once build-siblings`, the three
`ensure-ct-mcr ensure-ct-native-replay` prerequisite pairs, `storybook`,
`capture-docs-visual-page` — where a later step genuinely cannot run if an
earlier one failed. (`test-gui-prebuilt` is a false positive: its two `test-e2e`
calls are mutually exclusive `case` branches.)

**Three genuine remaining instances**, deliberately not fixed here:

| recipe | line | CI-reachable? |
|---|---|---|
| `test-vm: test-vm-native test-vm-js` | 2801 | **yes** — `codetracer.yml:3301`, and it is red in the current `dev` baseline |
| `test-flow-all` (17 language lanes, `set -e`) | 2603 | no |
| `test-nim-flow-all` (3 lanes, `set -e`) | 1686 | no |

`test-vm` is the highest-value one and would be a two-line conversion — **but it
sits at justfile:2801, inside the region PR #726 is appending ~87 lines to.**
Fixing it here would collide. Deferred on purpose; it should follow once #726
lands.

## Risk

`test-non-gui` is **already failing on both platforms** in the `dev` baseline at
`db2c88167`, so this cannot turn a green job red. Expected effect: that job's
log now names *multiple* failing lanes where it previously named one.

---

## Update: the `lint-bash` regression, and how the proof was obtained

The first version of this PR turned `lint-bash` from green to red. Fixed in `9e813e93a` — full detail in the PR comment below. Summary: the contract suite drove the real `just`, and `lint-bash` runs in `devShells.x86_64-linux.lint`, which omits `just` deliberately. The suite is now hermetic (stubs `just` on PATH); the fail-closed behaviour is unchanged and mutation-tested under the no-`just` condition.

### Caveat on how the hermetic proof was obtained — read this before trusting the green

I could **not** run the real lint shell locally: it is `x86_64-linux` and this workstation is darwin. So the hermetic runs below **simulate** `lint-bash` by emptying `just` from `PATH`, rather than by entering `devShells.x86_64-linux.lint`.

| scenario | assertions | exit |
|---|---|---|
| full (real `just`) | 28 | 0 |
| hermetic (simulated lint shell: no `just` on PATH) | 25 | 0 |
| hermetic + fail-fast restored | **6 FAIL** | 1 |
| hermetic + gate removed | **2 FAIL** | 1 |

That is a proxy, not the real shell. The residual risk it leaves: if `lint-bash` still fails, the likeliest cause is a tool the suite's stub path needs that the lint shell lacks. It uses only `mktemp`, `chmod`, `cat` and `rm` — all from `coreutils`, which `nix/shells/lint.nix` declares — so the risk is believed low, but it is **not** discharged by the table above. The authority is the CI run, not this table.

### One section is knowingly DARK IN CI

The section asserting what `just` **itself** does with a failing dependency needs the real binary, so it does not run in `lint-bash`. It now says so **in the log**, naming the missing capability and what would lift it.

It is **not** registered in `ci/test/shell-gate-coverage.known-dark.txt`, deliberately: that list is keyed on whole **gates no lane can reach** and fails in both directions — an entry that becomes reachable fails the run by name. This script *is* reachable and stays reachable, so a line for it would be false the day it was written; its ceiling is also reserved for BLOCKED gates. `ci/lib/known-test-failures.tsv` does not fit either — it registers cases that FAIL with a signature, and requires the failing set to equal the registered set exactly; this section does not fail, it does not run.

**No registry in the tree has section granularity.** That is reported as a gap rather than resolved by inventing a fourth registry.
