### PR TITLE
fix(ct-test): two defects that kept the cross-language provider gate red

### DIFF
--- a/src/ct_test/frameworks/m12_fallback_common.nim
+++ b/src/ct_test/frameworks/m12_fallback_common.nim
@@ -312,6 +312,64 @@ proc fallbackRecord*(spec: M12FallbackSpec; scope: TestScope): ProviderResult[
               some(tsFailed), "Assembly fixture build failed", build.output)])
       return recordCommand(spec.providerId, scope, @[exe], @[],
           normalizedRelative(scope.projectRoot, scope.file))
+    of "ada-fallback":
+      # Ada builds before it records, like Pascal/Fortran/assembly above, and
+      # for the same reason plus one that is specific to it.
+      #
+      # THE GENERAL REASON. `recordFallback`'s tail records
+      # `sh -lc '<fileCommand>'`, so everything the fixture command runs is
+      # recorded, not just the fixture. `adaFileCommand` is the only M12
+      # command that shells out to `rm`, `mkdir` and `cp` — Fortran compiles
+      # and runs, Pascal makes its unit directory in its BUILD command (which
+      # runs here, outside the recording), and assembly assembles. Ada was
+      # never added to this dispatch, so it alone took the tail and recorded
+      # its own scratch-directory setup.
+      #
+      # WHY THAT IS NOT MERELY UNTIDY. Those three utilities are resolved by
+      # the recorded login shell, so they are the platform's, while
+      # `libct_interpose.so` is built from the recorder sibling against the
+      # dev shell's C library. Preloading the second into the first is a
+      # cross-libc load, and on the CI image it fails outright at the first
+      # link of the chain:
+      #
+      #   rm: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
+      #       (required by .../codetracer-native-recorder/ct_cli/libct_interpose.so)
+      #
+      # `&&` then short-circuits, `sh` exits 1, and the provider reports
+      # "native recording failed with exit code 1" with no trace — which reads
+      # as a recorder fault but is the fixture recording the wrong processes.
+      # gnatmake's own output is built by the dev shell's toolchain, so once
+      # only that executable is recorded the preload is same-libc again.
+      #
+      # WHY THE SCRATCH DIRECTORY IS STILL NEEDED. gnatmake writes .ali and .o
+      # beside the source it compiles, so the fixture tree must not be the
+      # build directory. That is a setup concern, and setup belongs here,
+      # where a non-zero exit is reported as a build failure, rather than
+      # inside the recording.
+      let
+        exe = tempExecutable("ct-m12-ada", scope.file)
+        buildDir = exe & "-build"
+        parsed = splitFile(scope.file)
+        buildFile = buildDir / (parsed.name & parsed.ext)
+        buildCommand = commandWithNixShell(
+          "rm -rf " & shellQuote(buildDir) & " && mkdir -p " &
+            shellQuote(buildDir) & " && cp " & shellQuote(scope.file) & " " &
+            shellQuote(buildFile) & " && cd " & shellQuote(buildDir) &
+            " && gnatmake -g -o " & shellQuote(exe) & " " &
+            shellQuote(buildFile),
+          spec.runTool, spec.nixPackages)
+        build = execCapturedShell(buildCommand, cwd = scope.projectRoot)
+      if build.exitCode != 0:
+        return ProviderResult[seq[TestEvent]](
+          diagnostics: @[diagnostic(dsError,
+              "Ada fixture build failed with exit code " & $build.exitCode,
+              scope.file)],
+          value: @[event(tekFailure, spec.providerId,
+              spec.providerId & ":record-build:" & scope.selector,
+              if scope.testId.len > 0: scope.testId else: scope.selector,
+              some(tsFailed), "Ada fixture build failed", build.output)])
+      return recordCommand(spec.providerId, scope, @[exe], @[],
+          normalizedRelative(scope.projectRoot, scope.file))
     of "lean-fallback":
       return recordCommand(spec.providerId, scope, @["lean", "--run",
           scope.file], spec.nixPackages,

--- a/src/ct_test/ruby_providers_test.nim
+++ b/src/ct_test/ruby_providers_test.nim
@@ -31,6 +31,57 @@ proc rspecSample(): string =
 proc minitestSample(): string =
   minitestRoot() / "test/calculator_test.rb"
 
+proc rubyRecorderSibling(): string =
+  ## The real ``codetracer-ruby-recorder`` checkout beside this one, or ``""``.
+  ## Only the *test* is allowed to look here: it is describing the machine it
+  ## runs on, whereas the provider must answer from the workspace it is given
+  ## (``workspace_scope.siblingRepoInWorkspace``).
+  ##
+  ## PROBE THE COMPILED EXTENSION, NOT THE WRAPPER — the same trap
+  ## ``scripts/detect-siblings.sh`` documents at its own Ruby block.
+  ## ``gems/codetracer-ruby-recorder/bin/codetracer-ruby-recorder`` is a Ruby
+  ## shim CHECKED INTO GIT at mode 100755, so it is present in every fresh
+  ## clone and a probe of it can never fail — it would report a recorder that
+  ## was never built and move the failure to a `require` error inside
+  ## ``CodeTracer::Native.load_extension!``. What has to exist is the cdylib
+  ## that shim loads, which is what is probed here.
+  let
+    candidate = getCurrentDir().parentDir / "codetracer-ruby-recorder"
+    extDir = candidate / "gems" / "codetracer-ruby-recorder" / "ext" /
+      "native_tracer" / "target" / "release"
+  for name in ["codetracer_ruby_recorder.so",
+               "codetracer_ruby_recorder.bundle",
+               "libcodetracer_ruby_recorder.so",
+               "libcodetracer_ruby_recorder.dylib",
+               "libcodetracer_ruby_recorder.bundle"]:
+    if fileExists(extDir / name):
+      return candidate
+  ""
+
+proc haveRubyRecorder(): bool =
+  rubyRecorderSibling().len > 0 or
+    findExe("codetracer-ruby-recorder").len > 0 or
+    getEnv("CODETRACER_RUBY_RECORDER_PATH", "").len > 0
+
+proc recorderWorkspace(fixtureRoot: string): string =
+  ## A temporary workspace that is a copy of ``fixtureRoot`` and also CONTAINS
+  ## the recorder checkout — the way a caller names a sibling recorder now that
+  ## ``rubyRecorderCommandPrefix`` resolves step 2 from the workspace it is
+  ## given instead of from the process working directory.
+  ##
+  ## The basename is preserved deliberately: ``ensureRubyBundle`` keys its
+  ## ``BUNDLE_PATH`` on ``splitPath(projectRoot).tail``, so a copy named like
+  ## the fixture reuses the bundle the fixture already installed rather than
+  ## driving a second, network-dependent ``bundle install`` inside the gate.
+  result = getTempDir() / ("ct-ruby-record-workspace-" &
+      $getCurrentProcessId()) / splitPath(fixtureRoot).tail
+  removeDir(result.parentDir)
+  createDir(result.parentDir)
+  copyDir(fixtureRoot, result)
+  let sibling = rubyRecorderSibling()
+  if sibling.len > 0:
+    createSymlink(sibling, result / "codetracer-ruby-recorder")
+
 proc itemBySelector(catalog: TestCatalog; selector: string): TestItem =
   for item in catalog.items:
     if item.selector == selector:
@@ -546,14 +597,39 @@ suite "ct-test M9 Ruby RSpec and Minitest providers":
       "1 runs, 1 assertions, 0 failures, 0 errors, 0 skips")
 
   test "RSpec records one real nested example to non-empty CTFS":
