### PR TITLE
ci: test-non-gui builds db-backend and never cloned the recorder it needs

### DIFF
--- a/.github/workflows/codetracer.yml
+++ b/.github/workflows/codetracer.yml
@@ -2784,6 +2784,30 @@ jobs:
           gh-token: ${{ steps.ci_token.outputs.token }}
           submodules: 'false'
 
+      - name: Clone codetracer-native-recorder sibling
+        # `Run recorder-gated ViewModel tests` below is `just
+        # test-vm-recorder-gated`, whose body does `(cd src/db-backend && cargo
+        # build --bin replay-server)` when no replay-server is already on disk.
+        # `src/db-backend/build.rs` resolves the Nim MCR emulator as a sibling
+        # of this checkout and panics at build.rs:170 without it. This runner is
+        # ephemeral, so there is no leftover clone to make that accidentally
+        # work.
+        #
+        # Latent rather than observed: on the runs inspected, this job died
+        # earlier (`test-web-renderer-mounts`) and never reached the step. It is
+        # the same defect as test-non-gui's, found by the same contract, and
+        # fixing one without the other would leave that contract failing.
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
+        with:
+          repo: metacraft-labs/codetracer-native-recorder
+          # flake.lock's rev, matching the nixos leg's pinned `siblings:` entry
+          # -- the two legs of one job must not test different recorders.
+          ref: 7e0400b364196ec731967a4dd4a3e931c73732f3
+          path: ${{ github.workspace }}/../codetracer-native-recorder
+          gh-token: ${{ steps.ci_token.outputs.token }}
+          # No .gitmodules in that repo; clone-repo's sed is unconditional.
+          submodules: 'false'
+
       - name: Clone runquota sibling
         # The `just build-once` step below compiles `ct`, whose import chain
         # (src/ct/codetracer.nim -> ../ct_test/ct_test ->
@@ -3386,11 +3410,33 @@ jobs:
         # belongs in the same job as the trace-layer units above.
         run: nix develop .#devShells.x86_64-linux.default --command just test-mcr-enrichment-units
 
+      - name: Allow direnv in cloned codetracer-native-recorder
+        # `src/db-backend/build.rs` shells out to `direnv exec <recorder-root>
+        # bash ct_emulator/build_native_api.sh`; a fresh clone's `.envrc` is
+        # blocked, so direnv refuses and the build script panics at
+        # build.rs:972. Idempotent; same step lint-rust carries.
+        run: |
+          nix develop .#devShells.x86_64-linux.default -c \
+            direnv allow "${{ github.workspace }}/../codetracer-native-recorder"
+
+      - name: Resolve ct_emulator nimble dependencies
+        # `ct_emulator.nimble` declares `requires "results"`, which a fresh nim
+        # install does not have; without this the generated-C step aborts with
+        # `cannot open file: results`.
+        run: |
+          nix develop .#devShells.x86_64-linux.default -c \
+            direnv exec "${{ github.workspace }}/../codetracer-native-recorder" \
+              bash -c 'cd "${{ github.workspace }}/../codetracer-native-recorder/ct_emulator" && nimble install --depsOnly -y'
+
       - name: Run recorder-gated ViewModel tests (JS recorder + replay-server)
         # Builds the JS recorder sibling via scripts/build-siblings.sh, builds
         # replay-server, then runs the recorder-gated unit VM suites with a
         # zero-test guard that fails if they all skip (so a missing recorder
         # cannot masquerade as a pass).
+        env:
+          # `syscall_replay.nim` imports `stew/endians2`, undeclared in
+          # `ct_emulator.nimble`; codetracer's pinned submodule copy supplies it.
+          CT_EMULATOR_EXTRA_NIM_PATHS: ${{ github.workspace }}/libs/nim-stew/stew:${{ github.workspace }}/libs/nim-stew:${{ github.workspace }}/libs/nim-result
         run: nix develop .#devShells.x86_64-linux.default --command just test-vm-recorder-gated
 
       - name: Build ct (needed by the CLI dispatch tests)
