### PR TITLE
Stop reading the retired meta.json and paths.json from recordings

### DIFF
--- a/src/backend-manager/src/meta_dat.rs
+++ b/src/backend-manager/src/meta_dat.rs
@@ -123,6 +123,15 @@ const FLAG_HAS_SPAN_STREAM: u16 = 1 << 13;
 /// without the constant, every count-bearing container would be refused here
 /// and the trace would look unopenable rather than merely unfamiliar.
 const FLAG_HAS_LINE_COUNT_TABLE: u16 = 1 << 14;
+
+/// Bit 15 — `corrmark.ns` correlation index + `markers.dat`/`.off` (WTCI).
+///
+/// backend-manager has no use for the index, but a bit outside
+/// `KNOWN_FLAGS_MASK` makes `parse_meta_dat` reject the whole container — so
+/// without this constant every recording that declares a correlation marker
+/// would fail to open here, rather than opening with an index this component
+/// ignores.
+const FLAG_HAS_CORRELATION_INDEX: u16 = 1 << 15;
 const KNOWN_FLAGS_MASK: u16 = FLAG_HAS_MCR_FIELDS
     | FLAG_HAS_REPLAY_LAUNCH_FIELDS
     | FLAG_HAS_LAYOUT_SNAPSHOT
@@ -137,7 +146,8 @@ const KNOWN_FLAGS_MASK: u16 = FLAG_HAS_MCR_FIELDS
     | FLAG_HAS_IO_EVENT_STREAM
     | FLAG_HAS_INTERNING_TABLES
     | FLAG_HAS_SPAN_STREAM
-    | FLAG_HAS_LINE_COUNT_TABLE;
+    | FLAG_HAS_LINE_COUNT_TABLE
+    | FLAG_HAS_CORRELATION_INDEX;
 
 // ── Public types ─────────────────────────────────────────────────────────
 

--- a/src/ct/trace/ctfs_sources.nim
+++ b/src/ct/trace/ctfs_sources.nim
@@ -395,24 +395,15 @@ proc materializeCtfsSources*(ctFilePath, outputFolder: string): bool =
     return false
 
   var paths: seq[string] = @[]
-  var pathsJsonNonEmpty = false
-  try:
-    let pathsJson = reader.readCtfsFile("paths.json")
-    if pathsJson.len > 0:
-      writeFile(outputFolder / "paths.json", pathsJson)
-      for pathNode in parseJson(pathsJson):
-        if pathNode.kind == JString:
-          paths.add pathNode.getStr()
-      result = true
-      pathsJsonNonEmpty = paths.len > 0
-  except CatchableError:
-    discard
-
-  # CTFS v4 containers replace the legacy JSON ``paths.json`` internal
-  # file with the binary ``paths.dat`` + ``paths.off`` interning table.
-  # When the JSON form is absent, decode the binary table so the
-  # frontend still gets a ``paths.json`` sidecar and the bundled
-  # ``files/`` payload is materialised below.
+  # NOTE: two different files are called ``paths.json`` in this proc. The one
+  # written to ``outputFolder`` is the SIDECAR the frontend reads to build the
+  # filesystem jstree, and it stays. The container-INTERNAL ``paths.json`` that
+  # used to be read here first is the retired legacy metadata sidecar, and is
+  # gone — recorded paths come from ``paths.dat`` or ``meta.dat`` below.
+  # A recorded container carries its source paths in the binary
+  # ``paths.dat`` + ``paths.off`` interning table. Decode it so the frontend
+  # gets a ``paths.json`` sidecar and the bundled ``files/`` payload is
+  # materialised below.
   if not result:
     try:
       let interningPaths = extractInterningTablePaths(reader)
@@ -423,15 +414,11 @@ proc materializeCtfsSources*(ctFilePath, outputFolder: string): bool =
     except CatchableError as e:
       echo "ct host: warning: failed to decode CTFS paths.dat: ", e.msg
 
