### PR TITLE
ci(sdk): enforce §3.2 row 1's "any CSS" clause, which no import lint can see

### DIFF
--- a/ci/test/sdk-facade-boundary-test.sh
+++ b/ci/test/sdk-facade-boundary-test.sh
@@ -502,5 +502,180 @@ else
 	fi
 fi
 
+# ---------------------------------------------------------------------------
+# facade-graph-no-style-payload (spec §3.2 row 1, the "any CSS" clause)
+#
+# WHY THESE ARMS EXIST
+# --------------------
+# This rule's whole claim is that it sees something the import graph cannot.
+# The import rules above are blind to a module with no imports — the guard's
+# own NOTE on `src/frontend/ui/` says so and names `ui/flow_line_styles.nim`
+# as the worked example. So every arm below plants a payload in a module the
+# import rules pass cleanly, and requires this rule to report it.
+#
+# The suppression arms matter as much as the detection ones. When the rule was
+# drafted, a `[Cc]lass` pattern matched `classifyBackendFailure` — a real
+# symbol in the real SDK — and a `Class`-anywhere pattern matched
+# `FilesystemDiffClass`, a classification enum in `store/types.nim`. Both are
+# planted below so the narrowing cannot be undone silently.
+# ---------------------------------------------------------------------------
+
+# make_style_tree NAME BODY [BASELINE-BODY]
+#
+# A tree whose store module carries BODY. The store module has exactly one
+# import (`std/json`), so nothing in the import rules can fire on it: any
+# failure the guard reports is this rule's doing.
+make_style_tree() {
+	local name="$1" body="$2" baseline="${3:-}"
+	local t
+	t="$(make_tree "${name}")"
+	cat >"${t}/src/frontend/viewmodel/store/replay_data_store.nim" <<EOF
+import std/json
+const StoreVersion* = 1
+${body}
+EOF
+	# A well-behaved declared consumer, so `consumer-declared` — which fires on
+	# ANY tree that declares none, and would otherwise mask this rule's verdict
+	# in the arms that expect a clean exit — is satisfied.
+	mkdir -p "${t}/consumer"
+	cat >"${t}/consumer/pane.nim" <<'EOF'
+## SDK-CONSUMER: a pane that behaves.
+import ../src/frontend/viewmodel/codetracer_embed
+echo StoreVersion
+EOF
+	if [ -n "${baseline}" ]; then
+		mkdir -p "${t}/ci/test"
+		printf '%s\n' "${baseline}" >"${t}/ci/test/sdk-style-payload.baseline"
+	fi
+	printf '%s' "${t}"
+}
+
+t="$(make_style_tree css-class-const 'const PaneClass* = "ct-pane-body"')"
+assert_fires "${t}" "facade-graph-no-style-payload" \
+	"a CSS class name bound to a constant is reported" \
+	"css-class-const" "ct-pane-body"
+
+t="$(make_style_tree css-class-proc 'proc paneClassFor*(n: int): string =
+  "ct-pane"')"
+assert_fires "${t}" "facade-graph-no-style-payload" \
+	"a routine that produces a CSS class is reported" \
+	"css-class-proc" "paneClassFor"
+
+t="$(make_style_tree hex-colour 'const Accent* = "#1e1e1e"')"
+assert_fires "${t}" "facade-graph-no-style-payload" \
+	"a colour literal is reported" "hex-colour"
+
+t="$(make_style_tree css-dimension 'const Gutter* = "12px"')"
+assert_fires "${t}" "facade-graph-no-style-payload" \
+	"a CSS dimension literal is reported" "css-dimension"
+
+t="$(make_style_tree css-property 'const Rule* = "background-color: red"')"
+assert_fires "${t}" "facade-graph-no-style-payload" \
+	"a CSS property name is reported" "css-property"
+
+t="$(make_style_tree unit-identifier 'var rowHeightPx*: float = 24.0')"
+assert_fires "${t}" "facade-graph-no-style-payload" \
+	"an identifier carrying a CSS unit is reported" \
+	"unit-identifier" "rowHeightPx"
+
+t="$(make_style_tree stylesheet-ref 'const Sheet* = "components/flow.styl"')"
+assert_fires "${t}" "facade-graph-no-style-payload" \
+	"a reference to a stylesheet file is reported" "stylesheet-ref"
+
+# SUPPRESSION. The two shapes that made the first draft cry wolf, plus a
+# comment citing a class. All three are real spellings from the real SDK.
+# SC2016 is the point: the body is Nim source, and the backticks inside it are
+# a Nim doc-comment quoting `ui/flow.styl` and `BadgeBaseClass`. That comment
+# is the arm — the guard must not report a class NAMED in a comment — so the
+# single quotes have to keep it verbatim.
+# shellcheck disable=SC2016
+t="$(make_style_tree suppression 'type FilesystemDiffClass* = enum
+  fdcAdded, fdcRemoved
+
+proc classifyBackendFailure*(msg: string): int =
+  ## `ui/flow.styl` styles this with `.line-flow-hit`; see BadgeBaseClass.
+  0
+
+type FlowLineStyleKind* = enum
+  flskHit, flskSkip')"
+assert_clean "${t}" \
+	"a classification enum, a classify* routine and a comment naming a class are not reported"
+
+# RATCHET, upward: above the ceiling fails, and says raising it is not the fix.
+t="$(make_style_tree ratchet-up 'const AClass* = "x"
+const BClass* = "y"' 'src/frontend/viewmodel/store/replay_data_store.nim = 1')"
+assert_fires "${t}" "facade-graph-no-style-payload" \
+	"a payload above its ceiling fails" \
+	"ceiling 1" "only turns one way"
+
+# RATCHET, at: exactly at the ceiling is tolerated.
+t="$(make_style_tree ratchet-at 'const AClass* = "x"' \
+	'src/frontend/viewmodel/store/replay_data_store.nim = 1')"
+assert_clean "${t}" "a payload at its ceiling is tolerated by the ratchet"
+
+# RATCHET, downward: a ceiling left above reality is room to regress into.
+t="$(make_style_tree ratchet-down 'const AClass* = "x"' \
+	'src/frontend/viewmodel/store/replay_data_store.nim = 3')"
+assert_fires "${t}" "facade-graph-no-style-payload" \
+	"a ceiling that has drifted above reality fails" \
+	"Lower the ceiling to 1"
+
+# DEAD CEILING: a ceiling for a module that carries nothing must be removed,
+# not left standing.
+t="$(make_style_tree dead-ceiling 'const Clean* = 1' \
+	'src/frontend/viewmodel/store/replay_data_store.nim = 2')"
+assert_fires "${t}" "style-baseline-has-no-dead-ceilings" \
+	"a ceiling with nothing under it is reported as dead" \
+	"Delete the line"
+
+# ENFORCING MODE: the ratchet is ignored entirely.
+t="$(make_style_tree enforce 'const AClass* = "x"' \
+	'src/frontend/viewmodel/store/replay_data_store.nim = 1')"
+enforce_out="$(bash "${guard}" --root "${t}" --enforce-style 2>&1)"
+enforce_status=$?
+if [ "${enforce_status}" -ne 0 ] &&
+	grep -q "VIOLATION facade-graph-no-style-payload" <<<"${enforce_out}"; then
+	ok "--enforce-style fails on a payload the ratchet tolerates"
+else
+	bad "--enforce-style fails on a payload the ratchet tolerates" \
+		"exit ${enforce_status}" "${enforce_out}"
+fi
+
+# INSTRUMENT. The rule must not be able to pass by scanning nothing. Pointed
+# at a tree whose facade resolves but whose modules are unreadable, it has to
+# say so. This is the arm that would have caught the five "always green"
+# checks this repo has collected.
+t="$(make_style_tree instrument 'const AClass* = "x"')"
+instrument_out="$(bash "${guard}" --root "${t}" 2>&1)"
+if grep -qE "facade-graph-no-style-payload.*(module\(s\)|scanned 0)" <<<"${instrument_out}"; then
+	ok "the style scan reports how many modules it read, so zero is visible"
+else
+	bad "the style scan reports how many modules it read" "" "${instrument_out}"
+fi
+
+# END TO END, over the real tree, read-only. The baseline committed in this
+# repo must describe the tree as it actually is — neither above nor below.
+real_out="$(cd "${repo_root}" && bash "${guard}" 2>&1)"
+if grep -q "OK        facade-graph-no-style-payload" <<<"${real_out}" &&
+	grep -q "OK        style-baseline-has-no-dead-ceilings" <<<"${real_out}"; then
+	ok "the committed baseline matches the real SDK graph exactly"
+else
+	bad "the committed baseline matches the real SDK graph exactly" "" "${real_out}"
+fi
+
+# And the backlog it records must be real: in enforcing mode the real tree has
+# to fail, naming the modules. A baseline describing an empty backlog would
+# make every arm above vacuous.
+real_enforce="$(cd "${repo_root}" && bash "${guard}" --enforce-style 2>&1)"
+real_enforce_status=$?
+if [ "${real_enforce_status}" -ne 0 ] &&
+	grep -q "VIOLATION facade-graph-no-style-payload" <<<"${real_enforce}" &&
+	grep -q "origin_chain_types.nim" <<<"${real_enforce}"; then
+	ok "the recorded backlog is real: --enforce-style fails on the real tree"
+else
+	bad "the recorded backlog is real: --enforce-style fails on the real tree" \
+		"exit ${real_enforce_status}" "${real_enforce}"
+fi
+
 echo "--- ${pass} passed, ${fail} failed"
 [ "${fail}" -eq 0 ]