@@ -5319,10 +5365,114 @@ jobs:
           # (run 31719867246, job 94513828226). Pinned by the
           # "codetracer-trace-format implies codetracer-trace-format-nim"
           # assertion in ci/test/sibling-provisioning-test.sh.
+          #
+          # codetracer-native-recorder is NOT about the BEAM recorder, and it is
+          # not optional. `Run tests` below is `./ci/test/non-gui.sh` -> `just
+          # test` -> `test-rust` -> `pushd src/db-backend; cargo nextest run
+          # --bin replay-server`, and `src/db-backend/build.rs` resolves the Nim
+          # MCR emulator as a sibling of this checkout and PANICS without it:
+          #
+          #   thread 'main' panicked at build.rs:170:5:
+          #   db-backend requires the sibling `codetracer-native-recorder`
+          #   checkout, and it was not found.
+          #
+          # This job had that clone until 504274e13 (2026-06-23), which migrated
+          # the open-coded resolve-mcr-ref + clone-repo steps to setup-dev-env
+          # and carried the recorder into the new `siblings:` list of every job
+          # that had one EXCEPT this one. Two prose references to the dropped
+          # steps survive in this job's comments ("Same sibling-pin pattern as
+          # codetracer-native-recorder (resolve-mcr-ref + clone-repo + nix-
+          # develop build)", "same idempotent pattern as the
+          # codetracer-native-recorder direnv-allow step above") and are what
+          # made the omission read as deliberate.
           siblings: |
             codetracer-beam-recorder=dev
             codetracer-trace-format=dev
             codetracer-trace-format-nim=dev
+            # Pinned, not `=dev`: ci/test/sibling-provisioning-test.sh keeps a
+            # ratchet on branch-tip entries that "is lowered as blocks are
+            # converted and is never raised", so a new one has to arrive
+            # already converted. This is flake.lock's
+            # `codetracer-native-recorder` rev -- the revision this repo
+            # already declares, and the same one #720 is converting the other
+            # blocks to.
+            codetracer-native-recorder=7e0400b364196ec731967a4dd4a3e931c73732f3
+
+      - name: Clone codetracer-native-recorder (macOS)
+        # The `Setup dev env (BEAM siblings, nixos)` step above carries
+        # `if: matrix.platform == 'nixos'`, so the macOS leg gets no siblings
+        # from it -- the same asymmetry that left this leg without
+        # codetracer-trace-format for months (see the header of
+        # ci/test/sibling-provisioning-test.sh). Clone the recorder with the
+        # `clone-repo` + `ref: dev` pattern the other macOS siblings in this job
+        # use.
+        #
+        # macOS has NOT been silently fine without it. It is a persistent
+        # self-hosted runner, and a recorder clone left in the shared work
+        # directory by another job is why this leg reaches build.rs:972
+        # (`.envrc is blocked`) instead of build.rs:170 (`not found`). That is a
+        # leftover, not provisioning: it is whatever revision the last job to
+        # want it happened to pin, and it is absent on a fresh host.
+        #
+        # `submodules: 'false'`: codetracer-native-recorder has no .gitmodules,
+        # and clone-repo's sed is unconditional.
+        if: matrix.platform == 'macos'
+        uses: metacraft-labs/metacraft-github-actions/clone-repo@dev
+        with:
+          repo: metacraft-labs/codetracer-native-recorder
+          # flake.lock's rev, matching the nixos leg's pinned `siblings:` entry
+          # -- the two legs of one job must not test different recorders.
+          ref: 7e0400b364196ec731967a4dd4a3e931c73732f3
+          path: ${{ github.workspace }}/../codetracer-native-recorder
+          gh-token: ${{ steps.ci_token.outputs.token }}
+          submodules: 'false'
+
+      - name: Allow direnv in cloned codetracer-native-recorder (nixos)
+        # `build.rs` shells out to `direnv exec <recorder-root> bash
+        # ct_emulator/build_native_api.sh` to materialise the generated C before
+        # the Rust build. A fresh clone's `.envrc` is in the "blocked" state, so
+        # direnv refuses and the build script panics at build.rs:972 with
+        # `build_native_api.sh exited with status exit status: 1`. That is the
+        # SECOND failure this job hits, not an alternative to the first: the
+        # macOS leg reaches it today only because the persistent runner still
+        # carries a recorder clone left by another job, so it gets past the
+        # build.rs:170 panic and dies here instead. Both legs need the allow.
+        #
+        # Idempotent, and it persists only in the runner's local direnv state
+        # dir. Same three-step shape lint-rust already uses.
+        if: matrix.platform == 'nixos'
+        run: |
+          nix develop .#devShells.x86_64-linux.default -c \
+            direnv allow "${{ github.workspace }}/../codetracer-native-recorder"
+
+      - name: Allow direnv in cloned codetracer-native-recorder (macOS)
+        # `nix develop .` (not `.#devShells.x86_64-linux.default`): the macOS
+        # leg selects the host-default aarch64-darwin shell, exactly as
+        # ci/test/non-gui.sh does.
+        if: matrix.platform == 'macos'
+        run: |
+          nix develop . -c \
+            direnv allow "${{ github.workspace }}/../codetracer-native-recorder"
+
+      - name: Resolve ct_emulator nimble dependencies (nixos)
+        # `build_native_api.sh` runs `nim c ... ct_emulator.nim`, whose .nimble
+        # declares `requires "results"`. A fresh nim install has no global
+        # `results` package and the script aborts with `cannot open file:
+        # results`. Run `nimble install --depsOnly` once inside the recorder's
+        # own direnv env so nim/nimble resolve from the recorder's flake --
+        # idempotent, and copied from the lint-rust step of the same name.
+        if: matrix.platform == 'nixos'
+        run: |
+          nix develop .#devShells.x86_64-linux.default -c \
+            direnv exec "${{ github.workspace }}/../codetracer-native-recorder" \
+              bash -c 'cd "${{ github.workspace }}/../codetracer-native-recorder/ct_emulator" && nimble install --depsOnly -y'
+
+      - name: Resolve ct_emulator nimble dependencies (macOS)
+        if: matrix.platform == 'macos'
+        run: |
+          nix develop . -c \
+            direnv exec "${{ github.workspace }}/../codetracer-native-recorder" \
+              bash -c 'cd "${{ github.workspace }}/../codetracer-native-recorder/ct_emulator" && nimble install --depsOnly -y'
 
       - name: Allow direnv in cloned codetracer-beam-recorder
         # ``elixir_flow_dap_test.rs`` / ``erlang_flow_dap_test.rs``
