### PR TITLE
ci: keep the aggregate's lane names visible to the reachability walk

### DIFF
--- a/ci/test/shell-gate-coverage.sh
+++ b/ci/test/shell-gate-coverage.sh
@@ -719,12 +719,44 @@ refs_of_text() {
 
 	# `just <recipe>`, unchanged: a recipe name is not a path and the position
 	# rule above does not apply to it.
-	function justrefs(line,   n, i, j, t, u, arr) {
+	#
+	# AND ONE DISPATCHER, for the same reason the positional-parameter clause
+	# above exists. `ci/lib/run-just-lanes.sh <aggregate> <lane>...` runs each
+	# of its arguments as `just <lane>`; the names are real recipes and it
+	# really does invoke them, but they stand as ARGUMENTS, so a rule about
+	# `just` in command position cannot see them.
+	#
+	# It went blind exactly once and this is the entry: converting `just test`
+	# and `test-bpf` off dependency lists onto that runner left
+	# `scripts/test-build-alignment.sh` and `ci/test/sibling-backend-path-test.sh`
+	# reachable from nothing, and this guard failed them by name (merge
+	# a4681be7, job 102285037564). Both scripts were still RUNNING — the walk
+	# had gone blind, not the coverage. Note the apostrophe-free prose: this
+	# whole awk program is inside a single-quoted shell string, so one
+	# apostrophe in a comment ends it and the file stops parsing.
+	#
+	# Same widening direction as the positional clause, and the same argument
+	# for it: this credits a line that has ALREADY DECLARED it executes its
+	# arguments, and it fires on nothing else. The alternative was to keep the
+	# lane names invisible and record two live gates as dark, which would have
+	# been false in a file that fails in both directions.
+	function justrefs(line,   n, i, j, t, u, arr, dispatch) {
 		n = split(line, arr, /[ \t]+/)
+		dispatch = 0
 		for (i = 1; i <= n; i++) {
 			t = arr[i]
 			gsub(/^[^A-Za-z0-9_.\/-]+/, "", t)
 			gsub(/[^A-Za-z0-9_.\/-]+$/, "", t)
+			# Every name-shaped token after the dispatcher is a recipe it runs.
+			# The first names the aggregate itself, which is simply true too.
+			if (dispatch) {
+				u = t
+				gsub(/^[^A-Za-z0-9_-]+/, "", u)
+				gsub(/[^A-Za-z0-9_-]+$/, "", u)
+				if (u ~ /^[A-Za-z0-9_][A-Za-z0-9_-]*$/) print "J " u
+				continue
+			}
+			if (t ~ /run-just-lanes\.sh$/) { dispatch = 1; continue }
 			if (t != "just") continue
 			# Skip flags, and the VALUE of a flag that takes one — otherwise
 			# `just --justfile X recipe` reports the recipe as `--justfile`.

--- a/justfile
+++ b/justfile
@@ -784,28 +784,38 @@ test-ct-print:
 test:
   #!/usr/bin/env bash
   set -uo pipefail
-  lanes=(
-    test-build-alignment
-    test-flake-pin-alignment
-    test-python-version-alignment
-    test-sibling-backend-path
-    test-agent-api-contract
-    test-rust
-    test-nimsuggest
-  )
   # A genuine capability gate, not a hidden failure: the cross-repo tests need
   # a checkout of codetracer-native-backend, and ci/test/non-gui.sh explicitly
   # sets CODETRACER_RR_BACKEND_PATH= so they do not run in this CI job.  When
-  # the path IS set the lane is appended to the list above, so it aggregates
-  # exactly like every other lane — it cannot be silently skipped once chosen,
-  # and its failure fails `just test`.
+  # the path IS set the lane joins the list below, so it aggregates exactly
+  # like every other lane — it cannot be silently skipped once chosen, and its
+  # failure fails `just test`.
   if [ -n "${CODETRACER_RR_BACKEND_PATH:-}" ]; then
     echo "codetracer-native-backend detected — cross-repo tests included"
-    lanes+=(cross-test)
+    set -- cross-test
   else
     echo "CODETRACER_RR_BACKEND_PATH not set — skipping cross-repo tests"
+    set --
   fi
-  bash ci/lib/run-just-lanes.sh test "${lanes[@]}"
+  # THE SEVEN LANE NAMES ARE LITERAL ARGUMENTS ON THIS INVOCATION, and that is
+  # load-bearing beyond style.  They used to be built up in a bash array, which
+  # made them invisible to `ci/test/shell-gate-coverage.sh`: its walk reaches a
+  # recipe only through a name it can SEE, and an array element is not one.
+  # `scripts/test-build-alignment.sh` and `ci/test/sibling-backend-path-test.sh`
+  # were reachable through nothing else, so converting this recipe off a
+  # dependency list orphaned them (merge a4681be7, job 102285037564).  Both were
+  # still RUNNING the whole time — the walk had gone blind, not the coverage —
+  # but a reachability guard that cannot see a live edge is exactly the defect
+  # this recipe's own aggregate exists to prevent.  Keep them literal here.
+  bash ci/lib/run-just-lanes.sh test \
+    test-build-alignment \
+    test-flake-pin-alignment \
+    test-python-version-alignment \
+    test-sibling-backend-path \
+    test-agent-api-contract \
+    test-rust \
+    test-nimsuggest \
+    "$@"
 
 # Run all GUI tests headlessly against an already-built CodeTracer binary.
 test-gui-prebuilt *args:


### PR DESCRIPTION
Fixes the `lint-nim` regression from merge `a4681be7` (job `102285037564`), at `ci/test/shell-gate-coverage.sh`:

```
[FAILED] ci/test/sibling-backend-path-test.sh is reachable from NO workflow lane,
         NO recipe a lane calls, and NO other reachable script
[FAILED] scripts/test-build-alignment.sh is reachable from NO workflow lane, ...
RESULT: FAILED — 2 check(s)
```

## The finding: both scripts were still RUNNING

This is the part that decides which fix is correct. The `test-non-gui` log from that same tree shows:

```
=== test: lane test-build-alignment PASSED ===
=== test: lane test-sibling-backend-path PASSED ===
```

**No coverage was lost. The walk went blind.** "Unreachable by the walk" and "never runs" are different things, and only the second is lost coverage. So recording these two in `shell-gate-coverage.known-dark.txt` would have been *false* — and that file fails in both directions, so it would have gone red again the moment anyone wired them up or noticed.

## Why it went blind

Converting `just test` off a dependency list moved the lane names into a bash array:

```bash
lanes=(test-build-alignment ...)
bash ci/lib/run-just-lanes.sh test "${lanes[@]}"
```

The walk reaches a recipe through a name it can **see** — `just <recipe>` in command position. An array element is not one, and neither is an argument to a dispatcher. Those two scripts were reachable through nothing else, so they were orphaned the instant the dependency list went away. The gate caught it by name: the system working.

## Fixed from both ends — and both halves are necessary

1. **The seven lane names are literal arguments again**, not array elements. `cross-test` still joins them conditionally via `set -- cross-test` / `set --`, so the `CODETRACER_RR_BACKEND_PATH` capability gate is unchanged — **verified: 7 lanes without it, 8 with it.**
2. **`justrefs` learns one dispatcher:** every name-shaped argument after `ci/lib/run-just-lanes.sh` is a recipe it runs.

This is the same widening the positional-parameter clause directly above it already makes, for the reason that clause states: it credits a line that has **already declared it executes its arguments**, and it fires on nothing else.

## Measured, gate run directly (bash 5.3.9)

| tree | result | reachable |
|---|---|---|
| `dev` @ `db7bcf4a8` (reproduced the red) | `FAILED — 2 check(s)` | 197 / 239 |
| this PR | `RESULT: OK` | **199 / 239** |

`199 − 197` = exactly the two scripts. Nothing else moved.

### Both halves proven necessary, and the gate proven still sharp

- **Drop one lane from the list** → gate FAILS by name, 198 reachable. So the widening did **not** blind it.
- **Revert only the walk change, keep literal names** → still `FAILED — 2 check(s)`, 197 reachable. So the literal names alone are *not* sufficient; the dispatcher rule is doing real work, and without it `test-bpf`'s four lanes stay invisible regardless.

`ci/test/run-just-lanes-test.sh` still passes both modes (25 hermetic / 28 full). shellcheck clean. `just --summary` parses.

## Two traps recorded for the next editor

- The `justrefs` awk program lives inside a **single-quoted shell string**, so one apostrophe in a comment ends the string and the file stops parsing. Two of mine did exactly that; the symptom is a *bash* syntax error pointing at an *awk* line, which is a confusing place to start looking. Those comments are now apostrophe-free.
- **Not reformatted:** `shfmt -l -ln auto -s` already lists `shell-gate-coverage.sh` on pristine `dev`, so that is pre-existing and not this change's to fix. CI enforces shellcheck here, not shfmt.