-    ensureRubyBundle(rspecRoot())
-    let catalog = rspecFileCatalog(rspecRoot(), rspecSample()).value
+    ## Runs against a workspace that CONTAINS the recorder checkout, which is
+    ## how a caller names a sibling recorder now that the provider no longer
+    ## searches the process working directory.
+    ##
+    ## This test used to name the fixture project itself as the workspace. That
+    ## worked only while ``rubyRecorderCommandPrefix`` seeded its sibling search
+    ## from ``getCurrentDir().parentDir`` — i.e. while the answer depended on
+    ## where the shell happened to be standing. When that resolver was anchored
+    ## to the caller's workspace, the JavaScript suite's matching test was moved
+    ## to a named workspace and this one was not, so it kept naming a directory
+    ## with no recorder in it and the provider correctly refused to record.
+    ## The refusal is right; the workspace this test named was wrong.
+    ##
+    ## Per ci/test/ct-providers.sh, a recording test must FAIL rather than skip
+    ## when its recorder is absent — a silent skip is how recorder coverage
+    ## disappears — so the absence is asserted, not tolerated.
+    if not haveRubyRecorder():
+      checkpoint("codetracer-ruby-recorder is required: build the sibling " &
+        "checkout (`direnv exec ../codetracer-ruby-recorder just build`) or " &
+        "set CODETRACER_RUBY_RECORDER_PATH")
+    check haveRubyRecorder()
+
+    let workspace = recorderWorkspace(rspecRoot())
+    defer: removeDir(workspace.parentDir)
+    let sampleInWorkspace = workspace / "spec/calculator_spec.rb"
+    ensureRubyBundle(workspace)
+    let catalog = rspecFileCatalog(workspace, sampleInWorkspace).value
     let nested = catalog.itemBySelector(RspecAddsSelector)
     let provider = newRubyRspecM1Provider()
     let recordResult = provider.provider.record(TestScope(
       kind: tskSingle,
-      projectRoot: rspecRoot(),
-      file: rspecSample(),
+      projectRoot: workspace,
+      file: sampleInWorkspace,
       testId: nested.id,
       selector: nested.selector))
 