@@ -5434,6 +5584,14 @@ jobs:
         run: ./ci/test/non-gui.sh
         env:
           CODETRACER_CI_PLATFORM: ${{ matrix.platform }}
+          # The emulator's `syscall_replay.nim` imports `stew/endians2`, which
+          # `ct_emulator.nimble` does not declare, so the `nimble install
+          # --depsOnly` above cannot supply it and a fresh Nim build cannot
+          # resolve the module. Codetracer ships a pinned copy as a submodule;
+          # `build_native_api.sh` picks it up from here as `--path:` flags. Same
+          # variable lint-rust, windows-rust-components and the macOS
+          # db-backend leg already set.
+          CT_EMULATOR_EXTRA_NIM_PATHS: ${{ github.workspace }}/libs/nim-stew/stew:${{ github.workspace }}/libs/nim-stew:${{ github.workspace }}/libs/nim-result
 
   test-ui-tests:
     strategy:

--- a/ci/test/sibling-provisioning-test.sh
+++ b/ci/test/sibling-provisioning-test.sh
@@ -916,6 +916,15 @@ echo "db-backend cargo legs provision codetracer-native-recorder"
 # vacuous pass. Two vacuous greens have already been paid for in this file.
 readonly DB_BACKEND_ANCHOR='cross-repo-tests.yml:shell-recorder-tests'
 
+# The anchor above is a LITERAL-pattern site (`cd src/db-backend`). It says
+# nothing about the derived half, so if the justfile walk broke -- a recipe
+# renamed, `run-just-lanes.sh` replaced, the seed patterns stopped matching --
+# that anchor would go on passing while every `just`-mediated call site
+# vanished from this contract's scope, which is precisely the eleven-week
+# silence this scanner was extended to end. Anchor the derived half separately,
+# on the site that produced the evidence.
+readonly DB_BACKEND_DERIVED_ANCHOR='codetracer.yml:test-non-gui'
+
 # A job satisfies this contract by naming the composite instead of the repo --
 # which is the shape this contract WANTS, and also a way to launder the defect
 # past it. If `setup-db-backend-siblings` ever stops provisioning
