### PR TITLE
fix(py-bridge): add_watchpoint returned an id for a command the backend refuses

### DIFF
--- a/python-api/codetracer/trace.py
+++ b/python-api/codetracer/trace.py
@@ -751,8 +751,23 @@ class Trace:
         """Set a watchpoint that triggers when the expression's value changes.
 
         The daemon translates this into a DAP ``setDataBreakpoints``
-        command.  When execution continues, it will stop at the point
-        where the watched expression's value changes.
+        command, and waits for the backend to say whether the watchpoint
+        was accepted.
+
+        A returned ID therefore means the backend accepted the
+        watchpoint, not merely that the request was sent.  (It used to
+        return an ID regardless; the following :meth:`continue_forward`
+        then ran to the end of the trace and raised ``StopIteration``
+        with nothing to explain why.)
+
+        .. warning::
+
+           The replay backend does **not** currently implement
+           ``setDataBreakpoints`` at all, so against a real recording
+           this raises :class:`TraceError` carrying the backend's own
+           refusal.  That is the truthful answer: watchpoints have never
+           worked, and this method used to hide that behind a plausible
+           ID.  Use :meth:`add_breakpoint` instead.
 
         Parameters:
             expression: The expression to watch (e.g., ``"counter"``).
@@ -762,7 +777,8 @@ class Trace:
             :meth:`remove_watchpoint`.
 
         Raises:
-            TraceError: If the daemon reports an error.
+            TraceError: If the daemon reports an error, or if the
+                backend did not accept the watchpoint.
         """
         response = self._connection.send_request("ct/py-add-watchpoint", {
             "tracePath": self._path,

--- a/src/backend-manager/src/backend_manager.rs
+++ b/src/backend-manager/src/backend_manager.rs
@@ -1498,37 +1498,57 @@ impl BackendManager {
             {
                 let pending = ds.py_bridge.pending_requests.remove(idx);
 
-                // Fire-and-forget requests: silently consume the backend
-                // response without forwarding anything to the client.
-                // This is used for setDataBreakpoints commands whose
-                // results the client does not need.
-                if pending.kind == PendingPyRequestKind::FireAndForget {
+                // Responses this daemon deliberately does not inspect,
+                // each carrying the reason that made not inspecting it
+                // safe (see `UnobservedReason`).  Silently consume.
+                if matches!(pending.kind, PendingPyRequestKind::Unobserved(_)) {
                     return;
                 }
 
-                // `ct/py-add-breakpoint`: the backend's per-line
-                // `verified` flag decides whether this succeeded, and it
-                // is handled here rather than in the formatter table
-                // below because a refusal also has to be rolled back out
-                // of the daemon's own breakpoint table.
-                if let PendingPyRequestKind::AddBreakpoint {
-                    trace_path,
-                    bp_id,
-                    index,
-                } = &pending.kind
-                {
-                    let (success, body_or_error) =
-                        python_bridge::format_add_breakpoint_response(msg, *index, *bp_id);
+                // `ct/py-add-breakpoint` and `ct/py-add-watchpoint`: the
+                // backend's per-entry `verified` flag decides whether
+                // these succeeded, and they are handled here rather than
+                // in the formatter table below because a refusal also
+                // has to be rolled back out of the daemon's own table.
+                let point_verdict = match &pending.kind {
+                    PendingPyRequestKind::AddBreakpoint {
+                        trace_path,
+                        bp_id,
+                        index,
+                    } => Some((
+                        python_bridge::format_add_breakpoint_response(msg, *index, *bp_id),
+                        trace_path.clone(),
+                        *bp_id,
+                        false,
+                    )),
+                    PendingPyRequestKind::AddWatchpoint {
+                        trace_path,
+                        wp_id,
+                        index,
+                    } => Some((
+                        python_bridge::format_add_watchpoint_response(msg, *index, *wp_id),
+                        trace_path.clone(),
+                        *wp_id,
+                        true,
+                    )),
+                    _ => None,
+                };
 
+                if let Some(((success, body_or_error), trace_path, point_id, is_watchpoint)) =
+                    point_verdict
+                {
                     if !success {
-                        // Drop the breakpoint the backend refused, so it
-                        // is not re-sent with every subsequent add for
-                        // this file — and so a later `remove_breakpoint`
-                        // cannot be answered for an id that never bound.
+                        // Drop the point the backend refused, so it is
+                        // not re-sent with every subsequent add for this
+                        // file — and so a later `remove_*` cannot be
+                        // answered for an id that never bound.
                         if let Some(ds) = self.daemon_state.as_mut() {
-                            ds.py_bridge
-                                .breakpoint_state_mut(trace_path)
-                                .forget_breakpoint(*bp_id);
+                            let state = ds.py_bridge.breakpoint_state_mut(&trace_path);
+                            if is_watchpoint {
+                                state.forget_watchpoint(point_id);
+                            } else {
+                                state.forget_breakpoint(point_id);
+                            }
                         }
                     }
 
@@ -1599,8 +1619,9 @@ impl BackendManager {
                         python_bridge::format_resolve_variable_step_response(msg, &pending.expression)
                     }
                     PendingPyRequestKind::AddBreakpoint { .. }
-                    | PendingPyRequestKind::FireAndForget => {
-                        // Both are answered above; unreachable.
+                    | PendingPyRequestKind::AddWatchpoint { .. }
+                    | PendingPyRequestKind::Unobserved(_) => {
+                        // All are answered above; unreachable.
                         return;
                     }
                 };
@@ -3686,7 +3707,9 @@ impl BackendManager {
                 let _ = self.message(backend_id, dap_request).await;
                 if let Some(ds) = self.daemon_state.as_mut() {
                     ds.py_bridge.pending_requests.push(PendingPyRequest {
-                        kind: PendingPyRequestKind::FireAndForget,
+                        kind: PendingPyRequestKind::Unobserved(
+                            python_bridge::UnobservedReason::SetPointsResyncAfterRemoval,
+                        ),
                         client_id: 0,
                         original_seq: 0,
                         backend_seq: dap_seq,
@@ -3797,8 +3820,10 @@ impl BackendManager {
 
         self.reset_ttl_for_backend_id(backend_id);
 
-        // Update the watchpoint state.
-        let (wp_id, all_expressions) = match self.daemon_state.as_mut() {
+        // Update the watchpoint state.  `index` is where this
+        // watchpoint's verdict will sit in the backend's per-entry
+        // `setDataBreakpoints` response.
+        let (wp_id, all_expressions, index) = match self.daemon_state.as_mut() {
             Some(ds) => {
                 let bp_state = ds.py_bridge.breakpoint_state_mut(&trace_path);
                 bp_state.add_watchpoint(&expression)
@@ -3826,26 +3851,48 @@ impl BackendManager {
             }
         });
 
-        let _ = self.message(backend_id, dap_request).await;
+        // WAIT for the backend, exactly as `ct/py-add-breakpoint` does,
+        // and for the same reason: the backend's answer is the only
+        // place that says whether the watchpoint was accepted.  This one
+        // is the more severe of the two — the replay backend has no
+        // `setDataBreakpoints` arm at all and answers
+        // `success: false, "command setDataBreakpoints not supported
+        // here"`.  While this was fire-and-forget that refusal was
+        // discarded and `Trace.add_watchpoint()` returned a positive id
+        // for a watchpoint nothing anywhere had accepted, after which
+        // `continue_forward()` ran to the end of the trace.
+        if let Err(e) = self.message(backend_id, dap_request).await {
+            // Roll back: nothing was sent, so the daemon must not keep a
+            // watchpoint the backend has never heard of.
+            if let Some(ds) = self.daemon_state.as_mut() {
+                ds.py_bridge
+                    .breakpoint_state_mut(&trace_path)
+                    .forget_watchpoint(wp_id);
+            }
+            self.send_py_command_error(
+                seq,
+                "ct/py-add-watchpoint",
+                &format!("failed to send command to backend: {e}"),
+            );
+            return Ok(());
+        }
+
+        let client_id = self.lookup_client_for_seq(seq).unwrap_or(0);
         if let Some(ds) = self.daemon_state.as_mut() {
             ds.py_bridge.pending_requests.push(PendingPyRequest {
-                kind: PendingPyRequestKind::FireAndForget,
-                client_id: 0,
-                original_seq: 0,
+                kind: PendingPyRequestKind::AddWatchpoint {
+                    trace_path,
+                    wp_id,
+                    index,
+                },
+                client_id,
+                original_seq: seq,
                 backend_seq: dap_seq,
-                response_command: String::new(),
-                expression: String::new(),
+                response_command: "ct/py-add-watchpoint".to_string(),
+                expression,
             });
         }
 
-        let response = json!({
-            "type": "response",
-            "request_seq": seq,
-            "success": true,
-            "command": "ct/py-add-watchpoint",
-            "body": {"watchpointId": wp_id}
-        });
-        self.send_response_for_seq(seq, response);
         Ok(())
     }
 
@@ -3961,7 +4008,9 @@ impl BackendManager {
                 let _ = self.message(backend_id, dap_request).await;
                 if let Some(ds) = self.daemon_state.as_mut() {
                     ds.py_bridge.pending_requests.push(PendingPyRequest {
-                        kind: PendingPyRequestKind::FireAndForget,
+                        kind: PendingPyRequestKind::Unobserved(
+                            python_bridge::UnobservedReason::SetPointsResyncAfterRemoval,
+                        ),
                         client_id: 0,
                         original_seq: 0,
                         backend_seq: dap_seq,
@@ -6045,7 +6094,9 @@ impl BackendManager {
                 });
                 // Fire-and-forget: consume the responses silently.
                 ds.py_bridge.pending_requests.push(PendingPyRequest {
-                    kind: PendingPyRequestKind::FireAndForget,
+                    kind: PendingPyRequestKind::Unobserved(
+                            python_bridge::UnobservedReason::OpenTraceCachedSessionReset,
+                        ),
                     client_id: 0,
                     original_seq: 0,
                     backend_seq: clear_bp_seq,
@@ -6053,7 +6104,9 @@ impl BackendManager {
                     expression: String::new(),
                 });
                 ds.py_bridge.pending_requests.push(PendingPyRequest {
-                    kind: PendingPyRequestKind::FireAndForget,
+                    kind: PendingPyRequestKind::Unobserved(
+                            python_bridge::UnobservedReason::OpenTraceCachedSessionReset,
+                        ),
                     client_id: 0,
                     original_seq: 0,
                     backend_seq: reset_seq,

--- a/src/backend-manager/src/python_bridge.rs
+++ b/src/backend-manager/src/python_bridge.rs
@@ -150,13 +150,38 @@ impl BreakpointState {
 
     /// Adds a watchpoint on the given expression.
     ///
-    /// Returns `(wp_id, all_active_expressions)`.
-    pub fn add_watchpoint(&mut self, expression: &str) -> (i64, Vec<String>) {
+    /// Returns `(wp_id, all_active_expressions, index)`, where `index`
+    /// is this watchpoint's position in the `setDataBreakpoints`
+    /// `breakpoints` array the caller is about to send — and therefore
+    /// the position of its own `verified` verdict in the response.
+    ///
+    /// Same contract as [`Self::add_breakpoint`], for the same reason:
+    /// the index depends on [`Self::all_watchpoint_expressions`]'s
+    /// ordering, which the caller has no business knowing, and which was
+    /// nondeterministic until this needed it.
+    pub fn add_watchpoint(&mut self, expression: &str) -> (i64, Vec<String>, usize) {
         self.next_wp_id += 1;
         let wp_id = self.next_wp_id;
         self.watchpoints.insert(wp_id, expression.to_string());
         let all = self.all_watchpoint_expressions();
-        (wp_id, all)
+        // `all_watchpoint_expressions` orders by ascending watchpoint id
+        // and ids are monotonic, so the entry just inserted is last.
+        let index = all.len() - 1;
+        (wp_id, all, index)
+    }
+
+    /// Drops a watchpoint from the daemon's table WITHOUT deriving a new
+    /// expression list for the backend.
+    ///
+    /// The watchpoint counterpart of [`Self::forget_breakpoint`], and it
+    /// rolls back an `add_watchpoint` the backend refused.  No follow-up
+    /// `setDataBreakpoints` is needed: the backend applied (or rejected)
+    /// the request it was sent, and dropping the offending expression
+    /// here leaves the two tables agreeing.
+    ///
+    /// Returns whether the id was known.
+    pub fn forget_watchpoint(&mut self, wp_id: i64) -> bool {
+        self.watchpoints.remove(&wp_id).is_some()
     }
 
     /// Removes a watchpoint by its ID.
@@ -171,9 +196,21 @@ impl BreakpointState {
         }
     }
 
-    /// Returns all active watchpoint expressions.
+    /// Returns all active watchpoint expressions, ordered by ascending
+    /// watchpoint id.
+    ///
+    /// The order is part of the contract, not an accident — the same
+    /// contract [`Self::breakpoints_for_file`] documents.  The caller
+    /// sends this list as the `setDataBreakpoints` `breakpoints` array
+    /// and reads the per-entry `verified` flags back out *positionally*;
+    /// raw `HashMap::values` iteration made which answer belongs to
+    /// which watchpoint a coin flip, so a refusal could be reported
+    /// against another watchpoint's id.  It also made the id the mock
+    /// backend assigns by position (`id: i + 1`) shuffle between calls.
     pub fn all_watchpoint_expressions(&self) -> Vec<String> {
-        self.watchpoints.values().cloned().collect()
+        let mut entries: Vec<(i64, &String)> = self.watchpoints.iter().map(|(id, e)| (*id, e)).collect();
+        entries.sort_by_key(|(id, _)| *id);
+        entries.into_iter().map(|(_, e)| e.clone()).collect()
     }
 
     /// Adds a tracepoint at the given source location with the given expression.
@@ -428,10 +465,84 @@ pub enum PendingPyRequestKind {
         bp_id: i64,
         index: usize,
     },
-    /// Fire-and-forget commands (e.g., `setDataBreakpoints`) whose backend
-    /// responses should be silently consumed and not forwarded to any
-    /// client.
-    FireAndForget,
+    /// `ct/py-add-watchpoint` -> backend `setDataBreakpoints`.
+    ///
+    /// The exact twin of [`Self::AddBreakpoint`], and it exists for the
+    /// same reason: `setDataBreakpoints` reports a watchpoint it could
+    /// not place per-entry, as `verified: false`, and the request-level
+    /// `success` says nothing about whether anything was watched.
+    ///
+    /// The stakes here are higher than for breakpoints, because the
+    /// replay backend (`db-backend` / `replay-server`) has **no**
+    /// `setDataBreakpoints` arm in its DAP dispatch at all: the command
+    /// falls through to `dap_command_to_step_action`, which fails, and
+    /// the backend answers `success: false` with `command
+    /// setDataBreakpoints not supported here`.  While this request fired
+    /// and forgot, that refusal was dropped and `Trace.add_watchpoint()`
+    /// handed back a positive id for a watchpoint that no component
+    /// anywhere had accepted.
+    ///
+    /// The only implementation of `setDataBreakpoints` in this tree is
+    /// the daemon's own mock backend, which answers `verified: true`
+    /// unconditionally — which is why no test could have caught this.
+    ///
+    /// Fields mirror [`Self::AddBreakpoint`]: `index` is where this
+    /// watchpoint's verdict sits in the backend's per-entry array,
+    /// `wp_id` is the id to hand back on success, and `trace_path` keys
+    /// the [`BreakpointState`] to roll back on refusal.
+    AddWatchpoint {
+        trace_path: PathBuf,
+        wp_id: i64,
+        index: usize,
+    },
+    /// A backend response this daemon deliberately does not look at.
+    ///
+    /// The variant carries the REASON rather than being a bare
+    /// `FireAndForget`, because a bare one is an unanswerable question:
+    /// it records that nobody looked without recording why that was
+    /// safe.  Both defects fixed in this module — `ct/py-add-breakpoint`
+    /// and `ct/py-add-watchpoint` — were sitting on that bare variant,
+    /// and were indistinguishable from the genuinely-safe uses beside
+    /// them.  Adding a case to [`UnobservedReason`] is meant to be
+    /// uncomfortable.
+    Unobserved(UnobservedReason),
+}
+
+/// Why a particular backend response is deliberately not inspected.
+///
+/// Every variant is a claim that must be true: that nothing the client
+/// was already told depends on the answer.  If you cannot write that
+/// sentence for a new call site, it does not belong here — it needs a
+/// `PendingPyRequestKind` of its own that waits, like
+/// [`PendingPyRequestKind::AddBreakpoint`] does.
+#[derive(Debug, PartialEq)]
+pub enum UnobservedReason {
+    /// The `setBreakpoints` re-sent after `ct/py-remove-breakpoint`, and
+    /// the `setDataBreakpoints` re-sent after `ct/py-remove-watchpoint`.
+    ///
+    /// These re-state a set the backend has already accepted, minus one
+    /// entry, so there is no new verdict to read — the entries that
+    /// remain are the ones that already bound.
+    ///
+    /// KNOWN RESIDUAL RISK, stated rather than hidden: if the backend
+    /// refuses the re-send outright, the removed breakpoint stays live
+    /// in the replay engine while the client has already been told
+    /// `removed: true`.  For watchpoints this is not hypothetical — the
+    /// replay backend refuses *every* `setDataBreakpoints` (see
+    /// [`PendingPyRequestKind::AddWatchpoint`]) — but a watchpoint that
+    /// was never set cannot fail to be removed either, so no client is
+    /// currently misled by it.  Fixing the removal path properly means
+    /// giving it the same waiting treatment as the add path.
+    SetPointsResyncAfterRemoval,
+    /// The `setBreakpoints`-to-empty and `ct/run-to-entry` sent when
+    /// `ct/open-trace` re-attaches to a session that is already loaded.
+    ///
+    /// KNOWN RESIDUAL RISK, stated rather than hidden: the cached-session
+    /// reply asserts `cached: true` and the caller assumes the replay
+    /// position was reset to the entry point.  Neither reset is observed,
+    /// so a backend that refused them would leave the caller stepping
+    /// from wherever the previous script stopped.
+    OpenTraceCachedSessionReset,
 }
 
 /// A pending synchronous Python bridge request waiting for a backend
@@ -551,6 +662,81 @@ pub fn format_add_breakpoint_response(
                 .and_then(Value::as_str)
                 .unwrap_or("<unknown>");
             format!("backend did not bind a breakpoint at {path}:{line}")
+        });
+    (false, serde_json::json!({"message": message}))
+}
+
+/// Reads the backend's `setDataBreakpoints` answer for ONE watchpoint
+/// and says whether that watchpoint is actually being watched.
+///
+/// The watchpoint twin of [`format_add_breakpoint_response`], and the
+/// same three-way read: a request-level refusal, a response that carries
+/// no verdict for this entry, and a per-entry `verified: false` are all
+/// failures, and all three carry the backend's own words forward.
+///
+/// The request-level arm is the one that fires in practice.  The replay
+/// backend has no `setDataBreakpoints` handler, so it answers
+/// `success: false` with `command setDataBreakpoints not supported here`
+/// — and that sentence is exactly what a caller needs to see, instead of
+/// a watchpoint id and a `continue_forward()` that runs to the end of
+/// the trace.
+///
+/// Returns `(success, body_or_error)`: on success the `ct/py-add-watchpoint`
+/// body, otherwise a `{"message": ...}` object.
+pub fn format_add_watchpoint_response(
+    backend_response: &Value,
+    index: usize,
+    wp_id: i64,
+) -> (bool, Value) {
+    if !backend_response
+        .get("success")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        let message = backend_response
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("backend rejected setDataBreakpoints");
+        return (false, serde_json::json!({"message": message}));
+    }
+
+    let entry = backend_response
+        .get("body")
+        .and_then(|b| b.get("breakpoints"))
+        .and_then(Value::as_array)
+        .and_then(|bps| bps.get(index));
+
+    let Some(entry) = entry else {
+        return (
+            false,
+            serde_json::json!({
+                "message": format!(
+                    "backend's setDataBreakpoints response carried no verdict \
+                     for this watchpoint (wanted entry {index}); response: \
+                     {backend_response}"
+                )
+            }),
+        );
+    };
+
+    if entry
+        .get("verified")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return (true, serde_json::json!({"watchpointId": wp_id}));
+    }
+
+    let message = entry
+        .get("message")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            let data_id = entry
+                .get("dataId")
+                .and_then(Value::as_str)
+                .unwrap_or("<unknown>");
+            format!("backend did not set a watchpoint on {data_id}")
         });
     (false, serde_json::json!({"message": message}))
 }
@@ -1348,6 +1534,159 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// The watchpoint list the daemon sends as the `setDataBreakpoints`
+    /// `breakpoints` array must be ordered by ascending watchpoint id.
+    ///
+    /// This is not a style preference.  The daemon reads the per-entry
+    /// `verified` verdicts back out of the response POSITIONALLY, so an
+    /// unordered list pairs one watchpoint's answer with another
+    /// watchpoint's id — it would report the wrong expression as
+    /// unwatchable, or accept an id the backend refused.  It also makes
+    /// the id assigned by position shuffle between otherwise identical
+    /// calls.
+    ///
+    /// `all_watchpoint_expressions` iterated a `HashMap` before this,
+    /// which is why eight entries are used: `HashMap` iteration would
+    /// have to land on the insertion order by chance, 1 in 8! ≈ 1 in
+    /// 40320, for this to pass by accident.
+    #[test]
+    fn test_all_watchpoint_expressions_are_ordered_by_watchpoint_id() {
+        let mut state = BreakpointState::default();
+
+        let names = [
+            "zeta", "yankee", "xray", "whiskey", "victor", "uniform", "tango", "sierra",
+        ];
+        let mut ids = Vec::new();
+        for name in names {
+            let (wp_id, all, index) = state.add_watchpoint(name);
+            ids.push(wp_id);
+            assert_eq!(
+                all[index], name,
+                "add_watchpoint's index must name the slot this watchpoint's \
+                 own verdict occupies in the backend's answer; it pointed at \
+                 {:?} instead of {name:?} in {all:?}",
+                all[index]
+            );
+        }
+
+        assert_eq!(
+            state.all_watchpoint_expressions(),
+            names.iter().map(|n| n.to_string()).collect::<Vec<_>>(),
+            "watchpoints must come back in ascending-id (= insertion) order",
+        );
+
+        // And the order must survive a removal from the middle: the
+        // surviving entries keep their relative positions, so a verdict
+        // read positionally still lands on the watchpoint that asked.
+        state.remove_watchpoint(ids[3]);
+        assert_eq!(
+            state.all_watchpoint_expressions(),
+            vec![
+                "zeta".to_string(),
+                "yankee".to_string(),
+                "xray".to_string(),
+                "victor".to_string(),
+                "uniform".to_string(),
+                "tango".to_string(),
+                "sierra".to_string(),
+            ],
+        );
+    }
+
+    /// A backend that refuses `setDataBreakpoints` outright must be
+    /// reported as a failure carrying the backend's own sentence.
+    ///
+    /// This is the arm that fires against the real replay backend, whose
+    /// DAP dispatch has no `setDataBreakpoints` handler at all: the
+    /// command falls through to `dap_command_to_step_action`, which
+    /// fails, and `handle_message_browser` answers `success: false` with
+    /// `command setDataBreakpoints not supported here`.  That sentence
+    /// is the only thing that distinguishes "your expression was wrong"
+    /// from "this backend cannot watch anything", so it must reach the
+    /// caller verbatim.
+    #[test]
+    fn test_format_add_watchpoint_response_forwards_a_request_level_refusal() {
+        let refusal = json!({
+            "type": "response",
+            "request_seq": 7,
+            "success": false,
+            "command": "setDataBreakpoints",
+            "message": "command setDataBreakpoints not supported here",
+            "body": {},
+        });
+
+        let (success, body) = format_add_watchpoint_response(&refusal, 0, 1);
+        assert!(
+            !success,
+            "a refused setDataBreakpoints must not be answered as a set watchpoint",
+        );
+        assert_eq!(
+            body.get("message").and_then(Value::as_str),
+            Some("command setDataBreakpoints not supported here"),
+        );
+    }
+
+    /// A request-level success whose per-entry verdict is
+    /// `verified: false` is still a failure, and still carries the
+    /// backend's reason.
+    #[test]
+    fn test_format_add_watchpoint_response_reads_the_per_entry_verdict() {
+        let answer = json!({
+            "success": true,
+            "body": {"breakpoints": [
+                {"id": 1, "verified": true,  "dataId": "counter"},
+                {"id": 2, "verified": false, "dataId": "nope", "message": "no such data"},
+            ]},
+        });
+
+        let (ok, body) = format_add_watchpoint_response(&answer, 0, 11);
+        assert!(ok);
+        assert_eq!(body.get("watchpointId").and_then(Value::as_i64), Some(11));
+
+        let (bad, body) = format_add_watchpoint_response(&answer, 1, 12);
+        assert!(!bad);
+        assert_eq!(
+            body.get("message").and_then(Value::as_str),
+            Some("no such data"),
+        );
+    }
+
+    /// A response that carries no verdict for this watchpoint at all is
+    /// a failure that says what was missing — reporting success there
+    /// would recreate the exact silence this formatter exists to end.
+    #[test]
+    fn test_format_add_watchpoint_response_refuses_a_missing_verdict() {
+        let answer = json!({"success": true, "body": {"breakpoints": []}});
+        let (ok, body) = format_add_watchpoint_response(&answer, 0, 3);
+        assert!(!ok);
+        assert!(
+            body.get("message")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .contains("no verdict"),
+            "got: {body}",
+        );
+    }
+
+    /// Rolling back a refused watchpoint drops it from the daemon's own
+    /// table, so it is not re-sent with the next add for this trace.
+    #[test]
+    fn test_forget_watchpoint_rolls_back_a_refused_add() {
+        let mut state = BreakpointState::default();
+        let (wp1, _, _) = state.add_watchpoint("counter");
+        let (_wp2, _, _) = state.add_watchpoint("total");
+
+        assert!(state.forget_watchpoint(wp1));
+        assert_eq!(
+            state.all_watchpoint_expressions(),
+            vec!["total".to_string()],
+        );
+        assert!(
+            !state.forget_watchpoint(wp1),
+            "forgetting an unknown id must say so rather than report success",
+        );
+    }
+
     #[test]
     fn test_method_to_dap_command_known_methods() {
         assert_eq!(method_to_dap_command("step_over"), Some(("next", false)));
@@ -1952,14 +2291,19 @@ mod tests {
     fn test_watchpoint_state_add_and_remove() {
         let mut state = BreakpointState::default();
 
-        let (wp1, all1) = state.add_watchpoint("counter");
+        let (wp1, all1, idx1) = state.add_watchpoint("counter");
         assert_eq!(wp1, 1);
         assert_eq!(all1, vec!["counter".to_string()]);
+        assert_eq!(idx1, 0);
 
-        let (wp2, all2) = state.add_watchpoint("total");
+        let (wp2, all2, idx2) = state.add_watchpoint("total");
         assert_eq!(wp2, 2);
-        assert!(all2.contains(&"counter".to_string()));
-        assert!(all2.contains(&"total".to_string()));
+        // Ordered by ascending watchpoint id, and the index names the
+        // slot this watchpoint's `verified` verdict occupies in the
+        // backend's `setDataBreakpoints` answer.
+        assert_eq!(all2, vec!["counter".to_string(), "total".to_string()]);
+        assert_eq!(idx2, 1);
+        assert_eq!(all2[idx2], "total".to_string());
 
         // Remove the first watchpoint.
         let remaining = state.remove_watchpoint(wp1);
@@ -2018,7 +2362,7 @@ mod tests {
         // IDs should not be reused after clear.
         let (bp_id, _, _) = state.add_breakpoint("main.nim", 10);
         assert!(bp_id > 1, "breakpoint ID should not be reused");
-        let (wp_id, _) = state.add_watchpoint("counter");
+        let (wp_id, _, _) = state.add_watchpoint("counter");
         assert!(wp_id > 1, "watchpoint ID should not be reused");
         let (tp_id, _) = state.add_tracepoint("main.c", 42, "log(x)");
         assert!(tp_id > 1, "tracepoint ID should not be reused");

--- a/src/backend-manager/tests/real_recording_integration.rs
+++ b/src/backend-manager/tests/real_recording_integration.rs
@@ -16032,3 +16032,205 @@ fn every_skip_site_is_routed_through_the_prerequisite_gate() {
          calls them back to reporting PASSED while doing nothing: {unenforced:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// M5-Custom-1c: `ct/py-add-watchpoint` must not answer for the backend
+// ---------------------------------------------------------------------------
+
+/// Sends `ct/py-add-watchpoint` and waits for the response, skipping any
+/// interleaved events.  Returns the full response JSON.
+async fn send_py_add_watchpoint(
+    client: &mut UnixStream,
+    seq: i64,
+    trace_path: &Path,
+    expression: &str,
+    log_path: &Path,
+) -> Result<Value, String> {
+    let req = json!({
+        "type": "request",
+        "command": "ct/py-add-watchpoint",
+        "seq": seq,
+        "arguments": {
+            "tracePath": trace_path.to_string_lossy(),
+            "expression": expression,
+        }
+    });
+
+    log_line(
+        log_path,
+        &format!("-> ct/py-add-watchpoint seq={seq} expression={expression}"),
+    );
+
+    client
+        .write_all(&dap_encode(&req))
+        .await
+        .map_err(|e| format!("write ct/py-add-watchpoint: {e}"))?;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return Err("timeout waiting for ct/py-add-watchpoint response".to_string());
+        }
+
+        let msg = timeout(remaining, dap_read(client))
+            .await
+            .map_err(|_| "timeout waiting for ct/py-add-watchpoint response".to_string())?
+            .map_err(|e| format!("read ct/py-add-watchpoint: {e}"))?;
+
+        if msg.get("type").and_then(Value::as_str).unwrap_or("") == "event" {
+            log_line(log_path, &format!("add-watchpoint: skipped event: {msg}"));
+            continue;
+        }
+
+        log_line(log_path, &format!("<- ct/py-add-watchpoint response: {msg}"));
+        return Ok(msg);
+    }
+}
+
+/// M5-Custom-1c. `ct/py-add-watchpoint` MUST NOT answer a watchpoint id for
+/// a watchpoint the backend never accepted.
+///
+/// This is the twin of `test_real_custom_add_breakpoint_reports_unresolvable_path`
+/// on the watchpoint surface, and the more severe of the two.  The replay
+/// backend has **no** `setDataBreakpoints` arm in its DAP dispatch
+/// (`src/db-backend/src/dap_server.rs::handle_request`): the command falls
+/// through to `dap_command_to_step_action`, which fails, and
+/// `handle_message_browser` answers
+///
+///   success: false,
+///   message: "command setDataBreakpoints not supported here"
+///
+/// The daemon used to send that `setDataBreakpoints` fire-and-forget and
+/// answer the Python client `success: true` with a positive `watchpointId`
+/// before the backend had seen the request; the refusal was then swallowed by
+/// the `FireAndForget` arm of the response router.  `Trace.add_watchpoint()`
+/// therefore returned an id for a watchpoint that no component anywhere had
+/// accepted, and the following `continue_forward()` ran to the end of the
+/// trace and raised `StopIteration` with nothing to explain it.
+///
+/// Note what this test does NOT assert: it does not require the backend to
+/// support watchpoints.  It requires the daemon to report what the backend
+/// actually said.  If `setDataBreakpoints` is implemented later, the first
+/// arm becomes a success and this test's first assertion is the thing that
+/// must then be updated -- deliberately, by someone who has read the new
+/// behaviour, rather than silently.
+///
+/// The only implementation of `setDataBreakpoints` anywhere in this tree is
+/// the daemon's own mock DAP backend, which answers `verified: true`
+/// unconditionally.  That mismatch -- a test double more capable than the
+/// component it stands in for -- is why no test could have caught this, and
+/// is why this test insists on the real backend.
+#[tokio::test]
+async fn test_real_py_add_watchpoint_does_not_answer_for_the_backend() {
+    let (test_dir, log_path) = setup_test_dir("real_py_add_watchpoint_verdict");
+    let mut success = false;
+
+    let result: Result<(), String> = async {
+        let db_backend = match find_db_backend() {
+            Some(path) => path,
+            None => {
+                log_line(&log_path, "SKIP: db-backend not found");
+                println!(
+                    "test_real_py_add_watchpoint_does_not_answer_for_the_backend: \
+                     SKIP (db-backend not found)"
+                );
+                return Ok(());
+            }
+        };
+        let recorder = match find_ruby_recorder() {
+            Some(p) => p,
+            None => {
+                log_line(&log_path, "SKIP: ruby recorder not found");
+                println!(
+                    "test_real_py_add_watchpoint_does_not_answer_for_the_backend: \
+                     SKIP (ruby recorder not found)"
+                );
+                return Ok(());
+            }
+        };
+
+        let trace_dir = create_ruby_recording(&test_dir, &recorder, &log_path)?;
+
+        let (mut daemon, socket_path) =
+            start_daemon_with_real_backend(&test_dir, &log_path, &db_backend, &[]).await;
+
+        let mut client = connect_to_daemon_socket(&socket_path)
+            .await
+            .map_err(|e| format!("connect: {e}"))?;
+        sleep(Duration::from_millis(200)).await;
+
+        let open_resp = open_trace(&mut client, 26_000, &trace_dir, &log_path).await?;
+        assert_eq!(
+            open_resp.get("success").and_then(Value::as_bool),
+            Some(true),
+            "ct/open-trace should succeed for the ruby recording, got: {open_resp}"
+        );
+
+        drain_events(&mut client, &log_path).await;
+
+        let resp =
+            send_py_add_watchpoint(&mut client, 26_001, &trace_dir, "counter", &log_path).await?;
+
+        // The daemon must report the backend's verdict, whatever it is --
+        // never a verdict of its own invented before the backend answered.
+        let reported = resp.get("success").and_then(Value::as_bool);
+        assert_eq!(
+            reported,
+            Some(false),
+            "ct/py-add-watchpoint answered success for a watchpoint the \
+             replay backend never accepted -- it has no setDataBreakpoints \
+             handler at all.  A `watchpointId` here names a watchpoint that \
+             exists nowhere but in the daemon's own table, and the caller's \
+             next `continue_forward()` runs to the end of the trace with \
+             nothing to say why.  got: {resp}"
+        );
+
+        let message = resp
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        assert!(
+            message.contains("setDataBreakpoints"),
+            "the refusal must carry the backend's own sentence, which is what \
+             tells 'this backend cannot watch anything' apart from 'your \
+             expression was wrong'; got message: {message:?}"
+        );
+        assert!(
+            resp.get("body")
+                .and_then(|b| b.get("watchpointId"))
+                .is_none(),
+            "a refused add_watchpoint must not hand back an id; got: {resp}"
+        );
+
+        // And the refused watchpoint must be rolled out of the daemon's own
+        // table, so the next add for this trace does not re-send it and
+        // inherit its failure.  A second add must fail on its OWN account,
+        // with the same single-entry refusal rather than a stale one.
+        let second =
+            send_py_add_watchpoint(&mut client, 26_002, &trace_dir, "total", &log_path).await?;
+        assert_eq!(
+            second.get("success").and_then(Value::as_bool),
+            Some(false),
+            "got: {second}"
+        );
+
+        let _ = daemon.kill().await;
+        Ok(())
+    }
+    .await;
+
+    match &result {
+        Ok(()) => success = true,
+        Err(e) => log_line(&log_path, &format!("TEST FAILED: {e}")),
+    }
+
+    report(
+        "test_real_py_add_watchpoint_does_not_answer_for_the_backend",
+        &log_path,
+        success,
+    );
+    assert!(success, "see log at {}", log_path.display());
+    let _ = std::fs::remove_dir_all(&test_dir);
+}


### PR DESCRIPTION
fix(py-bridge): add_watchpoint returned an id for a command the backend refuses

`Trace.add_watchpoint(expr)` followed by `continue_forward()` runs to the
end of the trace and raises `StopIteration`, with nothing anywhere in the
API's output to say why.  This is the same defect `ct/py-add-breakpoint`
had (4a690741d), on the surface beside it, and it is the more severe of
the two.

`ct/py-add-watchpoint` sent its `setDataBreakpoints` to the backend
fire-and-forget: it answered the client `success: true` with a positive
`watchpointId` before the backend had even seen the request, and the
response router then dropped the backend's answer on the `FireAndForget`
arm.

What that answer says is not `verified: false`.  The replay backend has
NO `setDataBreakpoints` arm in its DAP dispatch at all
(`db-backend/src/dap_server.rs::handle_request`): the command falls
through to `dap_command_to_step_action`, which fails, and
`handle_message_browser` answers

  success: false,
  message: "command setDataBreakpoints not supported here"

So the id handed back named a watchpoint that no component anywhere had
accepted.  Watchpoints have never worked; `add_watchpoint` hid that
behind a plausible integer.

`ct/py-add-watchpoint` now waits for the backend and forwards its verdict
-- both the request-level refusal above and, if `setDataBreakpoints` is
ever implemented, the per-entry `verified` flag.  A refused watchpoint is
dropped from the daemon's table too, so it is not re-sent with every
later add for the same trace.

## The type change, and what it forced

`PendingPyRequestKind::FireAndForget` is replaced by
`PendingPyRequestKind::Unobserved(UnobservedReason)`.  A bare
`FireAndForget` is an unanswerable question: it records that nobody
looked at a response without recording why that was safe, so a genuine
defect sitting on it is indistinguishable from the safe uses beside it --
which is exactly how both this and the breakpoint defect survived.  Every
construction site now has to name its justification, and the two that
remain state their residual risk in `UnobservedReason`'s own docs rather
than in a commit message nobody will read again:

- `SetPointsResyncAfterRemoval` -- the `setBreakpoints` /
  `setDataBreakpoints` re-sent after a removal.  Restates a set the
  backend already accepted, minus one entry.  RESIDUAL RISK: a backend
  that refuses the re-send leaves the removed point live while the client
  has been told `removed: true`.
- `OpenTraceCachedSessionReset` -- the clear-breakpoints and
  `ct/run-to-entry` sent when `ct/open-trace` re-attaches to a loaded
  session.  RESIDUAL RISK: the reply asserts `cached: true` and the
  caller assumes the replay position was reset; neither reset is
  observed.

Both are named defects of the same class, left visible rather than
narrowed out of scope.

## `all_watchpoint_expressions` now orders by ascending watchpoint id

The order became load-bearing the moment the per-entry verdicts had to be
paired back with the ids that asked for them -- `HashMap::values` would
have made that pairing a coin flip and reported one watchpoint's refusal
against another's id.  It was already wrong before that: the mock backend
assigns ids by position (`id: i + 1`), so watchpoint identity shuffled
between otherwise identical calls.  Same fix, and same reasoning, as
`breakpoints_for_file`.

## Tests

`test_all_watchpoint_expressions_are_ordered_by_watchpoint_id` is the
regression test for the ordering half, and was observed RED before the
fix -- eight entries, so `HashMap` iteration would have to land on
insertion order by chance (1 in 8! ~ 1 in 40320):

  assertion `left == right` failed: add_watchpoint's index must name the
  slot this watchpoint's own verdict occupies in the backend's answer; it
  pointed at "zeta" instead of "yankee" in ["yankee", "zeta"]

`test_real_py_add_watchpoint_does_not_answer_for_the_backend` is the
regression test for the defect itself, over a real Ruby recording and a
real backend.  It asserts the daemon reports what the backend said, NOT
that watchpoints fail -- if `setDataBreakpoints` is implemented later,
its first assertion is what must be updated, deliberately.

NOT EXECUTED LOCALLY, and this is the honest limit of this commit: this
macOS checkout cannot build `replay-server` (its
`codetracer_trace_writer_nim` build script needs a nimble-provisioned Nim
toolchain that only the nix dev shell supplies), so the test self-skips
here.  The 209 other `session-manager` unit tests pass; the one
pre-existing failure,
`browser_stream_host::tests::verify_reframing_a_real_browser_recording_reproduces_it_byte_for_byte`,
needs `scripts/materialize-recording.sh` and has zero references to
anything this commit touches.

Note that `ct/py-add-watchpoint` had NO test of any kind before this:
`grep -c 'py-add-watchpoint'` over every file in
`src/backend-manager/tests/` returns 0, against 243 hits for `breakpoint`
in `real_recording_integration.rs` alone.  That file's own module doc
claims an "M5 -- Breakpoints and Watchpoints" section; the section covers
breakpoints only.  The single implementation of `setDataBreakpoints`
anywhere in this tree is the daemon's own mock DAP backend, which answers
`verified: true` unconditionally -- a test double more capable than the
component it stands in for, which is why no test could have caught this.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
