### PR TITLE
fix(noir): the surviving Run-test arm claimed a start it was never given

### DIFF
--- a/src/frontend/ui/editor.nim
+++ b/src/frontend/ui/editor.nim
@@ -2842,17 +2842,51 @@ proc makeTestAction(self: EditorViewComponent, line: int, isPythonTest: bool = f
       return
 
     if not editorTestRunHook.isNil:
-      # A HOST TOOK IT, or said why it could not. Either way the button never
-      # starts animating over a message that went nowhere.
-      let refusal = editorTestRunHook(self.name, selector, line)
-      if refusal.len > 0:
-        self.api.errorMessage($refusal)
-        return
+      # ARM THE SPINNER BEFORE THE DISPATCH, for exactly the reason
+      # `runTestFromGutter` does — see the long note there. This arm carried
+      # the PRE-FIX ordering: it called the hook first and armed afterwards,
+      # so a dispatch refused SYNCHRONOUSLY INSIDE the hook settled while
+      # `spinningTestEditors` was still empty and `activeTestId` still unset,
+      # swept nothing, and then these lines armed an animation no second
+      # settle would ever arrive to clear. `loadAnimation`'s 400-frame cap was
+      # the only thing that ended it: two minutes of "Running..." under a
+      # `"<selector>" started` message, over a run that was declined before
+      # the click finished.
+      #
+      # The gutter was repaired; this widget is still painted whenever an
+      # editor has a `#[test]` or a Python test and no catalog entry for that
+      # line, and `editorTestRunHook` is installed globally, so the defect was
+      # live on the surviving arm.
+      #
+      # WHAT WAS THERE BEFORE IS REMEMBERED so the unwind puts back exactly
+      # what this click displaced: the commonest refusal is `already-running`,
+      # where a real run owns the spinner and a blanket settle would visibly
+      # "finish" it.
+      let wasSpinning = spinningTestEditors.find(self) >= 0
+      let previousTestId = self.activeTestId
       capture testId:
         self.activeTestId = testId
         self.redrawActiveTestButton()
-      if spinningTestEditors.find(self) < 0:
+      if not wasSpinning:
         spinningTestEditors.add(self)
+
+      let refusal = editorTestRunHook(self.name, selector, line)
+      if refusal.len > 0:
+        # UNWIND WHAT THIS CLICK ARMED, and no more.
+        if wasSpinning:
+          self.activeTestId = previousTestId
+          self.redrawActiveTestButton()
+        else:
+          settleEditorTestRun()
+        self.api.errorMessage($refusal)
+        return
+
+      # ALREADY SETTLED, INSIDE THE CALL. The dispatch was refused or answered
+      # synchronously and the settle has already emptied the list. Nothing is
+      # running, so "started" is not claimed and no animation is left behind.
+      if spinningTestEditors.find(self) < 0:
+        return
+
       self.api.infoMessage(&"\"{selector}\" started")
       return
 

--- a/src/frontend/ui/web_noir_build.nim
+++ b/src/frontend/ui/web_noir_build.nim
@@ -493,7 +493,7 @@ proc startTrace(producer: NoirBuildProducer; tmpl: ProjectTemplate)
 
 proc dispatch(producer: NoirBuildProducer; tmpl: ProjectTemplate;
               phase: NoirBuildPhase; args: seq[string]; stdin: string;
-              label: string)
+              label: string): string
   ## Forward-declared because `onPhaseExit` chains — `nriTestRecord` runs three
   ## phases and each dispatch happens inside the previous one's exit — and the
   ## definition needs `onPhaseExit` for its own callbacks. `startTrace` above
@@ -564,7 +564,10 @@ proc onPhaseExit(producer: NoirBuildProducer; tmpl: ProjectTemplate;
            "ok=true passed=" & $producer.lastTests.passed &
            " failed=" & $producer.lastTests.failed &
            " recording=" & activeRecordSelector)