@@ -945,6 +954,139 @@ else
 		"entry gone, that credit is a fiction and the assertion below would pass while" \
 		"every one of those jobs panicked in build.rs."
 fi
+
+# ---------------------------------------------------------------------------
+# The cargo invocation is usually NOT what a workflow step says.
+#
+# The three literal patterns below (`cd src/db-backend`, `--manifest-path
+# src/db-backend`, `run-cross-repo-tests.sh`) are what a step writes when it
+# drives cargo directly. Most steps do not: they say `just <recipe>`, or they
+# name a script under `ci/` that says it. `test-non-gui` runs
+# `./ci/test/non-gui.sh` -> `just test` -> `ci/lib/run-just-lanes.sh test ...
+# test-rust ...` -> `pushd src/db-backend; cargo nextest run --bin
+# replay-server`, and NOTHING in that chain is a string this scanner used to
+# match. So the job compiled build.rs on both legs while this contract reported
+# "ok", and had done since 504274e13 (2026-06-23) dropped its recorder clone in
+# the migration to setup-dev-env -- a regression this file exists to catch and
+# did not, for eleven weeks.
+#
+# Rather than add `just test` as a fourth literal -- which would be the same
+# mistake one indirection later -- derive the recipe set from the justfile:
+#
+#   seed      recipes whose body cd/pushd's into src/db-backend
+#   closure   + recipes that invoke a seeded one, either as `just <recipe>` or
+#             as a lane argument of `ci/lib/run-just-lanes.sh <label> <lane>...`
+#             (the aggregate dispatcher; `just test`'s lane names are literal
+#             arguments there precisely so walks like this one can see them)
+#   scripts   + shell files under ci/ or scripts/ that invoke a closure recipe
+#
+# A step then counts as a db-backend call site if it says `just <closure
+# recipe>` or names one of those scripts. Derived, so a renamed recipe or a new
+# aggregate cannot quietly drop a job out of this contract's scope.
+# ---------------------------------------------------------------------------
+just_names=()
+just_bodies=()
+_cur_recipe=""
+_cur_body=""
+while IFS= read -r line || [ -n "$line" ]; do
+	case "$line" in
+	# A recipe header starts at column 0 and has a colon. Body lines are
+	# indented; comments at column 0 belong to no recipe.
+	[A-Za-z0-9_-]*:*)
+		if [ -n "$_cur_recipe" ]; then
+			just_names+=("$_cur_recipe")
+			just_bodies+=("$_cur_body")
+		fi
+		_cur_recipe="${line%%:*}"
+		_cur_recipe="${_cur_recipe%% *}"
+		# The dependency list after the colon is part of the body: a
+		# recipe that reaches db-backend through a prerequisite reaches it.
+		_cur_body="${line#*:}"
+		;;
+	*)
+		[ -n "$_cur_recipe" ] && _cur_body="$_cur_body
+$line"
+		;;
+	esac
+done <"$REPO_ROOT/justfile"
+if [ -n "$_cur_recipe" ]; then
+	just_names+=("$_cur_recipe")
+	just_bodies+=("$_cur_body")
+fi
+unset _cur_recipe _cur_body
+
+db_recipes=""
+for _i in "${!just_names[@]}"; do
+	case "${just_bodies[$_i]}" in
+	*'cd src/db-backend'* | *'pushd src/db-backend'*)
+		db_recipes="$db_recipes ${just_names[$_i]}"
+		;;
+	esac
+done
+
+_grew=1
+while [ "$_grew" -eq 1 ]; do
+	_grew=0
+	for _i in "${!just_names[@]}"; do
+		case " $db_recipes " in
+		*" ${just_names[$_i]} "*) continue ;;
+		esac
+		# Tokenise the body so a lane name is compared whole: a substring
+		# test would let `test-rust-flow` satisfy a search for `test-rust`.
+		_reaches=0
+		_prev=""
+		_dispatch=0
+		for _tok in ${just_bodies[$_i]}; do
+			# A line-continuation backslash tokenises on its own; skipping
+			# it keeps `just \<newline> test-rust` resolvable. Written
+			# "\\" rather than '\' only to keep shellcheck's SC1003 quiet.
+			case "$_tok" in
+			"\\") continue ;;
+			esac
+			if [ "$_prev" = "just" ]; then
+				case " $db_recipes " in
+				*" $_tok "*) _reaches=1 ;;
+				esac
+			fi
+			if [ "$_dispatch" -eq 1 ]; then
+				case " $db_recipes " in
+				*" $_tok "*) _reaches=1 ;;
+				esac
+			fi
+			case "$_tok" in
+			*run-just-lanes.sh) _dispatch=1 ;;
+			esac
+			_prev="$_tok"
+		done
+		if [ "$_reaches" -eq 1 ]; then
+			db_recipes="$db_recipes ${just_names[$_i]}"
+			_grew=1
+		fi
+	done
+done
+unset _i _grew _tok _prev _dispatch _reaches
+
+# Shell files that invoke one of those recipes. Repo-relative, because that is
+# how a workflow step names them (`./ci/test/non-gui.sh`, `bash ci/...`).
+db_scripts=""
+while IFS= read -r _sh; do
+	_rel="${_sh#"$REPO_ROOT"/}"
+	_prev=""
+	while IFS= read -r line || [ -n "$line" ]; do
+		for _tok in $line; do
+			if [ "$_prev" = "just" ]; then
+				case " $db_recipes " in
+				*" $_tok "*)
+					db_scripts="$db_scripts $_rel"
+					break 3
+					;;
+				esac
+			fi
+			_prev="$_tok"
+		done
+	done <"$_sh"
+done < <(find "$REPO_ROOT/ci" "$REPO_ROOT/scripts" -name '*.sh' -type f 2>/dev/null)
+unset _sh _rel _prev _tok
 
 db_backend_sites=()
 db_backend_missing=()
