### PR TITLE
chore(deps): pin the trace format revision this tree compiles against

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -531,10 +531,10 @@
       "flake": false,
       "locked": {
         "lastModified": 1787817463,
-        "narHash": "sha256-o4OXq4/R4U7p7Nk/hpKrqdE+0g638RPwXkDYXNmtpFI=",
+        "narHash": "sha256-ipDOfSFyPPRRsYBWdkhj4W4wdd476gucNlxUOF7Dodw=",
         "owner": "metacraft-labs",
         "repo": "codetracer-trace-format-nim",
-        "rev": "d7eca441ae782bde3c6fa2ed225b250f0f83ab87",
+        "rev": "e19a92179a2a101b76d2f7887ced16347691c2aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The pinned revision predates the reader API that `src/ct_test/incremental/ctfs_seekable.nim` uses, so a build resolving the lock rather than an adjacent sibling checkout could not compile. CI was insulated only because it clones the sibling beside this repository, which means the pin itself was never exercised.

The revision recorded here also carries the GC-safety declaration on the path accessor, which is what lets the trace reader be used from a GC-safe context at all.

Verified: the edited lock evaluates (`nix flake metadata --no-update-lock-file`, exit 0), exactly one node's revision moved, and the node count is unchanged at 260.