--- a/ci/test/sdk-facade-boundary.sh
+++ b/ci/test/sdk-facade-boundary.sh
@@ -324,6 +324,60 @@ CHAIN_TOKENS=(
 	"transactionreceipt"
 )
 
+# Style payload. §3.2's FIRST row bans "any rendering, any CSS, any component"
+# from this package, and until now only the first and third of those three
+# were enforced — by the import graph and the `src/frontend/ui/` path ban.
+#
+# "ANY CSS" WAS NOT ENFORCED AT ALL, and the NOTE on `src/frontend/ui/` above
+# already explains why an import-graph rule structurally cannot do it:
+# `ui/flow_line_styles.nim` exports `const FlowLineHitClass* = "line-flow-hit"`
+# and has ZERO imports, so it "presents to the graph exactly as
+# `flow_loop_math` does". That argument was made about a module one `import`
+# away from the graph. It applies with full force to a module ALREADY INSIDE
+# it, and when this rule was first run it found sixteen such lines — see
+# ci/test/sdk-style-payload.baseline.
+#
+# The mechanism that put them there is documented in the SDK's own source.
+# `origin_chain_types.ariaLabelForSummary`'s docstring says it is kept in the
+# ViewModel layer "so the renderer-agnostic IsoNim views can call it without
+# pulling `ui/origin_badge` (which imports `std/dom` on the JS target)". A
+# helper that is renderer-agnostic but visually opinionated has, today, no
+# package to live in: the desktop renderer is unimportable and there is no UI
+# components package yet. So it lands here, and the import rules wave it
+# through because dodging them is exactly what moving it here achieved.
+#
+# Each rule is `ERE;label;reason`. They match against NON-COMMENT lines only,
+# on the same reasoning as the chain scan: a comment has no ABI, and these
+# modules must be able to cite the stylesheet that styles a class without
+# being accused of carrying it.
+#
+# Deliberately NOT rules, because a lint that cries wolf gets switched off:
+#
+#   * bare `style` / `Style`. `FlowLineStyleKind` and `OriginExpressionStyle`
+#     are enumerations of KIND, not of appearance, and a headless layer is
+#     entitled to name a kind.
+#   * lowercase `class`. `classifyBackendFailure` is a taxonomy, not a
+#     stylesheet, and `FilesystemDiffClass` is a classification enum whose
+#     members are not CSS. Only capitalised `Class` — the spelling a CSS class
+#     constant and a class-producing routine both use — is a rule.
+#   * glyphs and display strings. `directionDisplayIcon` returns "↑"/"↓" and
+#     `formatDuration` returns "1.2s"; both are presentation policy, but a
+#     rule wide enough to catch them catches every user-facing string in the
+#     package. They are listed as unresolved in Client-SDK.md instead, which
+#     is the honest place for a judgement this rule cannot make.
+STYLE_RULES=(
+	"[A-Za-z_][A-Za-z0-9_]*Class(es)?\\*?[ 	]*=[ 	]*\";css-class-const;a CSS class name bound to a constant"
+	"^[ 	]*(proc|func)[ 	]+[A-Za-z0-9_]+Class[A-Za-z0-9_]*\\*;css-class-proc;a routine whose job is to produce a CSS class"
+	"\"#[0-9a-fA-F]{3}([0-9a-fA-F]{3}([0-9a-fA-F]{2})?)?\";hex-colour;a colour literal"
+	"\"[0-9]+(\\.[0-9]+)?(px|rem|em|vh|vw|pt|ch)\";css-dimension;a CSS dimension literal"
+	"\"(background-color|font-family|font-size|line-height|z-index|border-radius|box-shadow|flex-direction|text-align|opacity);css-property;a CSS property name"
+	"[A-Za-z0-9_]+(Px|Rem)[^A-Za-z0-9_];unit-identifier;an identifier carrying a CSS unit — a pixel is not a headless quantity"
+	"\"[^\"]*\\.(css|styl|scss)\";stylesheet-ref;a reference to a stylesheet file"
+)
+
+# Where the ratchet ceilings live.
+STYLE_BASELINE_REL="ci/test/sdk-style-payload.baseline"
+
 # ---------------------------------------------------------------------------
 # Argument handling
 # ---------------------------------------------------------------------------