@@ -986,6 +1128,18 @@ for wf in "${SIBLING_SOURCE_FILES[@]}"; do
 			'codetracer-native-recorder='* | 'codetracer-native-recorder')
 				seen_recorder=1
 				;;
+			# A `clone-repo` step provisions the sibling just as a
+			# `siblings:` entry does, and is how the legs that get no
+			# `setup-dev-env` (this job's macOS half; viewmodel-tests
+			# throughout) obtain theirs. Matching only the `siblings:`
+			# spelling made those legs unsatisfiable by any correct fix
+			# -- the contract would have gone on failing after the
+			# provisioning was in place, which is the shape that gets a
+			# contract deleted rather than obeyed.
+			'repo: metacraft-labs/codetracer-native-recorder' | \
+				'repo: '*'/codetracer-native-recorder')
+				seen_recorder=1
+				;;
 			*'setup-db-backend-siblings'*)
 				# The composite provisions the three db-backend siblings --
 				# but only credit the caller while it demonstrably still
@@ -1007,16 +1161,39 @@ for wf in "${SIBLING_SOURCE_FILES[@]}"; do
 		# the cross-repo driver, whose `run_db_backend_test` does
 		# `cd "$REPO_ROOT/src/db-backend"; cargo test` (scripts/
 		# run-cross-repo-tests.sh:446).
+		_is_db_site=0
 		case "$stripped_line" in
 		'cd src/db-backend' | 'cd src/db-backend '* | "cd 'src/db-backend'"* | \
 			*'--manifest-path src/db-backend'* | *'--manifest-path=src/db-backend'* | \
 			*'run-cross-repo-tests.sh'*)
