### PR TITLE
ci: no-op control for #737 non-regression comparison (NOT FOR MERGE)

### DIFF
--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -61,3 +61,4 @@
 
 * Upgrade `nim` and `nimgraph`: `git pull` from upstream `devel` or a stable version, rebasing and squashing (I use `reset --soft HEAD~` several times for that) to collect most of our changes in single or two patches and push forward
 * Upgrade Electron: change Electron in `package.json`, nvm use 12, `npm install`, `npm install node-abi`, `node_modules/bin/electron-rebuild`
+


### PR DESCRIPTION
Control PR. **Do not merge.**

Its only change is one trailing newline in `docs/walkthrough.md`. It exists so that #737's CI failures can be compared against a `pull_request`-event run off the **same base commit** (`ceb111a13`), rather than against a `push` run — `pull_request`-gated jobs are absent from push runs and would read as new failures.

Close once #737 is resolved.