-  # M-REC-1.5/M4a: the ct_recorder (live MCR) trace-writer currently
-  # finalizes the internal ``paths.json`` as a placeholder ``"[]"`` even
-  # when the operator passed ``--source`` paths (those paths *do* land
-  # in ``meta.dat``'s ``paths`` field — see
-  # ``ct_recorder/trace_writer.nim`` TODO("meta-json-retirement")).
-  # Until ``paths.json`` is retired, mirror ``meta.dat``'s paths into
-  # the sidecar when the internal ``paths.json`` was empty so the
-  # importer derives a usable jstree root from the recorded source
-  # paths instead of leaving an empty list.
+  # M-REC-1.5/M4a: mirror ``meta.dat``'s ``paths`` field into the sidecar so
+  # the importer derives a usable jstree root from the recorded source paths
+  # instead of leaving an empty list. This used to be conditional on the
+  # container-internal ``paths.json`` having been empty; that file is retired,
+  # so ``meta.dat`` is now simply where recorded ``--source`` paths come from.
   #
   # Any sibling sidecar already present in ``outputFolder`` (e.g.
   # ``trace_paths.json`` written by the local manifest importer to
@@ -439,7 +426,7 @@ proc materializeCtfsSources*(ctFilePath, outputFolder: string): bool =
   # is merged in — without the merge ``normalizeImportedTracePaths``
   # would silently drop the sidecar because it prefers ``paths.json``
   # whenever it exists.
-  if not pathsJsonNonEmpty:
+  block:
     try:
       let metaPaths = parseCtfsMetaDat(reader.readCtfsFile("meta.dat")).paths
       var merged: seq[string] = @[]

--- a/src/db-backend/src/ctfs_trace_reader/ctfs_container.rs
+++ b/src/db-backend/src/ctfs_trace_reader/ctfs_container.rs
@@ -228,7 +228,7 @@ pub trait BlockSource: fmt::Debug + Send + Sync {
     }
 
     /// Whether the container is finalized (the writer has committed terminal
-    /// metadata such as `meta.dat`/`meta.json`).
+    /// metadata such as `meta.dat`).
     ///
     /// M0 sources back finalized, fully-written containers, so the default is
     /// `true`; follow-mode (M1) overrides this to surface in-progress