+			_is_db_site=1
+			;;
+		esac
+		# The derived half: `just <recipe>` for a recipe that reaches
+		# db-backend, and any ci/ or scripts/ shell file that does.
+		if [ "$_is_db_site" -eq 0 ]; then
+			_prev=""
+			for _tok in $stripped_line; do
+				if [ "$_prev" = "just" ]; then
+					case " $db_recipes " in
+					*" $_tok "*) _is_db_site=1 ;;
+					esac
+				fi
+				for _s in $db_scripts; do
+					case "$_tok" in
+					"$_s" | "./$_s") _is_db_site=1 ;;
+					esac
+				done
+				_prev="$_tok"
+			done
+			unset _prev _tok _s
+		fi
+		if [ "$_is_db_site" -eq 1 ]; then
 			db_backend_sites+=("$wf_name:$job")
 			if [ "$seen_recorder" -eq 0 ]; then
 				db_backend_missing+=("$wf_name:$line_no: job '$job' builds src/db-backend with no codetracer-native-recorder sibling before it")
 			fi
-			;;
-		esac
+		fi
 	done <"$wf"
 done
 
@@ -1037,6 +1214,27 @@ else
 		"found: ${db_backend_sites[*]:-<none>}"
 fi
 unset _anchor_found
+
+_derived_anchor_found=0
+for _s in "${db_backend_sites[@]}"; do
+	[ "$_s" = "$DB_BACKEND_DERIVED_ANCHOR" ] && _derived_anchor_found=1
+done
+unset _s
+
+if [ "$_derived_anchor_found" -eq 1 ]; then
+	ok "the justfile-derived db-backend walk still reaches its anchor (${#db_recipes} chars of recipe closure)"
+else
+	fail "the justfile-derived db-backend walk still reaches its anchor" \
+		"expected '$DB_BACKEND_DERIVED_ANCHOR' among the call sites. That job reaches" \
+		"cargo through ./ci/test/non-gui.sh -> just test -> run-just-lanes.sh ... test-rust" \
+		"-> pushd src/db-backend, and NO link in that chain is a literal this file" \
+		"matches -- it is found only by the derived walk. Losing it means the walk has" \
+		"broken and every just-mediated call site has silently left this contract." \
+		"recipe closure: ${db_recipes:-<empty>}" \
+		"scripts: ${db_scripts:-<none>}" \
+		"found: ${db_backend_sites[*]:-<none>}"
+fi
+unset _derived_anchor_found
 
 if [ "${#db_backend_missing[@]}" -eq 0 ]; then
 	ok "every db-backend cargo leg provisions codetracer-native-recorder first"
@@ -1546,7 +1744,11 @@ echo
 # four about the lock and the action that reads it (the action still runs the
 # command, it hand-writes no set or revision, the lock declares the set, and
 # every member is pinned to a 40-hex SHA).
-readonly EXPECTED_ASSERTIONS=27
+# 27 -> 28: assertion 2b's scanner grew a second, DERIVED half -- the justfile
+# closure that finds `just`-mediated db-backend builds -- and that half needs
+# its own anchor, because the existing one is a literal-pattern site and would
+# keep passing while the derived walk went blind.
+readonly EXPECTED_ASSERTIONS=28
 if [ "$assertions" -ne "$EXPECTED_ASSERTIONS" ]; then
 	printf 'FAIL: ran %d assertions, expected %d\n' "$assertions" "$EXPECTED_ASSERTIONS"
 	failures=$((failures + 1))


### PR DESCRIPTION
## The defect