-    dispatch(producer, tmpl, nbpTestRecord, noirTestArgs(),
+    # Discarded: this runs inside `onPhaseExit`, with no click waiting on an
+    # answer. A refusal here is painted into the build pane by `onRefusal`,
+    # and the `activeInFlight` check that follows every phase settles the run.
+    discard dispatch(producer, tmpl, nbpTestRecord, noirTestArgs(),
              $noirTestRecordRequest(templateVfsEntries(tmpl), tmpl.name,
                                     activeRecordSelector),
              "nargo test --record " & activeRecordSelector)
@@ -582,7 +585,9 @@ proc onPhaseExit(producer: NoirBuildProducer; tmpl: ProjectTemplate;
       # REFRESH VERSUS ENTER, decided here and carried into the trace phase.
       # The recording is produced either way; only the navigation differs.
       producer.replaySuppressOpen = not activeRecordOpenWhenDone
-      dispatch(producer, tmpl, nbpTrace, noirTraceArgs(),
+      # Discarded: same phase-exit continuation, and the `if activeInFlight`
+      # below already branches on whether this posted.
+      discard dispatch(producer, tmpl, nbpTrace, noirTraceArgs(),
                $noirTraceRequest(producer.artifact, noirTestRecordInputs),
                "nargo trace " & activeRecordSelector)
       if activeInFlight:
@@ -697,8 +702,26 @@ proc onPhaseExit(producer: NoirBuildProducer; tmpl: ProjectTemplate;
 
 proc dispatch(producer: NoirBuildProducer; tmpl: ProjectTemplate;
               phase: NoirBuildPhase; args: seq[string]; stdin: string;
-              label: string) =
+              label: string): string =
   ## Post one `start` to the worker, through the platform facade.
+  ##
+  ## RETURNS "" WHEN THE COMMAND WAS POSTED, and otherwise the sentence saying
+  ## why it was not.
+  ##
+  ## The return type is the point, and it is a change from `void`. Both
+  ## refusals below paint their sentence into the build pane through
+  ## `onRefusal` and then `return`, leaving `activeInFlight` false — so the
+  ## only way a caller could learn a dispatch had been declined was to read
+  ## that flag afterwards and infer it. `startNoirTestRecording` DID read it,
+  ## settled the run, and then fell off the end returning the implicit "",
+  ## which its own docstring defines as "the run was dispatched". The editor
+  ## read that "" as consent, armed a spinner and posted `"<test>" started`
+  ## over a run that had been declined before the click finished.
+  ##
+  ## A `void` here cannot be misread, because there is nothing to read; it can
+  ## only be assumed. Handing back the sentence forces all seven call sites to
+  ## say what they do with a refusal, and it hands the one caller that has a
+  ## user waiting on an answer the words to give them.
   ##
   ## `ctPlatform().process.start` and not `run`, because a Run has to be
   ## stoppable: `start` yields a `ProcessHandle` and `run` does not, and the ■
@@ -724,10 +747,10 @@ proc dispatch(producer: NoirBuildProducer; tmpl: ProjectTemplate;
     # attached `webNoModulesLoaded` as its degradation. That sentence names
     # the deployment rather than the command, which is the true statement
     # here, so it is shown instead of a generic refusal.
-    discard producer.onRefusal(
-      degradedBehaviour(platform.profile, capProcessSpawn))
+    let sentence = degradedBehaviour(platform.profile, capProcessSpawn)
+    discard producer.onRefusal(sentence)
     report($phase & "-refused", "reason=no-spawn")
-    return
+    return sentence
 
   proc onOutput(chunk: ProcessOutputChunk) =
     producer.onOutput(chunk)
@@ -751,12 +774,13 @@ proc dispatch(producer: NoirBuildProducer; tmpl: ProjectTemplate;
     # describes nothing.
     discard producer.onRefusal($started.error)
     report($phase & "-refused", "reason=" & $started.error.kind)
-    return
+    return $started.error
 
   activeHandle = started.value
   activeInFlight = true
   inc lastStartCount
   report($phase & "-started", "handle=" & $activeHandle)
+  return ""
 
 proc startTrace(producer: NoirBuildProducer; tmpl: ProjectTemplate) =
   let inputs = templateInputs(tmpl)
@@ -765,7 +789,9 @@ proc startTrace(producer: NoirBuildProducer; tmpl: ProjectTemplate) =
     discard producer.traceInputsMissing(noirInputsFile)
     report("trace-refused", "reason=no-inputs")
     return
-  dispatch(producer, tmpl, nbpTrace, noirTraceArgs(),
+  # Discarded: `startTrace` is `void` and every caller reaches it from a
+  # phase exit, not from a gesture. The refusal is painted in the pane.
+  discard dispatch(producer, tmpl, nbpTrace, noirTraceArgs(),
            $noirTraceRequest(producer.artifact, inputs), "nargo trace")
 
 proc startNoirBuild*(saved: seq[string] = @[]) =
@@ -788,7 +814,10 @@ proc startNoirBuild*(saved: seq[string] = @[]) =
     report("build-refused", "reason=no-build-vm")
     return
   activeIntent = nriBuild
-  dispatch(producer, tmpl, nbpCompile, noirCompileArgs(),
+  # Discarded: the Build button's own surface IS the build pane, so a
+  # refusal painted there by `onRefusal` is already in front of the user who
+  # pressed it. Nothing here claims the build started.
+  discard dispatch(producer, tmpl, nbpCompile, noirCompileArgs(),
            $noirVfsRequest(templateVfsEntries(tmpl), tmpl.name, nbmProgram),
            savedFilesLabel("nargo compile", saved))
 
@@ -849,7 +878,9 @@ proc startNoirRun*(saved: seq[string] = @[]) =
     report("run-refused", "reason=no-build-vm")
     return
   activeIntent = nriRun
-  dispatch(producer, tmpl, nbpCompile, noirCompileArgs(),
+  # Discarded: same as `startNoirBuild` — the Run button's surface is the
+  # build pane, and the refusal lands there.
+  discard dispatch(producer, tmpl, nbpCompile, noirCompileArgs(),
            $noirVfsRequest(templateVfsEntries(tmpl), tmpl.name, nbmDebug),
            savedFilesLabel("nargo compile --debug", saved))
 
@@ -933,7 +964,10 @@ proc startNoirTests*(saved: seq[string] = @[];
   let label =
     if only.len == 0: "nargo test"
     else: "nargo test --exact " & only.join(" ")
-  dispatch(producer, tmpl, nbpTest, noirTestArgs(),
+  # Discarded: `startNoirTests` is `void` and its surface is the Test Results
+  # pane, which `onRefusal` has already painted. The settle below is what stops
+  # the pane sitting `inFlight` behind a disabled play control.
+  discard dispatch(producer, tmpl, nbpTest, noirTestArgs(),
            $noirTestRequest(templateVfsEntries(tmpl), tmpl.name, only),
            savedFilesLabel(label, saved))
   if not activeInFlight:
@@ -1094,14 +1128,32 @@ proc startNoirTestRecording*(selector: string;
   activeRecordOpenWhenDone = openWhenDone
   if not noirTestRunStarted.isNil:
     noirTestRunStarted()
-  dispatch(producer, tmpl, nbpTest, noirTestArgs(),
+  let refusal = dispatch(producer, tmpl, nbpTest, noirTestArgs(),
            $noirTestRequest(templateVfsEntries(tmpl), tmpl.name, @[selector]),
            "nargo test --exact " & selector)
   if not activeInFlight:
+    # THE DISPATCH WAS DECLINED. This branch used to settle the run and then
+    # fall off the end returning the implicit "" — which this proc's own
+    # docstring defines as "the run was dispatched". The editor took that ""
+    # for consent, armed a spinner and posted `"<selector>" started`, and the
+    # settle above it had already swept a list the editor had not yet joined.
+    # Two minutes of "Running..." over a run declined before the click
+    # finished: the reported defect, produced here.
+    #
+    # The settle still happens — the pane must not sit `inFlight` behind a
+    # disabled play control — but the SENTENCE is handed back now, so the
+    # caller unwinds what it armed and shows the user the reason instead of a
+    # claim that it started.
     if not noirTestRunSink.isNil:
       noirTestRunSink(producer.lastTests, tmpl.name)
     if not noirTestRunSettled.isNil:
       noirTestRunSettled()
+    if refusal.len > 0:
+      return refusal
+    # `dispatch` posted the command and something else cleared `activeInFlight`
+    # before this line — the run is still over, and saying nothing here would
+    # put the "" back.
+    return "the run was not dispatched; the build pane says why"
 
 proc startNoirTest*(selector: string): string =
   ## Run ONE test — the editor's Run-test control, and the Test Results pane's

--- a/src/frontend/viewmodel/tests/unit/test_run_start_is_not_claimed_before_dispatch.nim
+++ b/src/frontend/viewmodel/tests/unit/test_run_start_is_not_claimed_before_dispatch.nim
@@ -1,0 +1,173 @@
+## A run control must not claim a run STARTED before anything took it.
+##
+## LANE: `vm-unit` (and `vm-unit-js`) by the directory glob.
+##
+## Compile and run:
+##   nim c -r src/frontend/viewmodel/tests/unit/test_run_start_is_not_claimed_before_dispatch.nim
+##
+## ## WHY THIS SUITE READS SOURCE TEXT, WHICH IS NOT WHAT A TEST SHOULD DO
+##
+## Both subjects live in `src/frontend/ui/`, which is JS-target and
+## DOM-bound: `editor.makeTestAction` builds a `Node` and talks to Monaco,
+## and `web_noir_build.dispatch` reaches `ctPlatform().process.start`
+## through the build pane. Neither can be instantiated by a `nim c` unit
+## suite, and the behavioural gate that CAN see them — arm G of
+## `ci/test/web_renderer_probe.mjs` — needs a served bundle and a
+## Playwright browser.
+##
+## That gate exists and it stays the real one. What it does not do is run
+## on every `vm-unit` invocation, and what it cannot do is fail for a
+## reason a reader can act on in one line. Both defects below are
+## STATEMENT ORDER — a claim made before the thing it claims — and
+## statement order is exactly what source text can pin cheaply and
+## exactly.
+##
+## So this is a contract test over two orderings, and its limits are
+## stated rather than implied:
+##
+##   * it is defeated by a rename or a reformat, which is why every
+##     needle below is asserted to be FINDABLE before it is asserted to
+##     be positioned — a suite that silently stopped locating its
+##     subject would pass while measuring nothing, and the `located`
+##     checks are what stop that;
+##   * it says nothing about whether the spinner clears, only about
+##     whether the claim is made before or after the answer.
+##
+## ## THE DEFECT
+##
+## A click on a Run-test control reached `editorTestRunHook`, which
+## reaches `web_noir_build.startNoirTestRecording`. When the platform has
+## no process-spawn capability — a deployment with the wasm worker script
+## missing — `dispatch` refuses BEFORE anything runs, paints the sentence
+## into the build pane, and returns without setting `activeInFlight`.
+##
+## `startNoirTestRecording` noticed that, settled the run, and then fell
+## off the end returning the implicit `""` — which its own docstring
+## defines as "the run was dispatched". The editor read `""` as consent.
+##
+## `runTestFromGutter` was repaired for this. `makeTestAction`'s inline
+## widget — still painted for any `#[test]` or Python test on a line the
+## catalog does not name — was not: it called the hook FIRST and armed
+## the spinner afterwards, so the settle that happened synchronously
+## inside the hook swept a list this editor had not yet joined, and then
+## the lines below armed an animation no second settle would arrive to
+## clear. `loadAnimation`'s 400-frame cap ended it two minutes later,
+## under a `"<selector>" started` message.
+
+import std/[os, strutils, unittest]
+
+const thisFile = currentSourcePath()
+
+proc repoFile(relative: string): string =
+  ## `src/frontend/viewmodel/tests/unit/<this>` -> repo root.
+  var root = thisFile.parentDir.parentDir.parentDir.parentDir.parentDir.parentDir
+  result = root / relative
+
+proc readSubject(relative: string): string =
+  let path = repoFile(relative)
+  require fileExists(path)
+  readFile(path)
+
+suite "a run control does not claim a start it has not been given":
+
+  test "`dispatch` hands back its refusal instead of leaving it to be inferred":
+    ## The type is the fix. A `void` `dispatch` cannot be misread, because
+    ## there is nothing to read — it can only be assumed, and the one
+    ## caller with a user waiting had assumed consent.
+    let source = readSubject("src/frontend/ui/web_noir_build.nim")
+
+    let declarations = source.count("proc dispatch(producer: NoirBuildProducer")
+    check declarations == 2  # forward declaration + definition
+
+    # Both must be string-returning. A forward declaration left at `void`
+    # is not a cosmetic mismatch: it is what the earlier call sites are
+    # typed against, and Nim resolves them through it.
+    var scan = 0
+    var stringReturning = 0
+    for _ in 0 ..< declarations:
+      let at = source.find("proc dispatch(producer: NoirBuildProducer", scan)
+      check at >= 0
+      # The signature spans three lines; take the whole of it.
+      let signatureEnd = source.find("label: string", at)
+      check signatureEnd >= 0
+      let tail = source[signatureEnd ..< min(signatureEnd + 40, source.len)]
+      if tail.startsWith("label: string): string"):
+        inc stringReturning
+      scan = at + 1
+    check stringReturning == 2
+
+  test "a declined dispatch is reported as a refusal, not as an empty string":
+    ## `startNoirTestRecording`'s contract is `"" means dispatched`. The
+    ## `not activeInFlight` branch is the one place that knows the
+    ## dispatch was declined, and it used to end by falling through to
+    ## the implicit `""`.
+    let source = readSubject("src/frontend/ui/web_noir_build.nim")
+
+    let procAt = source.find("proc startNoirTestRecording*(")
+    check procAt >= 0
+    let nextProc = source.find("\nproc ", procAt + 10)
+    check nextProc > procAt
+    let body = source[procAt ..< nextProc]
+
+    # The dispatch's answer must be BOUND, not discarded: this is the one
+    # caller that has a person waiting on it.
+    check body.contains("let refusal = dispatch(")
+
+    let branchAt = body.find("if not activeInFlight:")
+    check branchAt >= 0
+    let branch = body[branchAt .. ^1]
+
+    check branch.contains("return refusal")
+    # And the branch must not be able to run off its end: every path out
+    # of it returns a sentence.
+    let returns = branch.count("    return ")
+    check returns >= 2
+
+  test "the inline Run-test widget arms the spinner BEFORE it asks the host":
+    ## The ordering IS the defect. Armed after the hook, a dispatch
+    ## refused synchronously inside the hook settles a list this editor
+    ## has not joined yet, and the arm that follows is unreachable by any
+    ## later settle.
+    let source = readSubject("src/frontend/ui/editor.nim")
+
+    let widgetAt = source.find("proc makeTestAction(")
+    check widgetAt >= 0
+    let nextProc = source.find("\nproc ", widgetAt + 10)
+    check nextProc > widgetAt
+    let body = source[widgetAt ..< nextProc]
+
+    let hookAt = body.find("editorTestRunHook(self.name, selector, line)")
+    check hookAt >= 0
+    let armAt = body.find("spinningTestEditors.add(self)")
+    check armAt >= 0
+
+    check armAt < hookAt
+
+  test "and it does not say `started` when the run already settled inside the call":
+    ## `runTestFromGutter` carries this guard; the inline widget had no
+    ## equivalent, which is what turned a synchronous refusal into a
+    ## two-minute spinner under a false claim.
+    let source = readSubject("src/frontend/ui/editor.nim")
+
+    let widgetAt = source.find("proc makeTestAction(")
+    check widgetAt >= 0
+    let nextProc = source.find("\nproc ", widgetAt + 10)
+    check nextProc > widgetAt
+    let body = source[widgetAt ..< nextProc]
+
+    let hookAt = body.find("editorTestRunHook(self.name, selector, line)")
+    check hookAt >= 0
+    let claimAt = body.find("\" started\"")
+    check claimAt >= 0
+
+    # THE NEEDLE INCLUDES THE `return`, and that is not decoration. The
+    # pre-fix source contains the same condition twice as an ARM --
+    # `if spinningTestEditors.find(self) < 0:` / `spinningTestEditors.add(self)`
+    # -- so a needle that stopped at the colon matched the defect itself
+    # and reported green. It did, on the first run of this suite. What is
+    # being asserted is a guard that LEAVES, not a condition that reads
+    # the same list.
+    let guardAt = body.find(
+      "if spinningTestEditors.find(self) < 0:\n        return", hookAt)
+    check guardAt >= 0
+    check guardAt < claimAt


### PR DESCRIPTION
fix(noir): the surviving Run-test arm claimed a start it was never given

`runTestFromGutter` was repaired for this in 7ddcfc538. The inline widget
beside it was not, and neither was the proc underneath both of them.

## `startNoirTestRecording` answered "dispatched" for a declined dispatch

Its own docstring says `""` means the run was dispatched. When the
platform has no process-spawn capability -- a deployment whose wasm
worker script is missing -- `dispatch` refuses BEFORE anything runs,
paints the sentence into the build pane through `onRefusal`, and returns
without setting `activeInFlight`. `startNoirTestRecording` noticed that,
settled the run, and then fell off the end returning the implicit `""`.

So the one path that KNEW the dispatch had been declined was the one path
that reported consent.

## The type change: `dispatch` returns its refusal

`proc dispatch(...)` -> `proc dispatch(...): string`, `""` when the
command was posted and otherwise the sentence saying why it was not.

A `void` here cannot be misread, because there is nothing to read -- it
can only be inferred, and the only way to infer it was to check
`activeInFlight` afterwards. That is what every caller did, and it is
what the one caller with a person waiting got wrong. Returning the
sentence forced all seven call sites to say what they do with a refusal;
six discard it with a stated reason (their surface is the build pane,
which `onRefusal` has already painted), and the seventh -- the one the
editor calls -- hands it back.

Both declarations had to move: the forward declaration at :494 is what
the three earlier call sites resolve through, and leaving it `void` is
not a cosmetic mismatch. `nim js -d:ctRenderer -d:ctWeb` catches it, and
did.

## The inline Run-test widget armed its spinner after asking the host

`makeTestAction`'s click handler carried the PRE-FIX ordering: it called
`editorTestRunHook` first and armed the spinner afterwards. A dispatch
refused synchronously inside the hook reaches `settleEditorTestRun` while
`spinningTestEditors` is still empty and `activeTestId` still unset --
the settle sweeps nothing -- and then the following lines arm an
animation that no second settle will ever arrive to clear.
`loadAnimation`'s 400-frame cap ended it two minutes later, under a
`"<selector>" started` info message.

That is the reported defect verbatim, in the arm that survived. It is
still reachable: the widget is painted for any `#[test]` or Python test
on a line the catalog does not name (`isPythonTest` is not gated on
`haveCatalog`, and `haveCatalog` is per-editor), and `ui_js` installs
`editorTestRunHook` globally.

It now arms first, remembers what it displaced so an `already-running`
refusal does not stop a run that belongs to someone else, unwinds on a
returned sentence, and -- the guard the gutter has and this did not --
says nothing at all when the run settled inside the call.

## Tests: `test_run_start_is_not_claimed_before_dispatch.nim`

Four cases, all four observed RED against the `origin/dev` copies of both
subjects and green after:

  Check failed: stringReturning == 2 / was 0
  Check failed: body.contains("let refusal = dispatch(")
  Check failed: branch.contains("return refusal")
  Check failed: armAt < hookAt / armAt was 1980, hookAt was 1706
  Check failed: guardAt >= 0 / was -1

THIS SUITE READS SOURCE TEXT, and the file says so at length rather than
implying otherwise. Both subjects are in `src/frontend/ui/`, JS-target
and DOM-bound: `makeTestAction` builds a `Node` and talks to Monaco,
`dispatch` reaches `ctPlatform().process.start`. Neither can be
instantiated by a `nim c` suite, and the behavioural gate that can see
them -- arm G of `ci/test/web_renderer_probe.mjs` -- needs a served
bundle and a browser. Both defects are STATEMENT ORDER, which is what
source text pins cheaply and exactly. The gate stays the real one.

The fourth case earns its wording. Its first version searched for
`if spinningTestEditors.find(self) < 0:` and PASSED on the pre-fix
source -- because the defect contains that same condition, as an arm
rather than a guard. The needle now includes the `return`, so what is
asserted is a branch that leaves, not a condition that reads the same
list. An assertion that passes against the defect is worth recording,
not quietly correcting.

Executed locally: this suite red-then-green;
`test_run_control_refusal_is_shown.nim` still green (5/5) as a control;
`nim js --hints:off -d:chronicles_enabled=off -d:ctRenderer -d:ctWeb
src/frontend/ui_js.nim` builds the 16.8 MB renderer.

Found by sweeping `src/frontend/**` (517 `.nim` files) for the class
"reports a terminal outcome it never observed": 97 `cstring""` returns,
127 bare `return true`, 10 `proc` hook variables, 5 `Signal[...Proc]`
declarations, 55 `.isNil` branches within four lines of a success return.
Two confirmed, both here.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