@@ -494,10 +494,9 @@ impl BlockSource for LocalFileSource {
 ///   grows and its companion `steps.idx` gains a new offset entry, so the
 ///   newly-committed records become visible.
 /// - [`is_finalized`](BlockSource::is_finalized) becomes `true` once the
-///   container carries a non-empty `meta.dat` (new split-stream format) or
-///   `meta.json` (legacy format) — the writer commits terminal metadata last,
-///   so its presence means no further growth will occur and a follow reader can
-///   stop polling.
+///   container carries a non-empty `meta.dat` — the writer commits terminal
+///   metadata last, so its presence means no further growth will occur and a
+///   follow reader can stop polling.
 ///
 /// `refresh()` re-reads ONLY Block 0's `FileEntry` array (a single positional
 /// read per entry), never the whole container, so polling a multi-gigabyte
@@ -518,14 +517,18 @@ pub struct FollowFileSource {
     /// the raw container `size`, which only ever grows monotonically as bytes
     /// land on disk.
     file_sizes: HashMap<String, u64>,
-    /// `true` once a non-empty `meta.dat` / `meta.json` is observed.
+    /// `true` once a non-empty `meta.dat` is observed.
     finalized: bool,
 }
 
-/// Names whose non-empty presence seals a recording: the new split-stream
-/// binary metadata (`meta.dat`) and the legacy JSON metadata (`meta.json`).
-/// Either committed and non-empty means the writer has finished.
-const FINALIZATION_META_FILES: [&str; 2] = ["meta.dat", "meta.json"];
+/// Names whose non-empty presence seals a recording: the binary metadata
+/// document, committed and non-empty, means the writer has finished.
+///
+/// The retired `meta.json` used to be listed here too, and removing it was
+/// only safe once every writer emitted `meta.dat` unconditionally — a bundle
+/// with no dedicated streams used to omit it, and would then never have looked
+/// finalized to a follow reader.
+const FINALIZATION_META_FILES: [&str; 1] = ["meta.dat"];
 
 impl FollowFileSource {
     /// Open `path` for follow-mode positional reads and take an initial
@@ -1620,7 +1623,7 @@ mod tests {
         // Open the follow source BEFORE any growth.
         let mut follow = FollowFileSource::open(&path).unwrap();
         assert_eq!(follow.file_size("steps.dat"), Some(100), "initial FileEntry.Size");
-        assert!(!follow.is_finalized(), "no meta.dat/meta.json ⇒ not finalized");
+        assert!(!follow.is_finalized(), "no meta.dat ⇒ not finalized");
         let size_before = follow.current_size();
 
         // ── Simulate a chunk flush that grows "steps.dat" by 50 bytes IN PLACE.
@@ -1687,7 +1690,7 @@ mod tests {
     }
 
     /// M1 — `FollowFileSource.is_finalized()` flips to `true` once a non-empty
-    /// `meta.json` / `meta.dat` is observed on `refresh()`, and not before.
+    /// `meta.dat` is observed on `refresh()`, and not before.
     #[test]
     fn test_followfilesource_finalization_signal() {
         use std::io::{Seek, SeekFrom, Write};
@@ -1695,13 +1698,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("seal.ct");
 
-        // Two entries: a data file and a placeholder meta.json at size 0.
-        write_minimal_ctfs(&path, &[("steps.dat", b"abc"), ("meta.json", &[])]).unwrap();
+        // Two entries: a data file and a placeholder meta.dat at size 0.
+        write_minimal_ctfs(&path, &[("steps.dat", b"abc"), ("meta.dat", &[])]).unwrap();
 
         let mut follow = FollowFileSource::open(&path).unwrap();
-        assert!(!follow.is_finalized(), "meta.json size 0 ⇒ not finalized");
+        assert!(!follow.is_finalized(), "meta.dat size 0 ⇒ not finalized");
 
-        // Bump meta.json's FileEntry.Size to a non-zero value (its entry is the
+        // Bump meta.dat's FileEntry.Size to a non-zero value (its entry is the
         // SECOND in insertion order). We do not need real meta bytes — the
         // finalization signal is "FileEntry.Size > 0".
         let entry_offset = (HEADER_SIZE + EXTENDED_HEADER_SIZE + FILE_ENTRY_SIZE) as u64;
@@ -1714,7 +1717,7 @@ mod tests {
 
         assert!(!follow.is_finalized(), "still not finalized before refresh()");
         follow.refresh().unwrap();
-        assert!(follow.is_finalized(), "non-empty meta.json ⇒ finalized after refresh()");
+        assert!(follow.is_finalized(), "non-empty meta.dat ⇒ finalized after refresh()");
     }
 
     #[test]

--- a/src/db-backend/src/ctfs_trace_reader/meta_dat.rs
+++ b/src/db-backend/src/ctfs_trace_reader/meta_dat.rs
@@ -33,7 +33,8 @@
 //!           bit 12      — FLAG_HAS_INTERNING_TABLES (M23d — binary varint interning tables)
 //!           bit 13      — FLAG_HAS_SPAN_STREAM (RS-M1 — spans.dat/spans.idx/spantype.ns)
 //!           bit 14      — FLAG_HAS_LINE_COUNT_TABLE (paths.dat records carry line_count)
-//!           bit 15      — reserved (must be 0; readers reject if set)
+//!           bit 15      — FLAG_HAS_CORRELATION_INDEX (WTCI — corrmark.ns + markers.dat/.off)
+//!           (no bit is reserved; the flag word is fully allocated)
 //! varint-prefixed UTF-8 string : recording_id        (M-REC-1; v3+)
 //! varint-prefixed UTF-8 string : program
 //! varint                       : args_count
@@ -344,6 +345,31 @@ pub const FLAG_HAS_SPAN_STREAM: u16 = 1 << 13;
 /// (`FlagHasLineCountTable`).
 pub const FLAG_HAS_LINE_COUNT_TABLE: u16 = 1 << 14;
 
+/// Flag bit 15 — `FLAG_HAS_CORRELATION_INDEX` (WTCI).  When set the container
+/// ships `corrmark.ns`, the record-time B-tree index of the distributed-trace
+/// spans and boundary crossings the recording covers, together with the
+/// `markers.dat` / `markers.off` interning table its boundary labels resolve
+/// through.
+///
+/// **A hint, not a gate.**  Like bits 8..13 it says only what the container
+/// carries; the root file-entry array remains the authority, and it is the
+/// entry's presence — not this bit — that distinguishes "never indexed" from
+/// "indexed and covering nothing" (see
+/// `codetracer-specs/Testing/CTFS-Correlation-Marker-Contract.md` §9).
+///
+/// Recognising it here is nonetheless load-bearing: [`KNOWN_FLAGS_MASK`]
+/// refuses any container carrying an unknown bit outright, so without this
+/// constant a reader would reject every marker-bearing recording rather than
+/// ignore an index it has no use for.
+///
+/// Must match `codetracer_trace_writer::meta_dat::FLAG_HAS_CORRELATION_INDEX`
+/// (Rust writer) and the canonical Nim writer's `meta_dat.nim` bit 15.
+///
+/// Drafted against bit 14, which [`FLAG_HAS_LINE_COUNT_TABLE`] took first.
+/// Both describe the container, so they could not share a bit; neither had
+/// shipped, so moving this one cost no compatibility.
+pub const FLAG_HAS_CORRELATION_INDEX: u16 = 1 << 15;
+
 /// Bitmask of all flag bits this implementation understands.
 ///
 /// Any bit outside this mask is rejected by [`parse_meta_dat`] so future
@@ -362,7 +388,8 @@ const KNOWN_FLAGS_MASK: u16 = FLAG_HAS_MCR_FIELDS
     | FLAG_HAS_IO_EVENT_STREAM
     | FLAG_HAS_INTERNING_TABLES
     | FLAG_HAS_SPAN_STREAM
-    | FLAG_HAS_LINE_COUNT_TABLE;
+    | FLAG_HAS_LINE_COUNT_TABLE
+    | FLAG_HAS_CORRELATION_INDEX;
 
 // ── Public types ────────────────────────────────────────────────────────
 
@@ -1403,28 +1430,50 @@ mod tests {
 
     #[test]
     fn rejects_unknown_flag_bits() {
-        // Bit 15 is the lowest — and now the only — still-reserved flag: bits
-        // 0..=14 are all allocated in KNOWN_FLAGS_MASK, most recently bit 14
-        // (FLAG_HAS_LINE_COUNT_TABLE). The probe is pinned to
-        // `!KNOWN_FLAGS_MASK` rather than to a literal so that allocating a
-        // bit cannot leave this test probing a bit the reader now knows, where
-        // it would assert nothing.
+        // THE PROBE IS RETIRED, AND ITS ABSENCE IS THE ASSERTION.
+        //
+        // This test used to set the lowest still-reserved bit and require
+        // `parse_meta_dat` to refuse it, following the reserved range down as
+        // bits 8..=13 were allocated. Bit 14 went to FLAG_HAS_LINE_COUNT_TABLE
+        // and bit 15 to FLAG_HAS_CORRELATION_INDEX, so KNOWN_FLAGS_MASK is now
+        // the whole word and there is no flag value this reader can honestly
+        // call unknown. Crafting one would mean asserting against a bit the
+        // reader is supposed to know — a test of nothing.
+        //
+        // What stands in its place is the invariant that made the probe
+        // impossible. It fails the moment a bit is freed or the flag word
+        // grows, which is exactly the change that has to reinstate a probe
+        // against whatever that growth defines as unknown.
         assert_eq!(
-            !KNOWN_FLAGS_MASK, 0b1000_0000_0000_0000,
-            "bit 15 is the last unallocated flag bit; allocating it means the flag \
-             word has to grow, and this probe has to be rewritten against whatever \
-             that growth defines as unknown"
+            !KNOWN_FLAGS_MASK,
+            0,
+            "the flag word is exhausted; if this fails, a bit was freed or the \
+             field grew, and the unknown-flag probe this replaced must be \
+             reinstated against whatever is unknown now"
         );
-        let probe = !KNOWN_FLAGS_MASK;
+
+        // The rejection PATH stays covered by the other half of the same
+        // contract: a version this reader does not know is still refused.
         let mut buf = writer_compat_fixture_bytes();
-        buf[6..8].copy_from_slice(&probe.to_le_bytes());
-        match parse_meta_dat(&buf) {
-            Err(MetaDatError::UnknownFlags { flags, unknown_bits }) => {
-                assert_eq!(flags, probe);
-                assert_eq!(unknown_bits, probe);
-            }
-            other => panic!("expected UnknownFlags, got {other:?}"),
-        }
+        buf[4] = 99;
+        buf[5] = 0;
+        assert_eq!(parse_meta_dat(&buf), Err(MetaDatError::UnsupportedVersion(99)));
+    }
+
+    /// WTCI — the `FLAG_HAS_CORRELATION_INDEX` bit (15) parses cleanly.
+    ///
+    /// Same "readers before writers" guarantee bit 13 records: an unknown bit
+    /// is rejecting, so before this constant existed the db-backend refused
+    /// every recording that declared a correlation marker — not because it
+    /// needed the index, but because it did not recognise the announcement of
+    /// one.
+    #[test]
+    fn accepts_has_correlation_index_flag() {
+        let mut buf = writer_compat_fixture_bytes();
+        buf[6] = (FLAG_HAS_CORRELATION_INDEX & 0xFF) as u8;
+        buf[7] = (FLAG_HAS_CORRELATION_INDEX >> 8) as u8;
+        let parsed = parse_meta_dat(&buf).expect("bit 15 must parse cleanly");
+        assert_eq!(parsed.flags & FLAG_HAS_CORRELATION_INDEX, FLAG_HAS_CORRELATION_INDEX);
     }
 
     /// Bit 14 is a REJECTING bit, so before this constant existed the

--- a/src/db-backend/src/ctfs_trace_reader/span_stream.rs
+++ b/src/db-backend/src/ctfs_trace_reader/span_stream.rs
@@ -1469,25 +1469,30 @@ mod tests {
     /// goes through `parse_meta_dat` precisely so `KNOWN_FLAGS_MASK` governs the
     /// span path too.
     ///
-    /// The probe bit is derived from `KNOWN_FLAGS_MASK` rather than written as a
-    /// literal: allocating a bit would otherwise leave this test probing one the
-    /// reader now knows, where it would assert nothing.  Bit 14 was the literal
-    /// here until `FLAG_HAS_LINE_COUNT_TABLE` took it.
+    /// THE PROBE IS RETIRED, AND ITS ABSENCE IS THE ASSERTION.  The unknown bit
+    /// was derived from `KNOWN_FLAGS_MASK` rather than written as a literal, so
+    /// that allocating a bit could not leave this test probing one the reader
+    /// now knows.  Bit 14 went to `FLAG_HAS_LINE_COUNT_TABLE` and bit 15 to
+    /// `FLAG_HAS_CORRELATION_INDEX`, so the derivation now yields nothing:
+    /// there is no bit left this build can honestly call unknown.
+    ///
+    /// What remains is the invariant that made the probe impossible, plus the
+    /// control the probe was measured against.  The invariant fails the moment
+    /// the flag word grows, which is when the probe has to be reinstated.
     #[test]
     fn meta_dat_with_an_unknown_bit_alongside_bit_13_is_refused() {
-        let future_bit = lowest_unknown_flag_bit();
-        assert_ne!(
-            future_bit, 0,
-            "every flag bit is allocated, so there is no unknown bit to probe with — the flag word \
-             has to grow, and this test has to be rewritten against whatever that growth defines \
-             as unknown"
+        assert_eq!(
+            lowest_unknown_flag_bit(),
+            0,
+            "an unknown flag bit exists again, so the fail-closed probe this \
+             replaced must be reinstated: assert that bit 13 alongside it is \
+             refused"
         );
-        assert!(!meta_dat_has_span_stream(&meta_dat_bytes(
-            FLAG_HAS_SPAN_STREAM | future_bit
-        )));
 
-        // The control: bit 13 ALONE is recognised, so the refusal above is
-        // about the unknown bit and not about the span bit itself.
+        // The control the probe was measured against: bit 13 ALONE is
+        // recognised.  Keeping it means the span path is still asserted to
+        // read a well-formed span-bearing header, which is the half of this
+        // test that does not depend on an unknown bit existing.
         assert!(meta_dat_has_span_stream(&meta_dat_bytes(FLAG_HAS_SPAN_STREAM)));
     }
 

--- a/src/db-backend/tests/stylus_flow_integration.rs
+++ b/src/db-backend/tests/stylus_flow_integration.rs
@@ -36,7 +36,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use test_harness::{DapStdioTestClient, find_wazero, record_stylus_wasm_trace};
 
-use codetracer_trace_types::{EventLogKind, RecordEvent, TraceLowLevelEvent, TraceMetadata};
+use codetracer_trace_types::{EventLogKind, RecordEvent, TraceLowLevelEvent};
 
 const DEVNODE_RPC: &str = "http://localhost:8547";
 // Standard test private key for Arbitrum devnodes
@@ -286,17 +286,14 @@ fn record_stylus_trace(project_path: &Path) -> Result<(PathBuf, PathBuf, PathBuf
     Ok((wasm_path, trace_dir, temp_dir))
 }
 
-/// Load `TraceMetadata` from a `.ct` CTFS container in `trace_dir`.
+/// Load the recording's metadata from the `.ct` CTFS container in `trace_dir`.
 ///
-/// Per `Trace-Files/CTFS-Migration-Guide.md` §3e, the `.ct` container is
-/// the only supported materialized-trace format: metadata lives in
-/// `meta.dat` (or the older `meta.json` block written by recorders that
-/// have not yet migrated to the binary metadata format) inside the
-/// container.  The `meta.json` path is read here for compatibility with
-/// the in-tree Rust writer, which still emits it inside the container
-/// alongside event data.  Sidecar `trace_metadata.json` is no longer
+/// Per `Trace-Files/CTFS-Migration-Guide.md` §3e the `.ct` container is the
+/// only supported materialized-trace format, and `meta.dat` is where its
+/// metadata lives. The legacy `meta.json` block this used to read is retired —
+/// no writer emits it — and the sidecar `trace_metadata.json` was already not
 /// accepted.
-fn load_stylus_trace_metadata(trace_dir: &Path) -> Result<TraceMetadata, String> {
+fn load_stylus_trace_metadata(trace_dir: &Path) -> Result<db_backend::ctfs_trace_reader::meta_dat::MetaDat, String> {
     // Pick the first `*.ct` file in `trace_dir` (recorders may name it
     // `trace.ct` or `<program>.ct`).
     let ct_path = std::fs::read_dir(trace_dir)
@@ -309,9 +306,10 @@ fn load_stylus_trace_metadata(trace_dir: &Path) -> Result<TraceMetadata, String>
     let mut ctfs = db_backend::ctfs_trace_reader::ctfs_container::CtfsReader::open(&ct_path)
         .map_err(|e| format!("open {}: {}", ct_path.display(), e))?;
     let meta_bytes = ctfs
-        .read_file("meta.json")
-        .map_err(|e| format!("read meta.json from {}: {}", ct_path.display(), e))?;
-    serde_json::from_slice(&meta_bytes).map_err(|e| format!("parse meta.json from {}: {}", ct_path.display(), e))
+        .read_file("meta.dat")
+        .map_err(|e| format!("read meta.dat from {}: {}", ct_path.display(), e))?;
+    db_backend::ctfs_trace_reader::meta_dat::parse_meta_dat(&meta_bytes)
+        .map_err(|e| format!("parse meta.dat from {}: {:?}", ct_path.display(), e))
 }
 
 /// Copy the trace directory to an external fixture location if
@@ -558,11 +556,8 @@ fn test_stylus_trace_analysis() {
 
     // Parse and verify trace metadata.  Per the CTFS migration guide
     // (Trace-Files/CTFS-Migration-Guide.md §3e) the canonical home for
-    // metadata is `meta.json` (old CTFS) or `meta.dat` (new CTFS) inside
-    // the `.ct` container.  We prefer the legacy sidecar `trace_metadata.json`
-    // when it exists (current Stylus path), and otherwise extract
-    // `meta.json` from the `.ct` container via the CTFS reader library.
-    let metadata: TraceMetadata = load_stylus_trace_metadata(&trace_dir)
+    // metadata is `meta.dat` inside the `.ct` container.
+    let metadata = load_stylus_trace_metadata(&trace_dir)
         .unwrap_or_else(|e| panic!("Failed to load trace metadata from {}: {}", trace_dir.display(), e));
 
     assert!(


### PR DESCRIPTION
Replaces #733, which cannot be landed as-is: this repository allows only rebase-merge, and #733's conflict resolution against `dev` lives in a merge commit that a rebase would drop — silently restoring a `meta.dat` flag-bit collision. This branch carries the identical, verified tree as a single commit on top of `dev`, so a rebase-merge is a plain fast-forward.

A recording's metadata is `meta.dat`, and its source paths come from the binary interning table or from `meta.dat`'s own `paths` field. The two legacy JSON sidecars are no longer consulted anywhere.

Recognises the correlation-index header flag so a marker-bearing recording opens. The index sits on `meta.dat` bit 15: it was drafted against bit 14, which the per-file line-count table took first on `dev`, and both describe the container so they could not share one. Neither bit had shipped, so nothing on disk changes.

That spends the last bit of the flag word. Three tests probed the reserved range by naming the lowest unallocated bit; each now asserts the exhaustion directly and keeps the positive control it was measured against.

Verified locally: `cargo test -p db-backend --lib` gives 656 passing. Two `tracepoint_interpreter` tests fail, and they fail identically on unmodified `dev` — they record a Ruby trace with a locally-built recorder that still writes `meta.dat` v3, which `dev`'s own commit db33ac90 now refuses. `nim check` on the changed Nim file exits 0.