`test-non-gui` fails on **both** legs, and has since [`504274e13`](https://github.com/metacraft-labs/codetracer/commit/504274e13) (2026-06-23). The legs report different errors, which is why this has been triaged as two problems — or as a `codetracer-native-recorder` defect — more than once:

| leg | error |
|---|---|
| nixos | `panicked at build.rs:170:5: db-backend requires the sibling`codetracer-native-recorder`checkout, and it was not found.` |
| macOS | `direnv: error .../codetracer-native-recorder/.envrc is blocked` → `panicked at build.rs:972:17` |

It is **one omission**. `Run tests` is `./ci/test/non-gui.sh` → `just test` → `test-rust` → `pushd src/db-backend; cargo nextest run --bin replay-server`, and that `build.rs` resolves the Nim MCR emulator as a workspace sibling and panics without it. The job declares no `codetracer-native-recorder` anywhere.

- The **nixos** leg is ephemeral, so it gets the "not found" panic.
- The **macOS** leg is a persistent self-hosted runner that still carries a clone some *other* job left in the shared work directory, so it gets one step further and dies on the `.envrc` nobody allowed.

Neither leg is provisioned; only one of them has a leftover. Nothing is wrong with the recorder's own sources.

`504274e13` migrated this job's open-coded `resolve-mcr-ref` + `clone-repo` steps to `setup-dev-env` and carried the recorder into the new `siblings:` list of **every job that had one except this one**. Two comments referring to the deleted steps survived — *"Same sibling-pin pattern as codetracer-native-recorder (resolve-mcr-ref + clone-repo + nix-develop build)"* — which is what made the omission read as deliberate.

`viewmodel-tests` has the same defect, **latent**: `just test-vm-recorder-gated` does `(cd src/db-backend && cargo build --bin replay-server)` and that job clones no recorder either. Ephemeral, so no leftover would save it; on the runs inspected it died earlier and never reached the step.

## Why the contract that exists for this did not say so

Assertion 2b of `ci/test/sibling-provisioning-test.sh` has guarded exactly this since the `shell-recorder-tests` incident. Its scanner matched three literals — `cd src/db-backend`, `--manifest-path src/db-backend`, `run-cross-repo-tests.sh` — and **no link** in

```
./ci/test/non-gui.sh -> just test -> ci/lib/run-just-lanes.sh ... test-rust -> pushd src/db-backend
```

is any of them. The contract printed `ok` for eleven weeks over a job that panicked in `build.rs` on every run.

Adding `just test` as a fourth literal would be the same mistake one indirection later. The scanner now **derives** the set:

- recipes whose body `cd`/`pushd`es into `src/db-backend`
- plus recipes reaching one via `just <recipe>` or as a lane argument of `ci/lib/run-just-lanes.sh` (the aggregate dispatcher — `just test`'s lane names are literal arguments there precisely so walks like this can see them)
- plus `ci/` and `scripts/` shell files that invoke one

It also now counts a `clone-repo` step as provisioning, not only a `siblings:` entry. Without that, the legs that get no `setup-dev-env` (this job's macOS half, `viewmodel-tests` throughout) could not satisfy the contract by *any* correct fix — the shape that gets a contract deleted rather than obeyed.

## Proof (executed)

| | result |
|---|---|
| contract, before the workflow fix | **FAIL**, naming `codetracer.yml:3394 viewmodel-tests` and `codetracer.yml:5434 test-non-gui` |
| contract, after | `all 28 assertions passed` |
| `shellcheck -x ci/test/sibling-provisioning-test.sh` | clean |
| `yaml.safe_load` of the workflow | parses, 42 jobs |

The derived half gets **its own anchor** (`codetracer.yml:test-non-gui`). The existing anchor is a literal-pattern site and would keep passing while the justfile walk went blind — the exact failure mode this extension exists to end. That is the 27 → 28 assertion count, recorded at the self-accounting block.

New sibling entries are pinned to flake.lock's rev `7e0400b364196ec731967a4dd4a3e931c73732f3`, not `=dev`: this file keeps a ratchet on branch-tip entries that *"is lowered as blocks are converted and is never raised"*, so a new one has to arrive already converted. Same revision #720 is converting the other blocks to.

## Not claimed

**That these jobs now pass.** codetracer CI had a ~13h backlog and no verdict was available during this work. What is executed is above.

The macOS `nix develop . -c direnv allow` spelling is checked **statically**: `devShells.default` composes `nix/shells/ci-base.nix`, which carries `direnv` and `nimble` for every system in the flake. (`nix/shells/armShell.nix`, which lacks `direnv`, is imported by nothing.)

## Related, and deliberately not in this PR

`test-ui-tests (macos)` and `ct-test cross-language provider gate` fail for an unrelated reason that *also* wears the recorder's name: `build-siblings.sh` reports `codetracer-native-recorder (build failed)` when what actually failed is `ct_license_ffi` in **codetracer-native-backend**, with `E0063: missing field `keyring``. Fixed in metacraft-labs/codetracer-native-backend#91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)