### PR TITLE
chore(deps): bump the native recorder pin to pick up the multi-process fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -375,11 +375,11 @@
     "codetracer-native-recorder": {
       "flake": false,
       "locked": {
-        "lastModified": 1783307995,
-        "narHash": "sha256-hvbHLX9eaxXgB1CMLwZz6M1KKolwhAwjlP4w/kXHs00=",
+        "lastModified": 1789023022,
+        "narHash": "sha256-S124SMkq0yGFsZc4XpiBJ/HgQMlVnKgP+td6dkY82m8=",
         "owner": "metacraft-labs",
         "repo": "codetracer-native-recorder",
-        "rev": "7e0400b364196ec731967a4dd4a3e931c73732f3",
+        "rev": "7f56dc4a61f30715f5f9839b28964cc7d9ac6623",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What this changes

One line of intent, three lines of lock: the `codetracer-native-recorder`
input moves from `7e0400b3` to the recorder's current `dev` tip
`7f56dc4a`.

```
 flake.lock | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)
```

The diff is the `rev`, `narHash` and `lastModified` of that single node.
Nothing else in the lock moved — no unrelated inputs, no new transitive
nodes.

## Why

The input declares `github:metacraft-labs/codetracer-native-recorder/dev`,
but the lock had drifted a long way from the branch it follows: the
pinned commit dates from 6 July and sits **1379 commits behind** the
current tip. CodeTracer has therefore been building against a recorder
from two months ago.

The tip picks up a fix for multi-process recording, which previously
either failed at a load-dependent rate or came back quietly incomplete:

- **Forked children corrupted the parent's ring.** A child inherited an
  armed publication gate, the forking thread's per-thread state, and a
  ring manager still pointing at the parent's ring. A per-thread ring is
  single-producer by construction, so parent and child claimed the same
  slot, the write cursor advanced twice, and the consumer read the
  untouched second slot as committed — `malformed committed record slot:
  … event size too small: 0 < 26`. `ctReInitForChildProcess` now closes
  the publication gate as its first act and re-opens it only once the
  child has its own ring manager, ring and completed handshake.
- **Exec'd children were not followed.** A child that exec'd was not
  adopted onto its new image, so its events were dropped.

The `ct-test-providers` suite exercises multi-process recording and
cannot benefit from the recorder fix until this pin moves.

## On the age of the previous pin

Worth recording, since a two-month-old pin on a branch-tracking input
invites the question of whether something went wrong. It did not — the
provenance is ordinary and fully recoverable:

- `e67e56b36` ("chore(deps): use native recorder dev input", 6 July)
  switched this input from `stable` to `dev` and locked the then-current
  `dev` tip. The recorder commit was authored about four hours before the
  lock commit, exactly as a routine re-lock against a branch tip looks.
- `7e0400b3` is a normal ancestor of the recorder's `dev`: `merge-base`
  with `dev` is the commit itself, `rev-list --left-right --count` is
  `0 1379`, and it is contained in `dev` plus a couple of dozen other
  branches.

So the pin was never off-branch or unreachable; it was simply never
refreshed after the input started tracking a moving branch. The only
lesson is that a `ref = dev` input needs periodic re-locking, because
nothing about a stale pin fails loudly.

One caution for anyone auditing a pin this way: `git ls-remote` lists
only **ref tips**, so a commit 1379 back on `dev` cannot appear in its
output. Zero matches there is the expected result for any historical
commit and is not evidence that a pin is unreachable. Ancestry has to be
checked with `merge-base --is-ancestor` against a freshly fetched ref.

## Verification

The pin was not taken on trust. The flake resolves the input to a store
path, and both halves of the fix were read out of **that path**:

```
$ nix eval --raw --expr '(builtins.getFlake …).inputs.codetracer-native-recorder.outPath'
/nix/store/fbqkwlx3gxk25ckdcx026rn7h4kxmxgk-source
```

- `ct_interpose/src/ct_interpose/library_init.nim` — in
  `ctReInitForChildProcess`, `setConsumerAttached(false)` is the first
  statement after the `gMode != rmRecording` guard.
- `ct_cli/src/ct_cli/record_cmd.nim` — `adoptExecdChildImage` is defined
  and called on the handshaked-child path.

Neither is present at the old rev, so the bump is what makes the fix
reachable.

The lock was hand-edited rather than produced by `nix flake update`, so
its consistency was checked rather than assumed:
`nix flake metadata --no-update-lock-file` re-resolves all 260 nodes
against the edited lock, exits clean, and does not want to rewrite it.

CI is heavily backlogged, so the checks on this PR are not yet evidence
of anything either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