@@ -567,14 +643,26 @@ suite "ct-test M9 Ruby RSpec and Minitest providers":
     check mapped[nested.id].metadata["catalogTestId"] == nested.id
 
   test "Minitest records one real test method to non-empty CTFS":
-    ensureRubyBundle(minitestRoot())
-    let catalog = minitestFileCatalog(minitestRoot(), minitestSample()).value
+    ## Same workspace-naming requirement as the RSpec recording test above;
+    ## see the note there for why the fixture project alone is not a workspace
+    ## the provider can resolve a recorder from.
+    if not haveRubyRecorder():
+      checkpoint("codetracer-ruby-recorder is required: build the sibling " &
+        "checkout (`direnv exec ../codetracer-ruby-recorder just build`) or " &
+        "set CODETRACER_RUBY_RECORDER_PATH")
+    check haveRubyRecorder()
+
+    let workspace = recorderWorkspace(minitestRoot())
+    defer: removeDir(workspace.parentDir)
+    let sampleInWorkspace = workspace / "test/calculator_test.rb"
+    ensureRubyBundle(workspace)
+    let catalog = minitestFileCatalog(workspace, sampleInWorkspace).value
     let item = catalog.itemBySelector(MinitestAddsSelector)
     let provider = newRubyMinitestM1Provider()
     let recordResult = provider.provider.record(TestScope(
       kind: tskSingle,
-      projectRoot: minitestRoot(),
-      file: minitestSample(),
+      projectRoot: workspace,
+      file: sampleInWorkspace,
       testId: item.id,
       selector: item.selector))
 


### PR DESCRIPTION
Two independent defects in the `ct-test` provider suites, each found by
running the cross-language provider gate and reading what it actually
reported.

**The M12 Ada fixture recorded its own build steps.** Pascal, Fortran and
assembly each compile in a separate step and record only the executable
that step produced. Ada had no case in that dispatch, so it fell through
to the generic path and recorded `rm`, `mkdir`, `cp`, `gnatmake` and the
test program in one shell. Those utilities come from the platform, while
the recorder's interpose library is built against the development
toolchain's C library, so preloading one into the other failed at the
first command and the recording produced nothing. Ada now builds the way
its sibling languages already do.

**The two Ruby recording tests named a workspace with no recorder in it.**
Recorder resolution answers from the workspace the caller names and
searches nothing above it, so the provider correctly refused to record.
The refusal was right and the workspace the tests named was wrong — they
predate that resolution change, and the JavaScript suite's matching test
was updated at the time while these two were not. Both now use a
workspace containing the recorder, exactly as the JavaScript test does,
and assert the same real recording as before.

## Verification

Run against the gate job copied verbatim, with the real recorder siblings
built and no skip flags: all ten provider suites compile and run, the
three sibling recorder builds pass, and the Ruby suite goes from failing
to passing.

One caveat worth stating plainly: the M12 suite is **not yet reliably
green**. On the same code it passed one run and failed another, in a
different language each time, on recorder-side errors during multi-process
recording (`failed to send START to child`, and a zero-size committed ring
slot). That is a separate defect outside this repo and is being reported
separately; these two changes remove two real faults that were in front of
it, not that one.