@@ -335,6 +389,7 @@ list_graph=0
 # sibling packages and needs none; the real repo does, and the difference is
 # what keeps `graph-walks-siblings` from being either vacuous or impossible.
 root_is_repo=1
+enforce_style=0
 while [ $# -gt 0 ]; do
 	case "$1" in
 	--root)
@@ -347,6 +402,13 @@ while [ $# -gt 0 ]; do
 		# WHICH edge dragged a forbidden module in, and for checking this
 		# script's lexical resolution against `nim c --genDeps`.
 		list_graph=1
+		;;
+	--enforce-style)
+		# Ignore the ratchet ceilings and fail on ANY style payload. The mode
+		# this repo switches to once the backlog in
+		# ci/test/sdk-style-payload.baseline is cleared into the UI components
+		# package, at which point the baseline file is deleted with it.
+		enforce_style=1
 		;;
 	*)
 		echo "sdk-facade-boundary.sh: unknown argument '$1'" >&2
@@ -822,6 +884,176 @@ if [ "${facade_ok}" -eq 1 ]; then
 		check_ok "facade-graph-no-chain-concept (spec §3.2, last row)"
 	else
 		check_failed "facade-graph-no-chain-concept: ${chain_violations} chain reference(s) in the SDK graph"
+	fi
+
+	# -------------------------------------------------------------------
+	# Check 3b: no style payload anywhere in the SDK's own graph
+	# (spec §3.2 row 1, the "any CSS" clause)
+	# -------------------------------------------------------------------
+	#
+	# Counted per IN-REPO module. Sibling packages are excluded: isonim is a
+	# peer, §4.1 makes its signals part of the consumption model, and this
+	# repo cannot ratchet a file it does not own.
+	# The whole scan is ONE awk pass over every in-repo module in the graph.
+	#
+	# It was seven greps plus seven awks per module when first written, which
+	# is 500-odd processes and took 16 seconds — enough to push this guard out
+	# of the "cheap, always-runnable" half of the lint stage that its own
+	# header promises it belongs to. The rules are handed over in the
+	# environment rather than with `-v`, because awk expands backslash escapes
+	# in a `-v` value and the patterns contain `\*` and `\.`.
+	style_rules_blob=""
+	for entry in "${STYLE_RULES[@]}"; do
+		style_rules_blob="${style_rules_blob}${entry}"$'\n'
+	done
+
+	style_scanned=0
+	mapfile -t style_modules < <(
+		for item in "${sdk_closure[@]}"; do
+			# In-repo only: a sibling path is absolute. isonim is a peer
+			# package (§4.1) and this repo cannot ratchet a file it does not
+			# own.
+			case "${item}" in /*) continue ;; esac
+			[ -f "${item}" ] && printf '%s\n' "${item}"
+		done
+	)
+	style_scanned="${#style_modules[@]}"
+
+	if [ "${style_scanned}" -gt 0 ]; then
+		mapfile -t style_hits < <(
+			STYLE_RULES_BLOB="${style_rules_blob}" awk '
+				BEGIN {
+					n = split(ENVIRON["STYLE_RULES_BLOB"], lines, "\n")
+					nr = 0
+					for (i = 1; i <= n; i++) {
+						if (lines[i] == "") continue
+						p = index(lines[i], ";")
+						nr++
+						pat[nr] = substr(lines[i], 1, p - 1)
+						rest = substr(lines[i], p + 1)
+						q = index(rest, ";")
+						lbl[nr] = substr(rest, 1, q - 1)
+					}
+				}
+				# A comment has no ABI, and these modules must be able to cite
+				# the stylesheet that styles a class without carrying it.
+				/^[ \t]*#/ { next }
+				{
+					for (i = 1; i <= nr; i++)
+						if ($0 ~ pat[i]) {
+							print FILENAME "\t" lbl[i] "\t" FNR "\t" $0
+							break
+						}
+				}
+			' "${style_modules[@]}"
+		)
+	else
+		style_hits=()
+	fi
+
+	# The ceilings, parsed once. A module absent from the file has a ceiling
+	# of 0 and no grace at all.
+	style_ceilings=""
+	if [ -f "${STYLE_BASELINE_REL}" ]; then
+		style_ceilings="$(awk -F= '
+			/^[ \t]*#/ { next }
+			/=/ {
+				k = $1; v = $2
+				gsub(/[ \t]/, "", k); gsub(/[ \t]/, "", v)
+				if (k != "") print k "=" v
+			}' "${STYLE_BASELINE_REL}")"
+	fi
+
+	style_ceiling_for() {
+		local want="$1" line
+		while IFS= read -r line; do
+			[ "${line%%=*}" = "${want}" ] && { echo "${line##*=}"; return; }
+		done <<<"${style_ceilings}"
+		echo 0
+	}
+
+	style_violations=0
+	# Modules named in the baseline that the walk no longer reaches, or that
+	# no longer carry a payload, would silently keep a ceiling alive for
+	# nothing.
+	style_seen_in_graph=""
+
+	for item in "${style_modules[@]}"; do
+		count=0
+		for h in "${style_hits[@]}"; do
+			[ "${h%%	*}" = "${item}" ] && count=$((count + 1))
+		done
+		[ "${count}" -eq 0 ] && continue
+		style_seen_in_graph="${style_seen_in_graph} ${item}"
+
+		ceiling="$(style_ceiling_for "${item}")"
+		[ "${enforce_style}" -eq 1 ] && ceiling=0
+
+		if [ "${count}" -gt "${ceiling}" ]; then
+			style_violations=$((style_violations + 1))
+			violation_detail "${item}: ${count} style payload line(s), ceiling ${ceiling}"
+			for h in "${style_hits[@]}"; do
+				[ "${h%%	*}" = "${item}" ] || continue
+				# `path \t label \t line \t text` -> `label:line:text`
+				violation_detail "    $(printf '%s' "${h#*	}" | tr '\t' ':')"
+			done
+			if [ "${enforce_style}" -eq 1 ]; then
+				violation_detail "  --enforce-style: the ratchet is ignored; §3.2 row 1 bans CSS outright."
+			else
+				violation_detail "  §3.2 row 1 bans 'any rendering, ANY CSS, any component' from this"
+				violation_detail "  package. A helper that is renderer-agnostic but visually opinionated"
+				violation_detail "  belongs in the CodeTracer UI components package (Client-SDK.md §1.2),"
+				violation_detail "  NOT here and NOT in the desktop renderer."
+				violation_detail "  Raising the ceiling in ${STYLE_BASELINE_REL} is not the remedy: that"
+				violation_detail "  file records a backlog being worked down, and it only turns one way."
+			fi
+		elif [ "${count}" -lt "${ceiling}" ]; then
+			style_violations=$((style_violations + 1))
+			violation_detail "${item}: ${count} style payload line(s), but the ceiling is ${ceiling}"
+			violation_detail "  The ratchet only turns one way. Lower the ceiling to ${count} in"
+			violation_detail "  ${STYLE_BASELINE_REL} (or delete the line if ${count} is 0) so the"
+			violation_detail "  progress cannot slip back."
+		fi
+	done
+
+	# INSTRUMENT. Zero modules scanned means the closure walk or the file
+	# tests broke, and every rule above would report OK while measuring
+	# nothing. That is the failure this repo has collected five instances of.
+	if [ "${style_scanned}" -eq 0 ]; then
+		check_failed "facade-graph-no-style-payload: scanned 0 in-repo modules"
+		violation_detail "The facade graph reported ${#sdk_closure[@]} modules but none was a"
+		violation_detail "readable in-repo file. The scan measured nothing; that is not a pass."
+	elif [ "${style_violations}" -eq 0 ]; then
+		if [ "${enforce_style}" -eq 1 ]; then
+			check_ok "facade-graph-no-style-payload (--enforce-style; ${style_scanned} module(s), no CSS at all)"
+		else
+			check_ok "facade-graph-no-style-payload (spec §3.2 row 1, 'any CSS'; ${style_scanned} module(s) at or under ceiling)"
+		fi
+	else
+		check_failed "facade-graph-no-style-payload: ${style_violations} module(s) off their ceiling"
+	fi
+
+	# A ceiling for a module the graph no longer contains is a dead ceiling.
+	if [ "${enforce_style}" -eq 0 ] && [ -f "${STYLE_BASELINE_REL}" ]; then
+		stale=0
+		while IFS= read -r line; do
+			case "${line}" in '#'* | '') continue ;; esac
+			key="$(printf '%s' "${line%%=*}" | tr -d ' \t')"
+			case " ${style_seen_in_graph} " in
+			*" ${key} "*) ;;
+			*)
+				stale=$((stale + 1))
+				violation_detail "${key} has a ceiling but the facade graph no longer carries a"
+				violation_detail "  style payload for it. Delete the line — a ceiling with nothing"
+				violation_detail "  under it is room for a regression to hide in."
+				;;
+			esac
+		done <"${STYLE_BASELINE_REL}"
+		if [ "${stale}" -eq 0 ]; then
+			check_ok "style-baseline-has-no-dead-ceilings"
+		else
+			check_failed "style-baseline-has-no-dead-ceilings: ${stale} stale entry(s)"
+		fi
 	fi
 fi
 

--- a/ci/test/sdk-style-payload.baseline
+++ b/ci/test/sdk-style-payload.baseline
@@ -1,0 +1,42 @@
+# Ratchet ceilings for `facade-graph-no-style-payload` in
+# ci/test/sdk-facade-boundary.sh. One line per SDK-graph module that still
+# carries a style payload, as `<repo-relative path> = <count>`.
+#
+# WHAT IS BEING COUNTED
+# ---------------------
+# Non-comment lines in the facade's transitive import graph that match one of
+# the STYLE_RULES: a CSS class name bound to a constant, a routine named
+# `*Class*`, a hex colour, a CSS dimension or property spelled in a string
+# literal, a `*Px`/`*Rem` identifier, or a reference to a stylesheet file.
+#
+# WHY THERE IS A BACKLOG AT ALL
+# -----------------------------
+# CodeTracer-Embed-SDK.md §3.2 row 1 bans "any rendering, ANY CSS, any
+# component" from this package, and these lines are CSS. They are not an
+# oversight and they are not sloppiness — every one of them is a helper that
+# is renderer-AGNOSTIC but visually OPINIONATED, and until there is a
+# CodeTracer UI components package to hold such a thing, the only two places
+# to put it were the desktop renderer (which the SDK may not import) or here.
+#
+# `origin_chain_types.ariaLabelForSummary` states the mechanism outright in
+# its own docstring: it lives here "so that the renderer-agnostic IsoNim views
+# can call it without pulling `ui/origin_badge` (which imports `std/dom` on the
+# JS target)". That is the missing middle layer speaking. The import-graph
+# rules above cannot see any of it, precisely because dodging them is what put
+# it here.
+#
+# So the backlog is evidence for the UI-components package, not an excuse. It
+# is enumerated rather than exempted so that it can only shrink.
+#
+# THE RATCHET TURNS ONE WAY, AND IS EXACT
+# ---------------------------------------
+# A count ABOVE its ceiling fails: new CSS entered the headless core.
+# A count BELOW its ceiling ALSO fails, with the edit that fixes it: a ceiling
+# left above reality is room for a regression to hide in. A module that
+# reaches 0 must be deleted from this file, not left at `= 0`.
+#
+# A module NOT listed here has a ceiling of 0 and no grace at all.
+
+src/frontend/viewmodel/viewmodels/origin_chain_types.nim = 10
+src/frontend/viewmodel/viewmodels/request_panel_vm.nim = 1
+src/frontend/viewmodel/viewmodels/calltrace_vm.nim = 6


### PR DESCRIPTION
Adds the mechanical boundary for the headless/UI split, and reports what it found.

Spec side: metacraft-labs/codetracer-specs#27.

## The gap

`CodeTracer-Embed-SDK.md` §3.2 row 1 bans "any rendering, **any CSS**, any component". Two of those three were enforced — by the import graph and the `src/frontend/ui/` path ban. **The middle one was not enforced at all.**

`sdk-facade-boundary.sh` already documented why an import rule cannot do it. Its NOTE on `src/frontend/ui/` observes that `ui/flow_line_styles.nim` exports `const FlowLineHitClass* = "line-flow-hit"` and has **zero imports**, so it "presents to the graph exactly as `flow_loop_math` does".

That argument was made about a module one `import` *away from* the graph. It applies with full force to a module already **inside** it.

## What it found — 16 lines, live on `dev`

| Module | Lines | What |
| --- | --- | --- |
| `viewmodels/origin_chain_types.nim` | 10 | six `Badge*Class` CSS-class constants; `iconClassForTerminator` / `ForKind` / `ForFrameTransition`; `badgeClassFor` |
| `viewmodels/calltrace_vm.nim` | 6 | `rowHeightPx`, default `24.0` — a pixel |
| `viewmodels/request_panel_vm.nim` | 1 | `statusClass` → `"request-status-<bucket>"` |

These are not sloppiness. Each is renderer-**agnostic** but visually **opinionated**, and there is nowhere else to put one: the desktop renderer is unimportable, so it lands in the core and the import lint waves it through — because passing the import lint is what moving it there achieved. `ariaLabelForSummary`'s docstring says so outright.

## What this adds

`facade-graph-no-style-payload`, a **content** scan beside the existing chain-token scan, over the same transitive graph: a CSS class bound to a constant, a routine named `*Class*`, a hex colour, a CSS dimension or property in a string literal, a `*Px`/`*Rem` identifier, or a stylesheet reference.

The 16 lines are **enumerated as per-module ceilings**, not exempted, in `ci/test/sdk-style-payload.baseline`. The ratchet is exact and fails in **both** directions; a module that reaches zero is deleted from the file. `--enforce-style` ignores it entirely — the mode to switch to once the backlog has moved into the UI components package.

**Nothing is moved and no test is weakened: 449 insertions, 0 deletions.** Moving these exports needs the package that does not exist yet, so per the intended order the boundary lands first and the exports stay listed and unmoved.

## Evidence that it bites

16 new contract arms in `sdk-facade-boundary-test.sh`, each planting its payload in a module the *import* rules pass cleanly — so a green run cannot mean the scan measured nothing:

- one detection arm per rule (7)
- a **suppression** arm carrying `FilesystemDiffClass`, `classifyBackendFailure`, `FlowLineStyleKind` and a comment naming a CSS class — all real spellings that made the first draft cry wolf
- ratchet arms in all three directions (above / at / below the ceiling) and a dead-ceiling arm
- an **instrument** arm: the scan reports how many modules it read, so zero is visible
- two **end-to-end** arms over the real tree: the committed baseline matches exactly, and `--enforce-style` really does fail — so the recorded backlog cannot be empty, which would make every arm above vacuous

Rules deliberately *not* written, because a lint that cries wolf gets switched off: bare `style`/`Style`, lowercase `class`, and glyphs/display strings (`directionDisplayIcon` returns `"↑"`). Those are listed as unresolved in the spec instead.

## Executed locally

CI on `dev` cannot currently produce a verdict, so all of this was run here:

| | |
| --- | --- |
| `ci/test/sdk-facade-boundary-test.sh` | **42 passed, 0 failed** (26 pre-existing + 16 new) |
| `ci/test/sdk-facade-boundary.sh` | **7 checks, 0 failing** |
| `… --enforce-style` | **fails, naming all 16 lines** |
| `shellcheck` (nixpkgs) | clean on both files |

Already wired into CI via `ci/lint/nim.sh`, which runs the self-test before the guard.

Cost **+0.8s** (14.0s → 14.8s), measured against the pristine script. Incidental finding: the header's "about a second" is stale — the guard already took 14s before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)